### PR TITLE
fixup! [GlobalISel] Add combine for G_INTTOPTR(G_CONSTANT) -> G_CONSTANT

### DIFF
--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/combine-inttoptr-constant.mir
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/combine-inttoptr-constant.mir
@@ -6,7 +6,6 @@
 #
 # (c) Copyright 2023-2024 Advanced Micro Devices, Inc. or its affiliates
 # RUN: llc -march=amdgcn -run-pass=amdgpu-prelegalizer-combiner -verify-machineinstrs %s -o - | FileCheck %s
-# XFAIL: llvm-aie-regression
 
 ---
 name: inttoptr_constant_p0_s64
@@ -27,12 +26,12 @@ tracksRegLiveness: true
 body:             |
   bb.0:
     ; CHECK-LABEL: name: inttoptr_constant_nonintegral
-    ; CHECK: [[C:%[0-9]+]]:_(s64) = G_CONSTANT i64 0
-    ; CHECK-NEXT: [[INTTOPTR:%[0-9]+]]:_(p7) = G_INTTOPTR [[C]](s64)
-    ; CHECK-NEXT: $vgpr0_vgpr1 = COPY [[INTTOPTR]](p7)
-    %0:_(s64) = G_CONSTANT i64 0
+    ; CHECK: [[C:%[0-9]+]]:_(s160) = G_CONSTANT i160 0
+    ; CHECK-NEXT: [[INTTOPTR:%[0-9]+]]:_(p7) = G_INTTOPTR [[C]](s160)
+    ; CHECK-NEXT: SI_RETURN implicit [[INTTOPTR]](p7)
+    %0:_(s160) = G_CONSTANT i160 0
     %1:_(p7) = G_INTTOPTR %0
-    $vgpr0_vgpr1 = COPY %1
+    SI_RETURN implicit %1
 ...
 
 


### PR DESCRIPTION
This fixes the test after f0415f2a456d54daaa231c228d2c9f4ef2ce9b89 made p7 a 160-bit pointer type