### PR TITLE
[AIE2] Disable the findPostIncMatch combiner for 128-bit stores

### DIFF
--- a/llvm/lib/Target/AIE/AIELegalizerInfo.cpp
+++ b/llvm/lib/Target/AIE/AIELegalizerInfo.cpp
@@ -491,6 +491,60 @@ bool AIELegalizerInfo::legalizeCustom(LegalizerHelper &Helper,
   llvm_unreachable("Un-expected custom legalization");
 }
 
+bool AIELegalizerInfo::pack32BitVector(LegalizerHelper &Helper,
+                                       MachineInstr &MI,
+                                       Register SourceReg) const {
+  MachineIRBuilder &MIRBuilder = Helper.MIRBuilder;
+  MachineRegisterInfo &MRI = *MIRBuilder.getMRI();
+
+  const LLT SourceRegTy = MRI.getType(SourceReg);
+  const Register DstReg = MI.getOperand(0).getReg();
+  assert(SourceRegTy.getSizeInBits() == 32 &&
+         "cannot pack or unpack vectors larger or smaller than 32-bit");
+
+  const LLT S32 = LLT::scalar(32);
+  unsigned Offset = 0;
+  Register DstCastReg = MRI.createGenericVirtualRegister(S32);
+
+  // We want to skip the destination vector for unmerging and the source vector
+  // for merging
+  MachineOperand *Operand = MI.operands_begin() + 1,
+                 *OperandEnd = MI.operands_end();
+  MIRBuilder.buildConstant(DstCastReg, 0);
+
+  while (Operand != OperandEnd) {
+    Register DestinationOperand = Operand->getReg();
+    const LLT RegTy = MRI.getType(DestinationOperand);
+
+    if (RegTy.getScalarSizeInBits() != 32) {
+      const Register TmpReg32 = MRI.createGenericVirtualRegister(S32);
+      MIRBuilder.buildInstr(AIE2::G_ZEXT, {TmpReg32}, {DestinationOperand});
+      DestinationOperand = TmpReg32;
+    }
+
+    // Avoid a useless shift for the first element, since it doesn't get
+    // optimized out in O0.
+    const Register AccumulatorReg = MRI.createGenericVirtualRegister(S32);
+    if (Offset != 0) {
+      const MachineInstrBuilder ShiftConstant =
+          MIRBuilder.buildConstant(S32, Offset);
+      const MachineInstrBuilder Masked =
+          MIRBuilder.buildShl(S32, DestinationOperand, ShiftConstant);
+      MIRBuilder.buildOr(AccumulatorReg, DstCastReg, Masked);
+    } else {
+      MIRBuilder.buildOr(AccumulatorReg, DstCastReg, DestinationOperand);
+    }
+
+    DstCastReg = AccumulatorReg;
+    Offset += RegTy.getScalarSizeInBits();
+    ++Operand;
+  }
+
+  MIRBuilder.buildBitcast(DstReg, DstCastReg);
+  MI.eraseFromParent();
+  return true;
+}
+
 bool AIELegalizerInfo::legalizeG_BUILD_VECTOR(LegalizerHelper &Helper,
                                               MachineInstr &MI) const {
   MachineIRBuilder &MIRBuilder = Helper.MIRBuilder;
@@ -504,9 +558,14 @@ bool AIELegalizerInfo::legalizeG_BUILD_VECTOR(LegalizerHelper &Helper,
   const unsigned EltSize = DstVecEltTy.getScalarSizeInBits();
   assert((EltSize == 8 || EltSize == 16 || EltSize == 32) &&
          "non-existent integer size");
-  assert(DstVecSize > 64 && DstVecSize <= 1024 &&
-         "non-native vectors are not supported");
+  assert(DstVecSize == 32 || (DstVecSize > 64 && DstVecSize <= 1024 &&
+                              "non-native vectors are not supported"));
   assert(DstVecSize < 1024 && "vadd takes a 512-bit argument");
+
+  // If our vector is 32-bit we can store it as packed integer vector
+  if (DstVecSize == 32)
+    return pack32BitVector(Helper, MI, DstReg);
+
   // We are using an undef since we are building over multiple instructions
   const TypeSize VecEltTySize = DstVecEltTy.getSizeInBits();
   const LLT VecTy = LLT::fixed_vector(512 / VecEltTySize, DstVecEltTy);

--- a/llvm/lib/Target/AIE/AIELegalizerInfo.h
+++ b/llvm/lib/Target/AIE/AIELegalizerInfo.h
@@ -53,6 +53,8 @@ private:
   // Helper functions for legalization
   bool pack32BitVector(LegalizerHelper &Helper, MachineInstr &MI,
                        Register SourceReg) const;
+  bool unpack32BitVector(LegalizerHelper &Helper, MachineInstr &MI,
+                         Register SourceReg) const;
 };
 } // end namespace llvm
 #endif

--- a/llvm/lib/Target/AIE/AIELegalizerInfo.h
+++ b/llvm/lib/Target/AIE/AIELegalizerInfo.h
@@ -16,6 +16,7 @@
 #define LLVM_LIB_TARGET_AIE_AIEMACHINELEGALIZER_H
 
 #include "llvm/CodeGen/GlobalISel/LegalizerInfo.h"
+#include "llvm/CodeGen/Register.h"
 
 namespace llvm {
 
@@ -48,6 +49,10 @@ private:
   bool legalizeG_FPEXT(LegalizerHelper &Helper, MachineInstr &MI) const;
   bool legalizeG_FABS(LegalizerHelper &Helper, MachineInstr &MI) const;
   bool legalizeG_FADDSUB(LegalizerHelper &Helper, MachineInstr &MI) const;
+
+  // Helper functions for legalization
+  bool pack32BitVector(LegalizerHelper &Helper, MachineInstr &MI,
+                       Register SourceReg) const;
 };
 } // end namespace llvm
 #endif

--- a/llvm/test/CodeGen/AIE/GlobalISel/combine-loads-stores.mir
+++ b/llvm/test/CodeGen/AIE/GlobalISel/combine-loads-stores.mir
@@ -1505,9 +1505,10 @@ body: |
     ; CHECK-LABEL: name: postinc_2d_combine_128bit_load
     ; CHECK: [[COPY:%[0-9]+]]:_(p0) = COPY $p0
     ; CHECK-NEXT: [[C:%[0-9]+]]:_(s20) = G_CONSTANT i20 64
