### PR TITLE
[AIEX] Make computeAndFinalizeBundles resilient to pre-RA rescheduling

### DIFF
--- a/llvm/lib/Target/AIE/AIEBaseInstrInfo.h
+++ b/llvm/lib/Target/AIE/AIEBaseInstrInfo.h
@@ -29,42 +29,61 @@ namespace llvm {
 
 struct AIEBaseInstrInfo : public TargetInstrInfo {
   using TargetInstrInfo::TargetInstrInfo;
-  /// Return the opcode for a return instruction
 
-  virtual unsigned getReturnOpcode() const = 0;
+  /// Return the opcode for a return instruction
+  virtual unsigned getReturnOpcode() const {
+    llvm_unreachable("Target didn't implement getReturnOpcode");
+  }
 
   /// Return the opcode for a call instruction
   /// \param CallerF The function that makes the call
   /// \param IsIndirect Select function pointer call or direct call
   /// \param Select a tail call variant.
   virtual unsigned getCallOpcode(const MachineFunction &CallerF,
-                                 bool IsIndirect, bool IsTailCall) const = 0;
+                                 bool IsIndirect, bool IsTailCall) const {
+    llvm_unreachable("Target didn't implement getCallOpcode");
+  }
+
   /// Return the kind of slot that this instruction can be executed in.
   /// This is used to direct the packetization of simple instructions.
   /// NOTE: If this is called on a Composite Instruction (i.e. an instruction
   /// defining a Packet format, owning possibly multiples slots), the returned
   /// slot will be the default one (unknown).
-  virtual MCSlotKind getSlotKind(unsigned Opcode) const = 0;
-  virtual const MCSlotInfo *getSlotInfo(const MCSlotKind Kind) const = 0;
+  virtual MCSlotKind getSlotKind(unsigned Opcode) const {
+    llvm_unreachable("Target didn't implement getSlotKind");
+  }
+  virtual const MCSlotInfo *getSlotInfo(const MCSlotKind Kind) const {
+    llvm_unreachable("Target didn't implement getSlotInfo");
+  }
   /// Return the Packet formats for this target
-  virtual const PacketFormats &getPacketFormats() const = 0;
+  virtual const PacketFormats &getPacketFormats() const {
+    llvm_unreachable("Target didn't implement getPacketFormats");
+  }
   /// Return a nop of the given byte size, or the smallest if zero.
-  virtual unsigned getNopOpcode(size_t Size = 0) const = 0;
+  virtual unsigned getNopOpcode(size_t Size = 0) const {
+    llvm_unreachable("Target didn't implement getNopOpcode");
+  }
   /// Return an opcode that reverses the branch condition of a given
   /// instruction
   /// \param Opc Opcode of the branch to reverse
   /// \pre Opc must be a conditional branch
-  virtual unsigned getOppositeBranchOpcode(unsigned Opc) const = 0;
+  virtual unsigned getOppositeBranchOpcode(unsigned Opc) const {
+    llvm_unreachable("Target didn't implement getOppositeBranchOpcode");
+  }
   /// Return the opcode of an unconditional jump
-  virtual unsigned getJumpOpcode() const = 0;
+  virtual unsigned getJumpOpcode() const {
+    llvm_unreachable("Target didn't implement getJumpOpcode");
+  }
   /// Return Multi-Slot Pseudo opcode based on Reg type and imm. size
   virtual unsigned getConstantMovOpcode(MachineRegisterInfo &MRI,
                                         unsigned int Reg, APInt &Val) const {
-    return -1;
+    llvm_unreachable("Target didn't implement getConstantMovOpcode");
   }
   /// Returns the opcode for CYCLE_SEPARATOR meta instruction.
   /// Used for debugging purposes
-  virtual unsigned getCycleSeparatorOpcode() const { return -1; }
+  virtual unsigned getCycleSeparatorOpcode() const {
+    llvm_unreachable("Target didn't implement getCycleSeparatorOpcode");
+  }
   /// Check whether Opc represents a lock instruction
   virtual bool isLock(unsigned Opc) const { return false; }
   /// Check whether this is a delayed scheduling barrier induced from
@@ -124,10 +143,14 @@ struct AIEBaseInstrInfo : public TargetInstrInfo {
   }
 
   // Used for Load/Store combiners
-  virtual unsigned getOffsetMemOpcode(unsigned BaseMemOpcode) const = 0;
+  virtual unsigned getOffsetMemOpcode(unsigned BaseMemOpcode) const {
+    llvm_unreachable("Target didn't implement getOffsetMemOpcode");
+  }
   virtual std::optional<unsigned>
   getCombinedPostIncOpcode(MachineInstr &BaseMemI, MachineInstr &PtrAddI,
-                           TypeSize Size) const = 0;
+                           TypeSize Size) const {
+    llvm_unreachable("Target didn't implement getCombinedPostIncOpcode");
+  }
 
   // Opcodes related to hardware loop handling
   virtual bool isHardwareLoopDec(unsigned Opcode) const { return false; }

