### PR TITLE
Interactive scheduler / scheduler analyzer

### DIFF
--- a/llvm/test/CodeGen/AIE/aie2/end-to-end/Conv2D-red.ll
+++ b/llvm/test/CodeGen/AIE/aie2/end-to-end/Conv2D-red.ll
@@ -6,6 +6,9 @@
 ;
 ; (c) Copyright 2023-2024 Advanced Micro Devices, Inc. or its affiliates
 ; RUN: llc -O2 -mtriple=aie2 --enable-pipeliner=0 %s -o - | FileCheck %s --check-prefix=ASM
+; RUN: llc -O2 -mtriple=aie2 --enable-pipeliner=0 %s -o - --debug-only=machine-scheduler  \
+; RUN:    2>&1 | %imisched -d - \
+; RUN:    | FileCheck %s --check-prefix=SCHED-DUMP
 
 
 ; This is a reduced version of the Conv2D_0 MLLib benchmark which only contains
@@ -22,6 +25,13 @@
 
 ; The test is meant as a quick way to spot QoR regressions, but if the ASM is
 ; too unstable, we can use different FileCheck lines.
+
+
+; SCHED-DUMP: Region: conv2d.loop.nest:bb.2
+; SCHED-DUMP: Region: conv2d.loop.nest:bb.4
+; SCHED-DUMP: Region: conv2d.loop.nest:bb.3
+; SCHED-DUMP: Region: conv2d.loop.nest:bb.1
+; SCHED-DUMP: Region: conv2d.loop.nest:bb.0
 
 define dso_local void @conv2d.loop.nest(ptr %add.ptr6.i51, ptr %add.ptr5, ptr %cond, ptr %cond.i50, <16 x i32> %0, i32 %cond67.i79, i20 %idx.ext.i.i81, i20 %idx.ext.i404.i, i20 %idx.ext.i410.i, i20 %idx.ext.i434.i85, i32 %1, i20 %2, i20 %3, i20 %4, i20 %5, i20 %6, i32 %7, i32 %8, i32 %or9.i.i.i.i.i96, i32 %9, i20 %idx.ext.i422.i82, i20 %10, i20 %11, i20 %12, i20 %13, i20 %14, i20 %15, i20 %16, i20 %17, i20 %18, i20 %19, i20 %20, i20 %21, i20 %22, i20 %23, i32 %conv192.i107, i20 %24, i20 %idx.ext.i428.i, i20 %25, i20 %26, i20 %27, i32 %28) #1 {
 ; ASM-LABEL: conv2d.loop.nest:

--- a/llvm/test/CodeGen/AIE/aie2/lit.local.cfg
+++ b/llvm/test/CodeGen/AIE/aie2/lit.local.cfg
@@ -5,6 +5,11 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
 # (c) Copyright 2023-2024 Advanced Micro Devices, Inc. or its affiliates
+import os
+
 config.substitutions.insert(0, ('%last-mi-pass', 'machinemoduleinfo'))
 config.substitutions.insert(0, ('%topdown-single', '--issue-limit=1 --aie-bottomup-cycles=0'))
 config.substitutions.insert(0, ('%topdown-multi', '--issue-limit=6 --aie-bottomup-cycles=0'))
+
+imisched_path = os.path.join(config.llvm_src_root, 'utils', 'imisched.py')
+config.substitutions.insert(0, ('%imisched', f"{config.python_executable} {imisched_path}"))

--- a/llvm/test/tools/utils-unittest/lit.local.cfg
+++ b/llvm/test/tools/utils-unittest/lit.local.cfg
@@ -1,0 +1,11 @@
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+
+import os
+
+utils_path = os.path.join(config.llvm_src_root, "utils")
+config.environment["PYTHONPATH"] = utils_path
+config.suffixes = [".py"]

