### PR TITLE
[AIE2] Simplify Intrinsics with demanded bits VBCST

### DIFF
--- a/clang/test/CodeGen/aie/aie2/aie2-scl2vec-intrinsic.cpp
+++ b/clang/test/CodeGen/aie/aie2/aie2-scl2vec-intrinsic.cpp
@@ -435,7 +435,7 @@ v32uint16 test_insert(v32uint16 v, int idx, unsigned long long b) {
 
 // CHECK-LABEL: @_Z18test_broadcast_s16s(
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[CONV_I:%.*]] = sext i16 [[B:%.*]] to i32
+// CHECK-NEXT:    [[CONV_I:%.*]] = zext i16 [[B:%.*]] to i32
 // CHECK-NEXT:    [[TMP0:%.*]] = tail call noundef <32 x i16> @llvm.aie2.vbroadcast16.I512(i32 [[CONV_I]])
 // CHECK-NEXT:    ret <32 x i16> [[TMP0]]
 //
@@ -473,7 +473,7 @@ v16int32 test_broadcast_v2s32 (v2int32 b) {
 
 // CHECK-LABEL: @_Z26test_broadcast_to_v128int4DB8_(
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[CONV_I:%.*]] = sext i8 [[B:%.*]] to i32
+// CHECK-NEXT:    [[CONV_I:%.*]] = zext i8 [[B:%.*]] to i32
 // CHECK-NEXT:    [[TMP0:%.*]] = tail call noundef <64 x i8> @llvm.aie2.vbroadcast8.I512(i32 [[CONV_I]])
 // CHECK-NEXT:    ret <64 x i8> [[TMP0]]
 //