--- a/llvm/lib/Target/AIE/AIEBundle.h
+++ b/llvm/lib/Target/AIE/AIEBundle.h
@@ -45,6 +45,15 @@ public:
   Bundle(const AIEBaseMCFormats *FormatInterface)
       : FormatInterface(FormatInterface) {}
 
+  Bundle(const std::initializer_list<I *> &Instrs,
+         const AIEBaseMCFormats *FormatInterface)
+      : FormatInterface(FormatInterface) {
+    bool ComputeSlots = (FormatInterface != nullptr);
+    for (I *Instr : Instrs) {
+      add(Instr, std::nullopt, ComputeSlots);
+    }
+  }
+
   /// Returns whether adding Instr to the current bundle leaves it valid.
   /// \param Instr instruction to add.
   bool canAdd(I *Instr) const { return canAdd(Instr->getOpcode()); }
@@ -220,6 +229,11 @@ public:
   // Contained meta instructions (These will end up after the bundle)
   std::vector<I *> MetaInstrs;
 };
+
+template <class I> bool operator==(const Bundle<I> &B1, const Bundle<I> &B2) {
+  return std::tie(B1.Instrs, B1.SlotMap, B1.MetaInstrs) ==
+         std::tie(B2.Instrs, B2.SlotMap, B2.MetaInstrs);
+}
 
 using MCBundle = Bundle<MCInst>;
 using MachineBundle = Bundle<MachineInstr>;

--- a/llvm/lib/Target/AIE/AIEHazardRecognizer.cpp
+++ b/llvm/lib/Target/AIE/AIEHazardRecognizer.cpp
@@ -161,13 +161,20 @@ static cl::opt<int>
 
 int AIEHazardRecognizer::NumInstrsScheduled = 0;
 