--- a/llvm/test/tools/utils-unittest/test_miutils.py
+++ b/llvm/test/tools/utils-unittest/test_miutils.py
@@ -1,0 +1,27 @@
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+
+# RUN: %python %s
+
+import unittest
+from mischedutils import miutils
+
+
+class TestMIUtils(unittest.TestCase):
+
+    def test_trim_instr(self):
+        instr1 = "renamable $v0, $p0 = LD_vec $p0(tied-def 1), killed $m0 :: (load (<8 x s32>) from %ir.ptr_in)"
+        self.assertEqual(miutils.trim_instr_str(instr1), "$v0, $p0 = LD_vec $p0, $m0")
+
+        instr2 = "ST_vec $p0, 32, $v0, $m0, implicit-def $status_0, implicit $cr_0, implicit $cr_1"
+        self.assertEqual(
+            miutils.trim_instr_str(instr2),
+            "ST_vec $p0, 32, $v0, $m0, $status_0, $cr_0, $cr_1",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/llvm/test/tools/utils-unittest/test_schedlogparser.py
+++ b/llvm/test/tools/utils-unittest/test_schedlogparser.py
@@ -1,0 +1,140 @@
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+
+# RUN: %python %s
+
+import unittest
+from mischedutils import schedlogparser
+
+
+SCHED_REGION = r"""
+********** MI Scheduling **********
+double_bb:%bb.1 
+  From: BeginInstr foo bar
+    To: End
+ RegionInstrs: 2
+ScheduleDAGMI::schedule starting
+#blah
+#blah
+SU(0):   renamable $r0 = FOO_INSTR_0 renamable $r0, implicit-def $status, implicit $control0, implicit $control1
+  # Extra things...
+  Latency            : 3
+  Depth              : 0
+  Height             : 5
+  Successors:
+    SU(1): Out  Latency=3
+    ExitSU: Ord  Latency=2 Artificial
+SU(1):   renamable $r1 = FOO_INSTR_1 renamable $r1, implicit-def $status, implicit $control0, implicit $control1
+  # Extra things...
+  Latency            : 2
+  Depth              : 3
+  Height             : 2
+  Predecessors:
+    SU(0): Out  Latency=3
+  Successors:
+    ExitSU: Ord  Latency=2 Artificial
+#blah
+#blah
+** ScheduleDAGMI::schedule picking next node
+#blah
+#blah
+Queue BotQ.P: 
+Queue BotQ.A: 1 
+Pick Bot Reason-1 Reason-details
+Scheduling SU(1) renamable $r1 = FOO_INSTR_1 renamable $r1, implicit-def $status, implicit $control0, implicit $control1
+  Ready @1c
+#blah
+#blah
+** ScheduleDAGMI::schedule picking next node
+#blah
+#blah
+Cycle: 4 BotQ.A
+Queue BotQ.P: 
+Queue BotQ.A: 0 
+Pick Bot Reason Reason-details     
+Scheduling SU(0) renamable $r0 = FOO_INSTR_0 renamable $r0, implicit-def $status, implicit $control0, implicit $control1
+  Ready @4c
+#blah
+#blah
+** ScheduleDAGMI::schedule picking next node
+#blah
+#blah
+*** Final schedule for %bb.1 ***
+SU(0):   renamable $r0 = FOO_INSTR_0 renamable $r0, implicit-def $status, implicit $control0, implicit $control1
+SU(1):   renamable $r1 = FOO_INSTR_1 renamable $r1, implicit-def $status, implicit $control0, implicit $control1
+"""
+
+
+class TestLogParser(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.maxDiff = None
+
+    def test_one_region(self):
+        r = schedlogparser.process_region(
+            "double_bb", "bb.1", "BeginMI", "EndMI", SCHED_REGION
+        )
+
+        # Quickly verify that the numbers of SUs and actions match
+        self.assertEqual(len(r.sched_units), 2)
+        self.assertEqual(len(r.sched_actions), 2)
+
+        exp_su = {
+            0: schedlogparser.ScheduleUnit(
+                su_num=0,
+                instr="renamable $r0 = FOO_INSTR_0 renamable $r0, implicit-def $status, implicit $control0, implicit $control1",
+                latency=3,
+                depth=0,
+                height=5,
+            ),
+            1: schedlogparser.ScheduleUnit(
+                su_num=1,
+                instr="renamable $r1 = FOO_INSTR_1 renamable $r1, implicit-def $status, implicit $control0, implicit $control1",
+                latency=2,
+                depth=3,
+                height=2,
+            ),
+        }
+        self.assertEqual(r.sched_units, exp_su)
+
+        exp_actions = [
+            schedlogparser.ScheduleAction(
+                new_cycle=None,
+                pending=[],
+                available=[1],
+                picked_zone="Bot",
+                picked_reason="Reason-1",
+                picked_su=1,
+                picked_cycle=1,
+            ),
+            schedlogparser.ScheduleAction(
+                new_cycle=4,
+                pending=[],
+                available=[0],
+                picked_zone="Bot",
+                picked_reason="Reason",
+                picked_su=0,
+                picked_cycle=4,
+            ),
+        ]
+        self.assertEqual(r.sched_actions, exp_actions)
+
+        self.assertEqual(
+            r,
+            schedlogparser.RegionSchedule(
+                "double_bb", "bb.1", "BeginMI", "EndMI", exp_su, exp_actions
+            ),
+        )
+
+    def test_whole_log(self):
+        sched_log = f"{SCHED_REGION}foo\nbar\n{SCHED_REGION}"
+        regs = schedlogparser.process_log(sched_log)
+        self.assertEqual(len(regs), 2)
+        self.assertEqual(regs[0], regs[1])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/llvm/test/tools/utils-unittest/test_schedlogparser.py
+++ b/llvm/test/tools/utils-unittest/test_schedlogparser.py
@@ -43,6 +43,8 @@ SU(1):   renamable $r1 = FOO_INSTR_1 renamable $r1, implicit-def $status, implic
 #blah
 Queue BotQ.P: 
 Queue BotQ.A: 1 
+# Explain why
+# SU(1) was picked
 Pick Bot Reason-1 Reason-details
 Scheduling SU(1) renamable $r1 = FOO_INSTR_1 renamable $r1, implicit-def $status, implicit $control0, implicit $control1
   Ready @1c
@@ -105,6 +107,7 @@ class TestLogParser(unittest.TestCase):
                 new_cycle=None,
                 pending=[],
                 available=[1],
+                pick_details="# Explain why\n# SU(1) was picked\n",
                 picked_zone="Bot",
                 picked_reason="Reason-1",
                 picked_su=1,
@@ -114,6 +117,7 @@ class TestLogParser(unittest.TestCase):
                 new_cycle=4,
                 pending=[],
                 available=[0],
+                pick_details="",
                 picked_zone="Bot",
                 picked_reason="Reason",
                 picked_su=0,

--- a/llvm/utils/imisched.py
+++ b/llvm/utils/imisched.py
@@ -11,18 +11,26 @@ from mischedutils import schedlogparser
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("sched_log")
+    parser.add_argument("-d", "--dump", action="store_true")
     args = parser.parse_args()
 
     regions = []
     with open(args.sched_log, "r") as file:
         regions = schedlogparser.process_log(file.read())
-    for region in regions:
-        print(f"Region: {region.sched_fn}:{region.sched_bb}")
-        for action in region.sched_actions:
-            if action.new_cycle:
-                print(f"** Bump to c{action.new_cycle}")
-            print(f"* {action}")
-        print("")
+
+    if args.dump:
+        for region in regions:
+            print(f"Region: {region.sched_fn}:{region.sched_bb}")
+            for action in region.sched_actions:
+                if action.new_cycle:
+                    print(f"** Bump to c{action.new_cycle}")
+                print(f"* {action}")
+            print("")
+    else:
+        from mischedutils import interactive_sched
+
+        app = interactive_sched.InteractiveMISchedApp(regions)
+        app.run()
 
 
 if __name__ == "__main__":

--- a/llvm/utils/imisched.py
+++ b/llvm/utils/imisched.py
@@ -1,0 +1,29 @@
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+
+import argparse
+from mischedutils import schedlogparser
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("sched_log")
+    args = parser.parse_args()
+
+    regions = []
+    with open(args.sched_log, "r") as file:
+        regions = schedlogparser.process_log(file.read())
+    for region in regions:
+        print(f"Region: {region.sched_fn}:{region.sched_bb}")
+        for action in region.sched_actions:
+            if action.new_cycle:
+                print(f"** Bump to c{action.new_cycle}")
+            print(f"* {action}")
+        print("")
+
+
+if __name__ == "__main__":
+    main()

--- a/llvm/utils/imisched.py
+++ b/llvm/utils/imisched.py
@@ -5,18 +5,35 @@
 # (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
 
 import argparse
+import io
+import os
+import sys
+
 from mischedutils import schedlogparser
 
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("sched_log")
-    parser.add_argument("-d", "--dump", action="store_true")
+    parser.add_argument("sched_log", help="Log file to parse, or '-' to read stdin")
+    parser.add_argument(
+        "-d", "--dump", action="store_true", help="dump the sched regions"
+    )
     args = parser.parse_args()
 
     regions = []
-    with open(args.sched_log, "r") as file:
-        regions = schedlogparser.process_log(file.read())
+    if args.sched_log != "-":
+        if not sys.__stdin__.isatty():
+            print(
+                "Error: cannot get data from stdin and a file at the same time",
+                file=sys.stderr,
+            )
+            exit(1)
+        print(f"Parsing '{args.sched_log}'...")
+        with open(args.sched_log, "r") as file:
+            regions = schedlogparser.process_log(file.read())
+    else:
+        print("Parsing stdin...")
+        regions = schedlogparser.process_log(sys.__stdin__.read())
 
     if args.dump:
         for region in regions:
@@ -28,6 +45,10 @@ def main():
             print("")
     else:
         from mischedutils import interactive_sched
+
+        # Make sure Textual gets a fresh stdin for user keyboard inputs.
+        sys.__stdin__.flush()
+        sys.__stdin__ = io.TextIOWrapper(io.FileIO(os.open(os.ctermid(), os.O_RDONLY)))
 
         app = interactive_sched.InteractiveMISchedApp(regions)
         app.run()

--- a/llvm/utils/mischedutils/interactive_sched.py
+++ b/llvm/utils/mischedutils/interactive_sched.py
@@ -48,6 +48,7 @@ class PickedDisplay(Static):
 
 class PickDetails(VerticalScroll):
     """A widget explaining why the last SUnit was picked."""
+
     info_str = reactive("", recompose=True)
 
     def __init__(self) -> None:
@@ -65,6 +66,7 @@ class SUQueue(VerticalScroll):
     def __init__(self, queue_name: str) -> None:
         super().__init__(classes="queue")
         self.border_title = f"{queue_name} queue"
+        self.display = queue_name == "Available"
 
     def set_su_list(self, su_list: List[schedlogparser.ScheduleUnit]):
         """Update the list of SUnits debing displayed."""
@@ -80,6 +82,7 @@ class RegionSchedScreen(Screen):
         ("escape", "app.pop_screen", "Regions"),
         ("n", "schedule_next", "Next"),
         ("p", "unschedule_last", "Prev"),
+        ("q", "hide_pending", "Pending Queue"),
     ]
     CSS = """
     CycleLine {
@@ -103,6 +106,7 @@ class RegionSchedScreen(Screen):
         layout: grid;
         grid-size: 2;
         grid-columns: 1fr 2fr;
+        grid-rows: 3fr 2fr;
         min-height: 4;
         max-height: 12;
         height: 30%
@@ -162,6 +166,10 @@ class RegionSchedScreen(Screen):
         action = self.sched_region.sched_actions[self.next_action_idx]
         self.cycles[action.picked_cycle].children[-1].remove()
         self.update_info_container()
+
+    def action_hide_pending(self):
+        """Toggle the pending queue container."""
+        self.pending_queue.display = not self.pending_queue.display
 
     def update_info_container(self):
         """Update the various info widgets after scheduling/unscheduling a node."""

--- a/llvm/utils/mischedutils/interactive_sched.py
+++ b/llvm/utils/mischedutils/interactive_sched.py
@@ -6,9 +6,84 @@
 
 from typing import List
 
-from mischedutils import schedlogparser
+from mischedutils import miutils, schedlogparser
 from textual.app import App, ComposeResult
-from textual.widgets import Header, Footer, OptionList
+from textual.containers import VerticalScroll
+from textual.screen import Screen
+from textual.widgets import Header, Footer, OptionList, Static
+
+INSTR_CELL_SIZE = 48
+
+
+class CycleLine(Static):
+    """A single-line widget representing a VLIW packet."""
+
+    def __init__(self, cycle: int) -> None:
+        super().__init__()
+        self.cycle = cycle
+
+    def compose(self) -> ComposeResult:
+        """Create the initial widget, showing the cycle number."""
+        yield Static(f"c{self.cycle}", classes="cycle_num")
+
+    def add_su(self, su: schedlogparser.ScheduleUnit):
+        """Add a SUnit to this cycle."""
+        new_inst = Static(miutils.trim_instr_str(su.instr)[:INSTR_CELL_SIZE])
+        new_inst.styles.width = INSTR_CELL_SIZE
+        self.mount(new_inst)
+        self.scroll_visible()
+
+
+class RegionSchedScreen(Screen):
+    """A screen representing the schedule for one region."""
+
+    BINDINGS = [("escape", "app.pop_screen", "Regions"), ("n", "schedule_next", "Next")]
+    CSS = """
+    CycleLine {
+        layout: horizontal;
+    }
+    CycleLine > Static {
+        height: 1;
+        margin-right: 2;
+        background: $boost;
+    }
+    .cycle_num {
+        width: 4;
+    }
+    VerticalScroll {
+        border: dodgerblue;
+    }
+    """
+
+    def __init__(self, region: schedlogparser.RegionSchedule):
+        super().__init__()
+        self.sched_region = region
+        self.title = (
+            f"Region: {self.sched_region.sched_fn}:{self.sched_region.sched_bb}"
+        )
+        self.next_action_idx = 0
+
+    def compose(self) -> ComposeResult:
+        """Create the screen with VLIW cycles and various info widgets."""
+        yield Header()
+
+        actions = self.sched_region.sched_actions
+        max_cycle = max(actions, key=lambda a: a.picked_cycle).picked_cycle
+        self.cycles = [CycleLine(c) for c in range(max_cycle + 1)]
+        cycle_container = VerticalScroll(*self.cycles[::-1], id="cycles")
+        cycle_container.border_title = "Schedule"
+        yield cycle_container
+
+        yield Footer()
+
+    def action_schedule_next(self):
+        """Add the next instruction to the schedule."""
+        if self.next_action_idx >= len(self.sched_region.sched_actions):
+            return
+        action = self.sched_region.sched_actions[self.next_action_idx]
+        picked_su = self.sched_region.sched_units[action.picked_su]
+        self.cycles[action.picked_cycle].add_su(picked_su)
+        self.next_action_idx += 1
 
 
 class InteractiveMISchedApp(App):
@@ -26,6 +101,11 @@ class InteractiveMISchedApp(App):
         options = [f"{r.sched_fn}:{r.sched_bb}" for r in self.regions]
         yield OptionList(*options)
         yield Footer()
+
+    def on_option_list_option_selected(self, opt: OptionList.OptionSelected):
+        """Push a screen to interact with the schedule of the selected region."""
+        selected_region = self.regions[opt.option_index]
+        self.push_screen(RegionSchedScreen(selected_region))
 
     def action_toggle_dark(self) -> None:
         """An action to toggle dark mode."""

--- a/llvm/utils/mischedutils/interactive_sched.py
+++ b/llvm/utils/mischedutils/interactive_sched.py
@@ -1,0 +1,32 @@
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+
+from typing import List
+
+from mischedutils import schedlogparser
+from textual.app import App, ComposeResult
+from textual.widgets import Header, Footer, OptionList
+
+
+class InteractiveMISchedApp(App):
+    """A Textual app to visualize MachineScheduler decisions."""
+
+    BINDINGS = [("d", "toggle_dark", "Dark mode")]
+
+    def __init__(self, regions: List[schedlogparser.RegionSchedule]):
+        super().__init__()
+        self.regions = regions
+
+    def compose(self) -> ComposeResult:
+        """Create a home screen with the list of parsed regions."""
+        yield Header()
+        options = [f"{r.sched_fn}:{r.sched_bb}" for r in self.regions]
+        yield OptionList(*options)
+        yield Footer()
+
+    def action_toggle_dark(self) -> None:
+        """An action to toggle dark mode."""
+        self.dark = not self.dark

--- a/llvm/utils/mischedutils/interactive_sched.py
+++ b/llvm/utils/mischedutils/interactive_sched.py
@@ -37,7 +37,12 @@ class CycleLine(Static):
 class RegionSchedScreen(Screen):
     """A screen representing the schedule for one region."""
 
-    BINDINGS = [("escape", "app.pop_screen", "Regions"), ("n", "schedule_next", "Next")]
+
+    BINDINGS = [
+        ("escape", "app.pop_screen", "Regions"),
+        ("n", "schedule_next", "Next"),
+        ("p", "unschedule_last", "Prev"),
+    ]
     CSS = """
     CycleLine {
         layout: horizontal;
@@ -84,6 +89,14 @@ class RegionSchedScreen(Screen):
         picked_su = self.sched_region.sched_units[action.picked_su]
         self.cycles[action.picked_cycle].add_su(picked_su)
         self.next_action_idx += 1
+
+    def action_unschedule_last(self):
+        """Remove the last instruction from the schedule."""
+        if self.next_action_idx == 0:
+            return
+        self.next_action_idx -= 1
+        action = self.sched_region.sched_actions[self.next_action_idx]
+        self.cycles[action.picked_cycle].children[-1].remove()
 
 
 class InteractiveMISchedApp(App):

--- a/llvm/utils/mischedutils/miutils.py
+++ b/llvm/utils/mischedutils/miutils.py
@@ -1,0 +1,25 @@
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+
+
+def trim_instr_str(instr: str) -> str:
+    """Reduce "bloat" from instructions so they are shorter."""
+
+    # Remove operand qualifiers
+    bloat = [
+        "renamable ",
+        "dead ",
+        "killed ",
+        "implicit ",
+        "implicit-def ",
+        "(tied-def 0)",
+        "(tied-def 1)",
+    ]
+    for substr in bloat:
+        instr = instr.replace(substr, "")
+
+    # Remove MMOs and leading/trailing spaces
+    return instr.split(":")[0].strip()

--- a/llvm/utils/mischedutils/schedlogparser.py
+++ b/llvm/utils/mischedutils/schedlogparser.py
@@ -37,7 +37,7 @@ SCHED_ACTION_RE = re.compile(
     r"(^Cycle: (?P<new_cycle>[0-9]+) (?P<bumped_zone>\w+)Q\.A\n)?"
     r"^Queue BotQ\.P: (?P<pending>[0-9 ]*)\n"
     r"^Queue BotQ\.A: (?P<available>[0-9 ]*)\n"
-    r"(.*\n)*?"
+    r"(?P<pick_details>(.*\n)*?)"
     r"^Pick (?P<picked_zone>\S+) (?P<picked_reason>\S+).*?\n"
     r"^Scheduling SU\((?P<picked_su>[0-9]+)\).+?\n"
     r"^\s+Ready @(?P<ready_cycle>[0-9]+)c\n",
@@ -52,6 +52,7 @@ class ScheduleAction:
     new_cycle: Optional[int]
     pending: List[int]
     available: List[int]
+    pick_details: str
     picked_zone: str
     picked_reason: str
     picked_su: int
@@ -120,6 +121,7 @@ def process_region(sched_fn, sched_bb, begin_mi, end_mi, region_str) -> RegionSc
                 int_or_none(action["new_cycle"]),
                 pending,
                 available,
+                action["pick_details"],
                 action["picked_zone"],
                 action["picked_reason"],
                 int(action["picked_su"]),

--- a/llvm/utils/mischedutils/schedlogparser.py
+++ b/llvm/utils/mischedutils/schedlogparser.py
@@ -85,6 +85,10 @@ class RegionSchedule:
     sched_units: Dict[int, ScheduleUnit]
     sched_actions: List[ScheduleAction]
 
+    def get_sched_units(self, su_nums: List[int]) -> List[ScheduleUnit]:
+        """Return the SUnits that have the given numbers."""
+        return [self.sched_units[su_num] for su_num in su_nums]
+
 
 def int_or_none(s: str) -> Optional[int]:
     """Convert the string to an int, or return None if it is empty."""

--- a/llvm/utils/mischedutils/schedlogparser.py
+++ b/llvm/utils/mischedutils/schedlogparser.py
@@ -1,0 +1,152 @@
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+
+import re
+from dataclasses import dataclass
+from typing import Dict, List, Optional
+
+SU_STR = r"SU\((?P<su_num>[0-9]+)\):\s+(?P<su_mi>.+)\n"
+SU_DESC_RE = re.compile(
+    rf"^{SU_STR}"
+    r"(.*\n)+?"
+    r"^\s+Latency\s+: (?P<su_latency>[0-9]+)\n"
+    r"^\s+Depth\s+: (?P<su_depth>[0-9]+)\n"
+    r"^\s+Height\s+: (?P<su_height>[0-9]+)\n"
+    r"(.*\n)+?",
+    re.M,
+)
+
+
+@dataclass
+class ScheduleUnit:
+    """Corresponds to an LLVM SUnit, i.e. a node of the scheduling DAG."""
+
+    su_num: int
+    instr: str
+    latency: int
+    depth: int
+    height: int
+
+
+SCHED_ACTION_RE = re.compile(
+    r"^\*\* ScheduleDAGMI::schedule picking next node\n"
+    r"(.*\n)+?"
+    r"(^Cycle: (?P<new_cycle>[0-9]+) (?P<bumped_zone>\w+)Q\.A\n)?"
+    r"^Queue BotQ\.P: (?P<pending>[0-9 ]*)\n"
+    r"^Queue BotQ\.A: (?P<available>[0-9 ]*)\n"
+    r"(.*\n)*?"
+    r"^Pick (?P<picked_zone>\S+) (?P<picked_reason>\S+).*?\n"
+    r"^Scheduling SU\((?P<picked_su>[0-9]+)\).+?\n"
+    r"^\s+Ready @(?P<ready_cycle>[0-9]+)c\n",
+    re.M,
+)
+
+
+@dataclass
+class ScheduleAction:
+    """A decision of the scheduler, i.e. which node was just scheduled."""
+
+    new_cycle: Optional[int]
+    pending: List[int]
+    available: List[int]
+    picked_zone: str
+    picked_reason: str
+    picked_su: int
+    picked_cycle: int
+
+
+# Note "ScheduleDAGMI::schedule" makes sure we only match regions for the
+# postmisched. The pre-RA ScheduleDAGMILive is not supported yet.
+SCHED_REGION_RE = re.compile(
+    r"^[*]+ MI Scheduling [*]+\n"
+    r"^(?P<sched_fn>[\w.]+):%(?P<sched_bb>[\w.]+).*\n"
+    r"^\s+From:\s+(?P<begin_mi>.+)\n"
+    r"^\s+To:\s+(?P<end_mi>.+)\n"
+    r"^\s+RegionInstrs:\s+(?P<num_instrs>[0-9]+)\n"
+    r"^ScheduleDAGMI::schedule starting\n"
+    r"(.*\n)+?"
+    r"^[*]+ Final schedule for %(?P=sched_bb) [*]+\n"
+    rf"(^{SU_STR})+",
+    re.M,
+)
+
+
+@dataclass
+class RegionSchedule:
+    """A region of the code and its corresponding schedule."""
+
+    sched_fn: str
+    sched_bb: str
+    begin_mi: str
+    end_mi: str
+    sched_units: Dict[int, ScheduleUnit]
+    sched_actions: List[ScheduleAction]
+
+
+def int_or_none(s: str) -> Optional[int]:
+    """Convert the string to an int, or return None if it is empty."""
+    if s:
+        return int(s)
+    return None
+
+
+def process_region(sched_fn, sched_bb, begin_mi, end_mi, region_str) -> RegionSchedule:
+    """Process the scheduling log of a region into a RegionSchedule object."""
+    sched_units = dict()
+    for su in re.finditer(SU_DESC_RE, region_str):
+        su_num = int(su["su_num"])
+        sched_units[su_num] = ScheduleUnit(
+            su_num,
+            su["su_mi"],
+            int(su["su_latency"]),
+            int(su["su_depth"]),
+            int(su["su_height"]),
+        )
+
+    sched_actions: List[ScheduleAction] = []
+    for action in re.finditer(SCHED_ACTION_RE, region_str):
+        assert not action["bumped_zone"] or action["bumped_zone"] == "Bot"
+        pending = [int(num) for num in action["pending"].split()]
+        available = [int(num) for num in action["available"].split()]
+        sched_actions.append(
+            ScheduleAction(
+                int_or_none(action["new_cycle"]),
+                pending,
+                available,
+                action["picked_zone"],
+                action["picked_reason"],
+                int(action["picked_su"]),
+                int(action["ready_cycle"]),
+            )
+        )
+
+    if len(sched_actions) != region_str.count("Scheduling SU"):
+        for sched_action in sched_actions:
+            print(sched_action)
+        print(
+            f"Error: Actions={len(sched_actions)} "
+            f"Schedules={region_str.count('Scheduling SU')}"
+        )
+        exit(1)
+
+    return RegionSchedule(
+        sched_fn, sched_bb, begin_mi, end_mi, sched_units, sched_actions
+    )
+
+
+def process_log(log_str) -> List[RegionSchedule]:
+    """Process the scheduling log into a list of RegionSchedule."""
+    regions = []
+    for region in re.finditer(SCHED_REGION_RE, log_str):
+        r = process_region(
+            region["sched_fn"],
+            region["sched_bb"],
+            region["begin_mi"],
+            region["end_mi"],
+            region.group(),
+        )
+        regions.append(r)
+    return regions


### PR DESCRIPTION
Re-opened from private repo. Already reviewed.

This is a TUI tool that allows to replay the different scheduling actions back and forth for each region. The goal is to help us understand why we end up with a certain schedule and speed up investigations. I'd be happy to get some feedback. :)

This works by parsing the --debug-only=machine-scheduler logs, as I didn't want any invasive changes to MachineScheduler at this point.

Run like this `llc -O2 -mtriple=aie2 test.ll -o - --debug-only=machine-scheduler 2>&1 | python3 llvm/utils/imisched.py -`

This requires `textual`, which can be installed with pip install textual.

![image](https://github.com/Xilinx/llvm-aie/assets/41161573/06bbe50f-9137-4ad0-a352-f4d631ac8b6d)
![image](https://github.com/Xilinx/llvm-aie/assets/41161573/75648ba4-a7d9-4aa0-8e98-77c8e5df701a)
