### PR TITLE
G_BUILD_VECTOR & G_UNMERGE_VALUES legalization for 32-bit vectors

### DIFF
--- a/llvm/lib/Target/AIE/AIELegalizerInfo.h
+++ b/llvm/lib/Target/AIE/AIELegalizerInfo.h
@@ -53,6 +53,8 @@ private:
   // Helper functions for legalization
   bool pack32BitVector(LegalizerHelper &Helper, MachineInstr &MI,
                        Register SourceReg) const;
+  bool unpack32BitVector(LegalizerHelper &Helper, MachineInstr &MI,
+                         Register SourceReg) const;
 };
 } // end namespace llvm
 #endif

--- a/llvm/lib/Target/AIE/AIELegalizerInfo.h
+++ b/llvm/lib/Target/AIE/AIELegalizerInfo.h
@@ -16,6 +16,7 @@
 #define LLVM_LIB_TARGET_AIE_AIEMACHINELEGALIZER_H
 
 #include "llvm/CodeGen/GlobalISel/LegalizerInfo.h"
+#include "llvm/CodeGen/Register.h"
 
 namespace llvm {
 
@@ -48,6 +49,10 @@ private:
   bool legalizeG_FPEXT(LegalizerHelper &Helper, MachineInstr &MI) const;
   bool legalizeG_FABS(LegalizerHelper &Helper, MachineInstr &MI) const;
   bool legalizeG_FADDSUB(LegalizerHelper &Helper, MachineInstr &MI) const;
+
+  // Helper functions for legalization
+  bool pack32BitVector(LegalizerHelper &Helper, MachineInstr &MI,
+                       Register SourceReg) const;
 };
 } // end namespace llvm
 #endif

--- a/llvm/test/CodeGen/AIE/aie2/GlobalISel/legalize-build-vector.mir
+++ b/llvm/test/CodeGen/AIE/aie2/GlobalISel/legalize-build-vector.mir
@@ -470,3 +470,194 @@ body:           |
     %0:_(p0) = G_FRAME_INDEX %stack.0
     G_STORE %1(<4 x s32>), %0(p0) :: (store (<4 x s32>))
     PseudoRET implicit $lr
