### PR TITLE
[AIE] take care when creating check-lld-aie target

### DIFF
--- a/lld/CMakeLists.txt
+++ b/lld/CMakeLists.txt
@@ -206,6 +206,8 @@ add_subdirectory(wasm)
 add_subdirectory(cmake/modules)
 
 add_custom_target(check-lld-aie)
-add_dependencies(check-lld-aie 
-  check-lld-elf-aie
-)
+if(EXISTS check-lld-elf-aie)
+  add_dependencies(check-lld-aie 
+    check-lld-elf-aie
+  )
+endif()


### PR DESCRIPTION
Under some configurations, the dependencies might not exist.