-    ; CHECK-NEXT: [[AIE_POSTINC_2D_LOAD:%[0-9]+]]:_(<16 x s8>), [[AIE_POSTINC_2D_LOAD1:%[0-9]+]]:_(p0), [[AIE_POSTINC_2D_LOAD2:%[0-9]+]]:_(s20) = G_AIE_POSTINC_2D_LOAD [[COPY]], [[C]], [[C]], [[C]], [[C]] :: (load (<16 x s8>))
-    ; CHECK-NEXT: $p0 = COPY [[AIE_POSTINC_2D_LOAD1]](p0)
-    ; CHECK-NEXT: $q0 = COPY [[AIE_POSTINC_2D_LOAD]](<16 x s8>)
+    ; CHECK-NEXT: [[LOAD:%[0-9]+]]:_(<16 x s8>) = G_LOAD [[COPY]](p0) :: (load (<16 x s8>))
+    ; CHECK-NEXT: [[INT:%[0-9]+]]:_(p0), [[INT1:%[0-9]+]]:_(s20) = G_INTRINSIC intrinsic(@llvm.aie2.add.2d), [[COPY]](p0), [[C]](s20), [[C]](s20), [[C]](s20), [[C]](s20)
+    ; CHECK-NEXT: $p0 = COPY [[INT]](p0)
+    ; CHECK-NEXT: $q0 = COPY [[LOAD]](<16 x s8>)
       %0:_(p0) = COPY $p0
       %1:_(s20) = G_CONSTANT i20 64
       %2:_(<16 x s8>) = G_LOAD %0(p0) :: (load (<16 x s8>))
@@ -1523,9 +1524,10 @@ body: |
     ; CHECK-LABEL: name: postinc_3d_combine_128bit_load
     ; CHECK: [[COPY:%[0-9]+]]:_(p0) = COPY $p0
     ; CHECK-NEXT: [[C:%[0-9]+]]:_(s20) = G_CONSTANT i20 64
-    ; CHECK-NEXT: [[AIE_POSTINC_3D_LOAD:%[0-9]+]]:_(<16 x s8>), [[AIE_POSTINC_3D_LOAD1:%[0-9]+]]:_(p0), [[AIE_POSTINC_3D_LOAD2:%[0-9]+]]:_(s20), [[AIE_POSTINC_3D_LOAD3:%[0-9]+]]:_ = G_AIE_POSTINC_3D_LOAD [[COPY]], [[C]], [[C]], [[C]], [[C]], [[C]], [[C]], [[C]] :: (load (<16 x s8>))
-    ; CHECK-NEXT: $p0 = COPY [[AIE_POSTINC_3D_LOAD1]](p0)
-    ; CHECK-NEXT: $q0 = COPY [[AIE_POSTINC_3D_LOAD]](<16 x s8>)
+    ; CHECK-NEXT: [[LOAD:%[0-9]+]]:_(<16 x s8>) = G_LOAD [[COPY]](p0) :: (load (<16 x s8>))
+    ; CHECK-NEXT: [[INT:%[0-9]+]]:_(p0), [[INT1:%[0-9]+]]:_(s20), [[INT2:%[0-9]+]]:_(s20) = G_INTRINSIC intrinsic(@llvm.aie2.add.3d), [[COPY]](p0), [[C]](s20), [[C]](s20), [[C]](s20), [[C]](s20), [[C]](s20), [[C]](s20), [[C]](s20)
+    ; CHECK-NEXT: $p0 = COPY [[INT]](p0)
+    ; CHECK-NEXT: $q0 = COPY [[LOAD]](<16 x s8>)
       %0:_(p0) = COPY $p0
       %1:_(s20) = G_CONSTANT i20 64
       %2:_(<16 x s8>) = G_LOAD %0(p0) :: (load (<16 x s8>))

--- a/llvm/test/CodeGen/AIE/aie2/GlobalISel/legalize-build-vector.mir
+++ b/llvm/test/CodeGen/AIE/aie2/GlobalISel/legalize-build-vector.mir
@@ -470,3 +470,194 @@ body:           |
     %0:_(p0) = G_FRAME_INDEX %stack.0
     G_STORE %1(<4 x s32>), %0(p0) :: (store (<4 x s32>))
     PseudoRET implicit $lr
