### PR TITLE
[AIEX] Fix CR register assignments simplification pass

### DIFF
--- a/llvm/lib/Target/AIE/AIEPostSelectOptimize.cpp
+++ b/llvm/lib/Target/AIE/AIEPostSelectOptimize.cpp
@@ -57,6 +57,61 @@ static cl::opt<bool>
                              cl::desc("Enable post select optimize."));
 
 namespace {
+
+/// Information about a COPY that can be tracked by PhysRegCopyTracker.
+struct TrackableCopyOperands {
+  Register VirtReg;
+  MCRegister PhysReg;
+  bool IsPhysRegDef; // Whether PhysReg is being redefined.
+};
+
+/// Track SSA copies of simple physical registers.
+/// Simple means they don't have sub or super registers.
+class PhysRegCopyTracker {
+  DenseMap<MCRegister, SmallSet<Register, 4>> Copies;
+  const TargetRegisterInfo &TRI;
+
+public:
+  PhysRegCopyTracker(const MachineRegisterInfo &MRI)
+      : TRI(*MRI.getTargetRegisterInfo()) {
+    assert(MRI.isSSA() && "PhysRegCopyTracker can only track SSA copies");
+  }
+
+  /// Invalidate the copies of \p Reg.
+  void invalidateCopies(MCRegister Reg) { Copies.erase(Reg); }
+
+  /// Invalidate copies for any reg defined by \p MI
+  void invalidateDefCopies(const MachineInstr &MI) {
+    for (const MachineOperand &MO : MI.all_defs()) {
+      if (MO.getReg().isPhysical()) {
+        invalidateCopies(MO.getReg());
+      }
+    }
+  }
+
+  /// Track that \p VRegCopy is a copy of \p PhysReg
+  void trackCopy(MCRegister PhysReg, Register VRegCopy) {
+    assert(VRegCopy.isVirtual());
+    assert(range_size(TRI.regunits(PhysReg)) == 1 && "Phys reg has aliases.");
+    Copies[PhysReg].insert(VRegCopy);
+  }
+
+  /// Return true if \p VReg is a copy of \p PhysReg
+  bool isCopy(MCRegister PhysReg, Register VReg) const {
+    if (auto It = Copies.find(PhysReg); It != Copies.end())
+      return It->second.contains(VReg);
+    return false;
+  }
+
+  /// Returns true if \p MI is a COPY instruction that can be eliminated.
+  bool isRedundantCopy(const MachineInstr &MI) {
+    if (!MI.isCopy())
+      return false;
+    auto [DstReg, SrcReg] = MI.getFirst2Regs();
+    return DstReg.isPhysical() && isCopy(DstReg, SrcReg);
+  }
+};
+
 class AIEPostSelectOptimize : public MachineFunctionPass {
 public:
   static char ID;
@@ -64,190 +119,60 @@ public:
   StringRef getPassName() const override { return "AIE Post Select Optimizer"; }
   bool runOnMachineFunction(MachineFunction &MF) override;
   void getAnalysisUsage(AnalysisUsage &AU) const override;
-
-private:
-  const MachineRegisterInfo *MRI;
-
-  /**
-   * @struct PhysRegDefInfoStruct
-   * @brief To track the PhysReg defs and the state of their use.
-   */
-  struct PhysRegDefInfoStruct {
-    // Tracks the last visited def. Change with every new def.
-    MachineInstr *LastVisitedDef = nullptr;
-    // Tracks if the PhysReg is used in between current def and LastVisitedDef.
-    bool IsUsed = false;
-
-    PhysRegDefInfoStruct(MachineInstr *MI)
-        : LastVisitedDef(MI), IsUsed(false) {}
-  };
-
-  /// Collect all VirtReg to PhysReg copies that can be removed at the last.
-  DenseMap<Register, MachineInstr *> ErasableVirtRegToPhysRegCopies;
-
-  bool doPeepholeOpts(MachineBasicBlock &MBB);
-  bool eraseOrStoreRedundantPhysRegDefs(
-      MachineInstr &MI, DenseMap<Register, PhysRegDefInfoStruct> &PhysRegDefs);
-
-  /// Checks if the \p Op is an unallocatable phys reg.
-  bool isUnallocatablePhysReg(const MachineOperand &Op);
-
-  /// Checks if the src %virtreg of \p MI defines the same \p
-  /// PhysReg as the destination register of the \p MI.
-  bool isCopyFromPhysReg(const MachineInstr &MI, const Register PhysReg);
-
-  /// Store the first %virtreg to $physreg copy corresponding to \param MI.
-  void storeFirstIdentityCopy(MachineInstr &MI);
-
-  /// Erase \param MI if it is similar to \param LastVisitedDef.
-  bool eraseSimilarClobber(MachineInstr &MI, MachineInstr &LastVisitedDef);
 };
 } // end anonymous namespace
 
