### PR TITLE
[AIE2] Support splat vectors for 256-bit and 1024-bit vectors using VBCST

### DIFF
--- a/llvm/test/CodeGen/AIE/aie2/GlobalISel/prelegalizercombiner-splat-vector.mir
+++ b/llvm/test/CodeGen/AIE/aie2/GlobalISel/prelegalizercombiner-splat-vector.mir
@@ -8,6 +8,67 @@
 # RUN: llc -mtriple aie2 -run-pass=aie2-prelegalizer-combiner %s -verify-machineinstrs -o - | FileCheck %s
 
 ---
+name:            test_build_vector_256_8bit_scl
+body:             |
+  bb.1.entry:
+    ; CHECK-LABEL: name: test_build_vector_256_8bit_scl
+    ; CHECK: [[COPY:%[0-9]+]]:_(s32) = COPY $r0
+    ; CHECK-NEXT: [[AIE_BROADCAST_VECTOR:%[0-9]+]]:_(<64 x s8>) = G_AIE_BROADCAST_VECTOR [[COPY]](s32)
+    ; CHECK-NEXT: [[UV:%[0-9]+]]:_(<32 x s8>), [[UV1:%[0-9]+]]:_(<32 x s8>) = G_UNMERGE_VALUES [[AIE_BROADCAST_VECTOR]](<64 x s8>)
+    ; CHECK-NEXT: $wl0 = COPY [[UV]](<32 x s8>)
+    %0:_(s32) = COPY $r0
+    %1:_(s8) = G_TRUNC %0:_(s32)
+    %2:_(<32 x s8>) = G_BUILD_VECTOR %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8)
+    $wl0 = COPY %2:_(<32 x s8>)
+...
+
+---
+name:            test_build_vector_256_16bit_scl
+body:             |
+  bb.1.entry:
+    ; CHECK-LABEL: name: test_build_vector_256_16bit_scl
+    ; CHECK: [[COPY:%[0-9]+]]:_(s32) = COPY $r0
+    ; CHECK-NEXT: [[AIE_BROADCAST_VECTOR:%[0-9]+]]:_(<32 x s16>) = G_AIE_BROADCAST_VECTOR [[COPY]](s32)
+    ; CHECK-NEXT: [[UV:%[0-9]+]]:_(<16 x s16>), [[UV1:%[0-9]+]]:_(<16 x s16>) = G_UNMERGE_VALUES [[AIE_BROADCAST_VECTOR]](<32 x s16>)
+    ; CHECK-NEXT: $wl0 = COPY [[UV]](<16 x s16>)
+    %0:_(s32) = COPY $r0
+    %1:_(s16) = G_TRUNC %0:_(s32)
+    %2:_(<16 x s16>) = G_BUILD_VECTOR %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16)
+    $wl0 = COPY %2:_(<16 x s16>)
+...
+
+---
+name:            test_build_vector_256_32bit_scl
+body:             |
+  bb.1.entry:
+    ; CHECK-LABEL: name: test_build_vector_256_32bit_scl
+    ; CHECK: [[COPY:%[0-9]+]]:_(s32) = COPY $r0
+    ; CHECK-NEXT: [[AIE_BROADCAST_VECTOR:%[0-9]+]]:_(<16 x s32>) = G_AIE_BROADCAST_VECTOR [[COPY]](s32)
+    ; CHECK-NEXT: [[UV:%[0-9]+]]:_(<8 x s32>), [[UV1:%[0-9]+]]:_(<8 x s32>) = G_UNMERGE_VALUES [[AIE_BROADCAST_VECTOR]](<16 x s32>)
+    ; CHECK-NEXT: $wl0 = COPY [[UV]](<8 x s32>)
+    %1:_(s32) = COPY $r0
+    %2:_(<8 x s32>) = G_BUILD_VECTOR %1:_(s32), %1:_(s32), %1:_(s32), %1:_(s32), %1:_(s32), %1:_(s32), %1:_(s32), %1:_(s32)
+    $wl0 = COPY %2:_(<8 x s32>)
+...
+
+# Invalid Vector for broadcast.
+# As one of the element in G_BUILD_VECTOR is different from others, ideally this should not converted into G_AIE_BROADCAST_VECTOR
+---
+name:            test_build_vector_256_32bit_scl_invalid
+body:             |
+  bb.1.entry:
+    ; CHECK-LABEL: name: test_build_vector_256_32bit_scl_invalid
+    ; CHECK: [[COPY:%[0-9]+]]:_(s32) = COPY $r0
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(s32) = COPY $r1
+    ; CHECK-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<8 x s32>) = G_BUILD_VECTOR [[COPY]](s32), [[COPY]](s32), [[COPY]](s32), [[COPY1]](s32), [[COPY]](s32), [[COPY]](s32), [[COPY]](s32), [[COPY]](s32)
+    ; CHECK-NEXT: $wl0 = COPY [[BUILD_VECTOR]](<8 x s32>)
+    %1:_(s32) = COPY $r0
+    %2:_(s32) = COPY $r1
+    %3:_(<8 x s32>) = G_BUILD_VECTOR %1:_(s32), %1:_(s32), %1:_(s32), %2:_(s32), %1:_(s32), %1:_(s32), %1:_(s32), %1:_(s32)
+    $wl0 = COPY %3:_(<8 x s32>)
+...
+
+---
 name:            test_build_vector_512_8bit_scl
 body:             |
   bb.1.entry:
