### PR TITLE
Update CI names

### DIFF
--- a/.github/workflows/amd-aie-tests.yml
+++ b/.github/workflows/amd-aie-tests.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   check_all:
     if: github.repository_owner == 'Xilinx'
-    name: Test llvm,clang
+    name: Test AIE llvm,clang,lld
     uses: ./.github/workflows/llvm-project-tests.yml
     with:
       build_target: check-llvm-aie check-clang-aie check-lld-aie

--- a/.github/workflows/amd-aie-tests.yml
+++ b/.github/workflows/amd-aie-tests.yml
@@ -13,9 +13,11 @@ on:
       - 'aie-public'
 
 concurrency:
-  # Skip intermediate builds: always.
+  # A PR number if a pull request and otherwise the commit hash. This cancels
+  # queued and in-progress runs for the same PR (presubmit) or commit
+  # (postsubmit).
   # Cancel intermediate builds: only if it is a pull request build.
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.number || github.sha }}
   cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 
 jobs:

--- a/.github/workflows/amd-upstream-tests.yml
+++ b/.github/workflows/amd-upstream-tests.yml
@@ -21,21 +21,23 @@ concurrency:
 jobs:
   check_all:
     if: github.repository_owner == 'Xilinx'
-    name: Test llvm,clang
+    name: Test upstream llvm,clang
     uses: ./.github/workflows/llvm-project-tests.yml
     with:
       build_target: check-all
       projects: clang
       cache-key: amd-upstream
-      extra_cmake_args: '-DLLVM_USE_LINKER=gold -DLLVM_TARGETS_TO_BUILD="X86;ARM;AArch64;AMDGPU"'
+      extra_cmake_args: '-DLLVM_USE_LINKER=gold -DLLVM_TARGETS_TO_BUILD="X86;ARM;AArch64;AMDGPU" -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=""'
       os_list: '["ubuntu-latest", "windows-2019"]'
 
   check_lld:
     if: github.repository_owner == 'Xilinx'
-    name: Test lld
+    name: Test upstream lld
     uses: ./.github/workflows/llvm-project-tests.yml
     with:
       build_target: check-lld
       projects: lld
+      cache-key: amd-upstream
+      extra_cmake_args: '-DLLVM_USE_LINKER=gold -DLLVM_TARGETS_TO_BUILD="X86;ARM;AArch64;AMDGPU" -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=""'
       os_list: '["ubuntu-latest", "windows-2019"]'
 

--- a/.github/workflows/amd-upstream-tests.yml
+++ b/.github/workflows/amd-upstream-tests.yml
@@ -13,9 +13,11 @@ on:
       - 'aie-public'
 
 concurrency:
-  # Skip intermediate builds: always.
+  # A PR number if a pull request and otherwise the commit hash. This cancels
+  # queued and in-progress runs for the same PR (presubmit) or commit
+  # (postsubmit).
   # Cancel intermediate builds: only if it is a pull request build.
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.number || github.sha }}
   cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 
 jobs:


### PR DESCRIPTION
The job names show up in branch protection rules, so make these a little more descriptive.