@@ -484,7 +484,7 @@ v128int4 test_broadcast_to_v128int4 (v2int4 b) {
 // CHECK-LABEL: @_Z25test_broadcast_to_v64int8Dv2_a(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[TMP0:%.*]] = bitcast <2 x i8> [[B:%.*]] to i16
-// CHECK-NEXT:    [[CONV_I:%.*]] = sext i16 [[TMP0]] to i32
+// CHECK-NEXT:    [[CONV_I:%.*]] = zext i16 [[TMP0]] to i32
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call <32 x i16> @llvm.aie2.vbroadcast16.I512(i32 [[CONV_I]])
 // CHECK-NEXT:    [[TMP2:%.*]] = bitcast <32 x i16> [[TMP1]] to <64 x i8>
 // CHECK-NEXT:    ret <64 x i8> [[TMP2]]
@@ -556,9 +556,7 @@ v16float test_broadcast_float(float b) {
 
 // CHECK-LABEL: @_Z16test_shiftl_elemDv64_ai(
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[SEXT:%.*]] = shl i32 [[S:%.*]], 24
-// CHECK-NEXT:    [[CONV_I1:%.*]] = ashr exact i32 [[SEXT]], 24
-// CHECK-NEXT:    [[TMP0:%.*]] = tail call noundef <64 x i8> @llvm.aie2.vbroadcast8.I512(i32 [[CONV_I1]])
+// CHECK-NEXT:    [[TMP0:%.*]] = tail call noundef <64 x i8> @llvm.aie2.vbroadcast8.I512(i32 [[S:%.*]])
 // CHECK-NEXT:    [[TMP1:%.*]] = bitcast <64 x i8> [[V:%.*]] to <16 x i32>
 // CHECK-NEXT:    [[TMP2:%.*]] = bitcast <64 x i8> [[TMP0]] to <16 x i32>
 // CHECK-NEXT:    [[TMP3:%.*]] = tail call <16 x i32> @llvm.aie2.vshift.I512.I512(<16 x i32> [[TMP1]], <16 x i32> [[TMP2]], i32 0, i32 1)
@@ -581,8 +579,7 @@ v16int32 test_shiftl_elem(v16int32 v, int s) {
 
 // CHECK-LABEL: @_Z16test_shiftl_elemDv32_tj(
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[CONV_I1:%.*]] = and i32 [[S:%.*]], 65535
-// CHECK-NEXT:    [[TMP0:%.*]] = tail call noundef <32 x i16> @llvm.aie2.vbroadcast16.I512(i32 [[CONV_I1]])
+// CHECK-NEXT:    [[TMP0:%.*]] = tail call noundef <32 x i16> @llvm.aie2.vbroadcast16.I512(i32 [[S:%.*]])
 // CHECK-NEXT:    [[TMP1:%.*]] = bitcast <32 x i16> [[V:%.*]] to <16 x i32>
 // CHECK-NEXT:    [[TMP2:%.*]] = bitcast <32 x i16> [[TMP0]] to <16 x i32>
 // CHECK-NEXT:    [[TMP3:%.*]] = tail call <16 x i32> @llvm.aie2.vshift.I512.I512(<16 x i32> [[TMP1]], <16 x i32> [[TMP2]], i32 0, i32 2)
@@ -595,9 +592,7 @@ v32uint16 test_shiftl_elem(v32uint16 v, unsigned int s) {
 
 // CHECK-LABEL: @_Z16test_shiftr_elemDv32_si(
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[SEXT:%.*]] = shl i32 [[S:%.*]], 16
-// CHECK-NEXT:    [[CONV_I_I:%.*]] = ashr exact i32 [[SEXT]], 16
-// CHECK-NEXT:    [[TMP0:%.*]] = tail call noundef <32 x i16> @llvm.aie2.vbroadcast16.I512(i32 [[CONV_I_I]])
+// CHECK-NEXT:    [[TMP0:%.*]] = tail call noundef <32 x i16> @llvm.aie2.vbroadcast16.I512(i32 [[S:%.*]])
 // CHECK-NEXT:    [[TMP1:%.*]] = bitcast <32 x i16> [[TMP0]] to <16 x i32>
 // CHECK-NEXT:    [[TMP2:%.*]] = bitcast <32 x i16> [[V:%.*]] to <16 x i32>
 // CHECK-NEXT:    [[TMP3:%.*]] = tail call <16 x i32> @llvm.aie2.vshift.I512.I512(<16 x i32> [[TMP1]], <16 x i32> [[TMP2]], i32 0, i32 62)
@@ -611,8 +606,7 @@ v32int16 test_shiftr_elem(v32int16 v, int s) {
 //
 // CHECK-LABEL: @_Z16test_shiftr_elemDv64_hj(
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[CONV_I1:%.*]] = and i32 [[S:%.*]], 255
-// CHECK-NEXT:    [[TMP0:%.*]] = tail call noundef <64 x i8> @llvm.aie2.vbroadcast8.I512(i32 [[CONV_I1]])
+// CHECK-NEXT:    [[TMP0:%.*]] = tail call noundef <64 x i8> @llvm.aie2.vbroadcast8.I512(i32 [[S:%.*]])
 // CHECK-NEXT:    [[TMP1:%.*]] = bitcast <64 x i8> [[TMP0]] to <16 x i32>
 // CHECK-NEXT:    [[TMP2:%.*]] = bitcast <64 x i8> [[V:%.*]] to <16 x i32>
 // CHECK-NEXT:    [[TMP3:%.*]] = tail call <16 x i32> @llvm.aie2.vshift.I512.I512(<16 x i32> [[TMP1]], <16 x i32> [[TMP2]], i32 0, i32 63)
@@ -993,8 +987,8 @@ char test_ext_elem(v64int8 v, int idx) {
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[TMP0:%.*]] = bitcast <64 x i8> [[V:%.*]] to <32 x i16>
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call i32 @llvm.aie2.vextract.elem16.I512(<32 x i16> [[TMP0]], i32 [[IDX:%.*]], i32 1)
-// CHECK-NEXT:    [[CONV_I:%.*]] = trunc i32 [[TMP1]] to i16
-// CHECK-NEXT:    [[TMP2:%.*]] = bitcast i16 [[CONV_I]] to <2 x i8>
+// CHECK-NEXT:    [[CONV_I_I:%.*]] = trunc i32 [[TMP1]] to i16
+// CHECK-NEXT:    [[TMP2:%.*]] = bitcast i16 [[CONV_I_I]] to <2 x i8>
 // CHECK-NEXT:    ret <2 x i8> [[TMP2]]
 //
 v2int8 test_ext_v2int8(v64int8 v, int idx) {
@@ -1005,8 +999,8 @@ v2int8 test_ext_v2int8(v64int8 v, int idx) {
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[TMP0:%.*]] = bitcast <64 x i8> [[V:%.*]] to <32 x i16>
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call i32 @llvm.aie2.vextract.elem16.I512(<32 x i16> [[TMP0]], i32 2, i32 1)
-// CHECK-NEXT:    [[CONV_I:%.*]] = trunc i32 [[TMP1]] to i16
-// CHECK-NEXT:    [[TMP2:%.*]] = bitcast i16 [[CONV_I]] to <2 x i8>
+// CHECK-NEXT:    [[CONV_I_I:%.*]] = trunc i32 [[TMP1]] to i16
+// CHECK-NEXT:    [[TMP2:%.*]] = bitcast i16 [[CONV_I_I]] to <2 x i8>
 // CHECK-NEXT:    ret <2 x i8> [[TMP2]]
 //
 v2int8 test_ext_v2int8_idx2(v64int8 v) {

--- a/llvm/lib/Target/AIE/AIE2InstrPatterns.td
+++ b/llvm/lib/Target/AIE/AIE2InstrPatterns.td
@@ -776,7 +776,9 @@ def : VEQZ_INSTR<int_aie2_veqz32, VEQZ_32>;
 
 // VBCST
 def : Pat<(int_aie2_vbroadcast8_I512 eR:$s0),  (VBCST_8 eR:$s0)>;
+def : Pat<(int_aie2_vbroadcast8_I512 (and eR:$rs1, 255)), (VBCST_8 eR:$rs1)>;
 def : Pat<(int_aie2_vbroadcast16_I512 eR:$s0), (VBCST_16 eR:$s0)>;
+def : Pat<(int_aie2_vbroadcast16_I512 (and eR:$rs1, 65535)), (VBCST_16 eR:$rs1)>;
 def : Pat<(int_aie2_vbroadcast32_I512 eR:$s0), (VBCST_32 eR:$s0)>;
 def : Pat<(int_aie2_vbroadcast64_I512 eL:$s0), (VBCST_64 eL:$s0)>;
 def : Pat<(int_aie2_vbroadcast16_bf512 eR:$s0), (VBCST_16 eR:$s0)>;

--- a/llvm/lib/Target/AIE/AIE2TargetTransformInfo.h
+++ b/llvm/lib/Target/AIE/AIE2TargetTransformInfo.h
@@ -65,6 +65,8 @@ public:
                                 HardwareLoopInfo &HWLoopInfo);
 
   bool isProfitableOuterLSR(const Loop &L) const;
+  std::optional<Instruction *> instCombineIntrinsic(InstCombiner &IC,
+                                                    IntrinsicInst &II) const;
 };
 
 } // end namespace llvm