@@ -17,19 +78,6 @@ body:             |
     ; CHECK-NEXT: $x0 = COPY [[AIE_BROADCAST_VECTOR]](<64 x s8>)
     %0:_(s32) = COPY $r0
     %1:_(s8) = G_TRUNC %0:_(s32)
-    %2:_(<64 x s8>) = G_BUILD_VECTOR %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8)
-    $x0 = COPY %2:_(<64 x s8>)
-...
-
----
-name:            test_build_vector_512_8bit_scl_const
-body:             |
-  bb.1.entry:
-    ; CHECK-LABEL: name: test_build_vector_512_8bit_scl_const
-    ; CHECK: [[C:%[0-9]+]]:_(s32) = G_CONSTANT i32 5
-    ; CHECK-NEXT: [[AIE_BROADCAST_VECTOR:%[0-9]+]]:_(<64 x s8>) = G_AIE_BROADCAST_VECTOR [[C]](s32)
-    ; CHECK-NEXT: $x0 = COPY [[AIE_BROADCAST_VECTOR]](<64 x s8>)
-    %1:_(s8) = G_CONSTANT i8 5
     %2:_(<64 x s8>) = G_BUILD_VECTOR %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8)
     $x0 = COPY %2:_(<64 x s8>)
 ...
@@ -49,19 +97,6 @@ body:             |
 ...
 
 ---
-name:            test_build_vector_512_16bit_scl_const
-body:             |
-  bb.1.entry:
-    ; CHECK-LABEL: name: test_build_vector_512_16bit_scl_const
-    ; CHECK: [[C:%[0-9]+]]:_(s32) = G_CONSTANT i32 1024
-    ; CHECK-NEXT: [[AIE_BROADCAST_VECTOR:%[0-9]+]]:_(<32 x s16>) = G_AIE_BROADCAST_VECTOR [[C]](s32)
-    ; CHECK-NEXT: $x0 = COPY [[AIE_BROADCAST_VECTOR]](<32 x s16>)
-    %1:_(s16) = G_CONSTANT i16 1024
-    %2:_(<32 x s16>) = G_BUILD_VECTOR %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16)
-    $x0 = COPY %2:_(<32 x s16>)
-...
-
----
 name:            test_build_vector_512_32bit_scl
 body:             |
   bb.1.entry:
@@ -75,6 +110,7 @@ body:             |
 ...
 
 # Invalid Vector for broadcast.
+# As one of the element in G_BUILD_VECTOR is different from others, ideally this should not converted into G_AIE_BROADCAST_VECTOR
 ---
 name:            test_build_vector_512_32bit_scl_invalid
 body:             |

--- a/llvm/test/CodeGen/AIE/aie2/GlobalISel/prelegalizercombiner-splat-vector.mir
+++ b/llvm/test/CodeGen/AIE/aie2/GlobalISel/prelegalizercombiner-splat-vector.mir
@@ -125,3 +125,64 @@ body:             |
     %3:_(<16 x s32>) = G_BUILD_VECTOR %1:_(s32), %1:_(s32), %1:_(s32), %2:_(s32), %1:_(s32), %1:_(s32), %1:_(s32), %1:_(s32), %1:_(s32), %1:_(s32), %1:_(s32), %1:_(s32), %1:_(s32), %1:_(s32), %1:_(s32), %1:_(s32)
     $x0 = COPY %3:_(<16 x s32>)
 ...
