### PR TITLE
[AIE] Pass -nostdlib to the Peano builtins and runtimes build

### DIFF
--- a/clang/cmake/caches/Peano-AIE-runtime-libraries.cmake
+++ b/clang/cmake/caches/Peano-AIE-runtime-libraries.cmake
@@ -25,6 +25,13 @@ foreach(target ${LLVM_BUILTIN_TARGETS})
   set(BUILTINS_${target}_CMAKE_C_FLAGS "--target=${target}" CACHE STRING "")
   set(BUILTINS_${target}_CMAKE_CXX_FLAGS "--target=${target}" CACHE STRING "")
   set(BUILTINS_${target}_CMAKE_ASM_FLAGS "--target=${target}" CACHE STRING "")
+  # The runtimes CMake system passes the LLVM_USE_LINKER option set for the host
+  # compilation down to the runtimes build. That triggers a compile & link check
+  # for the cross compiler, which does not have a complete sysroot yet.
+  # As a workaround, pass -nostdlib to the cross compiler. The runtimes build
+  # shouldn't expect the stdlibs to be available anyway
+  set(BUILTINS_${target}_CMAKE_EXE_LINKER_FLAGS "-nostdlib" CACHE STRING "")
+  set(RUNTIMES_${target}_CMAKE_EXE_LINKER_FLAGS "-nostdlib" CACHE STRING "")
 endforeach()
 
 set(LIBCXX_ENABLE_SHARED OFF CACHE BOOL "")


### PR DESCRIPTION
When building Peano with a custom linker, e.g. ld.lld, the option LLVM_ENABLE_LLD is also passed to the runtimes build. That triggers a CMake compile check while configuring the runtimes build, which fails because we try to link the standard libraries.

This patch adds the -nostdlib option to the runtimes linker options, allowing the check to succeed.