### PR TITLE
[AIE] Internalize non-kernel symbols.

### DIFF
--- a/llvm/lib/Target/AIE/AIE2TargetMachine.h
+++ b/llvm/lib/Target/AIE/AIE2TargetMachine.h
@@ -43,9 +43,6 @@ public:
   TargetPassConfig *createPassConfig(PassManagerBase &PM) override;
   /// PostRAScheduling is scheduled as part of PreSched2 passes.
   bool targetSchedulesPostRAScheduling() const override { return true; }
-  void registerDefaultAliasAnalyses(AAManager &) override;
-  void registerPassBuilderCallbacks(PassBuilder &PB,
-                                    bool PopulateClassToPassNames) override;
 };
 
 } // namespace llvm

--- a/llvm/lib/Target/AIE/AIETargetMachine.h
+++ b/llvm/lib/Target/AIE/AIETargetMachine.h
@@ -50,6 +50,10 @@ public:
   MachineFunctionInfo *
   createMachineFunctionInfo(BumpPtrAllocator &Allocator, const Function &F,
                             const TargetSubtargetInfo *STI) const override;
+
+  void registerDefaultAliasAnalyses(AAManager &) override;
+  void registerPassBuilderCallbacks(PassBuilder &PB,
+                                    bool PopulateClassToPassNames) override;
 };
 
 class AIETargetMachine : public AIEBaseTargetMachine {

--- a/llvm/lib/Target/AIE/CMakeLists.txt
+++ b/llvm/lib/Target/AIE/CMakeLists.txt
@@ -117,6 +117,7 @@ add_llvm_target(AIECodeGen
    Core
    CodeGen
    CodeGenTypes
+   IPO
    MC
    AIEAsmPrinter
    AIEDesc

--- a/llvm/test/CodeGen/AIE/aie1/llc-pipeline.ll
+++ b/llvm/test/CodeGen/AIE/aie1/llc-pipeline.ll
@@ -24,6 +24,8 @@
 ; AIE-O0123-NEXT:Machine Module Information
 ; AIE-O0123-NEXT:Target Transform Information
 
+; AIE-O123-NEXT:AIE complex addressing modes based Alias Analysis
+; AIE-O123-NEXT:External Alias Analysis
 ; AIE-O123-NEXT:Type-Based Alias Analysis
 ; AIE-O123-NEXT:Scoped NoAlias Alias Analysis
 ; AIE-O123-NEXT:Assumption Cache Tracker

--- a/llvm/test/CodeGen/AIE/internalize.ll
+++ b/llvm/test/CodeGen/AIE/internalize.ll
@@ -1,0 +1,116 @@
+; RUN: opt -O1 -S -mtriple=aie2-none-unknown-elf -aie-internalize-symbols < %s | FileCheck --check-prefix=ONLYMAIN %s
+; RUN: opt -O1 -S -mtriple=aie2-none-unknown-elf -aie-internalize-symbols -aie-internalize-skip-functions="skipfunc1,skipfunc2,skipfunc3" < %s | FileCheck --check-prefix=FUNCLIST %s
+
+; ONLYMAIN-NOT: @gvar_unused
+; FUNCLIST-NOT: @gvar_unused
+@gvar_unused = addrspace(1) global i32 undef, align 4
+
+; ONLYMAIN: @gvar_used{{.*}}addrspace(1) global i32 undef, align 4
+; FUNCLIST: @gvar_used{{.*}}addrspace(1) global i32 undef, align 4
+@gvar_used = addrspace(1) global i32 undef, align 4
+
+; ONLYMAIN: @gvar_func_ptr{{.*}}global ptr null
+; FUNCLIST: @gvar_func_ptr{{.*}}global ptr null
+@gvar_func_ptr = global ptr null
+
+; ONLYMAIN-NOT: define{{.*}}void @func_unused
+; FUNCLIST-NOT: define{{.*}}void @func_unused
+define void @func_unused(ptr addrspace(1) %out, i32 %val) {
+entry:
+  store volatile i32 %val, ptr addrspace(1) %out
+  ret void
+}
+
+; ONLYMAIN: define{{.*}}void @func_used_noinline
+; FUNCLIST-NOT: define{{.*}}void @func_used_noinline
+define void @func_used_noinline(ptr addrspace(1) %out, i32 %val) #0 {
+entry:
+  store volatile i32 %val, ptr addrspace(1) %out
+  ret void
+}
+
+; ONLYMAIN-NOT: define{{.*}}void @func_used_alwaysinline
+; FUNCLIST-NOT: define{{.*}}void @func_used_alwaysinline
+define void @func_used_alwaysinline(ptr addrspace(1) %out, i32 %val) #1 {
+entry:
+  store volatile i32 %val, ptr addrspace(1) %out
+  ret void
+}
+
+; ONLYMAIN: declare void @decl_func()
+; FUNCLIST-NOT: declare void @decl_func()
+declare void @decl_func()
+
+; ONLYMAIN: define{{.*}}void @main()
+; ONLYMAIN: call{{.*}}void @func_used_noinline
+; ONLYMAIN: store volatile
+; ONLYMAIN: call{{.*}}void @decl_func()
+; ONLYMAIN: ret void
+; FUNCLIST-NOT: define{{.*}}void @main()
+define void @main() {
+entry:
+    %val = add i32 42, 0
+    tail call fastcc void @func_used_noinline(ptr addrspace(1) @gvar_used, i32 %val)
+    tail call fastcc void @func_used_alwaysinline(ptr addrspace(1) @gvar_used, i32 %val)
+    tail call fastcc void @decl_func()
+    ret void
+}
+
+; ONLYMAIN-NOT: define{{.*}}@func_used_skipfunc1
+; FUNCLIST: define{{.*}}void @func_used_skipfunc1
+define void @func_used_skipfunc1(ptr addrspace(1) %out, i32 %val) #0 {
+entry:
+  store i32 %val, ptr addrspace(1) %out
+  ret void
+}
+
+; ONLYMAIN-NOT: define{{.*}}@skipfunc1()
+; FUNCLIST: define{{.*}}void @skipfunc1()
+; FUNCLIST: call{{.*}}void @func_used_skipfunc1
+; FUNCLIST: ret void
+define void @skipfunc1() {
+entry:
+    %val = add i32 42, 0
+    tail call fastcc void @func_used_skipfunc1(ptr addrspace(1) @gvar_used, i32 %val)
+    ret void
+}
+
+; ONLYMAIN-NOT: define{{.*}}void @func_used_skipfunc2
+; FUNCLIST: define{{.*}}void @func_used_skipfunc2
+define void @func_used_skipfunc2(ptr addrspace(1) %out, i32 %val) #0 {
+entry:
+  store i32 %val, ptr addrspace(1) %out
+  ret void
+}
+
+; ONLYMAIN-NOT: define{{.*}}@skipfunc2()
+; FUNCLIST: define{{.*}}void @skipfunc2()
+; FUNCLIST: call{{.*}}void @func_used_skipfunc2
+; FUNCLIST: ret void
+define void @skipfunc2() {
+entry:
+    %val = add i32 42, 0
+    tail call fastcc void @func_used_skipfunc2(ptr addrspace(1) @gvar_used, i32 %val)
+    ret void
+}
+
+; ONLYMAIN-NOT: define{{.*}}@func_used_skipfunc3
+; FUNCLIST: define{{.*}}void @func_used_skipfunc3
+define void @func_used_skipfunc3(ptr addrspace(1) %out, i32 %val) #0 {
+entry:
+  store i32 %val, ptr addrspace(1) %out
+  ret void
+}
+
+; ONLYMAIN-NOT: define{{.*}}@skipfunc3()
+; FUNCLIST: define{{.*}}void @skipfunc3()
+; FUNCLIST: store ptr @func_used_skipfunc3, ptr @gvar_func_ptr, align 4
+; FUNCLIST: ret void
+define void @skipfunc3() {
+entry:
+    store ptr @func_used_skipfunc3, ptr @gvar_func_ptr, align 4
+    ret void
+}
+
+attributes #0 = { noinline nounwind }
+attributes #1 = { alwaysinline nounwind }


### PR DESCRIPTION
This saves compilation time, size of the final
executable, and size of any intermediate dumps.

Run Internalize pass early in the opt pipeline followed by global DCE pass. To enable it RT can pass -aie-internalize-symbols option.

Edit: Also some refactoring.