### PR TITLE
[AIE2] More robust ISel for 128-bit set/extract intrinsics

### DIFF
--- a/llvm/lib/Target/AIE/AIE2InstructionSelector.cpp
+++ b/llvm/lib/Target/AIE/AIE2InstructionSelector.cpp
@@ -4915,10 +4915,11 @@ bool AIE2InstructionSelector::selectExtractI128(MachineInstr &I,
     llvm_unreachable("Unexpected input size for extracting 128-bit vector");
   }
 
-  // Select using a COPY to W registers. The upper half will be undefined.
-  MIB.buildInstr(TargetOpcode::COPY, {DstReg}, {}).addReg(SrcReg, 0, SubReg);
-  if (!RBI.constrainGenericRegister(DstReg, AIE2::VEC128RegClass, MRI))
-    return false;
+  // Select using a COPY to a 128-bit register.
+  MachineInstr *CopyMI = MIB.buildInstr(TargetOpcode::COPY, {DstReg}, {})
+                             .addReg(SrcReg, 0, SubReg);
+  constrainOperandRegClass(*MF, TRI, MRI, TII, RBI, *CopyMI,
+                           AIE2::VEC128RegClass, CopyMI->getOperand(0));
 
   I.eraseFromParent();
   return true;

--- a/llvm/lib/Target/AIE/AIE2InstructionSelector.cpp
+++ b/llvm/lib/Target/AIE/AIE2InstructionSelector.cpp
@@ -616,19 +616,10 @@ bool AIE2InstructionSelector::select(MachineInstr &I) {
     case Intrinsic::aie2_get_coreid:
       return selectGetCoreID(I, MRI);
 
-    case Intrinsic::aie2_get_I256_I128: {
-      Register DstReg = I.getOperand(0).getReg();
-      Register SrcReg = I.getOperand(2).getReg();
-      auto CopyInstr =
-          MIB.buildInstr(TargetOpcode::COPY, {DstReg}, {}).addReg(SrcReg);
-      if (!selectCopy(*CopyInstr, MRI))
-        return false;
-      I.eraseFromParent();
-      return true;
-    }
     case Intrinsic::aie2_extract_I128_I512:
       return selectExtractI128(I, I.getOperand(0).getReg(),
                                I.getOperand(2).getReg(), MRI);
+    case Intrinsic::aie2_get_I256_I128:
     case Intrinsic::aie2_set_I512_I128:
       return selectSetI128(I, I.getOperand(0), I.getOperand(2), MRI);
     default:

--- a/llvm/test/CodeGen/AIE/aie2/GlobalISel/inst-select-128bit-intrinsics.mir
+++ b/llvm/test/CodeGen/AIE/aie2/GlobalISel/inst-select-128bit-intrinsics.mir
@@ -50,23 +50,44 @@ body:             |
 ...
 
 ---
-name:            test_set_v32int16
+name:            test_set_128_in_512
 legalized:       true
 regBankSelected: true
 body:             |
   bb.1.entry:
     liveins: $q0
 
-    ; CHECK-LABEL: name: test_set_v32int16
+    ; CHECK-LABEL: name: test_set_128_in_512
     ; CHECK: liveins: $q0
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:vec128 = COPY $q0
     ; CHECK-NEXT: [[COPY1:%[0-9]+]]:vec256 = COPY [[COPY]]
-    ; CHECK-NEXT: [[DEF:%[0-9]+]]:vec256 = IMPLICIT_DEF
-    ; CHECK-NEXT: [[REG_SEQUENCE:%[0-9]+]]:vec512 = REG_SEQUENCE [[COPY1]], %subreg.sub_256_lo, [[DEF]], %subreg.sub_256_hi
+    ; CHECK-NEXT: [[REG_SEQUENCE:%[0-9]+]]:vec512 = REG_SEQUENCE [[COPY1]], %subreg.sub_256_lo
     ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[REG_SEQUENCE]]
     %1:vregbank(<4 x s32>) = COPY $q0
     %2:vregbank(<16 x s32>) = G_INTRINSIC intrinsic(@llvm.aie2.set.I512.I128), %1(<4 x s32>)
     PseudoRET implicit $lr, implicit %2
+...
 
+# Similar to above, but the ins/outs are already in "annoying" reg classes
+---
+name:            test_set_128_in_512_regclass
+legalized:       true
+regBankSelected: true
+body:             |
+  bb.1.entry:
+    liveins: $q0
+
+    ; CHECK-LABEL: name: test_set_128_in_512_regclass
+    ; CHECK: liveins: $q0
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:mws = COPY $q0
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:vec128 = COPY [[COPY]]
+    ; CHECK-NEXT: [[COPY2:%[0-9]+]]:vec256 = COPY [[COPY1]]
+    ; CHECK-NEXT: [[REG_SEQUENCE:%[0-9]+]]:vec512 = REG_SEQUENCE [[COPY2]], %subreg.sub_256_lo
+    ; CHECK-NEXT: [[COPY3:%[0-9]+]]:ebml = COPY [[REG_SEQUENCE]]
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[COPY3]]
+    %1:mws(<4 x s32>) = COPY $q0
+    %2:ebml(<16 x s32>) = G_INTRINSIC intrinsic(@llvm.aie2.set.I512.I128), %1(<4 x s32>)
+    PseudoRET implicit $lr, implicit %2
 ...

--- a/llvm/test/CodeGen/AIE/aie2/GlobalISel/inst-select-128bit-intrinsics.mir
+++ b/llvm/test/CodeGen/AIE/aie2/GlobalISel/inst-select-128bit-intrinsics.mir
@@ -6,16 +6,16 @@
 #
 # (c) Copyright 2023-2024 Advanced Micro Devices, Inc. or its affiliates
 # RUN: llc -mtriple aie2 -run-pass=instruction-select %s -verify-machineinstrs -o - | FileCheck %s