+...
+
+---
+name:            test_build_vector_32_16
+body:             |
+  bb.1.entry:
+    ; CHECK-LABEL: name: test_build_vector_32_16
+    ; CHECK: [[C:%[0-9]+]]:_(s32) = G_CONSTANT i32 1
+    ; CHECK-NEXT: [[C1:%[0-9]+]]:_(s32) = G_CONSTANT i32 2
+    ; CHECK-NEXT: [[C2:%[0-9]+]]:_(s32) = G_CONSTANT i32 0
+    ; CHECK-NEXT: [[OR:%[0-9]+]]:_(s32) = G_OR [[C2]], [[C]]
+    ; CHECK-NEXT: [[C3:%[0-9]+]]:_(s32) = G_CONSTANT i32 16
+    ; CHECK-NEXT: [[SHL:%[0-9]+]]:_(s32) = G_SHL [[C1]], [[C3]](s32)
+    ; CHECK-NEXT: [[OR1:%[0-9]+]]:_(s32) = G_OR [[OR]], [[SHL]]
+    ; CHECK-NEXT: [[BITCAST:%[0-9]+]]:_(<2 x s16>) = G_BITCAST [[OR1]](s32)
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[BITCAST]](<2 x s16>)
+    %0:_(s16) = G_CONSTANT i16 1
+    %1:_(s16) = G_CONSTANT i16 2
+    %2:_(<2 x s16>) = G_BUILD_VECTOR %0(s16), %1(s16)
+    PseudoRET implicit $lr, implicit %2
+...
+
+---
+name:            test_build_vector_32_8
+body:             |
+  bb.1.entry:
+    ; CHECK-LABEL: name: test_build_vector_32_8
+    ; CHECK: [[C:%[0-9]+]]:_(s32) = G_CONSTANT i32 1
+    ; CHECK-NEXT: [[C1:%[0-9]+]]:_(s32) = G_CONSTANT i32 2
+    ; CHECK-NEXT: [[C2:%[0-9]+]]:_(s32) = G_CONSTANT i32 3
+    ; CHECK-NEXT: [[C3:%[0-9]+]]:_(s32) = G_CONSTANT i32 4
+    ; CHECK-NEXT: [[C4:%[0-9]+]]:_(s32) = G_CONSTANT i32 0
+    ; CHECK-NEXT: [[OR:%[0-9]+]]:_(s32) = G_OR [[C4]], [[C]]
+    ; CHECK-NEXT: [[C5:%[0-9]+]]:_(s32) = G_CONSTANT i32 8
+    ; CHECK-NEXT: [[SHL:%[0-9]+]]:_(s32) = G_SHL [[C1]], [[C5]](s32)
+    ; CHECK-NEXT: [[OR1:%[0-9]+]]:_(s32) = G_OR [[OR]], [[SHL]]
+    ; CHECK-NEXT: [[C6:%[0-9]+]]:_(s32) = G_CONSTANT i32 16
+    ; CHECK-NEXT: [[SHL1:%[0-9]+]]:_(s32) = G_SHL [[C2]], [[C6]](s32)
+    ; CHECK-NEXT: [[OR2:%[0-9]+]]:_(s32) = G_OR [[OR1]], [[SHL1]]
+    ; CHECK-NEXT: [[C7:%[0-9]+]]:_(s32) = G_CONSTANT i32 24
+    ; CHECK-NEXT: [[SHL2:%[0-9]+]]:_(s32) = G_SHL [[C3]], [[C7]](s32)
+    ; CHECK-NEXT: [[OR3:%[0-9]+]]:_(s32) = G_OR [[OR2]], [[SHL2]]
+    ; CHECK-NEXT: [[BITCAST:%[0-9]+]]:_(<4 x s8>) = G_BITCAST [[OR3]](s32)
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[BITCAST]](<4 x s8>)
+    %0:_(s8) = G_CONSTANT i8 1
+    %1:_(s8) = G_CONSTANT i8 2
+    %2:_(s8) = G_CONSTANT i8 3
+    %3:_(s8) = G_CONSTANT i8 4
+    %4:_(<4 x s8>) = G_BUILD_VECTOR %0(s8), %1(s8), %2(s8), %3(s8)
+    PseudoRET implicit $lr, implicit %4
+...
+
+---
+name:            test_build_vector_32_8_negative
+body:             |
+  bb.1.entry:
+    ; CHECK-LABEL: name: test_build_vector_32_8_negative
+    ; CHECK: [[C:%[0-9]+]]:_(s32) = G_CONSTANT i32 0
+    ; CHECK-NEXT: [[C1:%[0-9]+]]:_(s32) = G_CONSTANT i32 255
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY [[C1]](s32)
+    ; CHECK-NEXT: [[OR:%[0-9]+]]:_(s32) = G_OR [[C]], [[COPY]]
+    ; CHECK-NEXT: [[C2:%[0-9]+]]:_(s32) = G_CONSTANT i32 254
+    ; CHECK-NEXT: [[C3:%[0-9]+]]:_(s32) = G_CONSTANT i32 8
+    ; CHECK-NEXT: [[SHL:%[0-9]+]]:_(s32) = G_SHL [[C2]], [[C3]](s32)
+    ; CHECK-NEXT: [[OR1:%[0-9]+]]:_(s32) = G_OR [[OR]], [[SHL]]
+    ; CHECK-NEXT: [[C4:%[0-9]+]]:_(s32) = G_CONSTANT i32 253
+    ; CHECK-NEXT: [[C5:%[0-9]+]]:_(s32) = G_CONSTANT i32 16
+    ; CHECK-NEXT: [[SHL1:%[0-9]+]]:_(s32) = G_SHL [[C4]], [[C5]](s32)
+    ; CHECK-NEXT: [[OR2:%[0-9]+]]:_(s32) = G_OR [[OR1]], [[SHL1]]
+    ; CHECK-NEXT: [[C6:%[0-9]+]]:_(s32) = G_CONSTANT i32 252
+    ; CHECK-NEXT: [[C7:%[0-9]+]]:_(s32) = G_CONSTANT i32 24
+    ; CHECK-NEXT: [[SHL2:%[0-9]+]]:_(s32) = G_SHL [[C6]], [[C7]](s32)
+    ; CHECK-NEXT: [[OR3:%[0-9]+]]:_(s32) = G_OR [[OR2]], [[SHL2]]
+    ; CHECK-NEXT: [[BITCAST:%[0-9]+]]:_(<4 x s8>) = G_BITCAST [[OR3]](s32)
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[BITCAST]](<4 x s8>)
+    %0:_(s8) = G_CONSTANT i8 -1
+    %1:_(s8) = G_CONSTANT i8 -2
+    %2:_(s8) = G_CONSTANT i8 -3
+    %3:_(s8) = G_CONSTANT i8 -4
+    %4:_(<4 x s8>) = G_BUILD_VECTOR %0(s8), %1(s8), %2(s8), %3(s8)
+    PseudoRET implicit $lr, implicit %4
+...
+
+---
+name:            test_build_vector_32_8_mixed
+body:             |
+  bb.1.entry:
+    ; CHECK-LABEL: name: test_build_vector_32_8_mixed
+    ; CHECK: [[C:%[0-9]+]]:_(s32) = G_CONSTANT i32 19
+    ; CHECK-NEXT: [[C1:%[0-9]+]]:_(s32) = G_CONSTANT i32 33
+    ; CHECK-NEXT: [[C2:%[0-9]+]]:_(s32) = G_CONSTANT i32 0
+    ; CHECK-NEXT: [[OR:%[0-9]+]]:_(s32) = G_OR [[C2]], [[C]]
+    ; CHECK-NEXT: [[C3:%[0-9]+]]:_(s32) = G_CONSTANT i32 232
+    ; CHECK-NEXT: [[C4:%[0-9]+]]:_(s32) = G_CONSTANT i32 8
+    ; CHECK-NEXT: [[SHL:%[0-9]+]]:_(s32) = G_SHL [[C3]], [[C4]](s32)
+    ; CHECK-NEXT: [[OR1:%[0-9]+]]:_(s32) = G_OR [[OR]], [[SHL]]
+    ; CHECK-NEXT: [[C5:%[0-9]+]]:_(s32) = G_CONSTANT i32 16
+    ; CHECK-NEXT: [[SHL1:%[0-9]+]]:_(s32) = G_SHL [[C1]], [[C5]](s32)
+    ; CHECK-NEXT: [[OR2:%[0-9]+]]:_(s32) = G_OR [[OR1]], [[SHL1]]
+    ; CHECK-NEXT: [[C6:%[0-9]+]]:_(s32) = G_CONSTANT i32 164
+    ; CHECK-NEXT: [[C7:%[0-9]+]]:_(s32) = G_CONSTANT i32 24
+    ; CHECK-NEXT: [[SHL2:%[0-9]+]]:_(s32) = G_SHL [[C6]], [[C7]](s32)
+    ; CHECK-NEXT: [[OR3:%[0-9]+]]:_(s32) = G_OR [[OR2]], [[SHL2]]
+    ; CHECK-NEXT: [[BITCAST:%[0-9]+]]:_(<4 x s8>) = G_BITCAST [[OR3]](s32)
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[BITCAST]](<4 x s8>)
+    %0:_(s8) = G_CONSTANT i8 19
+    %1:_(s8) = G_CONSTANT i8 -24
+    %2:_(s8) = G_CONSTANT i8 33
+    %3:_(s8) = G_CONSTANT i8 -92
+    %4:_(<4 x s8>) = G_BUILD_VECTOR %0(s8), %1(s8), %2(s8), %3(s8)
+    PseudoRET implicit $lr, implicit %4
+...
+
+---
+name:            test_build_vector_32_8_from_registers
+body:             |
+  bb.1.entry:
+    liveins: $r0, $r1, $r2, $r3
+    ; CHECK-LABEL: name: test_build_vector_32_8_from_registers
+    ; CHECK: liveins: $r0, $r1, $r2, $r3
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $r0
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(s32) = COPY $r1
+    ; CHECK-NEXT: [[COPY2:%[0-9]+]]:_(s32) = COPY $r2
+    ; CHECK-NEXT: [[COPY3:%[0-9]+]]:_(s32) = COPY $r3
+    ; CHECK-NEXT: [[C:%[0-9]+]]:_(s32) = G_CONSTANT i32 0
+    ; CHECK-NEXT: [[C1:%[0-9]+]]:_(s32) = G_CONSTANT i32 255
+    ; CHECK-NEXT: [[AND:%[0-9]+]]:_(s32) = G_AND [[COPY]], [[C1]]
+    ; CHECK-NEXT: [[OR:%[0-9]+]]:_(s32) = G_OR [[C]], [[AND]]
+    ; CHECK-NEXT: [[AND1:%[0-9]+]]:_(s32) = G_AND [[COPY1]], [[C1]]
+    ; CHECK-NEXT: [[C2:%[0-9]+]]:_(s32) = G_CONSTANT i32 8
+    ; CHECK-NEXT: [[SHL:%[0-9]+]]:_(s32) = G_SHL [[AND1]], [[C2]](s32)
+    ; CHECK-NEXT: [[OR1:%[0-9]+]]:_(s32) = G_OR [[OR]], [[SHL]]
+    ; CHECK-NEXT: [[AND2:%[0-9]+]]:_(s32) = G_AND [[COPY2]], [[C1]]
+    ; CHECK-NEXT: [[C3:%[0-9]+]]:_(s32) = G_CONSTANT i32 16
+    ; CHECK-NEXT: [[SHL1:%[0-9]+]]:_(s32) = G_SHL [[AND2]], [[C3]](s32)
+    ; CHECK-NEXT: [[OR2:%[0-9]+]]:_(s32) = G_OR [[OR1]], [[SHL1]]
+    ; CHECK-NEXT: [[AND3:%[0-9]+]]:_(s32) = G_AND [[COPY3]], [[C1]]
+    ; CHECK-NEXT: [[C4:%[0-9]+]]:_(s32) = G_CONSTANT i32 24
+    ; CHECK-NEXT: [[SHL2:%[0-9]+]]:_(s32) = G_SHL [[AND3]], [[C4]](s32)
+    ; CHECK-NEXT: [[OR3:%[0-9]+]]:_(s32) = G_OR [[OR2]], [[SHL2]]
+    ; CHECK-NEXT: [[BITCAST:%[0-9]+]]:_(<4 x s8>) = G_BITCAST [[OR3]](s32)
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[BITCAST]](<4 x s8>)
+    %0:_(s32) = COPY $r0
+    %1:_(s32) = COPY $r1
+    %2:_(s32) = COPY $r2
+    %3:_(s32) = COPY $r3
+    %4:_(s8) = G_TRUNC %0(s32)
+    %5:_(s8) = G_TRUNC %1(s32)
+    %6:_(s8) = G_TRUNC %2(s32)
+    %7:_(s8) = G_TRUNC %3(s32)
+    %8:_(<4 x s8>) = G_BUILD_VECTOR %4(s8), %5(s8), %6(s8), %7(s8)
+    PseudoRET implicit $lr, implicit %8
+...
+
+---
+name:            test_build_vector_32_8_register_constant
+body:             |
+  bb.1.entry:
+    liveins: $r0, $r1
+    ; CHECK-LABEL: name: test_build_vector_32_8_register_constant
+    ; CHECK: liveins: $r0, $r1
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $r0
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(s32) = COPY $r1
+    ; CHECK-NEXT: [[C:%[0-9]+]]:_(s32) = G_CONSTANT i32 19
+    ; CHECK-NEXT: [[C1:%[0-9]+]]:_(s32) = G_CONSTANT i32 33
+    ; CHECK-NEXT: [[C2:%[0-9]+]]:_(s32) = G_CONSTANT i32 0
+    ; CHECK-NEXT: [[OR:%[0-9]+]]:_(s32) = G_OR [[C2]], [[C]]
+    ; CHECK-NEXT: [[C3:%[0-9]+]]:_(s32) = G_CONSTANT i32 255
+    ; CHECK-NEXT: [[AND:%[0-9]+]]:_(s32) = G_AND [[COPY]], [[C3]]
+    ; CHECK-NEXT: [[C4:%[0-9]+]]:_(s32) = G_CONSTANT i32 8
+    ; CHECK-NEXT: [[SHL:%[0-9]+]]:_(s32) = G_SHL [[AND]], [[C4]](s32)
+    ; CHECK-NEXT: [[OR1:%[0-9]+]]:_(s32) = G_OR [[OR]], [[SHL]]
+    ; CHECK-NEXT: [[C5:%[0-9]+]]:_(s32) = G_CONSTANT i32 16
+    ; CHECK-NEXT: [[SHL1:%[0-9]+]]:_(s32) = G_SHL [[C1]], [[C5]](s32)
+    ; CHECK-NEXT: [[OR2:%[0-9]+]]:_(s32) = G_OR [[OR1]], [[SHL1]]
+    ; CHECK-NEXT: [[AND1:%[0-9]+]]:_(s32) = G_AND [[COPY1]], [[C3]]
+    ; CHECK-NEXT: [[C6:%[0-9]+]]:_(s32) = G_CONSTANT i32 24
+    ; CHECK-NEXT: [[SHL2:%[0-9]+]]:_(s32) = G_SHL [[AND1]], [[C6]](s32)
+    ; CHECK-NEXT: [[OR3:%[0-9]+]]:_(s32) = G_OR [[OR2]], [[SHL2]]
+    ; CHECK-NEXT: [[BITCAST:%[0-9]+]]:_(<4 x s8>) = G_BITCAST [[OR3]](s32)
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[BITCAST]](<4 x s8>)
+    %0:_(s32) = COPY $r0
+    %1:_(s32) = COPY $r1
+    %2:_(s8) = G_CONSTANT i8 19
+    %3:_(s8) = G_TRUNC %0(s32)
+    %4:_(s8) = G_CONSTANT i8 33
+    %5:_(s8) = G_TRUNC %1(s32)
+    %6:_(<4 x s8>) = G_BUILD_VECTOR %2(s8), %3(s8), %4(s8), %5(s8)
+    PseudoRET implicit $lr, implicit %6