-AIEHazardRecognizer::AIEHazardRecognizer(const AIEBaseInstrInfo *TII,
-                                         const InstrItineraryData *II,
-                                         bool IsPreRA)
+AIEHazardRecognizer::AIEHazardRecognizer(
+    const AIEBaseInstrInfo *TII, const InstrItineraryData *II, bool IsPreRA,
+    std::optional<unsigned> ScoreboardDepth)
     : TII(TII), ItinData(II) {
 
-  computeMaxLatency();
-  int Depth = computeScoreboardDepth();
+  int Depth = 0;
+  if (ScoreboardDepth.has_value()) {
+    MaxLatency = *ScoreboardDepth;
+    Depth = *ScoreboardDepth;
+  } else {
+    computeMaxLatency();
+    Depth = computeScoreboardDepth();
+  }
+
   Scoreboard.reset(Depth);
   MaxLookAhead = Depth;
   if (CLIssueLimit > 0)

--- a/llvm/lib/Target/AIE/AIEHazardRecognizer.h
+++ b/llvm/lib/Target/AIE/AIEHazardRecognizer.h
@@ -92,8 +92,12 @@ class AIEHazardRecognizer : public ScheduleHazardRecognizer {
   void computeMaxLatency();
 
 public:
+  /// ScoreboardDepth can be used to speficy a fixed depth without querying the
+  /// scheduling model. This is mostly used for testing, for other cases we
+  /// should trust the instruction itineraries.
   AIEHazardRecognizer(const AIEBaseInstrInfo *TII, const InstrItineraryData *II,
-                      bool IsPreRA);
+                      bool IsPreRA,
+                      std::optional<unsigned> ScoreboardDepth = std::nullopt);
   AIEHazardRecognizer(const TargetSubtargetInfo &SubTarget,
                       bool IsPreRA = false);
 

--- a/llvm/lib/Target/AIE/AIEMachineScheduler.h
+++ b/llvm/lib/Target/AIE/AIEMachineScheduler.h
@@ -28,6 +28,10 @@ using BlockType = AIE::BlockType;
 using Region = AIE::Region;
 using ScoreboardTrust = AIE::ScoreboardTrust;
 
+namespace AIE {
+std::vector<AIE::MachineBundle> computeAndFinalizeBundles(SchedBoundary &Zone);
+} // namespace AIE
+
 /// A MachineSchedStrategy implementation for AIE post RA scheduling.
 class AIEPostRASchedStrategy : public PostGenericScheduler {
   /// Maintain the state of interblock/loop-aware scheduling

--- a/llvm/unittests/CodeGen/MFCommon.inc
+++ b/llvm/unittests/CodeGen/MFCommon.inc
@@ -1,3 +1,14 @@
+//===- MFCommon.inc - Helpers for unit-testing the backend ----------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// Modifications (c) Copyright 2024 Advanced Micro Devices, Inc. or its
+// affiliates
+//
+//===----------------------------------------------------------------------===//
+
 // Add a few Bogus backend classes so we can create MachineInstrs without
 // depending on a real target.
 class BogusTargetLowering : public TargetLowering {
@@ -73,13 +84,15 @@ public:
   }
 };
 
-class BogusSubtarget : public TargetSubtargetInfo {
+template <typename TIIClass> class TestSubTarget : public TargetSubtargetInfo {
 public:
-  BogusSubtarget(TargetMachine &TM)
-      : TargetSubtargetInfo(Triple(""), "", "", "", {}, {}, nullptr, nullptr,
-                            nullptr, nullptr, nullptr, nullptr),
+  TestSubTarget(TargetMachine &TM, StringRef CPU = "", StringRef TuneCPU = "",
+                ArrayRef<SubtargetSubTypeKV> ProcDescs = {})
+      : TargetSubtargetInfo(Triple(""), CPU, TuneCPU, "", {}, ProcDescs,
+                            nullptr, nullptr, nullptr, nullptr, nullptr,
+                            nullptr),
         FL(), TL(TM) {}
-  ~BogusSubtarget() override {}
+  ~TestSubTarget() override {}
 
   const TargetFrameLowering *getFrameLowering() const override { return &FL; }
 
@@ -93,8 +106,9 @@ private:
   BogusFrameLowering FL;
   BogusRegisterInfo TRI;
   BogusTargetLowering TL;
-  TargetInstrInfo TII;
+  TIIClass TII;
 };
+using BogusSubTarget = TestSubTarget<TargetInstrInfo>;
 
 static TargetOptions getTargetOptionsForBogusMachine() {
   TargetOptions Opts;
@@ -102,39 +116,41 @@ static TargetOptions getTargetOptionsForBogusMachine() {
   return Opts;
 }
 
-class BogusTargetMachine : public LLVMTargetMachine {
+template <typename STClass> class TestTargetMachine : public LLVMTargetMachine {
 public:
-  BogusTargetMachine()
+  TestTargetMachine()
       : LLVMTargetMachine(Target(), "", Triple(""), "", "",
                           getTargetOptionsForBogusMachine(), Reloc::Static,
                           CodeModel::Small, CodeGenOptLevel::Default),
         ST(*this) {}
 
-  ~BogusTargetMachine() override {}
+  ~TestTargetMachine() override {}
 
   const TargetSubtargetInfo *getSubtargetImpl(const Function &) const override {
     return &ST;
   }
 
 private:
-  BogusSubtarget ST;
+  STClass ST;
 };
+using BogusTargetMachine = TestTargetMachine<BogusSubTarget>;
 
-BogusTargetMachine *createTargetMachine() {
+[[maybe_unused]] BogusTargetMachine *createTargetMachine() {
   static BogusTargetMachine BogusTM;
   return &BogusTM;
 }
 
-std::unique_ptr<MachineFunction> createMachineFunction(LLVMContext &Ctx,
-                                                       Module &M) {
+[[maybe_unused]] std::unique_ptr<MachineFunction>
+createMachineFunction(LLVMContext &Ctx, Module &M,
+                      LLVMTargetMachine *TM = nullptr) {
   auto Type = FunctionType::get(Type::getVoidTy(Ctx), false);
   auto F = Function::Create(Type, GlobalValue::ExternalLinkage, "Test", &M);
 
-  auto TM = createTargetMachine();
+  if (!TM)
+    TM = createTargetMachine();
   unsigned FunctionNum = 42;
   MachineModuleInfo MMI(TM);
   const TargetSubtargetInfo &STI = *TM->getSubtargetImpl(*F);
 
   return std::make_unique<MachineFunction>(*F, *TM, STI, FunctionNum, MMI);
 }
-

--- a/llvm/unittests/CodeGen/ScheduleDAGMITestUtils.h
+++ b/llvm/unittests/CodeGen/ScheduleDAGMITestUtils.h
@@ -78,7 +78,7 @@ protected:
 /// instructions without actual name or valid MCDesc.
 struct MISeq {
   std::vector<const MachineInstr *> Seq;
-  MISeq(std::initializer_list<const MachineInstr *> L) : Seq(L) {}
+  MISeq(ArrayRef<const MachineInstr *> L) : Seq(L) {}
   MISeq(const MachineBasicBlock &MBB) {
     for (const MachineInstr &MI : MBB)
       Seq.push_back(&MI);

--- a/llvm/unittests/CodeGen/ScheduleDAGMITestUtils.h
+++ b/llvm/unittests/CodeGen/ScheduleDAGMITestUtils.h
@@ -18,16 +18,29 @@ namespace llvm {
 
 class DummyScheduleDAGMI : public ScheduleDAGMI {
 public:
-  using ScheduleDAGMI::ScheduleDAGMI;
+  DummyScheduleDAGMI(MachineSchedContext *C, bool IsPreRA);
   ~DummyScheduleDAGMI() override;
 
   /// Initialize enough stuff in a similar manner to ScheduleDAGMI::schedule()
   /// so one can do "manual" scheduling.
   void prepareForBB(MachineBasicBlock *MBB);
 
-  /// Move \p MI to the Top or Bot Zone
+  /// Move \p MI to the top or bottom of the scheduling region.
   void scheduleInstr(MachineInstr *MI, bool IsTop,
                      std::optional<unsigned> EmissionCycle = std::nullopt);
+
+  /// Move \p MI to Zone and update its ReadyCycle
+  /// This essentially mimics the body of the scheduling loop inside
+  /// ScheduleDAGMI::schedule().
+  void scheduleInstr(MachineInstr *MI, SchedBoundary &Zone);
+
+  SchedBoundary &getSchedZone() { return SchedZone; }
+
+  bool hasVRegLiveness() const override { return IsPreRA; }
+
+protected:
+  bool IsPreRA;
+  SchedBoundary SchedZone;
 };
 
 class ScheduleDAGMITest : public testing::Test {
@@ -36,7 +49,7 @@ protected:
 
   /// Initialize a DummyScheduleDAGMI so it is ready to schedule instructions
   /// in \p MBB
-  void initializeScheduler();
+  virtual void initializeScheduler(bool IsPreRA = false);
 
   /// Create a dummy instruction for which MachineInstr::isDebugValue() is true
   /// It is pushed at the end of \p MBB

--- a/llvm/unittests/CodeGen/ScheduleDAGMITestUtils.h
+++ b/llvm/unittests/CodeGen/ScheduleDAGMITestUtils.h
@@ -32,7 +32,7 @@ public:
   /// Move \p MI to Zone and update its ReadyCycle
   /// This essentially mimics the body of the scheduling loop inside
   /// ScheduleDAGMI::schedule().
-  void scheduleInstr(MachineInstr *MI, SchedBoundary &Zone);
+  void scheduleInstr(MachineInstr *MI, SchedBoundary &Zone, int Delta = 0);
 
   SchedBoundary &getSchedZone() { return SchedZone; }
 
@@ -45,7 +45,7 @@ protected:
 
 class ScheduleDAGMITest : public testing::Test {
 protected:
-  ScheduleDAGMITest();
+  ScheduleDAGMITest(LLVMTargetMachine *TM = nullptr);
 
   /// Initialize a DummyScheduleDAGMI so it is ready to schedule instructions
   /// in \p MBB

--- a/llvm/unittests/Target/AIE/AIEScheduleDAGMITest.cpp
+++ b/llvm/unittests/Target/AIE/AIEScheduleDAGMITest.cpp
@@ -15,6 +15,15 @@
 
 using namespace llvm;
 
+namespace llvm::AIE {
+
+void PrintTo(const MachineBundle &B, std::ostream *OS) {
+  // Re-use MISeq to print something useful from MIs with dummy descriptors.
+  *OS << "Bundle{ " << MISeq(B.Instrs) << " }";
+}
+
+} // namespace llvm::AIE
+
 namespace {
 
 class DummyAIEHazardRecognizer : public AIEHazardRecognizer {
@@ -86,6 +95,49 @@ TEST_F(AIEScheduleDAGMITest, SchedWithDelta) {
   Scheduler->scheduleInstr(MI0, Bot); // Emit in cycle 3
 
   EXPECT_EQ(MISeq(*MBB), MISeq({MI2, MI1, MI0}));
+}
+
+/// Verify the behavior of computeAndFinalizeBundles. In pre-RA scheduling,
+/// it should also support the case where the SU's ReadyCycle is out-of-date
+/// due to it being moved by GenericScheduler::reschedulePhysReg().
+TEST_F(AIEScheduleDAGMITest, SchedThenMove) {
+  auto *MI0 = appendPlainInstr();
+  auto *MI1 = appendPlainInstr();
+  auto *MI2 = appendPlainInstr();
+
+  initializeScheduler(/*IsPreRA=*/true);
+  SchedBoundary &Bot = Scheduler->getSchedZone();
+
+  // Mark all instructions as available.
+  for (auto *MI : {MI0, MI1, MI2})
+    Bot.releaseNode(Scheduler->getSUnit(MI), /*ReadyCycle=*/0, false);
+
+  Scheduler->scheduleInstr(MI2, Bot);
+  Bot.bumpCycle(2);
+  Scheduler->scheduleInstr(MI1, Bot);
+  Bot.bumpCycle(3);
+  Scheduler->scheduleInstr(MI0, Bot);
+
+  EXPECT_EQ(MISeq(*MBB), MISeq({MI0, MI1, MI2}));
+
+  // Make sure the bundles are computed as expected, c1 should be empty.
+  const AIEBaseMCFormats *Fmts = nullptr;
+  std::vector<AIE::MachineBundle> ExpectedBundles = {
+      AIE::MachineBundle({MI0}, Fmts),  // c3
+      AIE::MachineBundle({MI1}, Fmts),  // c2
+      AIE::MachineBundle({}, Fmts),     // c1
+      AIE::MachineBundle({MI2}, Fmts)}; // c0
+  EXPECT_EQ(AIE::computeAndFinalizeBundles(Bot), ExpectedBundles);
+
+  // Now move an instruction to simulate GenericScheduler::reschedulePhysReg.
+  // This causes the SU's ReadyCycle to be out-of-sync with its position in MBB.
+  Scheduler->moveInstruction(MI2, MI1);
+  ExpectedBundles = {AIE::MachineBundle({MI0}, Fmts),      // c3
+                     AIE::MachineBundle({MI2, MI1}, Fmts), // c2
+                     AIE::MachineBundle({}, Fmts),         // c1
+                     AIE::MachineBundle({}, Fmts)};        // c0
+  EXPECT_EQ(Scheduler->getSUnit(MI2)->BotReadyCycle, 0U);
+  EXPECT_EQ(AIE::computeAndFinalizeBundles(Bot), ExpectedBundles);
 }
 
 } // end namespace

--- a/llvm/unittests/Target/AIE/AIEScheduleDAGMITest.cpp
+++ b/llvm/unittests/Target/AIE/AIEScheduleDAGMITest.cpp
@@ -1,0 +1,64 @@
+//===- AIEScheduleDAGMITest.cpp -------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+//
+//===----------------------------------------------------------------------===//
+
+#include "AIEHazardRecognizer.h"
+#include "AIEMachineScheduler.h"
+#include "ScheduleDAGMITestUtils.h"
+
+using namespace llvm;
+
+namespace {
+
+class DummyAIEHazardRecognizer : public AIEHazardRecognizer {
+public:
+  DummyAIEHazardRecognizer(const ScheduleDAG *DAG)
+      : AIEHazardRecognizer(nullptr, nullptr, DAG, /*ScoreboardDepth=*/0) {}
+
+  ~DummyAIEHazardRecognizer() override {}
+
+  HazardType getHazardType(SUnit *SU, int DeltaCycles) override {
+    return NoHazard;
+  }
+};
+
+/// A simple wrapper around ScheduleDAGMITest that initializes a scheduler
+/// and a scheduling zone (SchedBoundary) with a DummyAIEHazardRecognizer.
+class AIEScheduleDAGMITest : public ScheduleDAGMITest {
+protected:
+  void initializeScheduler(bool IsPreRA = false) override {
+    ScheduleDAGMITest::initializeScheduler(IsPreRA);
+    Scheduler->getSchedZone().HazardRec =
+        new DummyAIEHazardRecognizer(Scheduler.get());
+  }
+};
+
+/// Case where all instructions are scheduled in Bot.getCurrCycle()
+TEST_F(AIEScheduleDAGMITest, SchedNoDelta) {
+  auto *MI0 = appendPlainInstr();
+  auto *MI1 = appendPlainInstr();
+  auto *MI2 = appendPlainInstr();
+
+  initializeScheduler();
+  SchedBoundary &Bot = Scheduler->getSchedZone();
+
+  // Mark all instructions as available.
+  for (auto *MI : {MI0, MI1, MI2})
+    Bot.releaseNode(Scheduler->getSUnit(MI), /*ReadyCycle=*/0, false);
+
+  Scheduler->scheduleInstr(MI2, Bot);
+  Bot.bumpCycle(2);
+  Scheduler->scheduleInstr(MI0, Bot);
+  Bot.bumpCycle(3);
+  Scheduler->scheduleInstr(MI1, Bot);
+
+  EXPECT_EQ(MISeq(*MBB), MISeq({MI1, MI0, MI2}));
+}
+
+} // end namespace

--- a/llvm/unittests/Target/AIE/AIETestTarget.cpp
+++ b/llvm/unittests/Target/AIE/AIETestTarget.cpp
@@ -9,6 +9,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "AIETestTarget.h"
+#include "AIEBaseInstrInfo.h"
 #include "llvm/CodeGen/MachineModuleInfo.h"
 #include "llvm/CodeGen/TargetFrameLowering.h"
 #include "llvm/CodeGen/TargetInstrInfo.h"
@@ -46,11 +47,11 @@ SubtargetSubTypeKV ProcModels[] = {SubtargetSubTypeKV{
 
 } // namespace
 
-class AIETestSubTarget : public TestSubTarget<TargetInstrInfo> {
+class AIETestSubTarget : public TestSubTarget<AIEBaseInstrInfo> {
 public:
   AIETestSubTarget(TargetMachine &TM)
-      : TestSubTarget<TargetInstrInfo>(TM, "aie-test", "aie-test", ProcModels) {
-  }
+      : TestSubTarget<AIEBaseInstrInfo>(TM, "aie-test", "aie-test",
+                                        ProcModels) {}
 };
 
 LLVMTargetMachine *llvm::AIE::createAIETestTargetMachine() {

--- a/llvm/unittests/Target/AIE/AIETestTarget.cpp
+++ b/llvm/unittests/Target/AIE/AIETestTarget.cpp
@@ -1,0 +1,59 @@
+//===- AIETestTarget.cpp --------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+//
+//===----------------------------------------------------------------------===//
+
+#include "AIETestTarget.h"
+#include "llvm/CodeGen/MachineModuleInfo.h"
+#include "llvm/CodeGen/TargetFrameLowering.h"
+#include "llvm/CodeGen/TargetInstrInfo.h"
+#include "llvm/CodeGen/TargetLowering.h"
+#include "llvm/MC/TargetRegistry.h"
+
+using namespace llvm;
+
+namespace {
+
+// Include helper functions to define a testing target.
+#include "MFCommon.inc"
+
+MCSchedModel AIETestSchedModel = {
+    1000, // IssueWidth
+    1000, // MicroOpBufferSize
+    MCSchedModel::DefaultLoopMicroOpBufferSize,
+    MCSchedModel::DefaultLoadLatency,
+    MCSchedModel::DefaultHighLatency,
+    MCSchedModel::DefaultMispredictPenalty,
+    true,    // PostRAScheduler
+    true,    // CompleteModel
+    false,   // EnableIntervals
+    0,       // Processor ID
+    nullptr, // No resources
+    nullptr, // No sched classes
+    0,       // No resources
+    0,       // No sched classes
+    nullptr, // No Itinerary
+    nullptr  // No extra processor descriptor
+};
+
+SubtargetSubTypeKV ProcModels[] = {SubtargetSubTypeKV{
+    "aie-test", FeatureBitArray({}), FeatureBitArray({}), &AIETestSchedModel}};
+
+} // namespace
+
+class AIETestSubTarget : public TestSubTarget<TargetInstrInfo> {
+public:
+  AIETestSubTarget(TargetMachine &TM)
+      : TestSubTarget<TargetInstrInfo>(TM, "aie-test", "aie-test", ProcModels) {
+  }
+};
+
+LLVMTargetMachine *llvm::AIE::createAIETestTargetMachine() {
+  static TestTargetMachine<AIETestSubTarget> AIETM;
+  return &AIETM;
+}

--- a/llvm/unittests/Target/AIE/AIETestTarget.h
+++ b/llvm/unittests/Target/AIE/AIETestTarget.h
@@ -1,0 +1,18 @@
+//===- AIETestTarget.h ----------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/Target/TargetMachine.h"
+
+namespace llvm::AIE {
+
+/// Create an AIE-like target that can be used for unit-tests.
+LLVMTargetMachine *createAIETestTargetMachine();
+
+} // namespace llvm::AIE

--- a/llvm/unittests/Target/AIE/CMakeLists.txt
+++ b/llvm/unittests/Target/AIE/CMakeLists.txt
@@ -27,6 +27,7 @@ set(LLVM_LINK_COMPONENTS
 add_llvm_target_unittest(AIETests
   ${LLVM_MAIN_SRC_DIR}/unittests/CodeGen/ScheduleDAGMITestUtils.cpp
   AIEScheduleDAGMITest.cpp
+  AIETestTarget.cpp
   BundleTest.cpp
   HazardRecognizerTest.cpp
   )

--- a/llvm/unittests/Target/AIE/CMakeLists.txt
+++ b/llvm/unittests/Target/AIE/CMakeLists.txt
@@ -6,6 +6,7 @@
 # (c) Copyright 2023-2024 Advanced Micro Devices, Inc. or its affiliates
 include_directories(
   ${LLVM_MAIN_SRC_DIR}/lib/Target/AIE
+  ${LLVM_MAIN_SRC_DIR}/unittests/CodeGen
   ${LLVM_BINARY_DIR}/lib/Target/AIE
   )
 
@@ -24,6 +25,8 @@ set(LLVM_LINK_COMPONENTS
 )
 
 add_llvm_target_unittest(AIETests
+  ${LLVM_MAIN_SRC_DIR}/unittests/CodeGen/ScheduleDAGMITestUtils.cpp
+  AIEScheduleDAGMITest.cpp
   BundleTest.cpp
   HazardRecognizerTest.cpp
   )


### PR DESCRIPTION
See `GenericScheduler::reschedulePhysReg()`, this can actually move instructions like copies or immidiate moves without updating their ReadyCycle. We rely on that ready cycle for getting an accurate view of the constructed VLIW bundles.

Most of the commits are really setting up some test infrastructure so we can better unit-test the scheduler. That infra can later be used to upgrade our HazardRecognizer test as well. Here it is mostly used to test the `AIE::computeAndFinalizeBundles()` in isolation. See the last commit.