+
+---
+name:            test_build_vector_1024_8bit_scl
+body:             |
+  bb.1.entry:
+    ; CHECK-LABEL: name: test_build_vector_1024_8bit_scl
+    ; CHECK: [[COPY:%[0-9]+]]:_(s32) = COPY $r0
+    ; CHECK-NEXT: [[AIE_BROADCAST_VECTOR:%[0-9]+]]:_(<64 x s8>) = G_AIE_BROADCAST_VECTOR [[COPY]](s32)
+    ; CHECK-NEXT: [[CONCAT_VECTORS:%[0-9]+]]:_(<128 x s8>) = G_CONCAT_VECTORS [[AIE_BROADCAST_VECTOR]](<64 x s8>), [[AIE_BROADCAST_VECTOR]](<64 x s8>)
+    ; CHECK-NEXT: $y2 = COPY [[CONCAT_VECTORS]](<128 x s8>)
+    %0:_(s32) = COPY $r0
+    %1:_(s8) = G_TRUNC %0:_(s32)
+    %2:_(<128 x s8>) = G_BUILD_VECTOR %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8), %1:_(s8)
+    $y2 = COPY %2:_(<128 x s8>)
+...
+
+---
+name:            test_build_vector_1024_16bit_scl
+body:             |
+  bb.1.entry:
+    ; CHECK-LABEL: name: test_build_vector_1024_16bit_scl
+    ; CHECK: [[COPY:%[0-9]+]]:_(s32) = COPY $r0
+    ; CHECK-NEXT: [[AIE_BROADCAST_VECTOR:%[0-9]+]]:_(<32 x s16>) = G_AIE_BROADCAST_VECTOR [[COPY]](s32)
+    ; CHECK-NEXT: [[CONCAT_VECTORS:%[0-9]+]]:_(<64 x s16>) = G_CONCAT_VECTORS [[AIE_BROADCAST_VECTOR]](<32 x s16>), [[AIE_BROADCAST_VECTOR]](<32 x s16>)
+    ; CHECK-NEXT: $y2 = COPY [[CONCAT_VECTORS]](<64 x s16>)
+    %0:_(s32) = COPY $r0
+    %1:_(s16) = G_TRUNC %0:_(s32)
+    %2:_(<64 x s16>) = G_BUILD_VECTOR %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16), %1:_(s16)
+    $y2 = COPY %2:_(<64 x s16>)
+...
+
+---
+name:            test_build_vector_1024_32bit_scl
+body:             |
+  bb.1.entry:
+    ; CHECK-LABEL: name: test_build_vector_1024_32bit_scl
+    ; CHECK: [[COPY:%[0-9]+]]:_(s32) = COPY $r0
+    ; CHECK-NEXT: [[AIE_BROADCAST_VECTOR:%[0-9]+]]:_(<16 x s32>) = G_AIE_BROADCAST_VECTOR [[COPY]](s32)
+    ; CHECK-NEXT: [[CONCAT_VECTORS:%[0-9]+]]:_(<32 x s32>) = G_CONCAT_VECTORS [[AIE_BROADCAST_VECTOR]](<16 x s32>), [[AIE_BROADCAST_VECTOR]](<16 x s32>)
+    ; CHECK-NEXT: $y2 = COPY [[CONCAT_VECTORS]](<32 x s32>)
+    %1:_(s32) = COPY $r0
+    %2:_(<32 x s32>) = G_BUILD_VECTOR %1:_(s32), %1:_(s32), %1:_(s32), %1:_(s32), %1:_(s32), %1:_(s32), %1:_(s32), %1:_(s32), %1:_(s32), %1:_(s32), %1:_(s32), %1:_(s32), %1:_(s32), %1:_(s32), %1:_(s32), %1:_(s32), %1:_(s32), %1:_(s32), %1:_(s32), %1:_(s32), %1:_(s32), %1:_(s32), %1:_(s32), %1:_(s32), %1:_(s32), %1:_(s32), %1:_(s32), %1:_(s32), %1:_(s32), %1:_(s32), %1:_(s32), %1:_(s32)
+    $y2 = COPY %2:_(<32 x s32>)
+...
+
+# Invalid Vector for broadcast.
+# As one of the element in G_BUILD_VECTOR is different from others, ideally this should not converted into G_AIE_BROADCAST_VECTOR
+---
+name:            test_build_vector_1024_32bit_scl_invalid
+body:             |
+  bb.1.entry:
+    ; CHECK-LABEL: name: test_build_vector_1024_32bit_scl_invalid
+    ; CHECK: [[COPY:%[0-9]+]]:_(s32) = COPY $r0
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(s32) = COPY $r1
+    ; CHECK-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<32 x s32>) = G_BUILD_VECTOR [[COPY]](s32), [[COPY]](s32), [[COPY]](s32), [[COPY1]](s32), [[COPY]](s32), [[COPY]](s32), [[COPY]](s32), [[COPY]](s32), [[COPY]](s32), [[COPY]](s32), [[COPY]](s32), [[COPY]](s32), [[COPY]](s32), [[COPY]](s32), [[COPY]](s32), [[COPY]](s32), [[COPY]](s32), [[COPY]](s32), [[COPY]](s32), [[COPY1]](s32), [[COPY]](s32), [[COPY]](s32), [[COPY]](s32), [[COPY]](s32), [[COPY]](s32), [[COPY]](s32), [[COPY]](s32), [[COPY]](s32), [[COPY]](s32), [[COPY]](s32), [[COPY]](s32), [[COPY]](s32)
+    ; CHECK-NEXT: $y2 = COPY [[BUILD_VECTOR]](<32 x s32>)
+    %1:_(s32) = COPY $r0
+    %2:_(s32) = COPY $r1
+    %3:_(<32 x s32>) = G_BUILD_VECTOR %1:_(s32), %1:_(s32), %1:_(s32), %2:_(s32), %1:_(s32), %1:_(s32), %1:_(s32), %1:_(s32), %1:_(s32), %1:_(s32), %1:_(s32), %1:_(s32), %1:_(s32), %1:_(s32), %1:_(s32), %1:_(s32), %1:_(s32), %1:_(s32), %1:_(s32), %2:_(s32), %1:_(s32), %1:_(s32), %1:_(s32), %1:_(s32), %1:_(s32), %1:_(s32), %1:_(s32), %1:_(s32), %1:_(s32), %1:_(s32), %1:_(s32), %1:_(s32)
+    $y2 = COPY %3:_(<32 x s32>)
+...

