### PR TITLE
[RFC][AIE2] Add an IR Phi reordering pass

### DIFF
--- a/llvm/lib/Target/AIE/AIE2.h
+++ b/llvm/lib/Target/AIE/AIE2.h
@@ -41,10 +41,12 @@ FunctionPass *createAIE2PostLegalizerGenericCombiner();
 InstructionSelector *createAIE2InstructionSelector(const AIE2TargetMachine &,
                                                    AIE2Subtarget &,
                                                    AIE2RegisterBankInfo &);
+FunctionPass *createAIEPHISorterPass();
 
 void initializeAIE2PreLegalizerCombinerPass(PassRegistry &);
 void initializeAIE2PostLegalizerCustomCombinerPass(PassRegistry &);
 void initializeAIE2PostLegalizerGenericCombinerPass(PassRegistry &);
+void initializeAIEPHISorterPass(PassRegistry &);
 } // namespace llvm
 
 #endif

--- a/llvm/lib/Target/AIE/AIE2TargetMachine.cpp
+++ b/llvm/lib/Target/AIE/AIE2TargetMachine.cpp
@@ -63,6 +63,9 @@ static cl::opt<bool>
 static cl::opt<bool> EnablePreMISchedCoalescer(
     "aie-premisched-coalescer", cl::Hidden, cl::init(true),
     cl::desc("Run the coalescer again after the pre-RA scheduler"));
+static cl::opt<bool>
+    EnablePHIReorderPass("aie-phi-reorder", cl::Hidden, cl::init(true),
+                         cl::desc("Run the PHI reordering pass"));
 
 extern bool AIEDumpArtifacts;
 
@@ -140,6 +143,9 @@ void AIE2PassConfig::addIRPasses() {
     }
   }
   TargetPassConfig::addIRPasses();
