### PR TITLE
[AIE2] Fix SIGSEGV for VLDA_CONV.

### DIFF
--- a/llvm/test/CodeGen/AIE/aie2/GlobalISel/inst-select-vlda_conv.mir
+++ b/llvm/test/CodeGen/AIE/aie2/GlobalISel/inst-select-vlda_conv.mir
@@ -315,3 +315,25 @@ body: |
     %103:accregbank(<8 x s64>) = G_INTRINSIC intrinsic(@llvm.aie2.v16bf16.to.v16accfloat), %25:vregbank(<16 x s16>)
     PseudoRET implicit $lr, implicit %103
 ...
+
+# v16accfloat_to_v16bf16 "mayLoad". But it should not try and combine with VCONV_FP32_BF16.
+---
+name:            no_combine
+legalized:       true
+regBankSelected: true
+tracksRegLiveness: true
+body: |
+  bb.0:
+    liveins: $bml0
+    ; CHECK-LABEL: name: no_combine
+    ; CHECK: liveins: $bml0
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:acc512 = COPY $bml0
+    ; CHECK-NEXT: [[VCONV_BF16_FP32_:%[0-9]+]]:vec256 = VCONV_BF16_FP32 [[COPY]], implicit-def dead $srf2fflags, implicit $crf2fmask, implicit $crrnd
+    ; CHECK-NEXT: [[VCONV_FP32_BF16_:%[0-9]+]]:acc512 = VCONV_FP32_BF16 [[VCONV_BF16_FP32_]]
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[VCONV_FP32_BF16_]]
+    %1:accregbank(<8 x s64>) = COPY $bml0
+    %2:vregbank(<16 x s16>) = G_INTRINSIC_W_SIDE_EFFECTS intrinsic(@llvm.aie2.v16accfloat.to.v16bf16), %1:accregbank(<8 x s64>)
+    %3:accregbank(<8 x s64>) = G_INTRINSIC intrinsic(@llvm.aie2.v16bf16.to.v16accfloat), %2:vregbank(<16 x s16>)
+    PseudoRET implicit $lr, implicit %3
+...


### PR DESCRIPTION
We should not try and combine VCONV with anything but G_LOAD or the like.

`VCONV` instruction expects a `VLDA` to combine to `VLDA.CONV`. Currently, we only check the `mayLoad` attribute for any instruction to classify it as load and combine to `VLDA.CONV`, which is not right. We should check the correct opcodes that lead to `VLDA`. 
This PR resolves that and prohibits, for ex., `G_INTRINSIC_W_SIDE_EFFECTS intrinsic(@llvm.aie2.v16accfloat.to.v16bf16)`, which `mayLoad`, from combining to `VCONV.fp32.bf16` (and avoid a segfault from accessing non-existent MMOs).

https://jira.xilinx.com/browse/AIECC-676