--- a/llvm/test/CodeGen/AIE/aie2/GlobalISel/legalize-extract-vector-elt.mir
+++ b/llvm/test/CodeGen/AIE/aie2/GlobalISel/legalize-extract-vector-elt.mir
@@ -522,8 +522,7 @@ body:             |
     ; CHECK-NEXT: LIFETIME_END %stack.0
     ; CHECK-NEXT: [[C1:%[0-9]+]]:_(s32) = G_CONSTANT i32 65535
     ; CHECK-NEXT: [[AND:%[0-9]+]]:_(s32) = G_AND [[LOAD]], [[C1]]
-    ; CHECK-NEXT: $r0 = COPY [[AND]](s32)
-    ; CHECK-NEXT: PseudoRET implicit $lr, implicit $r0
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[AND]](s32)
     %1:_(<32 x s16>) = COPY $x0
     %4:_(s32) = G_CONSTANT i32 15
     %2:_(p0) = G_FRAME_INDEX %stack.0
@@ -533,8 +532,7 @@ body:             |
     %0:_(s16) = G_LOAD %2(p0) :: (volatile dereferenceable load (s16))
     LIFETIME_END %stack.0
     %5:_(s32) = G_ZEXT %0(s16)
-    $r0 = COPY %5(s32)
-    PseudoRET implicit $lr, implicit $r0
+    PseudoRET implicit $lr, implicit %5
 
 ...
 ---