--- a/llvm/test/CodeGen/AIE/aie2/GlobalISel/inst-select-vbcst.mir
+++ b/llvm/test/CodeGen/AIE/aie2/GlobalISel/inst-select-vbcst.mir
@@ -30,6 +30,29 @@ body:             |
 ...
 
 ---
+name:            VBCST_8_ZEXT
+alignment:       16
+legalized:       true
+regBankSelected: true
+body:             |
+  bb.1.entry:
+      liveins: $r0
+    ; CHECK-LABEL: name: VBCST_8_ZEXT
+    ; CHECK: liveins: $r0
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:er = COPY $r0
+    ; CHECK-NEXT: [[VBCST_8_:%[0-9]+]]:vec512 = VBCST_8 [[COPY]]
+    ; CHECK-NEXT: $x0 = COPY [[VBCST_8_]]
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit $x0
+      %2:gprregbank(s32) = COPY $r0
+      %4:gprregbank(s32) = G_CONSTANT i32 255
+      %3:gprregbank(s32) = G_AND %2, %4
+      %0:vregbank(<64 x s8>) = G_INTRINSIC intrinsic(@llvm.aie2.vbroadcast8.I512), %3:gprregbank(s32)
+      $x0 = COPY %0:vregbank(<64 x s8>)
+      PseudoRET implicit $lr, implicit $x0
+...
+
+---
 name:            VBCST_16
 alignment:       16
 legalized:       true
@@ -47,6 +70,30 @@ body:             |
     %2:gprregbank(s32) = COPY $r0
     %3:gprregbank(s32) = G_ASSERT_SEXT %2:gprregbank, 16
     %0:vregbank(<32 x s16>) = G_INTRINSIC intrinsic(@llvm.aie2.vbroadcast16.I512), %3:gprregbank(s32)
+    $x0 = COPY %0:vregbank(<32 x s16>)
+    PseudoRET implicit $lr, implicit $x0
+...
+
+---
+name:            VBCST_16_ZEXT
+alignment:       16
+legalized:       true
+regBankSelected: true
+body:             |
+  bb.1.entry:
+    liveins: $r0
+    ; CHECK-LABEL: name: VBCST_16_ZEXT
+    ; CHECK: liveins: $r0
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:er = COPY $r0
+    ; CHECK-NEXT: [[VBCST_16_:%[0-9]+]]:vec512 = VBCST_16 [[COPY]]
+    ; CHECK-NEXT: $x0 = COPY [[VBCST_16_]]
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit $x0
+    %2:gprregbank(s32) = COPY $r0
+    %3:gprregbank(s32) = G_ASSERT_SEXT %2, 16
+    %5:gprregbank(s32) = G_CONSTANT i32 65535
+    %4:gprregbank(s32) = G_AND %3, %5
+    %0:vregbank(<32 x s16>) = G_INTRINSIC intrinsic(@llvm.aie2.vbroadcast16.I512), %4:gprregbank(s32)
     $x0 = COPY %0:vregbank(<32 x s16>)
     PseudoRET implicit $lr, implicit $x0
 ...


### PR DESCRIPTION
Eliminating unnecessary sign-extensions for intrinsics that access sub-words of a 32-bit register