+
+  if (EnablePHIReorderPass && TM->getOptLevel() > CodeGenOptLevel::None)
+    addPass(createAIEPHISorterPass());
 }
 
 void AIE2PassConfig::addPreLegalizeMachineIR() {

--- a/llvm/lib/Target/AIE/AIEPHISorterPass.cpp
+++ b/llvm/lib/Target/AIE/AIEPHISorterPass.cpp
@@ -1,0 +1,101 @@
+//==========-- AIEPHISorterPass.cpp - Sort PHI nodes in loops --==============//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+//
+//===----------------------------------------------------------------------===//
+//
+// This Pass reorders PHI nodes in a more friendly way to Greedy Allocator
+//
+//===----------------------------------------------------------------------===//
+
+#include "AIE2.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Analysis/LoopInfo.h"
+#include "llvm/IR/Constants.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/IR/IntrinsicInst.h"
+#include "llvm/IR/IntrinsicsAArch64.h"
+#include "llvm/IR/LLVMContext.h"
+#include "llvm/InitializePasses.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Transforms/Utils/Cloning.h"
+
+using namespace llvm;
+
+#define DEBUG_TYPE "aie-phi-sorter"
+
+namespace {
+struct AIEPHISorter : public FunctionPass {
+  static char ID; // Pass identification, replacement for typeid
+  AIEPHISorter() : FunctionPass(ID) {
+    initializeAIEPHISorterPass(*PassRegistry::getPassRegistry());
+  }
+
+  bool runOnFunction(Function &F) override;
+
+  void getAnalysisUsage(AnalysisUsage &AU) const override {
+    AU.addRequired<LoopInfoWrapperPass>();
+    AU.setPreservesAll();
+  }
+};
+} // end anonymous namespace
+
+char AIEPHISorter::ID = 0;
+static const char *name = "AIE PHI Sorter Pass";
+INITIALIZE_PASS_BEGIN(AIEPHISorter, DEBUG_TYPE, name, false, false)
+INITIALIZE_PASS_DEPENDENCY(LoopInfoWrapperPass);
+INITIALIZE_PASS_END(AIEPHISorter, DEBUG_TYPE, name, false, false)
+
+FunctionPass *llvm::createAIEPHISorterPass() { return new AIEPHISorter(); }
+
+bool AIEPHISorter::runOnFunction(Function &F) {
+
+  const LoopInfo &LI = getAnalysis<LoopInfoWrapperPass>().getLoopInfo();
+  bool Changed = false;
+
+  for (BasicBlock &B : F) {
+    if (LI.getLoopFor(&B)) {
+      SmallVector<PHINode *> WorkList;
+      std::map<const Instruction *, unsigned> InstrOrder;
+      // Collect all interesting recursive PHI nodes.
+      for (auto &PHI : B.phis()) {
+        for (BasicBlock *BB : PHI.blocks()) {
+          // Check basically if this loop block
+          // is part of the body.
+          if (BB == &B)
+            WorkList.push_back(&PHI);
+        }
+      }
+
+      if (WorkList.empty())
+        continue;
+
+      Changed = true;
+      unsigned PositionCounter = 0;
+
+      // Collect instruction ordering.
+      for (auto &I : B)
+        InstrOrder[&I] = PositionCounter++;
+
+      // Reorder out-of-place the collected PHI nodes.
+      std::sort(WorkList.begin(), WorkList.end(),
+                [&](const PHINode *PhiA, const PHINode *PhiB) {
+                  const Instruction *InstA =
+                      dyn_cast<Instruction>(PhiA->getIncomingValueForBlock(&B));
+                  const Instruction *InstB =
+                      dyn_cast<Instruction>(PhiB->getIncomingValueForBlock(&B));
+                  return InstrOrder[InstA] < InstrOrder[InstB];
+                });
+
+      // Commit new ordering.
+      for (unsigned i = 0; i < WorkList.size() - 1; i++)
+        WorkList[i + 1]->moveAfter(WorkList[i]);
+    }
+  }
+  return Changed;
+}

--- a/llvm/lib/Target/AIE/CMakeLists.txt
+++ b/llvm/lib/Target/AIE/CMakeLists.txt
@@ -85,6 +85,7 @@ add_llvm_target(AIECodeGen
    AIEMaxLatencyFinder.cpp
    AIEMCInstLower.cpp
    AIEMIRFormatter.cpp
+   AIEPHISorterPass.cpp
    AIEPostSelectOptimize.cpp
    AIEPseudoBranchExpansion.cpp
    AIERegisterInfo.cpp

--- a/llvm/test/CodeGen/AIE/aie2/llc-pipeline-aie2.ll
+++ b/llvm/test/CodeGen/AIE/aie2/llc-pipeline-aie2.ll
@@ -83,6 +83,7 @@
 
 ; AIE-O123-NEXT:      Natural Loop Information
 ; AIE-O123-NEXT:      TLS Variable Hoist
+; AIE-O123-NEXT:      AIE PHI Sorter Pass
 ; AIE-O123-NEXT:      CodeGen Prepare
 
 ; AIE-O0123-NEXT:      Lower invoke and unwind, for unwindless code generators

--- a/llvm/test/CodeGen/AIE/aie2/loop.ll
+++ b/llvm/test/CodeGen/AIE/aie2/loop.ll
@@ -11,16 +11,16 @@ define i32 @accumulate(i32 %size, ptr %array) {
 ; CHECK-LABEL: accumulate:
 ; CHECK:         .p2align 4
 ; CHECK-NEXT:  // %bb.0: // %entry
-; CHECK-NEXT:    mova r2, #0; nopb ; nopxm
-; CHECK-NEXT:    ge r0, r2, r1
-; CHECK-NEXT:    jnz r0, #.LBB0_4
+; CHECK-NEXT:    mova r0, #0; nopb ; nopxm
+; CHECK-NEXT:    ge r1, r0, r1
+; CHECK-NEXT:    jnz r1, #.LBB0_3
 ; CHECK-NEXT:    nop // Delay Slot 5
 ; CHECK-NEXT:    nop // Delay Slot 4
 ; CHECK-NEXT:    nop // Delay Slot 3
 ; CHECK-NEXT:    nop // Delay Slot 2
 ; CHECK-NEXT:    nop // Delay Slot 1
 ; CHECK-NEXT:  // %bb.1:
-; CHECK-NEXT:    nopb ; mova r0, #0; nops ; movx r1, #2; nopm ; nopv
+; CHECK-NEXT:    nopb ; mova r2, #0; nops ; movx r1, #2; nopm ; nopv
 ; CHECK-NEXT:    .p2align 4
 ; CHECK-NEXT:  .LBB0_2: // %for.body
 ; CHECK-NEXT:    // =>This Inner Loop Header: Depth=1
@@ -40,21 +40,14 @@ define i32 @accumulate(i32 %size, ptr %array) {
 ; CHECK-NEXT:    nop // Delay Slot 3
 ; CHECK-NEXT:    nop // Delay Slot 2
 ; CHECK-NEXT:    add r0, r3, r0 // Delay Slot 1
-; CHECK-NEXT:  // %bb.3: // %for.cond.cleanup
+; CHECK-NEXT:    .p2align 4
+; CHECK-NEXT:  .LBB0_3: // %for.cond.cleanup
 ; CHECK-NEXT:    nopa ; ret lr
 ; CHECK-NEXT:    nop // Delay Slot 5
 ; CHECK-NEXT:    nop // Delay Slot 4
 ; CHECK-NEXT:    nop // Delay Slot 3
 ; CHECK-NEXT:    nop // Delay Slot 2
 ; CHECK-NEXT:    nop // Delay Slot 1
-; CHECK-NEXT:    .p2align 4
-; CHECK-NEXT:  .LBB0_4:
-; CHECK-NEXT:    ret lr
-; CHECK-NEXT:    nop // Delay Slot 5
-; CHECK-NEXT:    nop // Delay Slot 4
-; CHECK-NEXT:    nop // Delay Slot 3
-; CHECK-NEXT:    nop // Delay Slot 2
-; CHECK-NEXT:    mova r0, #0 // Delay Slot 1
 entry:
   %cmp6 = icmp sgt i32 %size, 0
   br i1 %cmp6, label %for.body, label %for.cond.cleanup


### PR DESCRIPTION
This pass helps Greedy to avoid spills.

This pass is indented to solve spill problems related to `-fno-unroll-loops`. No specific tests yet, just for evaluation and comments.