@@ -559,8 +557,7 @@ body:             |
     ; CHECK-NEXT: [[LOAD:%[0-9]+]]:_(s32) = G_LOAD [[FRAME_INDEX]](p0) :: (volatile dereferenceable load (s8))
     ; CHECK-NEXT: LIFETIME_END %stack.0
     ; CHECK-NEXT: [[SEXT_INREG:%[0-9]+]]:_(s32) = G_SEXT_INREG [[LOAD]], 8
-    ; CHECK-NEXT: $r0 = COPY [[SEXT_INREG]](s32)
-    ; CHECK-NEXT: PseudoRET implicit $lr, implicit $r0
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[SEXT_INREG]](s32)
     %1:_(<128 x s8>) = COPY $y2
     %4:_(s32) = G_CONSTANT i32 127
     %2:_(p0) = G_FRAME_INDEX %stack.0
@@ -570,9 +567,7 @@ body:             |
     %0:_(s8) = G_LOAD %2(p0) :: (volatile dereferenceable load (s8))
     LIFETIME_END %stack.0
     %5:_(s32) = G_SEXT %0(s8)
-    $r0 = COPY %5(s32)
-    PseudoRET implicit $lr, implicit $r0
-
+    PseudoRET implicit $lr, implicit %5
 ...
 ---
 name:            extract_16bit_1024
@@ -597,8 +592,7 @@ body:             |
     ; CHECK-NEXT: LIFETIME_END %stack.0
     ; CHECK-NEXT: [[C1:%[0-9]+]]:_(s32) = G_CONSTANT i32 65535
     ; CHECK-NEXT: [[AND:%[0-9]+]]:_(s32) = G_AND [[LOAD]], [[C1]]
-    ; CHECK-NEXT: $r0 = COPY [[AND]](s32)
-    ; CHECK-NEXT: PseudoRET implicit $lr, implicit $r0
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[AND]](s32)
     %1:_(<64 x s16>) = COPY $y2
     %4:_(s32) = G_CONSTANT i32 63
     %2:_(p0) = G_FRAME_INDEX %stack.0
@@ -608,7 +602,151 @@ body:             |
     %0:_(s16) = G_LOAD %2(p0) :: (volatile dereferenceable load (s16))
     LIFETIME_END %stack.0
     %5:_(s32) = G_ZEXT %0(s16)
-    $r0 = COPY %5(s32)
-    PseudoRET implicit $lr, implicit $r0
-
+    PseudoRET implicit $lr, implicit %5
 ...