+...
+
+---
+name:            test_build_vector_32_16
+body:             |
+  bb.1.entry:
+    ; CHECK-LABEL: name: test_build_vector_32_16
+    ; CHECK: [[C:%[0-9]+]]:_(s32) = G_CONSTANT i32 1
+    ; CHECK-NEXT: [[C1:%[0-9]+]]:_(s32) = G_CONSTANT i32 2
+    ; CHECK-NEXT: [[C2:%[0-9]+]]:_(s32) = G_CONSTANT i32 0
+    ; CHECK-NEXT: [[OR:%[0-9]+]]:_(s32) = G_OR [[C2]], [[C]]
+    ; CHECK-NEXT: [[C3:%[0-9]+]]:_(s32) = G_CONSTANT i32 16
+    ; CHECK-NEXT: [[SHL:%[0-9]+]]:_(s32) = G_SHL [[C1]], [[C3]](s32)
+    ; CHECK-NEXT: [[OR1:%[0-9]+]]:_(s32) = G_OR [[OR]], [[SHL]]
+    ; CHECK-NEXT: [[BITCAST:%[0-9]+]]:_(<2 x s16>) = G_BITCAST [[OR1]](s32)
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[BITCAST]](<2 x s16>)
+    %0:_(s16) = G_CONSTANT i16 1
+    %1:_(s16) = G_CONSTANT i16 2
+    %2:_(<2 x s16>) = G_BUILD_VECTOR %0(s16), %1(s16)
+    PseudoRET implicit $lr, implicit %2
+...
+
+---
+name:            test_build_vector_32_8
+body:             |
+  bb.1.entry:
+    ; CHECK-LABEL: name: test_build_vector_32_8
+    ; CHECK: [[C:%[0-9]+]]:_(s32) = G_CONSTANT i32 1
+    ; CHECK-NEXT: [[C1:%[0-9]+]]:_(s32) = G_CONSTANT i32 2
+    ; CHECK-NEXT: [[C2:%[0-9]+]]:_(s32) = G_CONSTANT i32 3
+    ; CHECK-NEXT: [[C3:%[0-9]+]]:_(s32) = G_CONSTANT i32 4
+    ; CHECK-NEXT: [[C4:%[0-9]+]]:_(s32) = G_CONSTANT i32 0
+    ; CHECK-NEXT: [[OR:%[0-9]+]]:_(s32) = G_OR [[C4]], [[C]]
+    ; CHECK-NEXT: [[C5:%[0-9]+]]:_(s32) = G_CONSTANT i32 8
+    ; CHECK-NEXT: [[SHL:%[0-9]+]]:_(s32) = G_SHL [[C1]], [[C5]](s32)
+    ; CHECK-NEXT: [[OR1:%[0-9]+]]:_(s32) = G_OR [[OR]], [[SHL]]
+    ; CHECK-NEXT: [[C6:%[0-9]+]]:_(s32) = G_CONSTANT i32 16
+    ; CHECK-NEXT: [[SHL1:%[0-9]+]]:_(s32) = G_SHL [[C2]], [[C6]](s32)
+    ; CHECK-NEXT: [[OR2:%[0-9]+]]:_(s32) = G_OR [[OR1]], [[SHL1]]
+    ; CHECK-NEXT: [[C7:%[0-9]+]]:_(s32) = G_CONSTANT i32 24
+    ; CHECK-NEXT: [[SHL2:%[0-9]+]]:_(s32) = G_SHL [[C3]], [[C7]](s32)
+    ; CHECK-NEXT: [[OR3:%[0-9]+]]:_(s32) = G_OR [[OR2]], [[SHL2]]
+    ; CHECK-NEXT: [[BITCAST:%[0-9]+]]:_(<4 x s8>) = G_BITCAST [[OR3]](s32)
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[BITCAST]](<4 x s8>)
+    %0:_(s8) = G_CONSTANT i8 1
+    %1:_(s8) = G_CONSTANT i8 2
+    %2:_(s8) = G_CONSTANT i8 3
+    %3:_(s8) = G_CONSTANT i8 4
+    %4:_(<4 x s8>) = G_BUILD_VECTOR %0(s8), %1(s8), %2(s8), %3(s8)
+    PseudoRET implicit $lr, implicit %4
+...
+
+---
+name:            test_build_vector_32_8_negative
+body:             |
+  bb.1.entry:
+    ; CHECK-LABEL: name: test_build_vector_32_8_negative
+    ; CHECK: [[C:%[0-9]+]]:_(s32) = G_CONSTANT i32 0
+    ; CHECK-NEXT: [[C1:%[0-9]+]]:_(s32) = G_CONSTANT i32 255
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY [[C1]](s32)
+    ; CHECK-NEXT: [[OR:%[0-9]+]]:_(s32) = G_OR [[C]], [[COPY]]
+    ; CHECK-NEXT: [[C2:%[0-9]+]]:_(s32) = G_CONSTANT i32 254
+    ; CHECK-NEXT: [[C3:%[0-9]+]]:_(s32) = G_CONSTANT i32 8
+    ; CHECK-NEXT: [[SHL:%[0-9]+]]:_(s32) = G_SHL [[C2]], [[C3]](s32)
+    ; CHECK-NEXT: [[OR1:%[0-9]+]]:_(s32) = G_OR [[OR]], [[SHL]]
+    ; CHECK-NEXT: [[C4:%[0-9]+]]:_(s32) = G_CONSTANT i32 253
+    ; CHECK-NEXT: [[C5:%[0-9]+]]:_(s32) = G_CONSTANT i32 16
+    ; CHECK-NEXT: [[SHL1:%[0-9]+]]:_(s32) = G_SHL [[C4]], [[C5]](s32)
+    ; CHECK-NEXT: [[OR2:%[0-9]+]]:_(s32) = G_OR [[OR1]], [[SHL1]]
+    ; CHECK-NEXT: [[C6:%[0-9]+]]:_(s32) = G_CONSTANT i32 252
+    ; CHECK-NEXT: [[C7:%[0-9]+]]:_(s32) = G_CONSTANT i32 24
+    ; CHECK-NEXT: [[SHL2:%[0-9]+]]:_(s32) = G_SHL [[C6]], [[C7]](s32)
+    ; CHECK-NEXT: [[OR3:%[0-9]+]]:_(s32) = G_OR [[OR2]], [[SHL2]]
+    ; CHECK-NEXT: [[BITCAST:%[0-9]+]]:_(<4 x s8>) = G_BITCAST [[OR3]](s32)
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[BITCAST]](<4 x s8>)
+    %0:_(s8) = G_CONSTANT i8 -1
+    %1:_(s8) = G_CONSTANT i8 -2
+    %2:_(s8) = G_CONSTANT i8 -3
+    %3:_(s8) = G_CONSTANT i8 -4
+    %4:_(<4 x s8>) = G_BUILD_VECTOR %0(s8), %1(s8), %2(s8), %3(s8)
+    PseudoRET implicit $lr, implicit %4
+...
+
+---
+name:            test_build_vector_32_8_mixed
+body:             |
+  bb.1.entry:
+    ; CHECK-LABEL: name: test_build_vector_32_8_mixed
+    ; CHECK: [[C:%[0-9]+]]:_(s32) = G_CONSTANT i32 19
+    ; CHECK-NEXT: [[C1:%[0-9]+]]:_(s32) = G_CONSTANT i32 33
+    ; CHECK-NEXT: [[C2:%[0-9]+]]:_(s32) = G_CONSTANT i32 0
+    ; CHECK-NEXT: [[OR:%[0-9]+]]:_(s32) = G_OR [[C2]], [[C]]
+    ; CHECK-NEXT: [[C3:%[0-9]+]]:_(s32) = G_CONSTANT i32 232
+    ; CHECK-NEXT: [[C4:%[0-9]+]]:_(s32) = G_CONSTANT i32 8
+    ; CHECK-NEXT: [[SHL:%[0-9]+]]:_(s32) = G_SHL [[C3]], [[C4]](s32)
+    ; CHECK-NEXT: [[OR1:%[0-9]+]]:_(s32) = G_OR [[OR]], [[SHL]]
+    ; CHECK-NEXT: [[C5:%[0-9]+]]:_(s32) = G_CONSTANT i32 16
+    ; CHECK-NEXT: [[SHL1:%[0-9]+]]:_(s32) = G_SHL [[C1]], [[C5]](s32)
+    ; CHECK-NEXT: [[OR2:%[0-9]+]]:_(s32) = G_OR [[OR1]], [[SHL1]]
+    ; CHECK-NEXT: [[C6:%[0-9]+]]:_(s32) = G_CONSTANT i32 164
+    ; CHECK-NEXT: [[C7:%[0-9]+]]:_(s32) = G_CONSTANT i32 24
+    ; CHECK-NEXT: [[SHL2:%[0-9]+]]:_(s32) = G_SHL [[C6]], [[C7]](s32)
+    ; CHECK-NEXT: [[OR3:%[0-9]+]]:_(s32) = G_OR [[OR2]], [[SHL2]]
+    ; CHECK-NEXT: [[BITCAST:%[0-9]+]]:_(<4 x s8>) = G_BITCAST [[OR3]](s32)
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[BITCAST]](<4 x s8>)
+    %0:_(s8) = G_CONSTANT i8 19
+    %1:_(s8) = G_CONSTANT i8 -24
+    %2:_(s8) = G_CONSTANT i8 33
+    %3:_(s8) = G_CONSTANT i8 -92
+    %4:_(<4 x s8>) = G_BUILD_VECTOR %0(s8), %1(s8), %2(s8), %3(s8)
+    PseudoRET implicit $lr, implicit %4
+...
+
+---
+name:            test_build_vector_32_8_from_registers
+body:             |
+  bb.1.entry:
+    liveins: $r0, $r1, $r2, $r3
+    ; CHECK-LABEL: name: test_build_vector_32_8_from_registers
+    ; CHECK: liveins: $r0, $r1, $r2, $r3
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $r0
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(s32) = COPY $r1
+    ; CHECK-NEXT: [[COPY2:%[0-9]+]]:_(s32) = COPY $r2
+    ; CHECK-NEXT: [[COPY3:%[0-9]+]]:_(s32) = COPY $r3
+    ; CHECK-NEXT: [[C:%[0-9]+]]:_(s32) = G_CONSTANT i32 0
+    ; CHECK-NEXT: [[C1:%[0-9]+]]:_(s32) = G_CONSTANT i32 255
+    ; CHECK-NEXT: [[AND:%[0-9]+]]:_(s32) = G_AND [[COPY]], [[C1]]
+    ; CHECK-NEXT: [[OR:%[0-9]+]]:_(s32) = G_OR [[C]], [[AND]]
+    ; CHECK-NEXT: [[AND1:%[0-9]+]]:_(s32) = G_AND [[COPY1]], [[C1]]
+    ; CHECK-NEXT: [[C2:%[0-9]+]]:_(s32) = G_CONSTANT i32 8
+    ; CHECK-NEXT: [[SHL:%[0-9]+]]:_(s32) = G_SHL [[AND1]], [[C2]](s32)
+    ; CHECK-NEXT: [[OR1:%[0-9]+]]:_(s32) = G_OR [[OR]], [[SHL]]
+    ; CHECK-NEXT: [[AND2:%[0-9]+]]:_(s32) = G_AND [[COPY2]], [[C1]]
+    ; CHECK-NEXT: [[C3:%[0-9]+]]:_(s32) = G_CONSTANT i32 16
+    ; CHECK-NEXT: [[SHL1:%[0-9]+]]:_(s32) = G_SHL [[AND2]], [[C3]](s32)
+    ; CHECK-NEXT: [[OR2:%[0-9]+]]:_(s32) = G_OR [[OR1]], [[SHL1]]
+    ; CHECK-NEXT: [[AND3:%[0-9]+]]:_(s32) = G_AND [[COPY3]], [[C1]]
+    ; CHECK-NEXT: [[C4:%[0-9]+]]:_(s32) = G_CONSTANT i32 24
+    ; CHECK-NEXT: [[SHL2:%[0-9]+]]:_(s32) = G_SHL [[AND3]], [[C4]](s32)
+    ; CHECK-NEXT: [[OR3:%[0-9]+]]:_(s32) = G_OR [[OR2]], [[SHL2]]
+    ; CHECK-NEXT: [[BITCAST:%[0-9]+]]:_(<4 x s8>) = G_BITCAST [[OR3]](s32)
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[BITCAST]](<4 x s8>)
+    %0:_(s32) = COPY $r0
+    %1:_(s32) = COPY $r1
+    %2:_(s32) = COPY $r2
+    %3:_(s32) = COPY $r3
+    %4:_(s8) = G_TRUNC %0(s32)
+    %5:_(s8) = G_TRUNC %1(s32)
+    %6:_(s8) = G_TRUNC %2(s32)
+    %7:_(s8) = G_TRUNC %3(s32)
+    %8:_(<4 x s8>) = G_BUILD_VECTOR %4(s8), %5(s8), %6(s8), %7(s8)
+    PseudoRET implicit $lr, implicit %8
+...
+
+---
+name:            test_build_vector_32_8_register_constant
+body:             |
+  bb.1.entry:
+    liveins: $r0, $r1
+    ; CHECK-LABEL: name: test_build_vector_32_8_register_constant
+    ; CHECK: liveins: $r0, $r1
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $r0
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(s32) = COPY $r1
+    ; CHECK-NEXT: [[C:%[0-9]+]]:_(s32) = G_CONSTANT i32 19
+    ; CHECK-NEXT: [[C1:%[0-9]+]]:_(s32) = G_CONSTANT i32 33
+    ; CHECK-NEXT: [[C2:%[0-9]+]]:_(s32) = G_CONSTANT i32 0
+    ; CHECK-NEXT: [[OR:%[0-9]+]]:_(s32) = G_OR [[C2]], [[C]]
+    ; CHECK-NEXT: [[C3:%[0-9]+]]:_(s32) = G_CONSTANT i32 255
+    ; CHECK-NEXT: [[AND:%[0-9]+]]:_(s32) = G_AND [[COPY]], [[C3]]
+    ; CHECK-NEXT: [[C4:%[0-9]+]]:_(s32) = G_CONSTANT i32 8
+    ; CHECK-NEXT: [[SHL:%[0-9]+]]:_(s32) = G_SHL [[AND]], [[C4]](s32)
+    ; CHECK-NEXT: [[OR1:%[0-9]+]]:_(s32) = G_OR [[OR]], [[SHL]]
+    ; CHECK-NEXT: [[C5:%[0-9]+]]:_(s32) = G_CONSTANT i32 16
+    ; CHECK-NEXT: [[SHL1:%[0-9]+]]:_(s32) = G_SHL [[C1]], [[C5]](s32)
+    ; CHECK-NEXT: [[OR2:%[0-9]+]]:_(s32) = G_OR [[OR1]], [[SHL1]]
+    ; CHECK-NEXT: [[AND1:%[0-9]+]]:_(s32) = G_AND [[COPY1]], [[C3]]
+    ; CHECK-NEXT: [[C6:%[0-9]+]]:_(s32) = G_CONSTANT i32 24
+    ; CHECK-NEXT: [[SHL2:%[0-9]+]]:_(s32) = G_SHL [[AND1]], [[C6]](s32)
+    ; CHECK-NEXT: [[OR3:%[0-9]+]]:_(s32) = G_OR [[OR2]], [[SHL2]]
+    ; CHECK-NEXT: [[BITCAST:%[0-9]+]]:_(<4 x s8>) = G_BITCAST [[OR3]](s32)
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[BITCAST]](<4 x s8>)
+    %0:_(s32) = COPY $r0
+    %1:_(s32) = COPY $r1
+    %2:_(s8) = G_CONSTANT i8 19
+    %3:_(s8) = G_TRUNC %0(s32)
+    %4:_(s8) = G_CONSTANT i8 33
+    %5:_(s8) = G_TRUNC %1(s32)
+    %6:_(<4 x s8>) = G_BUILD_VECTOR %2(s8), %3(s8), %4(s8), %5(s8)
+    PseudoRET implicit $lr, implicit %6

