### PR TITLE
[AIE2] Support broadcast_to_v16accfloat and broadcast_to_v16float

### DIFF
--- a/clang/include/clang/Basic/BuiltinsAIE.def
+++ b/clang/include/clang/Basic/BuiltinsAIE.def
@@ -272,7 +272,6 @@ BUILTIN(__builtin_aiev2_vbroadcast64_I512, "V16iV2i", "nc")
 BUILTIN(__builtin_aiev2_vbroadcast_bf16_bf512, "V32yy", "nc")
 BUILTIN(__builtin_aiev2_vbroadcast_bf32_bf512, "V32yV2y", "nc")
 BUILTIN(__builtin_aiev2_vbroadcast_bf64_bf512, "V32yV4y", "nc")
-BUILTIN(__builtin_aiev2_vbroadcastfloat_I512, "V16ff", "nc")
 BUILTIN(__builtin_aiev2_vbroadcast_zero_acc1024, "V16m", "nc")
 //scl2vec::broadcast_elem
 BUILTIN(__builtin_aiev2_vextract_broadcast8_I512, "V64cV64ci", "nc")

--- a/clang/lib/Headers/aiev2_scl2vec.h
+++ b/clang/lib/Headers/aiev2_scl2vec.h
@@ -521,13 +521,15 @@ broadcast_to_v32bfloat16(v4bfloat16 b) {
 
 INTRINSIC(v16accfloat)
 broadcast_to_v16accfloat(float b) {
-  return __builtin_aiev2_vbroadcastfloat_I512(b);
+  int as_int = __builtin_bit_cast(int, b);
+  return __builtin_aiev2_vbroadcast32_I512(as_int);
 }
 
-#if 0
 INTRINSIC(v16float)
-broadcast_to_v16float (float b) { return __builtin_aiev2_vbroadcast32_I512(b); }
-#endif
+broadcast_to_v16float(float b) {
+  int as_int = __builtin_bit_cast(int, b);
+  return __builtin_aiev2_vbroadcast32_I512(as_int);
+}
 
 INTRINSIC(v32bfloat16)
 broadcast_zero_to_v32bfloat16() { return broadcast_to_v32bfloat16(0); }

--- a/clang/test/CodeGen/aie/aie2/aie2-scl2vec-intrinsic.cpp
+++ b/clang/test/CodeGen/aie/aie2/aie2-scl2vec-intrinsic.cpp
@@ -1162,12 +1162,24 @@ v16accfloat test_shift(v16accfloat a, v16accfloat b, int shift_by) {
 
 // CHECK-LABEL: @_Z29test_broadcast_to_v16accfloatf(
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[TMP0:%.*]] = tail call <16 x float> @llvm.aie2.vbroadcastfloat.I512(float [[B:%.*]])
-// CHECK-NEXT:    [[TMP1:%.*]] = bitcast <16 x float> [[TMP0]] to <8 x i64>
-// CHECK-NEXT:    ret <8 x i64> [[TMP1]]
+// CHECK-NEXT:    [[TMP0:%.*]] = bitcast float [[B:%.*]] to i32
+// CHECK-NEXT:    [[TMP1:%.*]] = tail call <16 x i32> @llvm.aie2.vbroadcast32.I512(i32 [[TMP0]])
+// CHECK-NEXT:    [[TMP2:%.*]] = bitcast <16 x i32> [[TMP1]] to <8 x i64>
+// CHECK-NEXT:    ret <8 x i64> [[TMP2]]
 //
 v16accfloat test_broadcast_to_v16accfloat (float b) {
    return  broadcast_to_v16accfloat(b);
+}
+
+// CHECK-LABEL: @_Z26test_broadcast_to_v16floatf(
+// CHECK-NEXT:  entry:
+// CHECK-NEXT:    [[TMP0:%.*]] = bitcast float [[B:%.*]] to i32
+// CHECK-NEXT:    [[TMP1:%.*]] = tail call <16 x i32> @llvm.aie2.vbroadcast32.I512(i32 [[TMP0]])
+// CHECK-NEXT:    [[TMP2:%.*]] = bitcast <16 x i32> [[TMP1]] to <16 x float>
+// CHECK-NEXT:    ret <16 x float> [[TMP2]]
+//
+v16float test_broadcast_to_v16float (float b) {
+   return  broadcast_to_v16float(b);
 }
 
 // CHECK-LABEL: @_Z11test_shiftxDv32_u6__bf16S_ii(

--- a/llvm/include/llvm/IR/IntrinsicsAIE2.td
+++ b/llvm/include/llvm/IR/IntrinsicsAIE2.td
@@ -721,7 +721,6 @@ def int_aie2_vbroadcast64_I512 : ClangBuiltin<"__builtin_aiev2_vbroadcast64_I512
 def int_aie2_vbroadcast16_bf512 : ClangBuiltin<"__builtin_aiev2_vbroadcast_bf16_bf512">, AIEV2VBCST16bf512;
 def int_aie2_vbroadcast32_bf512 : ClangBuiltin<"__builtin_aiev2_vbroadcast_bf32_bf512">, AIEV2VBCST32bf512;
 def int_aie2_vbroadcast64_bf512 : ClangBuiltin<"__builtin_aiev2_vbroadcast_bf64_bf512">, AIEV2VBCST64bf512;
-def int_aie2_vbroadcastfloat_I512 : ClangBuiltin<"__builtin_aiev2_vbroadcastfloat_I512">, AIEV2VBCSTF32I512;
 def int_aie2_vbroadcast_zero_acc1024 : ClangBuiltin<"__builtin_aiev2_vbroadcast_zero_acc1024">, AIEV2VCLRACC1024;
 //scl2vec::broadcast_elem
 def int_aie2_vextract_broadcast8_I512  : ClangBuiltin<"__builtin_aiev2_vextract_broadcast8_I512">, AIEV2VEXTBCST8I512;


### PR DESCRIPTION
These "frontend intrinsics" were not properly supported and would crash the compiler if used. They now use __builtin_aiev2_vbroadcast32_I512 and are eventually selected to a VBCST_32 instruction. There is already an ISel test for this. See aie2/GlobalISel/inst-select-vbcst.mir.