--- a/llvm/test/CodeGen/AIE/aie2/end-to-end/Memops.ll
+++ b/llvm/test/CodeGen/AIE/aie2/end-to-end/Memops.ll
@@ -237,15 +237,8 @@ define dso_local void @lowerMemsetUsingWordVector32() local_unnamed_addr #2 {
 ; CHECK-LABEL: lowerMemsetUsingWordVector32:
 ; CHECK:         .p2align 4
 ; CHECK-NEXT:  // %bb.0: // %entry
-; CHECK-NEXT:    nopb ; mova r0, #0; nops ; nopxm ; nopv
-; CHECK-NEXT:    nopa ; vpush.lo.32 x0, r0, x0
-; CHECK-NEXT:    vpush.lo.32 x0, r0, x0
-; CHECK-NEXT:    vpush.lo.32 x0, r0, x0
-; CHECK-NEXT:    vpush.lo.32 x0, r0, x0
-; CHECK-NEXT:    vpush.lo.32 x0, r0, x0
-; CHECK-NEXT:    vpush.lo.32 x0, r0, x0
-; CHECK-NEXT:    vpush.lo.32 x0, r0, x0
-; CHECK-NEXT:    vpush.lo.32 x0, r0, x0
+; CHECK-NEXT:    mova r0, #0; nopb ; nopxm ; nops
+; CHECK-NEXT:    vbcst.32 x0, r0
 ; CHECK-NEXT:    movxm p0, #buffer1
 ; CHECK-NEXT:    vst wl0, [p0], #32; ret lr
 ; CHECK-NEXT:    st r0, [p0], #4 // Delay Slot 5


### PR DESCRIPTION
Support splat vectors for 256-bit and 1024-bit vectors using VBCST, through building a 512-bit broadcast vector instruction directly for 512-bit destination vectors. For 256-bit vectors, creates a 512-bit vector, broadcasts into it, and unmerges it into a 256-bit vector. For 1024-bit vectors, concatenates two 512-bit vectors to form the 1024-bit vector.