+
+---
+name: test_extract_32_0
+body: |
+  bb.1.entry:
+    liveins: $r0
+    ; CHECK-LABEL: name: test_extract_32_0
+    ; CHECK: liveins: $r0
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<4 x s8>) = COPY $r0
+    ; CHECK-NEXT: [[C:%[0-9]+]]:_(s32) = G_CONSTANT i32 0
+    ; CHECK-NEXT: [[BITCAST:%[0-9]+]]:_(s32) = G_BITCAST [[COPY]](<4 x s8>)
+    ; CHECK-NEXT: [[LSHR:%[0-9]+]]:_(s32) = G_LSHR [[BITCAST]], [[C]](s32)
+    ; CHECK-NEXT: $r2 = COPY [[LSHR]](s32)
+    %0:_(<4 x s8>) = COPY $r0
+    %5:_(s32) = G_CONSTANT i32 0
+    %4:_(s8) = G_EXTRACT_VECTOR_ELT %0(<4 x s8>), %5(s32)
+    %1:_(s32) = G_ANYEXT %4(s8)
+    $r2 = COPY %1(s32)
+...
+
+---
+name: test_extract_32_1
+body: |
+  bb.1.entry:
+    liveins: $r0
+    ; CHECK-LABEL: name: test_extract_32_1
+    ; CHECK: liveins: $r0
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<4 x s8>) = COPY $r0
+    ; CHECK-NEXT: [[BITCAST:%[0-9]+]]:_(s32) = G_BITCAST [[COPY]](<4 x s8>)
+    ; CHECK-NEXT: [[C:%[0-9]+]]:_(s32) = G_CONSTANT i32 8
+    ; CHECK-NEXT: [[LSHR:%[0-9]+]]:_(s32) = G_LSHR [[BITCAST]], [[C]](s32)
+    ; CHECK-NEXT: $r2 = COPY [[LSHR]](s32)
+    %0:_(<4 x s8>) = COPY $r0
+    %5:_(s32) = G_CONSTANT i32 1
+    %4:_(s8) = G_EXTRACT_VECTOR_ELT %0(<4 x s8>), %5(s32)
+    %1:_(s32) = G_ANYEXT %4(s8)
+    $r2 = COPY %1(s32)
+...
+
+---
+name: test_extract_32_2
+body: |
+  bb.1.entry:
+    liveins: $r0
+    ; CHECK-LABEL: name: test_extract_32_2
+    ; CHECK: liveins: $r0
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<4 x s8>) = COPY $r0
+    ; CHECK-NEXT: [[BITCAST:%[0-9]+]]:_(s32) = G_BITCAST [[COPY]](<4 x s8>)
+    ; CHECK-NEXT: [[C:%[0-9]+]]:_(s32) = G_CONSTANT i32 16
+    ; CHECK-NEXT: [[LSHR:%[0-9]+]]:_(s32) = G_LSHR [[BITCAST]], [[C]](s32)
+    ; CHECK-NEXT: $r2 = COPY [[LSHR]](s32)
+    %0:_(<4 x s8>) = COPY $r0
+    %5:_(s32) = G_CONSTANT i32 2
+    %4:_(s8) = G_EXTRACT_VECTOR_ELT %0(<4 x s8>), %5(s32)
+    %1:_(s32) = G_ANYEXT %4(s8)
+    $r2 = COPY %1(s32)
+...
+
+---
+name: test_extract_32_3
+body: |
+  bb.1.entry:
+    liveins: $r0
+    ; CHECK-LABEL: name: test_extract_32_3
+    ; CHECK: liveins: $r0
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<4 x s8>) = COPY $r0
+    ; CHECK-NEXT: [[BITCAST:%[0-9]+]]:_(s32) = G_BITCAST [[COPY]](<4 x s8>)
+    ; CHECK-NEXT: [[C:%[0-9]+]]:_(s32) = G_CONSTANT i32 24
+    ; CHECK-NEXT: [[LSHR:%[0-9]+]]:_(s32) = G_LSHR [[BITCAST]], [[C]](s32)
+    ; CHECK-NEXT: $r2 = COPY [[LSHR]](s32)
+    %0:_(<4 x s8>) = COPY $r0
+    %5:_(s32) = G_CONSTANT i32 3
+    %4:_(s8) = G_EXTRACT_VECTOR_ELT %0(<4 x s8>), %5(s32)
+    %1:_(s32) = G_ANYEXT %4(s8)
+    $r2 = COPY %1(s32)
+...
+
+---
+name: test_extract_16bit
+body: |
+  bb.1.entry:
+    ; CHECK-LABEL: name: test_extract_16bit
+    ; CHECK: [[C:%[0-9]+]]:_(s32) = G_CONSTANT i32 42
+    ; CHECK-NEXT: [[C1:%[0-9]+]]:_(s32) = G_CONSTANT i32 0
+    ; CHECK-NEXT: [[DEF:%[0-9]+]]:_(s32) = G_IMPLICIT_DEF
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY [[C1]](s32)
+    ; CHECK-NEXT: [[OR:%[0-9]+]]:_(s32) = G_OR [[COPY]], [[C]]
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(s32) = COPY [[C]](s32)
+    ; CHECK-NEXT: [[C2:%[0-9]+]]:_(s32) = G_CONSTANT i32 8
+    ; CHECK-NEXT: [[SHL:%[0-9]+]]:_(s32) = G_SHL [[COPY1]], [[C2]](s32)
+    ; CHECK-NEXT: [[OR1:%[0-9]+]]:_(s32) = G_OR [[OR]], [[SHL]]
+    ; CHECK-NEXT: [[C3:%[0-9]+]]:_(s32) = G_CONSTANT i32 255
+    ; CHECK-NEXT: [[AND:%[0-9]+]]:_(s32) = G_AND [[DEF]], [[C3]]
+    ; CHECK-NEXT: [[C4:%[0-9]+]]:_(s32) = G_CONSTANT i32 16
+    ; CHECK-NEXT: [[SHL1:%[0-9]+]]:_(s32) = G_SHL [[AND]], [[C4]](s32)
+    ; CHECK-NEXT: [[OR2:%[0-9]+]]:_(s32) = G_OR [[OR1]], [[SHL1]]
+    ; CHECK-NEXT: [[COPY2:%[0-9]+]]:_(s32) = COPY [[AND]](s32)
+    ; CHECK-NEXT: [[C5:%[0-9]+]]:_(s32) = G_CONSTANT i32 24
+    ; CHECK-NEXT: [[SHL2:%[0-9]+]]:_(s32) = G_SHL [[COPY2]], [[C5]](s32)
+    ; CHECK-NEXT: [[OR3:%[0-9]+]]:_(s32) = G_OR [[OR2]], [[SHL2]]
+    ; CHECK-NEXT: [[BITCAST:%[0-9]+]]:_(<4 x s8>) = G_BITCAST [[OR3]](s32)
+    ; CHECK-NEXT: [[BITCAST1:%[0-9]+]]:_(s32) = G_BITCAST [[BITCAST]](<4 x s8>)
+    ; CHECK-NEXT: [[LSHR:%[0-9]+]]:_(s32) = G_LSHR [[BITCAST1]], [[C1]](s32)
+    ; CHECK-NEXT: $r0 = COPY [[LSHR]](s32)
+  %0:_(s8) = G_CONSTANT i8 42
+  %1:_(<2 x s8>) = G_BUILD_VECTOR %0(s8), %0(s8)
+  %2:_(s32) = G_CONSTANT i32 0
+  %3:_(s8) = G_EXTRACT_VECTOR_ELT %1(<2 x s8>), %2(s32)
+  %4:_(s32) = G_ANYEXT %3(s8)
+  $r0 = COPY %4(s32)
+...
+---
+name: test_extract_128bit
+body: |
+  bb.1.entry:
+    ; CHECK-LABEL: name: test_extract_128bit
+    ; CHECK: [[C:%[0-9]+]]:_(s32) = G_CONSTANT i32 65
+    ; CHECK-NEXT: [[C1:%[0-9]+]]:_(s32) = G_CONSTANT i32 77
+    ; CHECK-NEXT: [[C2:%[0-9]+]]:_(s32) = G_CONSTANT i32 68
+    ; CHECK-NEXT: [[C3:%[0-9]+]]:_(s32) = G_CONSTANT i32 33
+    ; CHECK-NEXT: [[C4:%[0-9]+]]:_(s32) = G_CONSTANT i32 2
+    ; CHECK-NEXT: [[DEF:%[0-9]+]]:_(s32) = G_IMPLICIT_DEF
+    ; CHECK-NEXT: [[DEF1:%[0-9]+]]:_(<16 x s32>) = G_IMPLICIT_DEF
+    ; CHECK-NEXT: [[AIE_ADD_VECTOR_ELT_LEFT:%[0-9]+]]:_(<16 x s32>) = G_AIE_ADD_VECTOR_ELT_LEFT [[DEF1]], [[DEF]](s32)
+    ; CHECK-NEXT: [[AIE_ADD_VECTOR_ELT_LEFT1:%[0-9]+]]:_(<16 x s32>) = G_AIE_ADD_VECTOR_ELT_LEFT [[AIE_ADD_VECTOR_ELT_LEFT]], [[DEF]](s32)
+    ; CHECK-NEXT: [[AIE_ADD_VECTOR_ELT_LEFT2:%[0-9]+]]:_(<16 x s32>) = G_AIE_ADD_VECTOR_ELT_LEFT [[AIE_ADD_VECTOR_ELT_LEFT1]], [[DEF]](s32)
+    ; CHECK-NEXT: [[AIE_ADD_VECTOR_ELT_LEFT3:%[0-9]+]]:_(<16 x s32>) = G_AIE_ADD_VECTOR_ELT_LEFT [[AIE_ADD_VECTOR_ELT_LEFT2]], [[DEF]](s32)
+    ; CHECK-NEXT: [[AIE_ADD_VECTOR_ELT_LEFT4:%[0-9]+]]:_(<16 x s32>) = G_AIE_ADD_VECTOR_ELT_LEFT [[AIE_ADD_VECTOR_ELT_LEFT3]], [[C3]](s32)
+    ; CHECK-NEXT: [[AIE_ADD_VECTOR_ELT_LEFT5:%[0-9]+]]:_(<16 x s32>) = G_AIE_ADD_VECTOR_ELT_LEFT [[AIE_ADD_VECTOR_ELT_LEFT4]], [[C2]](s32)
+    ; CHECK-NEXT: [[AIE_ADD_VECTOR_ELT_LEFT6:%[0-9]+]]:_(<16 x s32>) = G_AIE_ADD_VECTOR_ELT_LEFT [[AIE_ADD_VECTOR_ELT_LEFT5]], [[C1]](s32)
+    ; CHECK-NEXT: [[AIE_ADD_VECTOR_ELT_LEFT7:%[0-9]+]]:_(<16 x s32>) = G_AIE_ADD_VECTOR_ELT_LEFT [[AIE_ADD_VECTOR_ELT_LEFT6]], [[C]](s32)
+    ; CHECK-NEXT: [[UV:%[0-9]+]]:_(<8 x s32>), [[UV1:%[0-9]+]]:_(<8 x s32>) = G_UNMERGE_VALUES [[AIE_ADD_VECTOR_ELT_LEFT7]](<16 x s32>)
+    ; CHECK-NEXT: [[AIE_SEXT_EXTRACT_VECTOR_ELT:%[0-9]+]]:_(s32) = G_AIE_SEXT_EXTRACT_VECTOR_ELT [[UV]](<8 x s32>), [[C4]](s32)
+    ; CHECK-NEXT: $r0 = COPY [[AIE_SEXT_EXTRACT_VECTOR_ELT]](s32)
+    %0:_(s32) = G_CONSTANT i32 65
+    %1:_(s32) = G_CONSTANT i32 77
+    %2:_(s32) = G_CONSTANT i32 68
+    %3:_(s32) = G_CONSTANT i32 33
+    %4:_(<4 x s32>) = G_BUILD_VECTOR %0(s32), %1(s32), %2(s32), %3(s32)
+    %5:_(s32) = G_CONSTANT i32 2
+    %6:_(s32) = G_EXTRACT_VECTOR_ELT %4(<4 x s32>), %5(s32)
+    $r0 = COPY %6(s32)

