### PR TITLE
[aie2] fix startup checks

### DIFF
--- a/clang/test/Driver/aie2/aie2-startup.c
+++ b/clang/test/Driver/aie2/aie2-startup.c
@@ -11,6 +11,6 @@
 // RUN: %clang %s -### --target=aie2-none-unknown-elf -ccc-install-dir  %S/../Inputs/basic_aie_tree/bin 2>&1 \
 // RUN:   | FileCheck -check-prefix=LIBS %s
 // LIBS: "{{.*}}ld.lld"
-// LIBS-SAME: "{{.*}}/lib/clang/{{.*}}/lib/aie2-none-unknown-elf/libclang_rt.builtins.a"
+// LIBS-SAME: "{{.*}}/lib/clang/{{.*}}/lib/{{(aie2-none-unknown-elf/libclang_rt.builtins.a)|(libclang_rt.builtins-aie2.a)}}"
 // LIBS-SAME: "{{.*}}/lib/aie2-none-unknown-elf/crt0.o"
 // LIBS-SAME: "{{.*}}/lib/aie2-none-unknown-elf/crt1.o"


### PR DESCRIPTION
Depending on how clang is configured, this test can have multiple correct answers.