-bool AIEPostSelectOptimize::doPeepholeOpts(MachineBasicBlock &MBB) {
-  bool Changed = false;
-  DenseMap<Register, PhysRegDefInfoStruct> PhysRegDefs;
-  for (MachineInstr &MI : make_early_inc_range(MBB)) {
-    Changed |= eraseOrStoreRedundantPhysRegDefs(MI, PhysRegDefs);
-  }
-  return Changed;
-}
-
-/// Check if the virtual register being copied to the phys reg was copied from
-/// from the same phys reg.
-bool AIEPostSelectOptimize::isCopyFromPhysReg(const MachineInstr &MI,
-                                              const Register PhysReg) {
+/// Returns whether the operands of \p MI can be tracked by PhysRegCopyTracker
+std::optional<TrackableCopyOperands>
+getTrackableCopyOperands(const MachineInstr &MI,
+                         const TargetRegisterInfo &TRI) {
   if (!MI.isCopy())
-    return false;
-  Register SrcReg = MI.getOperand(1).getReg();
-  if (SrcReg.isPhysical())
-    return SrcReg == PhysReg;
-  MachineInstr *VRegDef = MRI->getVRegDef(SrcReg);
-  if (!VRegDef)
-    return false;
-  return isCopyFromPhysReg(*VRegDef, PhysReg);
+    return {};
+
+  // We can track the operands of a copy if one is virtual and the other is a
+  // safe-to-simplify physical register. This is dictated by PhysRegCopyTracker.
+  auto CanTrackCopyOps = [&](Register Op1, Register Op2) {
+    return Op1.isVirtual() && Op2.isPhysical() &&
+           TRI.isSimplifiableReservedReg(Op2);
+  };
+
+  auto [DstReg, SrcReg] = MI.getFirst2Regs();
+  if (CanTrackCopyOps(DstReg, SrcReg)) {
+    return TrackableCopyOperands{DstReg, SrcReg, /*InvalidatePhysReg=*/false};
+  }
+  if (CanTrackCopyOps(SrcReg, DstReg)) {
+    // Here the phys reg is redefined. Notify PhysRegCopyTracker to invalidate
+    // its tracked copies.
+    return TrackableCopyOperands{SrcReg, DstReg, /*InvalidatePhysReg=*/true};
+  }
+  return {};
 }
 
-/// Stores the first identity copy to act as anchor for all the other copies and
-/// remove later if applicable.
-void AIEPostSelectOptimize::storeFirstIdentityCopy(MachineInstr &MI) {
-  assert(MI.getNumOperands() == 2 && "Expected only 2 operands in the MI");
-
-  if (!MI.getOperand(1).isReg())
-    return;
-
-  Register DstPhysReg = MI.getOperand(0).getReg();
-  Register SrcReg = MI.getOperand(1).getReg();
-  // We currently have $PhysReg = COPY SrcReg. Check if the SrcReg is virtual
-  // and find the def of the SrcReg to check for %virtreg = COPY $PhysReg.
-  if (ErasableVirtRegToPhysRegCopies.count(SrcReg) ||
-      !isCopyFromPhysReg(MI, DstPhysReg)) {
-    return;
-  }
-
-  // If the copy is found and copy propagation will lead to identity copy,
-  // then just store the current $PhysReg = COPY %virtreg MI to be removed
-  // later.
-  ErasableVirtRegToPhysRegCopies[SrcReg] = &MI;
-}
-
-/// If there is an intervening clobber but copy propagation suggests it
-/// comes from the same PhysReg, it can be removed.
-bool AIEPostSelectOptimize::eraseSimilarClobber(MachineInstr &MI,
-                                                MachineInstr &LastVisitedDef) {
-  if (!isCopyFromPhysReg(LastVisitedDef, MI.getOperand(0).getReg()) ||
-      !isCopyFromPhysReg(MI, LastVisitedDef.getOperand(0).getReg()))
-    return false;
-
-  Register MISrcReg = MI.getOperand(1).getReg();
-  if (ErasableVirtRegToPhysRegCopies.count(MISrcReg) &&
-      ErasableVirtRegToPhysRegCopies[MISrcReg] == &MI) {
-    ErasableVirtRegToPhysRegCopies.erase(MISrcReg);
-  }
-  LLVM_DEBUG(dbgs() << "Erasing redundant MI - " << MI);
-  MI.eraseFromParent();
-  return true;
-}
-
-/// Returns true if the register is an Unallocatable physical register.
-/// E.g. Control Registers.
-inline bool
-AIEPostSelectOptimize::isUnallocatablePhysReg(const MachineOperand &Op) {
-  return Op.isReg() && Op.getReg().isPhysical() && Op.isDef() &&
-         !MRI->isAllocatable(Op.getReg());
-}
-
-/// Erase or store possible redundant copies local to a basic block.
-bool AIEPostSelectOptimize::eraseOrStoreRedundantPhysRegDefs(
-    MachineInstr &MI, DenseMap<Register, PhysRegDefInfoStruct> &PhysRegDefs) {
-  // Update the IsUsed boolean of PhysRegDefs to track for any uses
-  // of the Unallocatable Phys Reg.
-  for (auto &[UnallocatablePhysReg, DefInfo] : PhysRegDefs) {
-    if (MI.readsRegister(UnallocatablePhysReg) ||
-        MI.hasRegisterImplicitUseOperand(UnallocatablePhysReg)) {
-      DefInfo.IsUsed = true;
-    }
-  }
-
-  // Return early if we are not looking at phys reg defines.
-  if (MI.getNumOperands() < 2 || !isUnallocatablePhysReg(MI.getOperand(0)))
-    return false;
-
-  assert(MI.getNumOperands() == 2 &&
-         "Expected only 2 operands in the physreg def!");
-
-  const Register DstPhysReg = MI.getOperand(0).getReg();
-
-  auto PhysRegDefsItr = PhysRegDefs.find(DstPhysReg);
-  const bool PhysRegNotFound = PhysRegDefsItr == PhysRegDefs.end();
-  if (PhysRegNotFound) {
-    // Add a new phys reg defining MI.
-    PhysRegDefs.insert(std::pair(DstPhysReg, PhysRegDefInfoStruct(&MI)));
-  }
-
-  // Store the first identity copy to be erased later.
-  // This is not removed now itself because we need this copy to be treated as
-  // anchor to help us find other copies.
-  storeFirstIdentityCopy(MI);
-
-  if (PhysRegNotFound)
-    return false;
-
-  PhysRegDefInfoStruct &DefInfo = PhysRegDefsItr->second;
-
-  /*CASE 1*/
-  // If the MI in the map corresponding to this UnallocatablePhysReg is
-  // identical to current MI, erase the current MI, since it is redundant.
-  // %0 = COPY $crsat
-  // $crsat = COPY %0
-  // %1 = opcode implicit $crsat
-  // $crsat = COPY %0 <------------ redundant
-  // %2 = opcode implicit $crsat
-  if (DefInfo.LastVisitedDef->isIdenticalTo(MI)) {
-    if (!MI.getOperand(1).isReg() || MI.getOperand(1).getReg().isVirtual()) {
-      LLVM_DEBUG(dbgs() << "Erasing redundant MI - " << MI);
-      MI.eraseFromParent();
-      return true;
-    }
-  }
-
-  /*CASE 2*/
-  // If there is an intervening clobber but copy propagation suggests it
-  // comes from the same PhysReg, it can be removed.
-  // %0 = COPY $crsat
-  // $crsat = COPY %0
-  // %1 = opcode implicit $crsat
-  // %2 = COPY $crsat
-  // $crsat = COPY %2 <------------ redundant
-  // %3 = opcode implicit $crsat
-  if (eraseSimilarClobber(MI, *DefInfo.LastVisitedDef))
-    return true;
-
+/// Remove copies to phys regs that are redundant.
+bool removeRedundantCopies(MachineBasicBlock &MBB,
+                           const MachineRegisterInfo &MRI) {
+  const TargetRegisterInfo &TRI = *MRI.getTargetRegisterInfo();
   bool Changed = false;
-  MachineInstr *CurrentDef = &MI;
-  // Change the LastVisitedDef to CurrentDef to increment our "anchor".
-  DefInfo.LastVisitedDef = CurrentDef;
-  DefInfo.IsUsed = false;
+  PhysRegCopyTracker CT(MRI);
+
+  /// Go through all instructions to collect copies and simplify redundant ones.
+  for (MachineInstr &MI : make_early_inc_range(MBB)) {
+    if (CT.isRedundantCopy(MI)) {
+      MI.eraseFromParent();
+      Changed = true;
+    } else if (auto Ops = getTrackableCopyOperands(MI, TRI)) {
+      if (Ops->IsPhysRegDef) {
+        // PhysReg is redefined: Track the copy but invalidate previous ones.
+        CT.invalidateCopies(Ops->PhysReg);
+      }
+      CT.trackCopy(Ops->PhysReg, Ops->VirtReg);
+    } else {
+      // For any other instruction, be conservative and invalidate copies for
+      // the phys regs that MI defines.
+      CT.invalidateDefCopies(MI);
+    }
+  }
+
   return Changed;
 }
 
@@ -342,21 +267,9 @@ bool AIEPostSelectOptimize::runOnMachineFunction(MachineFunction &MF) {
     Changed |= combineINSERT_SUBREG(MBB);
   }
 
-  MRI = &MF.getRegInfo();
-
-  ErasableVirtRegToPhysRegCopies.shrink_and_clear();
-
   // 2. Simplify reserved register assignments
   for (MachineBasicBlock &MBB : MF) {
-    Changed |= doPeepholeOpts(MBB);
-  }
-
-  // Remove all the collected VirtReg to UnallocatablePhysReg copies that would
-  // otherwise be inferred as identity copies.
-  for (auto &[_, CopyMI] : ErasableVirtRegToPhysRegCopies) {
-    LLVM_DEBUG(dbgs() << "Erasing redundant MI - " << *CopyMI);
-    CopyMI->eraseFromParent();
-    Changed = true;
+    Changed |= removeRedundantCopies(MBB, MF.getRegInfo());
   }
 
   return Changed;

--- a/llvm/test/CodeGen/AIE/aie2/GlobalISel/legalize-dyn-stackalloc.ll
+++ b/llvm/test/CodeGen/AIE/aie2/GlobalISel/legalize-dyn-stackalloc.ll
@@ -53,27 +53,29 @@ define void @test_loop_dyn_alloca(i32 noundef %n) {
 ; CHECK-LABEL: test_loop_dyn_alloca:
 ; CHECK:         .p2align 4
 ; CHECK-NEXT:  // %bb.0: // %entry
-; CHECK-NEXT:    paddb [sp], #32; nopa ; nops ; nopxm ; nopv
-; CHECK-NEXT:    st p7, [sp, #-32] // 4-byte Folded Spill
+; CHECK-NEXT:    nopa ; paddb [sp], #64; nopxm
+; CHECK-NEXT:    st p7, [sp, #-64] // 4-byte Folded Spill
 ; CHECK-NEXT:    mov p7, sp
-; CHECK-NEXT:    st r16, [sp, #-8] // 4-byte Folded Spill
+; CHECK-NEXT:    st r16, [sp, #-36] // 4-byte Folded Spill
 ; CHECK-NEXT:    mova r16, #1
-; CHECK-NEXT:    st r17, [sp, #-12] // 4-byte Folded Spill
+; CHECK-NEXT:    st r17, [sp, #-40] // 4-byte Folded Spill
 ; CHECK-NEXT:    mova r17, #0
-; CHECK-NEXT:    st r18, [sp, #-16] // 4-byte Folded Spill
+; CHECK-NEXT:    st r18, [sp, #-44] // 4-byte Folded Spill
 ; CHECK-NEXT:    mova r18, #10
-; CHECK-NEXT:    st r19, [sp, #-20] // 4-byte Folded Spill
+; CHECK-NEXT:    st r19, [sp, #-48] // 4-byte Folded Spill
 ; CHECK-NEXT:    mova r19, #2
-; CHECK-NEXT:    st r20, [sp, #-24] // 4-byte Folded Spill
+; CHECK-NEXT:    st r20, [sp, #-52] // 4-byte Folded Spill
 ; CHECK-NEXT:    mova r20, #-32
-; CHECK-NEXT:    st r21, [sp, #-28] // 4-byte Folded Spill
+; CHECK-NEXT:    st r21, [sp, #-56] // 4-byte Folded Spill
 ; CHECK-NEXT:    mova r21, #0
-; CHECK-NEXT:    st lr, [sp, #-4] // 4-byte Folded Spill
-; CHECK-NEXT:    padda [p7], #-32
+; CHECK-NEXT:    st lr, [sp, #-32] // 4-byte Folded Spill
+; CHECK-NEXT:    st p6, [sp, #-60] // 4-byte Folded Spill
+; CHECK-NEXT:    padda [p7], #-64
 ; CHECK-NEXT:    .p2align 4
 ; CHECK-NEXT:  .LBB1_1: // %for.body
 ; CHECK-NEXT:    // =>This Inner Loop Header: Depth=1
-; CHECK-NEXT:    nopa ; nopb ; nopx ; mov p1, sp; nops
+; CHECK-NEXT:    nopa ; nopx ; mov p6, sp
+; CHECK-NEXT:    mov p1, sp
 ; CHECK-NEXT:    lshl r0, r17, r19
 ; CHECK-NEXT:    add r0, r0, #31
 ; CHECK-NEXT:    jl #extern_call
@@ -82,7 +84,7 @@ define void @test_loop_dyn_alloca(i32 noundef %n) {
 ; CHECK-NEXT:    mov m0, r0 // Delay Slot 3
 ; CHECK-NEXT:    paddb [p1], m0 // Delay Slot 2
 ; CHECK-NEXT:    mov sp, p1 // Delay Slot 1
-; CHECK-NEXT:    nopb ; nopa ; nops ; add r17, r17, #1; nopm ; nopv
+; CHECK-NEXT:    nopa ; nopb ; add r17, r17, #1; nopm ; nops
 ; CHECK-NEXT:    ltu r0, r17, r16
 ; CHECK-NEXT:    add r21, r21, r0
 ; CHECK-NEXT:    xor r0, r17, r18
@@ -92,23 +94,24 @@ define void @test_loop_dyn_alloca(i32 noundef %n) {
 ; CHECK-NEXT:    nop // Delay Slot 4
 ; CHECK-NEXT:    nop // Delay Slot 3
 ; CHECK-NEXT:    nop // Delay Slot 2
-; CHECK-NEXT:    nop // Delay Slot 1
+; CHECK-NEXT:    mov sp, p6 // Delay Slot 1
 ; CHECK-NEXT:  // %bb.2: // %for.cond.cleanup
-; CHECK-NEXT:    nopb ; nopa ; nops ; nopx ; mov sp, p7; nopv
-; CHECK-NEXT:    lda p7, [sp, #-32] // 4-byte Folded Reload
-; CHECK-NEXT:    lda lr, [sp, #-4] // 4-byte Folded Reload
-; CHECK-NEXT:    lda r21, [sp, #-28] // 4-byte Folded Reload
-; CHECK-NEXT:    lda r20, [sp, #-24] // 4-byte Folded Reload
-; CHECK-NEXT:    lda r19, [sp, #-20] // 4-byte Folded Reload
-; CHECK-NEXT:    lda r18, [sp, #-16] // 4-byte Folded Reload
-; CHECK-NEXT:    lda r17, [sp, #-12] // 4-byte Folded Reload
-; CHECK-NEXT:    lda r16, [sp, #-8] // 4-byte Folded Reload
+; CHECK-NEXT:    nopa ; nopb ; nopx ; mov sp, p7
+; CHECK-NEXT:    lda p7, [sp, #-64] // 4-byte Folded Reload
+; CHECK-NEXT:    lda p6, [sp, #-60] // 4-byte Folded Reload
+; CHECK-NEXT:    lda lr, [sp, #-32] // 4-byte Folded Reload
+; CHECK-NEXT:    lda r21, [sp, #-56] // 4-byte Folded Reload
+; CHECK-NEXT:    lda r20, [sp, #-52] // 4-byte Folded Reload
+; CHECK-NEXT:    lda r19, [sp, #-48] // 4-byte Folded Reload
+; CHECK-NEXT:    lda r18, [sp, #-44] // 4-byte Folded Reload
+; CHECK-NEXT:    lda r17, [sp, #-40] // 4-byte Folded Reload
+; CHECK-NEXT:    lda r16, [sp, #-36] // 4-byte Folded Reload
 ; CHECK-NEXT:    ret lr
 ; CHECK-NEXT:    nop // Delay Slot 5
 ; CHECK-NEXT:    nop // Delay Slot 4
 ; CHECK-NEXT:    nop // Delay Slot 3
 ; CHECK-NEXT:    nop // Delay Slot 2
-; CHECK-NEXT:    paddb [sp], #-32 // Delay Slot 1
+; CHECK-NEXT:    paddb [sp], #-64 // Delay Slot 1
 entry:
   br label %for.body
 

--- a/llvm/test/CodeGen/AIE/aie2/GlobalISel/post-select-optimize-erase-physregs.mir
+++ b/llvm/test/CodeGen/AIE/aie2/GlobalISel/post-select-optimize-erase-physregs.mir
@@ -773,7 +773,6 @@ body:             |
 
 # $crfpmask is saved and restored twice around VNEGSUB_F instructions
 # Make sure we simplify this to only one vreg for saving and restoring.
-# FIXME: We use two vregs and copy to $crfpmask in between VNEGSUB_F
 ---
 name:            save_restore_twice
 alignment:       16
@@ -793,11 +792,9 @@ body:             |
     ; CHECK-NEXT: [[COPY2:%[0-9]+]]:ercr = COPY $crfpmask
     ; CHECK-NEXT: $crfpmask = MOV_scalar_imm10_pseudo 0
     ; CHECK-NEXT: [[VNEGSUB_F:%[0-9]+]]:acc512 = VNEGSUB_F [[COPY]], [[COPY1]], [[MOV_RLC_imm10_pseudo]], implicit-def $srfpflags, implicit $crfpmask
-    ; CHECK-NEXT: $crfpmask = COPY [[COPY2]]
-    ; CHECK-NEXT: [[COPY3:%[0-9]+]]:ercr = COPY $crfpmask
     ; CHECK-NEXT: $crfpmask = MOV_scalar_imm10_pseudo 1
     ; CHECK-NEXT: [[VNEGSUB_F1:%[0-9]+]]:acc512 = VNEGSUB_F [[COPY]], [[VNEGSUB_F]], [[MOV_RLC_imm10_pseudo]], implicit-def $srfpflags, implicit $crfpmask
-    ; CHECK-NEXT: $crfpmask = COPY [[COPY3]]
+    ; CHECK-NEXT: $crfpmask = COPY [[COPY2]]
     %0:acc512 = COPY $bml1
     %1:acc512 = COPY $bml2
     %2:er = MOV_RLC_imm10_pseudo 28

--- a/llvm/test/CodeGen/AIE/aie2/GlobalISel/post-select-optimize-erase-physregs.mir
+++ b/llvm/test/CodeGen/AIE/aie2/GlobalISel/post-select-optimize-erase-physregs.mir
@@ -207,6 +207,7 @@ body:             |
   ; CHECK-NEXT:   $crfpmask = COPY [[COPY2]]
   ; CHECK-NEXT:   [[VNEGSUB_F5:%[0-9]+]]:acc512 = VNEGSUB_F [[VNEGSUB_F4]], %11, [[MOV_RLC_imm10_pseudo]], implicit-def $srfpflags, implicit $crfpmask
   ; CHECK-NEXT:   [[VNEGSUB_F6:%[0-9]+]]:acc512 = VNEGSUB_F [[COPY]], [[VNEGSUB_F5]], [[MOV_RLC_imm10_pseudo]], implicit-def $srfpflags, implicit $crfpmask
+  ; CHECK-NEXT:   $crfpmask = COPY %13
   ; CHECK-NEXT:   [[VNEGSUB_F7:%[0-9]+]]:acc512 = VNEGSUB_F [[COPY]], [[VNEGSUB_F6]], [[MOV_RLC_imm10_pseudo]], implicit-def $srfpflags, implicit $crfpmask
   ; CHECK-NEXT:   PseudoJ_jump_imm %bb.3
   ; CHECK-NEXT: {{  $}}
@@ -221,7 +222,9 @@ body:             |
   ; CHECK-NEXT: bb.3:
   ; CHECK-NEXT:   $crfpmask = COPY [[COPY3]]
   ; CHECK-NEXT:   [[VNEGSUB_F10:%[0-9]+]]:acc512 = VNEGSUB_F [[COPY]], [[VNEGSUB_F7]], [[MOV_RLC_imm10_pseudo]], implicit-def $srfpflags, implicit $crfpmask
+  ; CHECK-NEXT:   $crfpmask = COPY [[COPY2]]
   ; CHECK-NEXT:   [[VNEGSUB_F11:%[0-9]+]]:acc512 = VNEGSUB_F [[COPY]], [[VNEGSUB_F10]], [[MOV_RLC_imm10_pseudo]], implicit-def $srfpflags, implicit $crfpmask
+  ; CHECK-NEXT:   $crfpmask = COPY [[COPY3]]
   ; CHECK-NEXT:   [[VNEGSUB_F12:%[0-9]+]]:acc512 = VNEGSUB_F [[COPY]], [[VNEGSUB_F11]], [[MOV_RLC_imm10_pseudo]], implicit-def $srfpflags, implicit $crfpmask
   bb.0.entry:
     successors: %bb.2(0x80000000); %bb.2(100.00%)
@@ -734,7 +737,6 @@ body:             |
 
 # %10 holds a copy of $crfpmask, but it is invalidated. Make sure uses
 # of %10 after the invalidation aren't simplified using $crfpmask.
-# FIXME: $crfpmask = COPY %10 should not be eliminated
 ---
 name:            invalidate_copy
 alignment:       16
@@ -751,8 +753,11 @@ body:             |
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:acc512 = COPY $bml1
     ; CHECK-NEXT: [[COPY1:%[0-9]+]]:acc512 = COPY $bml2
     ; CHECK-NEXT: [[MOV_RLC_imm10_pseudo:%[0-9]+]]:er = MOV_RLC_imm10_pseudo 28
+    ; CHECK-NEXT: $crfpmask = COPY $r0
+    ; CHECK-NEXT: [[COPY2:%[0-9]+]]:ercr = COPY $crfpmask
     ; CHECK-NEXT: $crfpmask = MOV_scalar_imm10_pseudo 0
     ; CHECK-NEXT: [[VNEGSUB_F:%[0-9]+]]:acc512 = VNEGSUB_F [[COPY]], [[COPY1]], [[MOV_RLC_imm10_pseudo]], implicit-def $srfpflags, implicit $crfpmask
+    ; CHECK-NEXT: $crfpmask = COPY [[COPY2]]
     ; CHECK-NEXT: [[VNEGSUB_F1:%[0-9]+]]:acc512 = VNEGSUB_F [[COPY]], [[VNEGSUB_F]], [[MOV_RLC_imm10_pseudo]], implicit-def $srfpflags, implicit $crfpmask
     %0:acc512 = COPY $bml1
     %1:acc512 = COPY $bml2
@@ -768,7 +773,7 @@ body:             |
 
 # $crfpmask is saved and restored twice around VNEGSUB_F instructions
 # Make sure we simplify this to only one vreg for saving and restoring.
-# FIXME: The restore COPY should not be eliminated.
+# FIXME: We use two vregs and copy to $crfpmask in between VNEGSUB_F
 ---
 name:            save_restore_twice
 alignment:       16
@@ -785,10 +790,14 @@ body:             |
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:acc512 = COPY $bml1
     ; CHECK-NEXT: [[COPY1:%[0-9]+]]:acc512 = COPY $bml2
     ; CHECK-NEXT: [[MOV_RLC_imm10_pseudo:%[0-9]+]]:er = MOV_RLC_imm10_pseudo 28
+    ; CHECK-NEXT: [[COPY2:%[0-9]+]]:ercr = COPY $crfpmask
     ; CHECK-NEXT: $crfpmask = MOV_scalar_imm10_pseudo 0
     ; CHECK-NEXT: [[VNEGSUB_F:%[0-9]+]]:acc512 = VNEGSUB_F [[COPY]], [[COPY1]], [[MOV_RLC_imm10_pseudo]], implicit-def $srfpflags, implicit $crfpmask
+    ; CHECK-NEXT: $crfpmask = COPY [[COPY2]]
+    ; CHECK-NEXT: [[COPY3:%[0-9]+]]:ercr = COPY $crfpmask
     ; CHECK-NEXT: $crfpmask = MOV_scalar_imm10_pseudo 1
     ; CHECK-NEXT: [[VNEGSUB_F1:%[0-9]+]]:acc512 = VNEGSUB_F [[COPY]], [[VNEGSUB_F]], [[MOV_RLC_imm10_pseudo]], implicit-def $srfpflags, implicit $crfpmask
+    ; CHECK-NEXT: $crfpmask = COPY [[COPY3]]
     %0:acc512 = COPY $bml1
     %1:acc512 = COPY $bml2
     %2:er = MOV_RLC_imm10_pseudo 28

--- a/llvm/test/CodeGen/AIE/aie2/GlobalISel/post-select-optimize-erase-physregs.mir
+++ b/llvm/test/CodeGen/AIE/aie2/GlobalISel/post-select-optimize-erase-physregs.mir
@@ -164,7 +164,6 @@ body:             |
     PseudoJ_jump_imm %bb.1
 
   bb.1:
-  ; predecessors: %bb.0
 
     $crfpmask = COPY %3:ercr
     %9:acc512 = VNEGSUB_F %0:acc512, %8:acc512, %2:er, implicit-def $srfpflags, implicit $crfpmask
@@ -245,7 +244,6 @@ body:             |
     PseudoJ_jump_imm %bb.2
 
   bb.1:
-  ; predecessors: %bb.2
     successors: %bb.3(0x80000000); %bb.3(100.00%)
 
     $crfpmask = COPY %3:ercr
@@ -257,7 +255,6 @@ body:             |
     PseudoJ_jump_imm %bb.3
 
   bb.2:
-  ; predecessors: %bb.0
     successors: %bb.1(0x80000000); %bb.1(100.00%)
 
     %10:ercr = COPY $crfpmask
@@ -268,7 +265,6 @@ body:             |
     PseudoJ_jump_imm %bb.1
 
   bb.3:
-  ; predecessors: %bb.1
 
     $crfpmask = COPY %10:ercr
     %16:acc512 = VNEGSUB_F %0:acc512, %15:acc512, %2:er, implicit-def $srfpflags, implicit $crfpmask
@@ -385,7 +381,6 @@ body:             |
     PseudoJ_jump_imm %bb.1
 
   bb.1:
-  ; predecessors: %bb.0
 
     %8:ercr = COPY $crsat
     $crsat = MOV_scalar_imm10_pseudo 0
@@ -493,7 +488,6 @@ body:             |
     PseudoJ_jump_imm %bb.1
 
   bb.1:
-  ; predecessors: %bb.0, %bb.1
     successors: %bb.1(0x40000000), %bb.2(0x40000000); %bb.1(50.00%), %bb.2(50.00%)
 
     %8:ercr = COPY $crsat
@@ -508,7 +502,6 @@ body:             |
     PseudoJ_jump_imm %bb.2
 
   bb.2:
-  ; predecessors: %bb.1
     successors: %bb.4(0x80000000); %bb.4(100.00%)
 
     %11:ercr = COPY $crsat
@@ -524,7 +517,6 @@ body:             |
     PseudoJ_jump_imm %bb.4
 
   bb.3:
-  ; predecessors: %bb.0
     successors: %bb.4(0x80000000); %bb.4(100.00%)
 
     $crsat = COPY %2:ercr
@@ -537,7 +529,6 @@ body:             |
     PseudoJ_jump_imm %bb.4
 
   bb.4:
-  ; predecessors: %bb.2, %bb.3
 
     $crsat = COPY %2:ercr
     $crupssign = COPY %1:er
@@ -633,7 +624,6 @@ body:             |
     PseudoJ_jump_imm %bb.1
 
   bb.1:
-  ; predecessors: %bb.0, %bb.3
     successors: %bb.2(0x80000000); %bb.2(100.00%)
 
     $crupssign = COPY %1:er
@@ -644,7 +634,6 @@ body:             |
     PseudoJ_jump_imm %bb.2
 
   bb.2:
-  ; predecessors: %bb.1, %bb.2
     successors: %bb.2(0x40000000), %bb.3(0x40000000); %bb.2(50.00%), %bb.3(50.00%)
     liveins: $r0
     $crupssign = COPY %1:er
@@ -657,7 +646,6 @@ body:             |
     PseudoJ_jump_imm %bb.3
 
   bb.3:
-  ; predecessors: %bb.2
     successors: %bb.1(0x40000000), %bb.4(0x40000000); %bb.1(50.00%), %bb.4(50.00%)
 
     $crupssign = COPY %1:er
@@ -669,7 +657,6 @@ body:             |
     PseudoJ_jump_imm %bb.4
 
   bb.4:
-  ; predecessors: %bb.3
 
     $crupssign = COPY %1:er
     %12:acc1024 = VLDA_UPS_S32_D8_ag_idx_imm %2:mss, %3:ep, 0, implicit-def $srups_of, implicit $crsat, implicit $crupssign
@@ -726,24 +713,91 @@ body:             |
     %3:ep = COPY $p0
     %4:acc1024 = VLDA_UPS_S32_D8_ag_idx_imm %2:mss, %3:ep, 0, implicit-def $srups_of, implicit $crsat, implicit $crupssign
 
-    ;; This MI will be removed due to dominating copy in %bb.2.
     $crupssign = MOV_scalar_imm10_pseudo 0
 
     PseudoJ_jump_imm %bb.1
 
   bb.1:
-  ; predecessors: %bb.0
     successors: %bb.2(0x80000000); %bb.2(100.00%)
 
     %5:er = MOV_RLC_imm10_pseudo 23
     PseudoJ_jump_imm %bb.2
 
   bb.2:
-  ; predecessors: %bb.1
     liveins: $r2
     %6:er = COPY $r2
     $crupssign = COPY %6:er
     %7:acc1024 = VLDA_UPS_S32_D8_ag_idx_imm %2:mss, %3:ep, 0, implicit-def $srups_of, implicit $crsat, implicit $crupssign
     $crupssign = MOV_scalar_imm10_pseudo 0
     %8:acc1024 = VLDA_UPS_S32_D8_ag_idx_imm %2:mss, %3:ep, 0, implicit-def $srups_of, implicit $crsat, implicit $crupssign
+...
+
+# %10 holds a copy of $crfpmask, but it is invalidated. Make sure uses
+# of %10 after the invalidation aren't simplified using $crfpmask.
+# FIXME: $crfpmask = COPY %10 should not be eliminated
+---
+name:            invalidate_copy
+alignment:       16
+legalized:       true
+regBankSelected: true
+selected:        true
+tracksRegLiveness: true
+body:             |
+  bb.0.entry:
+  liveins: $bml1, $bml2, $r0
+    ; CHECK-LABEL: name: invalidate_copy
+    ; CHECK: liveins: $bml1, $bml2, $r0
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:acc512 = COPY $bml1
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:acc512 = COPY $bml2
+    ; CHECK-NEXT: [[MOV_RLC_imm10_pseudo:%[0-9]+]]:er = MOV_RLC_imm10_pseudo 28
+    ; CHECK-NEXT: $crfpmask = MOV_scalar_imm10_pseudo 0
+    ; CHECK-NEXT: [[VNEGSUB_F:%[0-9]+]]:acc512 = VNEGSUB_F [[COPY]], [[COPY1]], [[MOV_RLC_imm10_pseudo]], implicit-def $srfpflags, implicit $crfpmask
+    ; CHECK-NEXT: [[VNEGSUB_F1:%[0-9]+]]:acc512 = VNEGSUB_F [[COPY]], [[VNEGSUB_F]], [[MOV_RLC_imm10_pseudo]], implicit-def $srfpflags, implicit $crfpmask
+    %0:acc512 = COPY $bml1
+    %1:acc512 = COPY $bml2
+    %2:er = MOV_RLC_imm10_pseudo 28
+    %3:er = COPY $r0
+    $crfpmask = COPY $r0
+    %10:ercr = COPY $crfpmask
+    $crfpmask = MOV_scalar_imm10_pseudo 0
+    %4:acc512 = VNEGSUB_F %0:acc512, %1:acc512, %2:er, implicit-def $srfpflags, implicit $crfpmask
+    $crfpmask = COPY %10
+    %5:acc512 = VNEGSUB_F %0:acc512, %4:acc512, %2:er, implicit-def $srfpflags, implicit $crfpmask
+...
+
+# $crfpmask is saved and restored twice around VNEGSUB_F instructions
+# Make sure we simplify this to only one vreg for saving and restoring.
+# FIXME: The restore COPY should not be eliminated.
+---
+name:            save_restore_twice
+alignment:       16
+legalized:       true
+regBankSelected: true
+selected:        true
+tracksRegLiveness: true
+body:             |
+  bb.0.entry:
+  liveins: $bml1, $bml2, $r0
+    ; CHECK-LABEL: name: save_restore_twice
+    ; CHECK: liveins: $bml1, $bml2, $r0
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:acc512 = COPY $bml1
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:acc512 = COPY $bml2
+    ; CHECK-NEXT: [[MOV_RLC_imm10_pseudo:%[0-9]+]]:er = MOV_RLC_imm10_pseudo 28
+    ; CHECK-NEXT: $crfpmask = MOV_scalar_imm10_pseudo 0
+    ; CHECK-NEXT: [[VNEGSUB_F:%[0-9]+]]:acc512 = VNEGSUB_F [[COPY]], [[COPY1]], [[MOV_RLC_imm10_pseudo]], implicit-def $srfpflags, implicit $crfpmask
+    ; CHECK-NEXT: $crfpmask = MOV_scalar_imm10_pseudo 1
+    ; CHECK-NEXT: [[VNEGSUB_F1:%[0-9]+]]:acc512 = VNEGSUB_F [[COPY]], [[VNEGSUB_F]], [[MOV_RLC_imm10_pseudo]], implicit-def $srfpflags, implicit $crfpmask
+    %0:acc512 = COPY $bml1
+    %1:acc512 = COPY $bml2
+    %2:er = MOV_RLC_imm10_pseudo 28
+    %10:ercr = COPY $crfpmask
+    $crfpmask = MOV_scalar_imm10_pseudo 0
+    %4:acc512 = VNEGSUB_F %0:acc512, %1:acc512, %2:er, implicit-def $srfpflags, implicit $crfpmask
+    $crfpmask = COPY %10
+    %11:ercr = COPY $crfpmask
+    $crfpmask = MOV_scalar_imm10_pseudo 1
+    %5:acc512 = VNEGSUB_F %0:acc512, %4:acc512, %2:er, implicit-def $srfpflags, implicit $crfpmask
+    $crfpmask = COPY %11
 ...

--- a/llvm/test/CodeGen/AIE/aie2/dyn-stackalloc.ll
+++ b/llvm/test/CodeGen/AIE/aie2/dyn-stackalloc.ll
@@ -53,27 +53,29 @@ define void @test_loop_dyn_alloca(i32 noundef %n) {
 ; CHECK-LABEL: test_loop_dyn_alloca:
 ; CHECK:         .p2align 4
 ; CHECK-NEXT:  // %bb.0: // %entry
-; CHECK-NEXT:    paddb [sp], #32; nopa ; nops ; nopxm ; nopv
-; CHECK-NEXT:    st p7, [sp, #-32] // 4-byte Folded Spill
+; CHECK-NEXT:    nopa ; paddb [sp], #64; nopxm
+; CHECK-NEXT:    st p7, [sp, #-64] // 4-byte Folded Spill
 ; CHECK-NEXT:    mov p7, sp
-; CHECK-NEXT:    st r16, [sp, #-8] // 4-byte Folded Spill
+; CHECK-NEXT:    st r16, [sp, #-36] // 4-byte Folded Spill
 ; CHECK-NEXT:    mova r16, #1
-; CHECK-NEXT:    st r17, [sp, #-12] // 4-byte Folded Spill
+; CHECK-NEXT:    st r17, [sp, #-40] // 4-byte Folded Spill
 ; CHECK-NEXT:    mova r17, #0
-; CHECK-NEXT:    st r18, [sp, #-16] // 4-byte Folded Spill
+; CHECK-NEXT:    st r18, [sp, #-44] // 4-byte Folded Spill
 ; CHECK-NEXT:    mova r18, #10
-; CHECK-NEXT:    st r19, [sp, #-20] // 4-byte Folded Spill
+; CHECK-NEXT:    st r19, [sp, #-48] // 4-byte Folded Spill
 ; CHECK-NEXT:    mova r19, #2
-; CHECK-NEXT:    st r20, [sp, #-24] // 4-byte Folded Spill
+; CHECK-NEXT:    st r20, [sp, #-52] // 4-byte Folded Spill
 ; CHECK-NEXT:    mova r20, #-32
-; CHECK-NEXT:    st r21, [sp, #-28] // 4-byte Folded Spill
+; CHECK-NEXT:    st r21, [sp, #-56] // 4-byte Folded Spill
 ; CHECK-NEXT:    mova r21, #0
-; CHECK-NEXT:    st lr, [sp, #-4] // 4-byte Folded Spill
-; CHECK-NEXT:    padda [p7], #-32
+; CHECK-NEXT:    st lr, [sp, #-32] // 4-byte Folded Spill
+; CHECK-NEXT:    st p6, [sp, #-60] // 4-byte Folded Spill
+; CHECK-NEXT:    padda [p7], #-64
 ; CHECK-NEXT:    .p2align 4
 ; CHECK-NEXT:  .LBB1_1: // %for.body
 ; CHECK-NEXT:    // =>This Inner Loop Header: Depth=1
-; CHECK-NEXT:    nopa ; nopb ; nopx ; mov p1, sp; nops
+; CHECK-NEXT:    nopa ; nopx ; mov p6, sp
+; CHECK-NEXT:    mov p1, sp
 ; CHECK-NEXT:    lshl r0, r17, r19
 ; CHECK-NEXT:    add r0, r0, #31
 ; CHECK-NEXT:    jl #extern_call
@@ -82,7 +84,7 @@ define void @test_loop_dyn_alloca(i32 noundef %n) {
 ; CHECK-NEXT:    mov m0, r0 // Delay Slot 3
 ; CHECK-NEXT:    paddb [p1], m0 // Delay Slot 2
 ; CHECK-NEXT:    mov sp, p1 // Delay Slot 1
-; CHECK-NEXT:    nopb ; nopa ; nops ; add r17, r17, #1; nopm ; nopv
+; CHECK-NEXT:    nopa ; nopb ; add r17, r17, #1; nopm ; nops
 ; CHECK-NEXT:    ltu r0, r17, r16
 ; CHECK-NEXT:    add r21, r21, r0
 ; CHECK-NEXT:    xor r0, r17, r18
@@ -92,23 +94,24 @@ define void @test_loop_dyn_alloca(i32 noundef %n) {
 ; CHECK-NEXT:    nop // Delay Slot 4
 ; CHECK-NEXT:    nop // Delay Slot 3
 ; CHECK-NEXT:    nop // Delay Slot 2
-; CHECK-NEXT:    nop // Delay Slot 1
+; CHECK-NEXT:    mov sp, p6 // Delay Slot 1
 ; CHECK-NEXT:  // %bb.2: // %for.cond.cleanup
-; CHECK-NEXT:    nopb ; nopa ; nops ; nopx ; mov sp, p7; nopv
-; CHECK-NEXT:    lda p7, [sp, #-32] // 4-byte Folded Reload
-; CHECK-NEXT:    lda lr, [sp, #-4] // 4-byte Folded Reload
-; CHECK-NEXT:    lda r21, [sp, #-28] // 4-byte Folded Reload
-; CHECK-NEXT:    lda r20, [sp, #-24] // 4-byte Folded Reload
-; CHECK-NEXT:    lda r19, [sp, #-20] // 4-byte Folded Reload
-; CHECK-NEXT:    lda r18, [sp, #-16] // 4-byte Folded Reload
-; CHECK-NEXT:    lda r17, [sp, #-12] // 4-byte Folded Reload
-; CHECK-NEXT:    lda r16, [sp, #-8] // 4-byte Folded Reload
+; CHECK-NEXT:    nopa ; nopb ; nopx ; mov sp, p7
+; CHECK-NEXT:    lda p7, [sp, #-64] // 4-byte Folded Reload
+; CHECK-NEXT:    lda p6, [sp, #-60] // 4-byte Folded Reload
+; CHECK-NEXT:    lda lr, [sp, #-32] // 4-byte Folded Reload
+; CHECK-NEXT:    lda r21, [sp, #-56] // 4-byte Folded Reload
+; CHECK-NEXT:    lda r20, [sp, #-52] // 4-byte Folded Reload
+; CHECK-NEXT:    lda r19, [sp, #-48] // 4-byte Folded Reload
+; CHECK-NEXT:    lda r18, [sp, #-44] // 4-byte Folded Reload
+; CHECK-NEXT:    lda r17, [sp, #-40] // 4-byte Folded Reload
+; CHECK-NEXT:    lda r16, [sp, #-36] // 4-byte Folded Reload
 ; CHECK-NEXT:    ret lr
 ; CHECK-NEXT:    nop // Delay Slot 5
 ; CHECK-NEXT:    nop // Delay Slot 4
 ; CHECK-NEXT:    nop // Delay Slot 3
 ; CHECK-NEXT:    nop // Delay Slot 2
-; CHECK-NEXT:    paddb [sp], #-32 // Delay Slot 1
+; CHECK-NEXT:    paddb [sp], #-64 // Delay Slot 1
 entry:
   br label %for.body
 


### PR DESCRIPTION
The first commit adds two examples where we are too optimistic and simplify too much. This is then fixed in the next two commits.

I rewrote the pass to rely on a more standard "available value" analysis. This introduces a copy tracker and is a bit similar to the `MachineCopyPropagation` pass, but simplified because we have a different use case. Mainly, we have a mix of vregs and phys regs, and the vregs are in ssa form.

I'd be happy with reviews from @martien-de-jong @andcarminati @abhinay-anubola 

FYI @konstantinschwarz I think you also noticed some bugs here.