-...
+
 ---
-name:            test_extract_v4int32
+name:            test_extract_512_to_128
 legalized:       true
 regBankSelected: true
 body:             |
   bb.1.entry:
     liveins: $x2
 
-    ; CHECK-LABEL: name: test_extract_v4int32
+    ; CHECK-LABEL: name: test_extract_512_to_128
     ; CHECK: liveins: $x2
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:vec512 = COPY $x2
@@ -24,8 +24,31 @@ body:             |
     %1:vregbank(<16 x s32>) = COPY $x2
     %2:vregbank(<4 x s32>) = G_INTRINSIC intrinsic(@llvm.aie2.extract.I128.I512), %1(<16 x s32>)
     PseudoRET implicit $lr, implicit %2
-
 ...
+
+# Similar to above, but the ins/outs are already in "annoying" reg classes
+---
+name:            test_extract_512_to_128_regclass
+legalized:       true
+regBankSelected: true
+body:             |
+  bb.1.entry:
+    liveins: $x2
+
+    ; CHECK-LABEL: name: test_extract_512_to_128_regclass
+    ; CHECK: liveins: $x2
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:ebml = COPY $x2
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:vec128 = COPY [[COPY]].sub_256_lo
+    ; CHECK-NEXT: [[COPY2:%[0-9]+]]:mws = COPY [[COPY1]]
+    ; CHECK-NEXT: $q0 = COPY [[COPY2]]
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit $q0
+    %1:ebml(<16 x s32>) = COPY $x2
+    %2:mws(<4 x s32>) = G_INTRINSIC intrinsic(@llvm.aie2.extract.I128.I512), %1(<16 x s32>)
+    $q0 = COPY %2
+    PseudoRET implicit $lr, implicit $q0
+...
+
 ---
 name:            test_set_v32int16
 legalized:       true

--- a/llvm/test/CodeGen/AIE/aie2/GlobalISel/inst-select-128bit-intrinsics.mir
+++ b/llvm/test/CodeGen/AIE/aie2/GlobalISel/inst-select-128bit-intrinsics.mir
@@ -91,3 +91,44 @@ body:             |
     %2:ebml(<16 x s32>) = G_INTRINSIC intrinsic(@llvm.aie2.set.I512.I128), %1(<4 x s32>)
     PseudoRET implicit $lr, implicit %2
 ...
+
+---
+name:            test_set_128_in_256
+legalized:       true
+regBankSelected: true
+body:             |
+  bb.1.entry:
+    liveins: $q0
+
+    ; CHECK-LABEL: name: test_set_128_in_256
+    ; CHECK: liveins: $q0
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:vec128 = COPY $q0
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:vec256 = COPY [[COPY]]
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[COPY1]]
+    %1:vregbank(<4 x s32>) = COPY $q0
+    %2:vregbank(<8 x s32>) = G_INTRINSIC intrinsic(@llvm.aie2.get.I256.I128), %1(<4 x s32>)
+    PseudoRET implicit $lr, implicit %2
+...
+
+# Similar to above, but the ins/outs are already in "annoying" reg classes
+---
+name:            test_set_128_in_256_regclass
+legalized:       true
+regBankSelected: true
+body:             |
+  bb.1.entry:
+    liveins: $q0
+
+    ; CHECK-LABEL: name: test_set_128_in_256_regclass
+    ; CHECK: liveins: $q0
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:mws = COPY $q0
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:vec128 = COPY [[COPY]]
+    ; CHECK-NEXT: [[COPY2:%[0-9]+]]:vec256 = COPY [[COPY1]]
+    ; CHECK-NEXT: [[COPY3:%[0-9]+]]:eamll = COPY [[COPY2]]
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[COPY3]]
+    %1:mws(<4 x s32>) = COPY $q0
+    %2:eamll(<8 x s32>) = G_INTRINSIC intrinsic(@llvm.aie2.get.I256.I128), %1(<4 x s32>)
+    PseudoRET implicit $lr, implicit %2
+...

--- a/llvm/test/CodeGen/AIE/aie2/GlobalISel/inst-select-128bit-pad-vector.mir
+++ b/llvm/test/CodeGen/AIE/aie2/GlobalISel/inst-select-128bit-pad-vector.mir
@@ -34,8 +34,7 @@ body:             |
     ; CHECK-LABEL: name: test_unpad_512_bit_v16int32
     ; CHECK: [[COPY:%[0-9]+]]:vec128 = COPY $q0
     ; CHECK-NEXT: [[COPY1:%[0-9]+]]:vec256 = COPY [[COPY]]
-    ; CHECK-NEXT: [[DEF:%[0-9]+]]:vec256 = IMPLICIT_DEF
-    ; CHECK-NEXT: [[REG_SEQUENCE:%[0-9]+]]:vec512 = REG_SEQUENCE [[COPY1]], %subreg.sub_256_lo, [[DEF]], %subreg.sub_256_hi
+    ; CHECK-NEXT: [[REG_SEQUENCE:%[0-9]+]]:vec512 = REG_SEQUENCE [[COPY1]], %subreg.sub_256_lo
     ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[REG_SEQUENCE]]
     %1:vregbank(<4 x s32>) = COPY $q0
     %2:vregbank(<16 x s32>) = G_AIE_PAD_VECTOR_UNDEF %1


### PR DESCRIPTION
We would fail when the ins/outs were already constrained into "not nice" register classes.