--- a/llvm/test/CodeGen/AIE/aie2/GlobalISel/legalize-unmerge-values.mir
+++ b/llvm/test/CodeGen/AIE/aie2/GlobalISel/legalize-unmerge-values.mir
@@ -288,3 +288,101 @@ body:             |
     %1(s8), %2(s8), %3(s8), %4(s8), %5(s8), %6(s8), %7(s8), %8(s8), %9(s8), %10(s8), %11(s8), %12(s8), %13(s8), %14(s8), %15(s8), %16(s8), %17(s8), %18(s8), %19(s8), %20(s8), %21(s8), %22(s8), %23(s8), %24(s8), %25(s8), %26(s8), %27(s8), %28(s8), %29(s8), %30(s8), %31(s8), %32(s8) = G_UNMERGE_VALUES %0(<32 x s8>)
     %33(s32) = G_SEXT %8(s8)
     PseudoRET implicit $lr, implicit %33
+...
+---
+name:           test_unmerge_v2s16
+registers:
+  - { id: 0, class: _, preferred-register: '' }
+  - { id: 1, class: _, preferred-register: '' }
+  - { id: 2, class: _, preferred-register: '' }
+  - { id: 3, class: _, preferred-register: '' }
+  - { id: 4, class: _, preferred-register: '' }
+  - { id: 5, class: _, preferred-register: '' }
+  - { id: 6, class: _, preferred-register: '' }
+legalized: false
+body:             |
+  bb.0.entry:
+    liveins: $r0
+    ; CHECK-LABEL: name: test_unmerge_v2s16
+    ; CHECK: liveins: $r0
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<2 x s16>) = COPY $r0
+    ; CHECK-NEXT: [[BITCAST:%[0-9]+]]:_(s32) = G_BITCAST [[COPY]](<2 x s16>)
+    ; CHECK-NEXT: [[C:%[0-9]+]]:_(s32) = G_CONSTANT i32 16
+    ; CHECK-NEXT: [[LSHR:%[0-9]+]]:_(s32) = G_LSHR [[BITCAST]], [[C]](s32)
+    ; CHECK-NEXT: [[SEXT_INREG:%[0-9]+]]:_(s32) = G_SEXT_INREG [[LSHR]], 16
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[SEXT_INREG]](s32)
+    %0:_(<2 x s16>) = COPY $r0
+    %1(s16), %2(s16) = G_UNMERGE_VALUES %0(<2 x s16>)
+    %3(s32) = G_SEXT %2(s16)
+    PseudoRET implicit $lr, implicit %3
+...
+---
+name:           test_unmerge_v4s8
+registers:
+  - { id: 0, class: _, preferred-register: '' }
+  - { id: 1, class: _, preferred-register: '' }
+  - { id: 2, class: _, preferred-register: '' }
+  - { id: 3, class: _, preferred-register: '' }
+  - { id: 4, class: _, preferred-register: '' }
+  - { id: 5, class: _, preferred-register: '' }
+  - { id: 6, class: _, preferred-register: '' }
+  - { id: 7, class: _, preferred-register: '' }
+  - { id: 8, class: _, preferred-register: '' }
+legalized: false
+body:             |
+  bb.0.entry:
+    liveins: $r0
+    ; CHECK-LABEL: name: test_unmerge_v4s8
+    ; CHECK: liveins: $r0
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<4 x s8>) = COPY $r0
+    ; CHECK-NEXT: [[BITCAST:%[0-9]+]]:_(s32) = G_BITCAST [[COPY]](<4 x s8>)
+    ; CHECK-NEXT: [[C:%[0-9]+]]:_(s32) = G_CONSTANT i32 24
+    ; CHECK-NEXT: [[LSHR:%[0-9]+]]:_(s32) = G_LSHR [[BITCAST]], [[C]](s32)
+    ; CHECK-NEXT: [[SEXT_INREG:%[0-9]+]]:_(s32) = G_SEXT_INREG [[LSHR]], 8
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[SEXT_INREG]](s32)
+    %0:_(<4 x s8>) = COPY $r0
+    %1(s8), %2(s8), %3(s8), %4(s8) = G_UNMERGE_VALUES %0(<4 x s8>)
+    %5(s32) = G_SEXT %4(s8)
+    PseudoRET implicit $lr, implicit %5
+...
+---
+name:           test_unmerge_32bit_order
+registers:
+  - { id: 0, class: _, preferred-register: '' }
+  - { id: 1, class: _, preferred-register: '' }
+  - { id: 2, class: _, preferred-register: '' }
+  - { id: 3, class: _, preferred-register: '' }
+  - { id: 4, class: _, preferred-register: '' }
+  - { id: 5, class: _, preferred-register: '' }
+  - { id: 6, class: _, preferred-register: '' }
+  - { id: 7, class: _, preferred-register: '' }
+  - { id: 8, class: _, preferred-register: '' }
+legalized: false
+body:             |
+  bb.0.entry:
+    liveins: $r0
+    ; CHECK-LABEL: name: test_unmerge_32bit_order
+    ; CHECK: liveins: $r0
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<4 x s8>) = COPY $r0
+    ; CHECK-NEXT: [[BITCAST:%[0-9]+]]:_(s32) = G_BITCAST [[COPY]](<4 x s8>)
+    ; CHECK-NEXT: [[C:%[0-9]+]]:_(s32) = G_CONSTANT i32 8
+    ; CHECK-NEXT: [[LSHR:%[0-9]+]]:_(s32) = G_LSHR [[BITCAST]], [[C]](s32)
+    ; CHECK-NEXT: [[C1:%[0-9]+]]:_(s32) = G_CONSTANT i32 16
+    ; CHECK-NEXT: [[LSHR1:%[0-9]+]]:_(s32) = G_LSHR [[BITCAST]], [[C1]](s32)
+    ; CHECK-NEXT: [[C2:%[0-9]+]]:_(s32) = G_CONSTANT i32 24
+    ; CHECK-NEXT: [[LSHR2:%[0-9]+]]:_(s32) = G_LSHR [[BITCAST]], [[C2]](s32)
+    ; CHECK-NEXT: [[SEXT_INREG:%[0-9]+]]:_(s32) = G_SEXT_INREG [[BITCAST]], 8
+    ; CHECK-NEXT: [[SEXT_INREG1:%[0-9]+]]:_(s32) = G_SEXT_INREG [[LSHR]], 8
+    ; CHECK-NEXT: [[SEXT_INREG2:%[0-9]+]]:_(s32) = G_SEXT_INREG [[LSHR1]], 8
+    ; CHECK-NEXT: [[SEXT_INREG3:%[0-9]+]]:_(s32) = G_SEXT_INREG [[LSHR2]], 8
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[SEXT_INREG]](s32), implicit [[SEXT_INREG1]](s32), implicit [[SEXT_INREG2]](s32), implicit [[SEXT_INREG3]](s32)
+    %0:_(<4 x s8>) = COPY $r0
+    %1(s8), %2(s8), %3(s8), %4(s8) = G_UNMERGE_VALUES %0(<4 x s8>)
+    %5(s32) = G_SEXT %1(s8)
+    %6(s32) = G_SEXT %2(s8)
+    %7(s32) = G_SEXT %3(s8)
+    %8(s32) = G_SEXT %4(s8)
+    PseudoRET implicit $lr, implicit %5, implicit %6, implicit %7, implicit %8


### PR DESCRIPTION
In this merge request, 32-bit vectors are iterated over and added iteratively to a 32-bit number. It does not support 16-bit build vectors since this type cannot occur within a properly legalized program. The intuition for this is as follows:

1. The legalizer removes code that it considers dead 
2. The legalizer considers code dead when it does a "not safe to move" operation (e.x. move, call or sequential load)
3. Build Vector does fall under those operations, therefore its result must be used somewhere
4. Global ISel uses Single Static Assignment, so variable types cannot change and must be defined exactly once
5. The legalizer works backward from the last instruction to the first instruction
6. Types must be the same when they're defined and used
7. If a 16-bit vector reaches the BV, there is another operation uses it and didn't set its type correctly. If that happens, we cannot fix it in the Build Vector since that would cause a conflict between the two types
8. Ergo such conflicts need to be resolved by legalizing them with the "not safe to move" operations

The opposite logic is done for G_UNMERGE_VALUES that iterates over a 32-bit number, shifts truncates them into separate scalar numbers and finishes once it has extracted all values. 