--- a/llvm/test/CodeGen/AIE/aie2/GlobalISel/legalize-unmerge-values.mir
+++ b/llvm/test/CodeGen/AIE/aie2/GlobalISel/legalize-unmerge-values.mir
@@ -288,3 +288,101 @@ body:             |
     %1(s8), %2(s8), %3(s8), %4(s8), %5(s8), %6(s8), %7(s8), %8(s8), %9(s8), %10(s8), %11(s8), %12(s8), %13(s8), %14(s8), %15(s8), %16(s8), %17(s8), %18(s8), %19(s8), %20(s8), %21(s8), %22(s8), %23(s8), %24(s8), %25(s8), %26(s8), %27(s8), %28(s8), %29(s8), %30(s8), %31(s8), %32(s8) = G_UNMERGE_VALUES %0(<32 x s8>)
     %33(s32) = G_SEXT %8(s8)
     PseudoRET implicit $lr, implicit %33
+...
+---
+name:           test_unmerge_v2s16
+registers:
+  - { id: 0, class: _, preferred-register: '' }
+  - { id: 1, class: _, preferred-register: '' }
+  - { id: 2, class: _, preferred-register: '' }
+  - { id: 3, class: _, preferred-register: '' }
+  - { id: 4, class: _, preferred-register: '' }
+  - { id: 5, class: _, preferred-register: '' }
+  - { id: 6, class: _, preferred-register: '' }
+legalized: false
+body:             |
+  bb.0.entry:
+    liveins: $r0
+    ; CHECK-LABEL: name: test_unmerge_v2s16
+    ; CHECK: liveins: $r0
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<2 x s16>) = COPY $r0
+    ; CHECK-NEXT: [[BITCAST:%[0-9]+]]:_(s32) = G_BITCAST [[COPY]](<2 x s16>)
+    ; CHECK-NEXT: [[C:%[0-9]+]]:_(s32) = G_CONSTANT i32 16
+    ; CHECK-NEXT: [[LSHR:%[0-9]+]]:_(s32) = G_LSHR [[BITCAST]], [[C]](s32)
+    ; CHECK-NEXT: [[SEXT_INREG:%[0-9]+]]:_(s32) = G_SEXT_INREG [[LSHR]], 16
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[SEXT_INREG]](s32)
+    %0:_(<2 x s16>) = COPY $r0
+    %1(s16), %2(s16) = G_UNMERGE_VALUES %0(<2 x s16>)
+    %3(s32) = G_SEXT %2(s16)
+    PseudoRET implicit $lr, implicit %3
+...
+---
+name:           test_unmerge_v4s8
+registers:
+  - { id: 0, class: _, preferred-register: '' }
+  - { id: 1, class: _, preferred-register: '' }
+  - { id: 2, class: _, preferred-register: '' }
+  - { id: 3, class: _, preferred-register: '' }
+  - { id: 4, class: _, preferred-register: '' }
+  - { id: 5, class: _, preferred-register: '' }
+  - { id: 6, class: _, preferred-register: '' }
+  - { id: 7, class: _, preferred-register: '' }
+  - { id: 8, class: _, preferred-register: '' }
+legalized: false
+body:             |
+  bb.0.entry:
+    liveins: $r0
+    ; CHECK-LABEL: name: test_unmerge_v4s8
+    ; CHECK: liveins: $r0
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<4 x s8>) = COPY $r0
+    ; CHECK-NEXT: [[BITCAST:%[0-9]+]]:_(s32) = G_BITCAST [[COPY]](<4 x s8>)
+    ; CHECK-NEXT: [[C:%[0-9]+]]:_(s32) = G_CONSTANT i32 24
+    ; CHECK-NEXT: [[LSHR:%[0-9]+]]:_(s32) = G_LSHR [[BITCAST]], [[C]](s32)
+    ; CHECK-NEXT: [[SEXT_INREG:%[0-9]+]]:_(s32) = G_SEXT_INREG [[LSHR]], 8
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[SEXT_INREG]](s32)
+    %0:_(<4 x s8>) = COPY $r0
+    %1(s8), %2(s8), %3(s8), %4(s8) = G_UNMERGE_VALUES %0(<4 x s8>)
+    %5(s32) = G_SEXT %4(s8)
+    PseudoRET implicit $lr, implicit %5
+...
+---
+name:           test_unmerge_32bit_order
+registers:
+  - { id: 0, class: _, preferred-register: '' }
+  - { id: 1, class: _, preferred-register: '' }
+  - { id: 2, class: _, preferred-register: '' }
+  - { id: 3, class: _, preferred-register: '' }
+  - { id: 4, class: _, preferred-register: '' }
+  - { id: 5, class: _, preferred-register: '' }
+  - { id: 6, class: _, preferred-register: '' }
+  - { id: 7, class: _, preferred-register: '' }
+  - { id: 8, class: _, preferred-register: '' }
+legalized: false
+body:             |
+  bb.0.entry:
+    liveins: $r0
+    ; CHECK-LABEL: name: test_unmerge_32bit_order
+    ; CHECK: liveins: $r0
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<4 x s8>) = COPY $r0
+    ; CHECK-NEXT: [[BITCAST:%[0-9]+]]:_(s32) = G_BITCAST [[COPY]](<4 x s8>)
+    ; CHECK-NEXT: [[C:%[0-9]+]]:_(s32) = G_CONSTANT i32 8
+    ; CHECK-NEXT: [[LSHR:%[0-9]+]]:_(s32) = G_LSHR [[BITCAST]], [[C]](s32)
+    ; CHECK-NEXT: [[C1:%[0-9]+]]:_(s32) = G_CONSTANT i32 16
+    ; CHECK-NEXT: [[LSHR1:%[0-9]+]]:_(s32) = G_LSHR [[BITCAST]], [[C1]](s32)
+    ; CHECK-NEXT: [[C2:%[0-9]+]]:_(s32) = G_CONSTANT i32 24
+    ; CHECK-NEXT: [[LSHR2:%[0-9]+]]:_(s32) = G_LSHR [[BITCAST]], [[C2]](s32)
+    ; CHECK-NEXT: [[SEXT_INREG:%[0-9]+]]:_(s32) = G_SEXT_INREG [[BITCAST]], 8
+    ; CHECK-NEXT: [[SEXT_INREG1:%[0-9]+]]:_(s32) = G_SEXT_INREG [[LSHR]], 8
+    ; CHECK-NEXT: [[SEXT_INREG2:%[0-9]+]]:_(s32) = G_SEXT_INREG [[LSHR1]], 8
+    ; CHECK-NEXT: [[SEXT_INREG3:%[0-9]+]]:_(s32) = G_SEXT_INREG [[LSHR2]], 8
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[SEXT_INREG]](s32), implicit [[SEXT_INREG1]](s32), implicit [[SEXT_INREG2]](s32), implicit [[SEXT_INREG3]](s32)
+    %0:_(<4 x s8>) = COPY $r0
+    %1(s8), %2(s8), %3(s8), %4(s8) = G_UNMERGE_VALUES %0(<4 x s8>)
+    %5(s32) = G_SEXT %1(s8)
+    %6(s32) = G_SEXT %2(s8)
+    %7(s32) = G_SEXT %3(s8)
+    %8(s32) = G_SEXT %4(s8)
+    PseudoRET implicit $lr, implicit %5, implicit %6, implicit %7, implicit %8


### PR DESCRIPTION
In the AIE2 architecture, there is not a complete correspondence between the capacities for the full-sized vector load instruction and the 128-bit vector load instruction. For this combiner we make use of the Shift-Round-Saturate variant, but this doesn't exist for the 128-bit instruction.