### PR TITLE
[RFC][AIE2][AA] Disambiguate pointers updated by intrinsics

### DIFF
--- a/llvm/lib/Target/AIE/AIEBaseAliasAnalysis.cpp
+++ b/llvm/lib/Target/AIE/AIEBaseAliasAnalysis.cpp
@@ -24,6 +24,7 @@
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Debug.h"
+#include <optional>
 
 using namespace llvm;
 
@@ -31,6 +32,11 @@ static cl::opt<unsigned> BaseObjectSearchLimit(
     "aie-alias-analysis-search-limit",
     cl::desc("Search depth limit for base objects in AIE alias analysis"),
     cl::init(100), cl::Hidden);
+
+static cl::opt<bool> DisambiguateAccessSameOriginPointers(
+    "aie-alias-analysis-disambiguation",
+    cl::desc("Disambiguate pointers derived from the same origin"),
+    cl::init(true), cl::Hidden);
 
 #define DEBUG_TYPE "aie-aa"
 
@@ -77,6 +83,36 @@ static bool isAIEPtrAddIntrinsic(Intrinsic::ID ID, unsigned &InPtrIdx) {
   return false;
 }
 
+/// This gives all indexes for read only operands ie.
+/// excluding counters.
+static SmallVector<unsigned, 5> getAddIntrinsicOps(Intrinsic::ID ID) {
+  switch (ID) {
+  case Intrinsic::aie2_add_2d:
+    return {1, 2, 3 /*,count*/};
+  case Intrinsic::aie2_add_3d:
+    return {1, 2, 3, 4, /*,count1*/ 6,
+            /*,count2*/};
+  default:
+    llvm_unreachable("Unknown intrinsic");
+  }
+
+  return {};
+}
+
+/// This gives all indexes counter operands.
+static SmallVector<unsigned, 5> getAddIntrinsicCounterOps(Intrinsic::ID ID) {
+  switch (ID) {
+  case Intrinsic::aie2_add_2d:
+    return {4};
+  case Intrinsic::aie2_add_3d:
+    return {5, 7};
+  default:
+    llvm_unreachable("Unknown intrinsic");
+  }
+
+  return {};
+}
+
 static const Value *lookThroughAIEAddressingModes(const Value *V) {
   if (const auto *Extract = dyn_cast<ExtractValueInst>(V)) {
     if (const auto *MaybeIntrinsicCall =
@@ -117,12 +153,320 @@ static const Value *getUnderlyingObjectAIE(const Value *V) {
   return V;
 }
 
+static const Value *skipCast(const Value *V) {
+  if (const Instruction *Instr = dyn_cast<const Instruction>(V)) {
+    if (Instr->isCast())
+      return Instr->getOperand(0);
+  }
+  return V;
+}
+
+struct IntrinsicArgsInfo {
+  SmallVector<const Value *, 5> ConstantArgs;
+  SmallVector<const Value *, 5> CounterArgs;
+};
+
+struct IntrinsicChainInfo {
+  // Calls up to a specific point.
+  unsigned IntrinsicCalls = 0;
+  // Total calls across the loop.
+  unsigned TotalIntrinsicCalls = 0;
+  // All parameters.
+  IntrinsicArgsInfo IntrinsicParameters;
+
+  // Same number of call until the point of interest.
+  bool hasSameNumberOfCalls(const IntrinsicChainInfo &Other) const {
+    return IntrinsicCalls == Other.IntrinsicCalls;
+  }
+
+  // Same number of calls accross the loop.
+  bool hasSameTotalNumberOfCalls(const IntrinsicChainInfo &Other) const {
+    return TotalIntrinsicCalls == Other.TotalIntrinsicCalls;
+  }
+
+  // Check for the same constant parameters.
+  bool hasSameParameters(const IntrinsicChainInfo &Other) const {
+    return IntrinsicParameters.ConstantArgs ==
+           Other.IntrinsicParameters.ConstantArgs;
+  }
+
+  // Check for the same initial values for the counters.
+  bool hasSameStartingCounters(const IntrinsicChainInfo &Other) const {
+
+    auto GetExternalIndex = [](const PHINode *Phi) {
+      return Phi->getIncomingBlock(0) == Phi->getParent() ? 1 : 0;
+    };
+
+    for (const Value *CountA : IntrinsicParameters.CounterArgs) {
+      // Some truncation can be expected.
+      CountA = skipCast(CountA);
+      if (auto *PhiA = dyn_cast<PHINode>(CountA)) {
+        const Value *ExtPhiValA =
+            PhiA->getIncomingValue(GetExternalIndex(PhiA));
+        for (const Value *CountB : Other.IntrinsicParameters.CounterArgs) {
+          CountB = skipCast(CountB);
+          if (auto *PhiB = dyn_cast<PHINode>(CountB)) {
+            const Value *ExtPhiValB =
+                PhiB->getIncomingValue(GetExternalIndex(PhiB));
+            if (ExtPhiValA != ExtPhiValB)
+              return false;
+          } else {
+            return false; // CountB is not PHI.
+          }
+        }
+      } else {
+        return false; // CountA is not PHI.
+      }
+    }
+    return true;
+  }
+
+  bool mayOverlap(const IntrinsicChainInfo &Other) const {
+    // Different number of updates in the chain.
+    // * but maybe with consistent updates (same steps)
+    if (!hasSameTotalNumberOfCalls(Other))
+      return true;
+
+    // Different parameters.
+    if (!hasSameParameters(Other))
+      return true;
+
+    // Every counter must start equally.
+    if (!hasSameStartingCounters(Other))
+      return true;
+
+    // Check for different steps of calculation.
+    if (hasSameNumberOfCalls(Other))
+      return true;
+
+    return false;
+  }
+};
+
+static IntrinsicArgsInfo collectIntrinsicOperands(const Value *V) {
+  const auto *Extract = dyn_cast<ExtractValueInst>(V);
+  assert(Extract && "Not an Extract");
+  const auto *IntrinsicCall =
+      dyn_cast<CallBase>(Extract->getAggregateOperand());
+  assert(IntrinsicCall && "Not an Intrinsic");
+  Intrinsic::ID ID = IntrinsicCall->getIntrinsicID();
+  IntrinsicArgsInfo Args;
+  // Necessary operands to disambiguate.
+  // Constants.
+  for (unsigned Op : getAddIntrinsicOps(ID)) {
+    Args.ConstantArgs.push_back(IntrinsicCall->getArgOperand(Op));
+  }
+  // Counters.
+  for (unsigned Op : getAddIntrinsicCounterOps(ID)) {
+    Args.CounterArgs.push_back(IntrinsicCall->getArgOperand(Op));
+  }
+  return Args;
+}
+
+// We can reach a pointer definition starting from a counter.
+static bool
+isAddressingIntrinsicOutput(ArrayRef<const Value *> AdressingOutputs,
+                            const Value *Intrinsic) {
+
+  for (const Value *Counter : AdressingOutputs) {
+    if (Intrinsic != lookThroughAIEAddressingModes(Counter))
+      return false;
+  }
+
+  return true;
+}
+
+static bool allInSameBB(SmallVector<const Value *> Values) {
+
+  for (unsigned I = 0; I < Values.size() - 1; I++) {
+    const Instruction *InstrA = dyn_cast<Instruction>(Values[I]);
+    const Instruction *InstrB = dyn_cast<Instruction>(Values[I + 1]);
+
+    if (!InstrA || !InstrB)
+      return false;
+
+    if (InstrA->getParent() != InstrB->getParent())
+      return false;
+  }
+  return true;
+}
+
+/// This function returns some tracking information related to the upward path
+/// that starts from a Value *TargetPointer to the Phi node that firstly defines
+/// a pointer value to the same ambiguous memory. We start the search from the
+/// last update of the pointer.
+std::optional<IntrinsicChainInfo>
+trackIntrinsicChain(const Value *LastUpdate, const Value *TargetPointer) {
+  IntrinsicChainInfo ChainInfo;
+  // We count backwards.
+  std::optional<unsigned> LastCalls = std::nullopt;
+  // Let's expose the real pointer.
+  TargetPointer = skipCast(TargetPointer);
+  for (unsigned Count = 0; Count < BaseObjectSearchLimit; ++Count) {
+    if (!allInSameBB({LastUpdate, TargetPointer}))
+      return std::nullopt;
+
+    LastUpdate = skipCast(LastUpdate);
+
+    // This information is crucial to calculate the number
+    // of pointer updates before TargetPointer.
+    if (LastUpdate == TargetPointer)
+      LastCalls = ChainInfo.TotalIntrinsicCalls;
+
+    if (!LastUpdate->getType()->isPointerTy())
+      return std::nullopt; // not a pointer.
+
+    if (auto *GEP = dyn_cast<GEPOperator>(LastUpdate)) {
+      if (!GEP->hasAllZeroIndices())
+        return std::nullopt; // No pointer arithmetic is allowed.
+      // The result pointer and the first operand have
+      // the same value
+      LastUpdate = GEP->getPointerOperand();
+    } else if (auto *PHI = dyn_cast<PHINode>(LastUpdate)) {
+      // Reached final destination.
+      if (LastCalls) {
+        ChainInfo.IntrinsicCalls = ChainInfo.TotalIntrinsicCalls - *LastCalls;
+        return ChainInfo;
+      }
+      return std::nullopt; // The object was not found.
+
+    } else {
+      const Value *AIEObject = lookThroughAIEAddressingModes(LastUpdate);
+
+      // lookThroughAIEAddressingModes cannot decode LastUpdate.
+      if (LastUpdate == AIEObject) {
+        return std::nullopt;
+      }
+
+      IntrinsicArgsInfo NewArgs = collectIntrinsicOperands(LastUpdate);
+
+      // Initialize counters.
+      if (!ChainInfo.IntrinsicParameters.CounterArgs.empty() &&
+          !isAddressingIntrinsicOutput(
+              ArrayRef(ChainInfo.IntrinsicParameters.CounterArgs), AIEObject)) {
+        // if we already have counters, we need to reach the same
+        // AIEObject from the counters. Otherwise we can have some undesired
+        // counter update in between.
+        return std::nullopt; // not reachable.
+      }
+
+      if (!ChainInfo.IntrinsicParameters.ConstantArgs.empty() &&
+          ChainInfo.IntrinsicParameters.ConstantArgs != NewArgs.ConstantArgs) {
+        // Constant iterator information mismatch between sequence of
+        // intrinsic calls. We stop here.
+        return std::nullopt;
+      }
+
+      // Update params for the next round.
+      ChainInfo.IntrinsicParameters.CounterArgs = NewArgs.CounterArgs;
+      ChainInfo.IntrinsicParameters.ConstantArgs = NewArgs.ConstantArgs;
+
+      LastUpdate = AIEObject;
+      ChainInfo.TotalIntrinsicCalls++;
+    }
+  }
+  return std::nullopt;
+}
+
+static AliasResult aliasAIEIntrinsic(const Value *ValueA, const Value *ValueB,
+                                     const Value *BaseA, const Value *BaseB) {
+
+  const PHINode *PhiA = dyn_cast<PHINode>(BaseA);
+  const PHINode *PhiB = dyn_cast<PHINode>(BaseB);
+
+  // Both bases must be PHI nodes.
+  if (!PhiA || !PhiB)
+    return AliasResult::MayAlias;
+
+  // Skip non-pointer values (cast from pointers?).
+  if (!PhiA->getType()->isPointerTy() || !PhiB->getType()->isPointerTy())
+    return AliasResult::MayAlias;
+
+  // Our target is loop-recurrent PHI nodes.
+  if (PhiA->getNumIncomingValues() != 2 || PhiB->getNumIncomingValues() != 2)
+    return AliasResult::MayAlias;
+
+  // Both PHI nodes must be in the same MBB.
+  if (PhiA->getParent() != PhiB->getParent())
+    return AliasResult::MayAlias;
+
+  auto IsPHIRecurrent = [](const PHINode *Phi) {
+    return Phi->getIncomingBlock(0) == Phi->getParent() ||
+           Phi->getIncomingBlock(1) == Phi->getParent();
+  };
+
+  // Both PHI nodes are recurrent.
+  if (!IsPHIRecurrent(PhiA) || !IsPHIRecurrent(PhiA)) {
+    return AliasResult::MayAlias;
+  }
+
+  auto GetExternalIndex = [](const PHINode *Phi) {
+    return Phi->getIncomingBlock(0) == Phi->getParent() ? 1 : 0;
+  };
+
+  auto GetInternalIndex = [](const PHINode *Phi) {
+    return Phi->getIncomingBlock(0) == Phi->getParent() ? 0 : 1;
+  };
+
+  const Value *ExtPhiValA = PhiA->getIncomingValue(GetExternalIndex(PhiA));
+  const Value *ExtPhiValB = PhiB->getIncomingValue(GetExternalIndex(PhiB));
+
+  // Both Phis must have the same value as an external incoming operand,
+  // so we guarantee that we have two new pointers rooted in the same
+  // original pointer.
+  //
+  // NOTE: We don't care if PhiA and PhiB are the same or not, so we can also
+  // disambiguate different steps starting from from the same pointer (Phi).
+  // We only care if the external value is the same.
+  // For example, we can have the following case:
+  // a =  phi ptr [ %an, %this_mbb ], [ %a_ext, %pred_mbb ]
+  // x1 = load (a)
+  // a1 = add_2d(a, /*fixed parameters + chained counters*/)
+  // x2 = load (a1)
+  // an = add_2d(a1, /*fixed parameters + chained counters*/)
+  // Where we can prove that those two loads are not aliasing, even though
+  // they are sharing the same phi node as an underlying object.
+  if (ExtPhiValA != ExtPhiValB)
+    return AliasResult::MayAlias;
+
+  // Most of the remaining code aims to prove that the two pointers
+  // are updated with same steps.
+
+  const Value *IntPhiValA = PhiA->getIncomingValue(GetInternalIndex(PhiA));
+  const Value *IntPhiValB = PhiB->getIncomingValue(GetInternalIndex(PhiB));
+
+  // Assumption: same basic block.
+  if (!allInSameBB({ValueA, ValueB, BaseA, BaseB, IntPhiValA, IntPhiValB}))
+    return AliasResult::MayAlias;
+
+  // Now we know that the pointers are updated consistently across
+  // loop iterations, let's look to the values.
+  auto ATracking = trackIntrinsicChain(IntPhiValA, ValueA);
+  if (!ATracking) // Non uniform address update accross the loop.
+    return AliasResult::MayAlias;
+
+  auto BTracking = trackIntrinsicChain(IntPhiValB, ValueB);
+  if (!BTracking) // Non uniform address update accross the loop.
+    return AliasResult::MayAlias;
+
+  // If there is no overlap, NoAlias
+  if (ATracking->mayOverlap(*BTracking))
+    return AliasResult::MayAlias;
+
+  return AliasResult::NoAlias;
+}
+
 AliasResult AIEBaseAAResult::alias(const MemoryLocation &LocA,
                                    const MemoryLocation &LocB,
                                    AAQueryInfo &AAQI, const Instruction *) {
 
   const Value *BaseA = getUnderlyingObjectAIE(LocA.Ptr);
   const Value *BaseB = getUnderlyingObjectAIE(LocB.Ptr);
+
+  if (DisambiguateAccessSameOriginPointers &&
+      aliasAIEIntrinsic(LocA.Ptr, LocB.Ptr, BaseA, BaseB) ==
+          AliasResult::NoAlias)
+    return AliasResult::NoAlias;
 
   // Our look-through didn't reveal a different object, pass on to the next
   // alias analysis

--- a/llvm/lib/Target/AIE/AIEBaseAliasAnalysis.h
+++ b/llvm/lib/Target/AIE/AIEBaseAliasAnalysis.h
@@ -14,12 +14,26 @@
 #ifndef LLVM_LIB_TARGET_AIE_AIEBASEALIASANALYSIS_H
 #define LLVM_LIB_TARGET_AIE_AIEBASEALIASANALYSIS_H
 
+#include "AIE.h"
 #include "llvm/Analysis/AliasAnalysis.h"
 
 namespace llvm {
 
 class DataLayout;
 class MemoryLocation;
+
+namespace AIE {
+
+/// Given two machine instructions of a loop, if we virtually
+/// unroll such loop, this function will give an AliasResult
+/// considering that MIA and MIB will be executed in the
+/// UnrollLevelMIA and UnrollLevelMIB iterations, respectively.
+/// UnrollLevel=0 means first iteration.
+AliasResult aliasAcrossVirtualUnrolls(const MachineInstr *MIA,
+                                      const MachineInstr *MIB,
+                                      unsigned UnrollLevelMIA,
+                                      unsigned UnrollLevelMIB);
+} // namespace AIE
 
 class AIEBaseAAResult : public AAResultBase {
   const DataLayout &DL;

--- a/llvm/test/CodeGen/AIE/aie2/end-to-end/Mul2D.ll
+++ b/llvm/test/CodeGen/AIE/aie2/end-to-end/Mul2D.ll
@@ -28,7 +28,7 @@ declare <16 x i64> @llvm.aie2.v32acc32()
 ; AA:  NoAlias:      <8 x i32> addrspace(5)* %in_ptr0.addr.058.ascast, <8 x i32> addrspace(5)* %in_ptr1.addr.057.ascast
 ; AA:  NoAlias:      <8 x i32> addrspace(5)* %in_ptr0.addr.058.ascast, <32 x i8> addrspace(6)* %out_ptr.addr.056.ascast
 ; AA:  NoAlias:      <8 x i32> addrspace(5)* %in_ptr1.addr.057.ascast, <32 x i8> addrspace(6)* %out_ptr.addr.056.ascast
-; AA:  MayAlias:     <8 x i32> addrspace(5)* %ascast.13, <8 x i32> addrspace(5)* %in_ptr0.addr.058.ascast
+; AA:  NoAlias:      <8 x i32> addrspace(5)* %ascast.13, <8 x i32> addrspace(5)* %in_ptr0.addr.058.ascast
 ; AA:  NoAlias:      <8 x i32> addrspace(5)* %ascast.13, <8 x i32> addrspace(5)* %in_ptr1.addr.057.ascast
 ; AA:  NoAlias:      <8 x i32> addrspace(5)* %ascast.13, <32 x i8> addrspace(6)* %out_ptr.addr.056.ascast
 ; AA:  NoAlias:      <8 x i32> addrspace(5)* %ascast.add.ptr.i, <8 x i32> addrspace(5)* %in_ptr0.addr.058.ascast

--- a/llvm/test/CodeGen/AIE/alias-analysis-pointer-disambiguation.ll
+++ b/llvm/test/CodeGen/AIE/alias-analysis-pointer-disambiguation.ll
@@ -1,0 +1,669 @@
+;
+; This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+; See https://llvm.org/LICENSE.txt for license information.
+; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+;
+; (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+; RUN: opt -mtriple=aie2 -passes=aa-eval -print-all-alias-modref-info -disable-output < %s 2>&1 | FileCheck %s --check-prefix=ENABLED-AIE-AA-DIS
+; RUN: opt -mtriple=aie2 -passes=aa-eval -print-all-alias-modref-info -disable-output \
+; RUN:    --aie-alias-analysis-disambiguation=false < %s 2>&1 | FileCheck %s --check-prefix=DISABLED-AIE-AA-DES
+
+
+declare { ptr, i20 } @llvm.aie2.add.2d(ptr, i20, i20, i20, i20)
+
+; ENABLED-AIE-AA-DIS-LABEL: Function: test
+; ENABLED-AIE-AA-DIS:  MayAlias:     i8* %ptr_load, i8* %ptr_store
+; ENABLED-AIE-AA-DIS:  NoAlias:      i8* %3, i8* %ptr_load
+; ENABLED-AIE-AA-DIS:  NoAlias:      i8* %3, i8* %ptr_store
+; ENABLED-AIE-AA-DIS:  NoAlias:      i8* %7, i8* %ptr_load
+; ENABLED-AIE-AA-DIS:  NoAlias:      i8* %7, i8* %ptr_store
+; ENABLED-AIE-AA-DIS:  MayAlias:     i8* %3, i8* %7
+; ENABLED-AIE-AA-DIS:  NoAlias:      i8* %10, i8* %ptr_load
+; ENABLED-AIE-AA-DIS:  NoAlias:      i8* %10, i8* %ptr_store
+; ENABLED-AIE-AA-DIS:  NoAlias:      i8* %10, i8* %3
+; ENABLED-AIE-AA-DIS:  NoAlias:      i8* %10, i8* %7
+; ENABLED-AIE-AA-DIS:  NoAlias:      i8* %14, i8* %ptr_load
+; ENABLED-AIE-AA-DIS:  NoAlias:      i8* %14, i8* %ptr_store
+; ENABLED-AIE-AA-DIS:  NoAlias:      i8* %14, i8* %3
+; ENABLED-AIE-AA-DIS:  NoAlias:      i8* %14, i8* %7
+; ENABLED-AIE-AA-DIS:  MayAlias:     i8* %10, i8* %14
+
+; DISABLED-AIE-AA-DES-LABEL: Function: test
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %ptr_load, i8* %ptr_store
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %3, i8* %ptr_load
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %3, i8* %ptr_store
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %7, i8* %ptr_load
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %7, i8* %ptr_store
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %3, i8* %7
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %10, i8* %ptr_load
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %10, i8* %ptr_store
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %10, i8* %3
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %10, i8* %7
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %14, i8* %ptr_load
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %14, i8* %ptr_store
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %14, i8* %3
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %14, i8* %7
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %10, i8* %14
+
+; Function Attrs: nofree norecurse nounwind mustprogress
+define dso_local i32 @test(ptr %a, i8 %b, i32 %c) local_unnamed_addr #0 {
+entry:
+  br label %for.body
+
+for.body:                                         ; preds = %entry, %for.body
+  %counter_load = phi i20 [ %9, %for.body ], [ 0, %entry ]
+  %counter_store = phi i20 [ %13, %for.body ], [ 0, %entry ]
+  %i.08 = phi i32 [ %inc, %for.body ], [ 0, %entry ]
+  %ptr_load = phi ptr [ %10, %for.body ], [ %a, %entry ]
+  %ptr_store = phi ptr [ %14, %for.body ], [ %a, %entry ]
+  load i8, ptr %ptr_load
+  store i8 %b, ptr %ptr_store
+
+  %1 = tail call { ptr, i20 } @llvm.aie2.add.2d(ptr %ptr_load, i20 0, i20 1, i20 2, i20 %counter_load)
+  %2 = extractvalue { ptr, i20 } %1, 1
+  %3 = extractvalue { ptr, i20 } %1, 0
+  load i8, ptr %3
+  
+  %5 = tail call { ptr, i20 } @llvm.aie2.add.2d(ptr %ptr_store, i20 0, i20 1, i20 2, i20 %counter_store)
+  %6 = extractvalue { ptr, i20 } %5, 1
+  %7 = extractvalue { ptr, i20 } %5, 0
+  store i8 %b, ptr %7
+
+  %8 = tail call { ptr, i20 } @llvm.aie2.add.2d(ptr %3, i20 0, i20 1, i20 2, i20 %2)
+  %9 = extractvalue { ptr, i20 } %8, 1
+  %10 = extractvalue { ptr, i20 } %8, 0
+  load i8, ptr %10
+
+  %12 = tail call { ptr, i20 } @llvm.aie2.add.2d(ptr %7, i20 0, i20 1, i20 2, i20 %6)
+  %13 = extractvalue { ptr, i20 } %12, 1
+  %14 = extractvalue { ptr, i20 } %12, 0
+  store i8 %b, ptr %14
+
+  %inc = add nuw nsw i32 %i.08, 1
+  %exitcond.not = icmp eq i32 %inc, %c
+  br i1 %exitcond.not, label %for.cond.cleanup, label %for.body
+
+for.cond.cleanup:                                 ; preds = %for.body
+  ret i32 0
+}
+
+; ENABLED-AIE-AA-DIS-LABEL: Function: test_diff_iteration
+; ENABLED-AIE-AA-DIS:  MayAlias:     i8* %ptr_load, i8* %ptr_store
+; ENABLED-AIE-AA-DIS:  NoAlias:      i8* %3, i8* %ptr_load
+; ENABLED-AIE-AA-DIS:  MayAlias:     i8* %3, i8* %ptr_store
+; ENABLED-AIE-AA-DIS:  MayAlias:     i8* %7, i8* %ptr_load
+; ENABLED-AIE-AA-DIS:  MayAlias:     i8* %7, i8* %ptr_store
+; ENABLED-AIE-AA-DIS:  MayAlias:     i8* %3, i8* %7
+; ENABLED-AIE-AA-DIS:  NoAlias:      i8* %10, i8* %ptr_load
+; ENABLED-AIE-AA-DIS:  MayAlias:     i8* %10, i8* %ptr_store
+; ENABLED-AIE-AA-DIS:  NoAlias:      i8* %10, i8* %3
+; ENABLED-AIE-AA-DIS:  MayAlias:     i8* %10, i8* %7
+; ENABLED-AIE-AA-DIS:  MayAlias:     i8* %14, i8* %ptr_load
+; ENABLED-AIE-AA-DIS:  MayAlias:     i8* %14, i8* %ptr_store
+; ENABLED-AIE-AA-DIS:  MayAlias:     i8* %14, i8* %3
+; ENABLED-AIE-AA-DIS:  MayAlias:     i8* %14, i8* %7
+; ENABLED-AIE-AA-DIS:  MayAlias:     i8* %10, i8* %14
+
+; DISABLED-AIE-AA-DES-LABEL: Function: test_diff_iteration
+; DISABLED-AIE-AA-DES:  MayAlias:     i8* %ptr_load, i8* %ptr_store
+; DISABLED-AIE-AA-DES:  MayAlias:     i8* %3, i8* %ptr_load
+; DISABLED-AIE-AA-DES:  MayAlias:     i8* %3, i8* %ptr_store
+; DISABLED-AIE-AA-DES:  MayAlias:     i8* %7, i8* %ptr_load
+; DISABLED-AIE-AA-DES:  MayAlias:     i8* %7, i8* %ptr_store
+; DISABLED-AIE-AA-DES:  MayAlias:     i8* %3, i8* %7
+; DISABLED-AIE-AA-DES:  MayAlias:     i8* %10, i8* %ptr_load
+; DISABLED-AIE-AA-DES:  MayAlias:     i8* %10, i8* %ptr_store
+; DISABLED-AIE-AA-DES:  MayAlias:     i8* %10, i8* %3
+; DISABLED-AIE-AA-DES:  MayAlias:     i8* %10, i8* %7
+; DISABLED-AIE-AA-DES:  MayAlias:     i8* %14, i8* %ptr_load
+; DISABLED-AIE-AA-DES:  MayAlias:     i8* %14, i8* %ptr_store
+; DISABLED-AIE-AA-DES:  MayAlias:     i8* %14, i8* %3
+; DISABLED-AIE-AA-DES:  MayAlias:     i8* %14, i8* %7
+; DISABLED-AIE-AA-DES:  MayAlias:     i8* %10, i8* %14
+
+; Function Attrs: nofree norecurse nounwind mustprogress
+define dso_local i32 @test_diff_iteration(ptr %a, i8 %b, i32 %c) local_unnamed_addr #0 {
+entry:
+  br label %for.body
+
+for.body:                                         ; preds = %entry, %for.body
+  %counter_load = phi i20 [ %9, %for.body ], [ 0, %entry ]
+  %counter_store = phi i20 [ %13, %for.body ], [ 0, %entry ]
+  %i.08 = phi i32 [ %inc, %for.body ], [ 0, %entry ]
+  %ptr_load = phi ptr [ %10, %for.body ], [ %a, %entry ]
+  %ptr_store = phi ptr [ %14, %for.body ], [ %a, %entry ]
+  load i8, ptr %ptr_load
+  store i8 %b, ptr %ptr_store
+
+  %1 = tail call { ptr, i20 } @llvm.aie2.add.2d(ptr %ptr_load, i20 0, i20 1, i20 2, i20 %counter_load)
+  %2 = extractvalue { ptr, i20 } %1, 1
+  %3 = extractvalue { ptr, i20 } %1, 0
+  load i8, ptr %3
+  
+  ; here we break the iteration, we cannot state NoAlias.
+  %5 = tail call { ptr, i20 } @llvm.aie2.add.2d(ptr %ptr_store, i20 16, i20 1, i20 2, i20 %counter_store)
+  %6 = extractvalue { ptr, i20 } %5, 1
+  %7 = extractvalue { ptr, i20 } %5, 0
+  store i8 %b, ptr %7
+
+  %8 = tail call { ptr, i20 } @llvm.aie2.add.2d(ptr %3, i20 0, i20 1, i20 2, i20 %2)
+  %9 = extractvalue { ptr, i20 } %8, 1
+  %10 = extractvalue { ptr, i20 } %8, 0
+  load i8, ptr %10
+
+  %12 = tail call { ptr, i20 } @llvm.aie2.add.2d(ptr %7, i20 0, i20 1, i20 2, i20 %6)
+  %13 = extractvalue { ptr, i20 } %12, 1
+  %14 = extractvalue { ptr, i20 } %12, 0
+  store i8 %b, ptr %14
+
+  %inc = add nuw nsw i32 %i.08, 1
+  %exitcond.not = icmp eq i32 %inc, %c
+  br i1 %exitcond.not, label %for.cond.cleanup, label %for.body
+
+for.cond.cleanup:                                 ; preds = %for.body
+  ret i32 0
+}
+
+; ENABLED-AIE-AA-DIS-LABEL: Function: test_with_gep_zero
+; ENABLED-AIE-AA-DIS:  MayAlias:     i8* %ptr_load, i8* %ptr_store
+; ENABLED-AIE-AA-DIS:  NoAlias:      i8* %3, i8* %ptr_load
+; ENABLED-AIE-AA-DIS:  NoAlias:      i8* %3, i8* %ptr_store
+; ENABLED-AIE-AA-DIS:  NoAlias:      i8* %gep, i8* %ptr_load 
+; ENABLED-AIE-AA-DIS:  NoAlias:      i8* %gep, i8* %ptr_store 
+; ENABLED-AIE-AA-DIS:  MayAlias:     i8* %3, i8* %gep 
+; ENABLED-AIE-AA-DIS:  NoAlias:      i8* %10, i8* %ptr_load
+; ENABLED-AIE-AA-DIS:  NoAlias:      i8* %10, i8* %ptr_store
+; ENABLED-AIE-AA-DIS:  NoAlias:      i8* %10, i8* %3
+; ENABLED-AIE-AA-DIS:  NoAlias:      i8* %10, i8* %gep 
+; ENABLED-AIE-AA-DIS:  NoAlias:      i8* %14, i8* %ptr_load
+; ENABLED-AIE-AA-DIS:  NoAlias:      i8* %14, i8* %ptr_store
+; ENABLED-AIE-AA-DIS:  NoAlias:      i8* %14, i8* %3
+; ENABLED-AIE-AA-DIS:  NoAlias:      i8* %14, i8* %gep
+; ENABLED-AIE-AA-DIS:  MayAlias:     i8* %10, i8* %14
+
+; DISABLED-AIE-AA-DES-LABEL: Function: test_with_gep_zero
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %ptr_load, i8* %ptr_store
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %3, i8* %ptr_load
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %3, i8* %ptr_store
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %gep, i8* %ptr_load
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %gep, i8* %ptr_store
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %3, i8* %gep
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %10, i8* %ptr_load
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %10, i8* %ptr_store
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %10, i8* %3
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %10, i8* %gep
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %14, i8* %ptr_load
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %14, i8* %ptr_store
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %14, i8* %3
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %14, i8* %gep
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %10, i8* %14
+
+; Function Attrs: nofree norecurse nounwind mustprogress
+define dso_local i32 @test_with_gep_zero(ptr %a, i8 %b, i32 %c) local_unnamed_addr #0 {
+entry:
+  br label %for.body
+
+for.body:                                         ; preds = %entry, %for.body
+  %counter_load = phi i20 [ %9, %for.body ], [ 0, %entry ]
+  %counter_store = phi i20 [ %13, %for.body ], [ 0, %entry ]
+  %i.08 = phi i32 [ %inc, %for.body ], [ 0, %entry ]
+  %ptr_load = phi ptr [ %10, %for.body ], [ %a, %entry ]
+  %ptr_store = phi ptr [ %14, %for.body ], [ %a, %entry ]
+  load i8, ptr %ptr_load
+  store i8 %b, ptr %ptr_store
+
+  %1 = tail call { ptr, i20 } @llvm.aie2.add.2d(ptr %ptr_load, i20 0, i20 1, i20 2, i20 %counter_load)
+  %2 = extractvalue { ptr, i20 } %1, 1
+  %3 = extractvalue { ptr, i20 } %1, 0
+  load i8, ptr %3
+  
+  %5 = tail call { ptr, i20 } @llvm.aie2.add.2d(ptr %ptr_store, i20 0, i20 1, i20 2, i20 %counter_store)
+  %6 = extractvalue { ptr, i20 } %5, 1
+  %7 = extractvalue { ptr, i20 } %5, 0
+
+  ; GEP with offset zero is ok.
+  %gep = getelementptr inbounds i8, ptr %7, i64 0
+
+  store i8 %b, ptr %gep
+
+  %8 = tail call { ptr, i20 } @llvm.aie2.add.2d(ptr %3, i20 0, i20 1, i20 2, i20 %2)
+  %9 = extractvalue { ptr, i20 } %8, 1
+  %10 = extractvalue { ptr, i20 } %8, 0
+  load i8, ptr %10
+
+  %12 = tail call { ptr, i20 } @llvm.aie2.add.2d(ptr %gep, i20 0, i20 1, i20 2, i20 %6)
+  %13 = extractvalue { ptr, i20 } %12, 1
+  %14 = extractvalue { ptr, i20 } %12, 0
+  store i8 %b, ptr %14
+
+  %inc = add nuw nsw i32 %i.08, 1
+  %exitcond.not = icmp eq i32 %inc, %c
+  br i1 %exitcond.not, label %for.cond.cleanup, label %for.body
+
+for.cond.cleanup:                                 ; preds = %for.body
+  ret i32 0
+}
+
+; ENABLED-AIE-AA-DIS-LABEL: Function: test_with_gep_non_zero
+; ENABLED-AIE-AA-DIS:  MayAlias:      i8* %ptr_load, i8* %ptr_store
+; ENABLED-AIE-AA-DIS:  NoAlias:       i8* %3, i8* %ptr_load
+; ENABLED-AIE-AA-DIS:  MayAlias:      i8* %3, i8* %ptr_store
+; ENABLED-AIE-AA-DIS:  MayAlias:      i8* %gep, i8* %ptr_load 
+; ENABLED-AIE-AA-DIS:  MayAlias:      i8* %gep, i8* %ptr_store 
+; ENABLED-AIE-AA-DIS:  MayAlias:      i8* %3, i8* %gep 
+; ENABLED-AIE-AA-DIS:  NoAlias:       i8* %10, i8* %ptr_load
+; ENABLED-AIE-AA-DIS:  MayAlias:      i8* %10, i8* %ptr_store
+; ENABLED-AIE-AA-DIS:  NoAlias:       i8* %10, i8* %3
+; ENABLED-AIE-AA-DIS:  MayAlias:      i8* %10, i8* %gep 
+; ENABLED-AIE-AA-DIS:  MayAlias:      i8* %14, i8* %ptr_load
+; ENABLED-AIE-AA-DIS:  MayAlias:      i8* %14, i8* %ptr_store
+; ENABLED-AIE-AA-DIS:  MayAlias:      i8* %14, i8* %3
+; ENABLED-AIE-AA-DIS:  MayAlias:      i8* %14, i8* %gep
+; ENABLED-AIE-AA-DIS:  MayAlias:      i8* %10, i8* %14
+
+; DISABLED-AIE-AA-DES-LABEL: Function: test_with_gep_non_zero
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %ptr_load, i8* %ptr_store
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %3, i8* %ptr_load
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %3, i8* %ptr_store
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %gep, i8* %ptr_load
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %gep, i8* %ptr_store
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %3, i8* %gep
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %10, i8* %ptr_load
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %10, i8* %ptr_store
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %10, i8* %3
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %10, i8* %gep
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %14, i8* %ptr_load
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %14, i8* %ptr_store
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %14, i8* %3
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %14, i8* %gep
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %10, i8* %14
+
+; Function Attrs: nofree norecurse nounwind mustprogress
+define dso_local i32 @test_with_gep_non_zero(ptr %a, i8 %b, i32 %c) local_unnamed_addr #0 {
+entry:
+  br label %for.body
+
+for.body:                                         ; preds = %entry, %for.body
+  %counter_load = phi i20 [ %9, %for.body ], [ 0, %entry ]
+  %counter_store = phi i20 [ %13, %for.body ], [ 0, %entry ]
+  %i.08 = phi i32 [ %inc, %for.body ], [ 0, %entry ]
+  %ptr_load = phi ptr [ %10, %for.body ], [ %a, %entry ]
+  %ptr_store = phi ptr [ %14, %for.body ], [ %a, %entry ]
+  load i8, ptr %ptr_load
+  store i8 %b, ptr %ptr_store
+
+  %1 = tail call { ptr, i20 } @llvm.aie2.add.2d(ptr %ptr_load, i20 0, i20 1, i20 2, i20 %counter_load)
+  %2 = extractvalue { ptr, i20 } %1, 1
+  %3 = extractvalue { ptr, i20 } %1, 0
+  load i8, ptr %3
+  
+  %5 = tail call { ptr, i20 } @llvm.aie2.add.2d(ptr %ptr_store, i20 0, i20 1, i20 2, i20 %counter_store)
+  %6 = extractvalue { ptr, i20 } %5, 1
+  %7 = extractvalue { ptr, i20 } %5, 0
+
+  ; GEP with offset != from zero is NOT ok.
+  %gep = getelementptr inbounds i8, ptr %7, i64 2
+
+  store i8 %b, ptr %gep
+
+  %8 = tail call { ptr, i20 } @llvm.aie2.add.2d(ptr %3, i20 0, i20 1, i20 2, i20 %2)
+  %9 = extractvalue { ptr, i20 } %8, 1
+  %10 = extractvalue { ptr, i20 } %8, 0
+  load i8, ptr %10
+
+  %12 = tail call { ptr, i20 } @llvm.aie2.add.2d(ptr %gep, i20 0, i20 1, i20 2, i20 %6)
+  %13 = extractvalue { ptr, i20 } %12, 1
+  %14 = extractvalue { ptr, i20 } %12, 0
+  store i8 %b, ptr %14
+
+  %inc = add nuw nsw i32 %i.08, 1
+  %exitcond.not = icmp eq i32 %inc, %c
+  br i1 %exitcond.not, label %for.cond.cleanup, label %for.body
+
+for.cond.cleanup:                                 ; preds = %for.body
+  ret i32 0
+}
+
+; ENABLED-AIE-AA-DIS-LABEL: Function: broke_counter_chain
+; ENABLED-AIE-AA-DIS:  MayAlias:     i8* %ptr_load, i8* %ptr_store
+; ENABLED-AIE-AA-DIS:  MayAlias:     i8* %3, i8* %ptr_load
+; ENABLED-AIE-AA-DIS:  MayAlias:     i8* %3, i8* %ptr_store
+; ENABLED-AIE-AA-DIS:  MayAlias:     i8* %7, i8* %ptr_load
+; ENABLED-AIE-AA-DIS:  NoAlias:      i8* %7, i8* %ptr_store
+; ENABLED-AIE-AA-DIS:  MayAlias:     i8* %3, i8* %7
+; ENABLED-AIE-AA-DIS:  MayAlias:     i8* %10, i8* %ptr_load
+; ENABLED-AIE-AA-DIS:  MayAlias:     i8* %10, i8* %ptr_store
+; ENABLED-AIE-AA-DIS:  MayAlias:     i8* %10, i8* %3
+; ENABLED-AIE-AA-DIS:  MayAlias:     i8* %10, i8* %7
+; ENABLED-AIE-AA-DIS:  MayAlias:     i8* %14, i8* %ptr_load
+; ENABLED-AIE-AA-DIS:  NoAlias:      i8* %14, i8* %ptr_store
+; ENABLED-AIE-AA-DIS:  MayAlias:     i8* %14, i8* %3
+; ENABLED-AIE-AA-DIS:  NoAlias:      i8* %14, i8* %7
+; ENABLED-AIE-AA-DIS:  MayAlias:     i8* %10, i8* %14
+
+; DISABLED-AIE-AA-DES-LABEL: Function: broke_counter_chain
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %ptr_load, i8* %ptr_store
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %3, i8* %ptr_load
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %3, i8* %ptr_store
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %7, i8* %ptr_load
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %7, i8* %ptr_store
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %3, i8* %7
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %10, i8* %ptr_load
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %10, i8* %ptr_store
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %10, i8* %3
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %10, i8* %7
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %14, i8* %ptr_load
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %14, i8* %ptr_store
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %14, i8* %3
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %14, i8* %7
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %10, i8* %14
+
+; Function Attrs: nofree norecurse nounwind mustprogress
+define dso_local i32 @broke_counter_chain(ptr %a, i8 %b, i32 %c) local_unnamed_addr #0 {
+entry:
+  br label %for.body
+
+for.body:                                         ; preds = %entry, %for.body
+  %counter_load = phi i20 [ %9, %for.body ], [ 0, %entry ]
+  %counter_store = phi i20 [ %13, %for.body ], [ 0, %entry ]
+  %i.08 = phi i32 [ %inc, %for.body ], [ 0, %entry ]
+  %ptr_load = phi ptr [ %10, %for.body ], [ %a, %entry ]
+  %ptr_store = phi ptr [ %14, %for.body ], [ %a, %entry ]
+  load i8, ptr %ptr_load
+  store i8 %b, ptr %ptr_store
+
+  %1 = tail call { ptr, i20 } @llvm.aie2.add.2d(ptr %ptr_load, i20 0, i20 1, i20 2, i20 %counter_load)
+  %2 = extractvalue { ptr, i20 } %1, 1
+  %3 = extractvalue { ptr, i20 } %1, 0
+  load i8, ptr %3
+  
+  %5 = tail call { ptr, i20 } @llvm.aie2.add.2d(ptr %ptr_store, i20 0, i20 1, i20 2, i20 %counter_store)
+  %6 = extractvalue { ptr, i20 } %5, 1
+  %7 = extractvalue { ptr, i20 } %5, 0
+  store i8 %b, ptr %7
+
+  ; here we break the counter chain.
+  %8 = tail call { ptr, i20 } @llvm.aie2.add.2d(ptr %3, i20 0, i20 1, i20 2, i20 2)
+  %9 = extractvalue { ptr, i20 } %8, 1
+  %10 = extractvalue { ptr, i20 } %8, 0
+  load i8, ptr %10
+
+  %12 = tail call { ptr, i20 } @llvm.aie2.add.2d(ptr %7, i20 0, i20 1, i20 2, i20 %6)
+  %13 = extractvalue { ptr, i20 } %12, 1
+  %14 = extractvalue { ptr, i20 } %12, 0
+  store i8 %b, ptr %14
+
+  %inc = add nuw nsw i32 %i.08, 1
+  %exitcond.not = icmp eq i32 %inc, %c
+  br i1 %exitcond.not, label %for.cond.cleanup, label %for.body
+
+for.cond.cleanup:                                 ; preds = %for.body
+  ret i32 0
+}
+
+; ENABLED-AIE-AA-DIS-LABEL: Function: diff_initial_counters
+; ENABLED-AIE-AA-DIS:  MayAlias:     i8* %ptr_load, i8* %ptr_store
+; ENABLED-AIE-AA-DIS:  NoAlias:      i8* %3, i8* %ptr_load
+; ENABLED-AIE-AA-DIS:  MayAlias:     i8* %3, i8* %ptr_store
+; ENABLED-AIE-AA-DIS:  MayAlias:     i8* %7, i8* %ptr_load
+; ENABLED-AIE-AA-DIS:  NoAlias:      i8* %7, i8* %ptr_store
+; ENABLED-AIE-AA-DIS:  MayAlias:     i8* %3, i8* %7
+; ENABLED-AIE-AA-DIS:  NoAlias:      i8* %10, i8* %ptr_load
+; ENABLED-AIE-AA-DIS:  MayAlias:     i8* %10, i8* %ptr_store
+; ENABLED-AIE-AA-DIS:  NoAlias:      i8* %10, i8* %3
+; ENABLED-AIE-AA-DIS:  MayAlias:     i8* %10, i8* %7
+; ENABLED-AIE-AA-DIS:  MayAlias:     i8* %14, i8* %ptr_load
+; ENABLED-AIE-AA-DIS:  NoAlias:      i8* %14, i8* %ptr_store
+; ENABLED-AIE-AA-DIS:  MayAlias:     i8* %14, i8* %3
+; ENABLED-AIE-AA-DIS:  NoAlias:      i8* %14, i8* %7
+; ENABLED-AIE-AA-DIS:  MayAlias:     i8* %10, i8* %14
+
+; DISABLED-AIE-AA-DES-LABEL: Function: diff_initial_counters
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %ptr_load, i8* %ptr_store
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %3, i8* %ptr_load
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %3, i8* %ptr_store
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %7, i8* %ptr_load
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %7, i8* %ptr_store
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %3, i8* %7
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %10, i8* %ptr_load
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %10, i8* %ptr_store
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %10, i8* %3
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %10, i8* %7
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %14, i8* %ptr_load
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %14, i8* %ptr_store
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %14, i8* %3
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %14, i8* %7
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %10, i8* %14
+
+; Function Attrs: nofree norecurse nounwind mustprogress
+define dso_local i32 @diff_initial_counters(ptr %a, i8 %b, i32 %c) local_unnamed_addr #0 {
+entry:
+  br label %for.body
+
+for.body:                                         ; preds = %entry, %for.body
+  %counter_load = phi i20 [ %9, %for.body ], [ 0, %entry ]
+  %counter_store = phi i20 [ %13, %for.body ], [ 2, %entry ] ; diff. counter initial value.
+  %i.08 = phi i32 [ %inc, %for.body ], [ 0, %entry ]
+  %ptr_load = phi ptr [ %10, %for.body ], [ %a, %entry ]
+  %ptr_store = phi ptr [ %14, %for.body ], [ %a, %entry ]
+  load i8, ptr %ptr_load
+  store i8 %b, ptr %ptr_store
+
+  %1 = tail call { ptr, i20 } @llvm.aie2.add.2d(ptr %ptr_load, i20 0, i20 1, i20 2, i20 %counter_load)
+  %2 = extractvalue { ptr, i20 } %1, 1
+  %3 = extractvalue { ptr, i20 } %1, 0
+  load i8, ptr %3
+  
+  %5 = tail call { ptr, i20 } @llvm.aie2.add.2d(ptr %ptr_store, i20 0, i20 1, i20 2, i20 %counter_store)
+  %6 = extractvalue { ptr, i20 } %5, 1
+  %7 = extractvalue { ptr, i20 } %5, 0
+  store i8 %b, ptr %7
+
+  %8 = tail call { ptr, i20 } @llvm.aie2.add.2d(ptr %3, i20 0, i20 1, i20 2, i20 %2)
+  %9 = extractvalue { ptr, i20 } %8, 1
+  %10 = extractvalue { ptr, i20 } %8, 0
+  load i8, ptr %10
+
+  %12 = tail call { ptr, i20 } @llvm.aie2.add.2d(ptr %7, i20 0, i20 1, i20 2, i20 %6)
+  %13 = extractvalue { ptr, i20 } %12, 1
+  %14 = extractvalue { ptr, i20 } %12, 0
+  store i8 %b, ptr %14
+
+  %inc = add nuw nsw i32 %i.08, 1
+  %exitcond.not = icmp eq i32 %inc, %c
+  br i1 %exitcond.not, label %for.cond.cleanup, label %for.body
+
+for.cond.cleanup:                                 ; preds = %for.body
+  ret i32 0
+}
+
+; ENABLED-AIE-AA-DIS-LABEL: Function: with_addrspace_cast
+; ENABLED-AIE-AA-DIS:  MayAlias:     i8* %ptr_load, i8* %ptr_store
+; ENABLED-AIE-AA-DIS:  NoAlias:      i8* %3, i8* %ptr_load
+; ENABLED-AIE-AA-DIS:  NoAlias:      i8* %3, i8* %ptr_store
+; ENABLED-AIE-AA-DIS:  NoAlias:      i8* %ptr_load, i8 addrspace(3)* %ptrcast
+; ENABLED-AIE-AA-DIS:  NoAlias:      i8* %ptr_store, i8 addrspace(3)* %ptrcast 
+; ENABLED-AIE-AA-DIS:  MayAlias:     i8* %3, i8 addrspace(3)* %ptrcast
+; ENABLED-AIE-AA-DIS:  NoAlias:      i8* %10, i8* %ptr_load
+; ENABLED-AIE-AA-DIS:  NoAlias:      i8* %10, i8* %ptr_store
+; ENABLED-AIE-AA-DIS:  NoAlias:      i8* %10, i8* %3
+; ENABLED-AIE-AA-DIS:  NoAlias:      i8* %10, i8 addrspace(3)* %ptrcast 
+; ENABLED-AIE-AA-DIS:  NoAlias:      i8* %14, i8* %ptr_load
+; ENABLED-AIE-AA-DIS:  NoAlias:      i8* %14, i8* %ptr_store
+; ENABLED-AIE-AA-DIS:  NoAlias:      i8* %14, i8* %3
+; ENABLED-AIE-AA-DIS:  NoAlias:      i8* %14, i8 addrspace(3)* %ptrcast 
+; ENABLED-AIE-AA-DIS:  MayAlias:     i8* %10, i8* %14
+
+; DISABLED-AIE-AA-DES-LABEL: Function: with_addrspace_cast
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %ptr_load, i8* %ptr_store
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %3, i8* %ptr_load
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %3, i8* %ptr_store
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %ptr_load, i8 addrspace(3)* %ptrcast
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %ptr_store, i8 addrspace(3)* %ptrcast
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %3, i8 addrspace(3)* %ptrcast
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %10, i8* %ptr_load
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %10, i8* %ptr_store
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %10, i8* %3
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %10, i8 addrspace(3)* %ptrcast
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %14, i8* %ptr_load
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %14, i8* %ptr_store
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %14, i8* %3
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %14, i8 addrspace(3)* %ptrcast
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %10, i8* %14
+
+; Function Attrs: nofree norecurse nounwind mustprogress
+define dso_local i32 @with_addrspace_cast(ptr %a, i8 %b, i32 %c) local_unnamed_addr #0 {
+entry:
+  br label %for.body
+
+for.body:                                         ; preds = %entry, %for.body
+  %counter_load = phi i20 [ %9, %for.body ], [ 0, %entry ]
+  %counter_store = phi i20 [ %13, %for.body ], [ 0, %entry ]
+  %i.08 = phi i32 [ %inc, %for.body ], [ 0, %entry ]
+  %ptr_load = phi ptr [ %10, %for.body ], [ %a, %entry ]
+  %ptr_store = phi ptr [ %14, %for.body ], [ %a, %entry ]
+  load i8, ptr %ptr_load
+  store i8 %b, ptr %ptr_store
+
+  %1 = tail call { ptr, i20 } @llvm.aie2.add.2d(ptr %ptr_load, i20 0, i20 1, i20 2, i20 %counter_load)
+  %2 = extractvalue { ptr, i20 } %1, 1
+  %3 = extractvalue { ptr, i20 } %1, 0
+  load i8, ptr %3
+  
+  %5 = tail call { ptr, i20 } @llvm.aie2.add.2d(ptr %ptr_store, i20 0, i20 1, i20 2, i20 %counter_store)
+  %6 = extractvalue { ptr, i20 } %5, 1
+  %7 = extractvalue { ptr, i20 } %5, 0
+
+  %ptrcast = addrspacecast ptr %7 to ptr addrspace(3)
+
+  store i8 %b, ptr addrspace(3) %ptrcast
+
+  %8 = tail call { ptr, i20 } @llvm.aie2.add.2d(ptr %3, i20 0, i20 1, i20 2, i20 %2)
+  %9 = extractvalue { ptr, i20 } %8, 1
+  %10 = extractvalue { ptr, i20 } %8, 0
+  load i8, ptr %10
+
+  %12 = tail call { ptr, i20 } @llvm.aie2.add.2d(ptr %7, i20 0, i20 1, i20 2, i20 %6)
+  %13 = extractvalue { ptr, i20 } %12, 1
+  %14 = extractvalue { ptr, i20 } %12, 0
+  store i8 %b, ptr %14
+
+  %inc = add nuw nsw i32 %i.08, 1
+  %exitcond.not = icmp eq i32 %inc, %c
+  br i1 %exitcond.not, label %for.cond.cleanup, label %for.body
+
+for.cond.cleanup:                                 ; preds = %for.body
+  ret i32 0
+}
+
+; ENABLED-AIE-AA-DIS-LABEL: Function: with_addrspace_cast_phi
+; ENABLED-AIE-AA-DIS:  MayAlias:    i8* %first_load_ptr, i8* %first_store_ptr 
+; ENABLED-AIE-AA-DIS:  NoAlias:      i8* %3, i8* %first_load_ptr
+; ENABLED-AIE-AA-DIS:  NoAlias:      i8* %3, i8* %first_store_ptr
+; ENABLED-AIE-AA-DIS:  NoAlias:      i8* %7, i8* %first_load_ptr
+; ENABLED-AIE-AA-DIS:  NoAlias:      i8* %7, i8* %first_store_ptr
+; ENABLED-AIE-AA-DIS:  MayAlias:     i8* %3, i8* %7
+; ENABLED-AIE-AA-DIS:  NoAlias:      i8* %10, i8* %first_load_ptr
+; ENABLED-AIE-AA-DIS:  NoAlias:      i8* %10, i8* %first_store_ptr
+; ENABLED-AIE-AA-DIS:  NoAlias:      i8* %10, i8* %3
+; ENABLED-AIE-AA-DIS:  NoAlias:      i8* %10, i8* %7
+; ENABLED-AIE-AA-DIS:  NoAlias:      i8* %14, i8* %first_load_ptr
+; ENABLED-AIE-AA-DIS:  NoAlias:      i8* %14, i8* %first_store_ptr
+; ENABLED-AIE-AA-DIS:  NoAlias:      i8* %14, i8* %3
+; ENABLED-AIE-AA-DIS:  NoAlias:      i8* %14, i8* %7
+; ENABLED-AIE-AA-DIS:  MayAlias:     i8* %10, i8* %14
+; ENABLED-AIE-AA-DIS:  NoAlias:      i8* %first_load_ptr, i8 addrspace(3)* %last_load_ptr
+; ENABLED-AIE-AA-DIS:  NoAlias:      i8* %first_store_ptr, i8 addrspace(3)* %last_load_ptr
+; ENABLED-AIE-AA-DIS:  NoAlias:      i8* %3, i8 addrspace(3)* %last_load_ptr
+; ENABLED-AIE-AA-DIS:  NoAlias:      i8* %7, i8 addrspace(3)* %last_load_ptr
+; ENABLED-AIE-AA-DIS:  MustAlias:    i8* %10, i8 addrspace(3)* %last_load_ptr
+; ENABLED-AIE-AA-DIS:  MayAlias:     i8* %14, i8 addrspace(3)* %last_load_ptr
+; ENABLED-AIE-AA-DIS:  NoAlias:      i8* %first_load_ptr, i8 addrspace(3)* %last_store_ptr
+; ENABLED-AIE-AA-DIS:  NoAlias:      i8* %first_store_ptr, i8 addrspace(3)* %last_store_ptr
+; ENABLED-AIE-AA-DIS:  NoAlias:      i8* %3, i8 addrspace(3)* %last_store_ptr
+; ENABLED-AIE-AA-DIS:  NoAlias:      i8* %7, i8 addrspace(3)* %last_store_ptr
+; ENABLED-AIE-AA-DIS:  MayAlias:     i8* %10, i8 addrspace(3)* %last_store_ptr
+; ENABLED-AIE-AA-DIS:  MustAlias:    i8* %14, i8 addrspace(3)* %last_store_ptr
+; ENABLED-AIE-AA-DIS:  MayAlias:     i8 addrspace(3)* %last_load_ptr, i8 addrspace(3)* %last_store_ptr
+
+; DISABLED-AIE-AA-DES-LABEL: Function: with_addrspace_cast_phi
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %first_load_ptr, i8* %first_store_ptr
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %3, i8* %first_load_ptr
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %3, i8* %first_store_ptr
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %7, i8* %first_load_ptr
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %7, i8* %first_store_ptr
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %3, i8* %7
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %10, i8* %first_load_ptr
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %10, i8* %first_store_ptr
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %10, i8* %3
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %10, i8* %7
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %14, i8* %first_load_ptr
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %14, i8* %first_store_ptr
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %14, i8* %3
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %14, i8* %7
+; DISABLED-AIE-AA-DES:  MayAlias:      i8* %10, i8* %14
+; DISABLED-AIE-AA-DIS:  MayAlias:      i8* %first_load_ptr, i8 addrspace(3)* %last_load_ptr
+; DISABLED-AIE-AA-DIS:  MayAlias:      i8* %first_store_ptr, i8 addrspace(3)* %last_load_ptr
+; DISABLED-AIE-AA-DIS:  MayAlias:      i8* %3, i8 addrspace(3)* %last_load_ptr
+; DISABLED-AIE-AA-DIS:  MayAlias:      i8* %7, i8 addrspace(3)* %last_load_ptr
+; DISABLED-AIE-AA-DIS:  MustAlias:     i8* %10, i8 addrspace(3)* %last_load_ptr
+; DISABLED-AIE-AA-DIS:  MayAlias:      i8* %14, i8 addrspace(3)* %last_load_ptr
+; DISABLED-AIE-AA-DIS:  MayAlias:      i8* %first_load_ptr, i8 addrspace(3)* %last_store_ptr
+; DISABLED-AIE-AA-DIS:  MayAlias:      i8* %first_store_ptr, i8 addrspace(3)* %last_store_ptr
+; DISABLED-AIE-AA-DIS:  MayAlias:      i8* %3, i8 addrspace(3)* %last_store_ptr
+; DISABLED-AIE-AA-DIS:  MayAlias:      i8* %7, i8 addrspace(3)* %last_store_ptr
+; DISABLED-AIE-AA-DIS:  MayAlias:      i8* %10, i8 addrspace(3)* %last_store_ptr
+; DISABLED-AIE-AA-DIS:  MustAlias:     i8* %14, i8 addrspace(3)* %last_store_ptr
+; DISABLED-AIE-AA-DIS:  MayAlias:      i8 addrspace(3)* %last_load_ptr, i8 addrspace(3)* %last_store_ptr
+
+; Function Attrs: nofree norecurse nounwind mustprogress
+define dso_local i32 @with_addrspace_cast_phi(ptr addrspace(3) %a, i8 %b, i32 %c) local_unnamed_addr #0 {
+entry:
+  br label %for.body
+
+for.body:                                         ; preds = %entry, %for.body
+  %counter_load = phi i20 [ %9, %for.body ], [ 0, %entry ]
+  %counter_store = phi i20 [ %13, %for.body ], [ 0, %entry ]
+  %i.08 = phi i32 [ %inc, %for.body ], [ 0, %entry ]
+  %ptr_load = phi ptr addrspace(3) [ %last_load_ptr, %for.body ], [ %a, %entry ]
+  %ptr_store = phi ptr addrspace(3) [ %last_store_ptr, %for.body ], [ %a, %entry ]
+  
+  %first_load_ptr = addrspacecast ptr addrspace(3) %ptr_load to ptr
+  %first_store_ptr = addrspacecast ptr addrspace(3) %ptr_store to ptr
+
+  load i8, ptr %first_load_ptr
+  store i8 %b, ptr %first_store_ptr
+
+  %1 = tail call { ptr, i20 } @llvm.aie2.add.2d(ptr %first_load_ptr, i20 0, i20 1, i20 2, i20 %counter_load)
+  %2 = extractvalue { ptr, i20 } %1, 1
+  %3 = extractvalue { ptr, i20 } %1, 0
+  load i8, ptr %3
+  
+  %5 = tail call { ptr, i20 } @llvm.aie2.add.2d(ptr %first_store_ptr, i20 0, i20 1, i20 2, i20 %counter_store)
+  %6 = extractvalue { ptr, i20 } %5, 1
+  %7 = extractvalue { ptr, i20 } %5, 0
+  store i8 %b, ptr %7
+
+  %8 = tail call { ptr, i20 } @llvm.aie2.add.2d(ptr %3, i20 0, i20 1, i20 2, i20 %2)
+  %9 = extractvalue { ptr, i20 } %8, 1
+  %10 = extractvalue { ptr, i20 } %8, 0
+  load i8, ptr %10
+
+  %12 = tail call { ptr, i20 } @llvm.aie2.add.2d(ptr %7, i20 0, i20 1, i20 2, i20 %6)
+  %13 = extractvalue { ptr, i20 } %12, 1
+  %14 = extractvalue { ptr, i20 } %12, 0
+  store i8 %b, ptr %14
+
+  %last_load_ptr = addrspacecast ptr %10 to ptr addrspace(3)
+  %last_store_ptr = addrspacecast ptr %14 to ptr addrspace(3)
+
+  load i8, ptr addrspace(3) %last_load_ptr
+  store i8 %b, ptr addrspace(3) %last_store_ptr
+
+  %inc = add nuw nsw i32 %i.08, 1
+  %exitcond.not = icmp eq i32 %inc, %c
+  br i1 %exitcond.not, label %for.cond.cleanup, label %for.body
+
+for.cond.cleanup:                                 ; preds = %for.body
+  ret i32 0
+}

--- a/llvm/unittests/Target/AIE/CMakeLists.txt
+++ b/llvm/unittests/Target/AIE/CMakeLists.txt
@@ -15,6 +15,7 @@ set(LLVM_LINK_COMPONENTS
   AIEDesc
   AIEInfo
   CodeGen
+  CodeGenTypes
   Core
   GlobalISel
   MC
@@ -22,6 +23,7 @@ set(LLVM_LINK_COMPONENTS
   SelectionDAG
   Support
   Target
+  TargetParser
 )
 
 add_llvm_target_unittest(AIETests
@@ -30,4 +32,7 @@ add_llvm_target_unittest(AIETests
   AIETestTarget.cpp
   BundleTest.cpp
   HazardRecognizerTest.cpp
+  VirtUnrollAliasAnalysisTest.cpp
   )
+
+set_property(TARGET AIETests PROPERTY FOLDER "Tests/UnitTests/TargetTests")

--- a/llvm/unittests/Target/AIE/VirtUnrollAliasAnalysisTest.cpp
+++ b/llvm/unittests/Target/AIE/VirtUnrollAliasAnalysisTest.cpp
@@ -1,0 +1,254 @@
+//===- VirtUnrollAliasAnalysisTest.cpp ------------------------------------===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+//
+//===----------------------------------------------------------------------===//
+
+#include "AIEBaseAliasAnalysis.h"
+#include "llvm/CodeGen/MIRParser/MIRParser.h"
+#include "llvm/CodeGen/MachineBlockFrequencyInfo.h"
+#include "llvm/CodeGen/MachineModuleInfo.h"
+#include "llvm/CodeGen/MachineSizeOpts.h"
+#include "llvm/MC/TargetRegistry.h"
+#include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/TargetSelect.h"
+#include "llvm/Target/TargetMachine.h"
+#include "gtest/gtest.h"
+#include <vector>
+
+using namespace llvm;
+
+namespace {
+
+std::unique_ptr<LLVMTargetMachine> createTargetMachine() {
+  auto TT(Triple::normalize("aie2--"));
+  std::string Error;
+  const Target *TheTarget = TargetRegistry::lookupTarget(TT, Error);
+  llvm::errs() << Error << "\n";
+  return std::unique_ptr<LLVMTargetMachine>(static_cast<LLVMTargetMachine *>(
+      TheTarget->createTargetMachine(TT, "", "", TargetOptions(), std::nullopt,
+                                     std::nullopt, CodeGenOptLevel::Default)));
+}
+
+class VirtUnrollAliasAnalysisTest : public testing::Test {
+protected:
+  static const char *MIRString;
+  LLVMContext Context;
+  std::unique_ptr<LLVMTargetMachine> TM;
+  std::unique_ptr<MachineModuleInfo> MMI;
+  std::unique_ptr<MIRParser> Parser;
+  std::unique_ptr<Module> M;
+
+  static void SetUpTestCase() {
+    LLVMInitializeAIETargetInfo();
+    LLVMInitializeAIETarget();
+    LLVMInitializeAIETargetMC();
+  }
+
+  void SetUp() override {
+    TM = createTargetMachine();
+    std::unique_ptr<MemoryBuffer> MBuffer =
+        MemoryBuffer::getMemBuffer(MIRString);
+    Parser = createMIRParser(std::move(MBuffer), Context);
+    if (!Parser)
+      report_fatal_error("null MIRParser");
+    M = Parser->parseIRModule();
+    if (!M)
+      report_fatal_error("parseIRModule failed");
+    M->setTargetTriple(TM->getTargetTriple().getTriple());
+    M->setDataLayout(TM->createDataLayout());
+    MMI = std::make_unique<MachineModuleInfo>(TM.get());
+    if (Parser->parseMachineFunctions(*M, *MMI.get()))
+      report_fatal_error("parseMachineFunctions failed");
+  }
+
+  MachineFunction *getMachineFunction(Module *M, StringRef Name) {
+    auto F = M->getFunction(Name);
+    if (!F)
+      report_fatal_error("null Function");
+    auto &MF = MMI->getOrCreateMachineFunction(*F);
+    return &MF;
+  }
+
+  void getInstructions(const MachineBasicBlock *MBB,
+                       std::vector<const MachineInstr *> &Instr) {
+    for (const MachineInstr &MI : *MBB) {
+      Instr.push_back(&MI);
+    }
+  }
+};
+
+TEST_F(VirtUnrollAliasAnalysisTest, TestSameIterators) {
+  const MachineFunction *F = getMachineFunction(M.get(), "test");
+  const MachineBasicBlock *MBB = F->getBlockNumbered(2);
+  std::vector<const MachineInstr *> Instr;
+  getInstructions(MBB, Instr);
+  const MachineInstr *Load1 = Instr[0];
+  const MachineInstr *Store1 = Instr[4];
+  const MachineInstr *Load2 = Instr[5];
+  const MachineInstr *Store2 = Instr[6];
+  const MachineInstr *Load3 = Instr[7];
+  const MachineInstr *Store3 = Instr[8];
+
+  // Same load, same virt unroll.
+  EXPECT_TRUE(AIE::aliasAcrossVirtualUnrolls(Load1, Load1, 0, 0) ==
+              AliasResult::MayAlias);
+  // Same load, same virt unroll (3rd iteration).
+  EXPECT_TRUE(AIE::aliasAcrossVirtualUnrolls(Load1, Load1, 2, 2) ==
+              AliasResult::MayAlias);
+  // Same load, diff. virt unroll.
+  EXPECT_TRUE(AIE::aliasAcrossVirtualUnrolls(Load1, Load1, 0, 1) ==
+              AliasResult::NoAlias);
+  // Diff. load, same virt unroll.
+  EXPECT_TRUE(AIE::aliasAcrossVirtualUnrolls(Load1, Load2, 0, 0) ==
+              AliasResult::NoAlias);
+  // Store and load with same virt unroll, same pointer step.
+  EXPECT_TRUE(AIE::aliasAcrossVirtualUnrolls(Load1, Store1, 0, 0) ==
+              AliasResult::MayAlias);
+  // Store and load with same virt unroll, same pointer step.
+  EXPECT_TRUE(AIE::aliasAcrossVirtualUnrolls(Load2, Store2, 0, 0) ==
+              AliasResult::MayAlias);
+  // Store and load with diff virt unroll, same pointer step.
+  EXPECT_TRUE(AIE::aliasAcrossVirtualUnrolls(Load3, Store3, 4, 0) ==
+              AliasResult::NoAlias);
+  // Store and load with diff virt unroll, diff pointer step.
+  // This case is interesting because the first store from the 3rd iteration
+  // will alias with the 3rd load of the second iteration since we are not
+  // updating the pointer after the last load and store (post. inc.).
+  EXPECT_TRUE(AIE::aliasAcrossVirtualUnrolls(Store1, Load3, 3, 2) ==
+              AliasResult::MayAlias);
+}
+
+const char *VirtUnrollAliasAnalysisTest::MIRString = R"MIR(
+--- |
+  ; Function Attrs: nofree nosync nounwind memory(none)
+  declare { ptr, i20 } @llvm.aie2.add.2d(ptr, i20, i20, i20, i20) #0
+  
+  ; Function Attrs: nofree nosync nounwind memory(readwrite, inaccessiblemem: none)
+  define dso_local i32 @test(ptr %a, i8 %b, i32 %c) local_unnamed_addr #1 {
+  entry:
+    %exitcond = icmp eq i32 %c, 0
+    br i1 %exitcond, label %for.cond.cleanup, label %for.body.preheader
+  
+  for.body.preheader:                               ; preds = %entry
+    br label %for.body
+  
+  for.body:                                         ; preds = %for.body.preheader, %for.body
+    %lsr.iv = phi i32 [ %c, %for.body.preheader ], [ %lsr.iv.next, %for.body ]
+    %counter_load = phi i20 [ %7, %for.body ], [ 0, %for.body.preheader ]
+    %counter_store = phi i20 [ %10, %for.body ], [ 0, %for.body.preheader ]
+    %sum0 = phi i8 [ %sum3, %for.body ], [ 0, %for.body.preheader ]
+    %ptr_load = phi ptr [ %8, %for.body ], [ %a, %for.body.preheader ]
+    %ptr_store = phi ptr [ %11, %for.body ], [ %a, %for.body.preheader ]
+    %load1 = load i8, ptr %ptr_load, align 1
+    %0 = tail call { ptr, i20 } @llvm.aie2.add.2d(ptr nonnull %ptr_load, i20 0, i20 1, i20 2, i20 %counter_load)
+    %1 = extractvalue { ptr, i20 } %0, 1
+    %2 = extractvalue { ptr, i20 } %0, 0
+    store i8 %b, ptr %ptr_store, align 1
+    %3 = tail call { ptr, i20 } @llvm.aie2.add.2d(ptr nonnull %ptr_store, i20 0, i20 1, i20 2, i20 %counter_store)
+    %4 = extractvalue { ptr, i20 } %3, 1
+    %5 = extractvalue { ptr, i20 } %3, 0
+    %load2 = load i8, ptr %2, align 1
+    %6 = tail call { ptr, i20 } @llvm.aie2.add.2d(ptr nonnull %2, i20 0, i20 1, i20 2, i20 %1)
+    %7 = extractvalue { ptr, i20 } %6, 1
+    %8 = extractvalue { ptr, i20 } %6, 0
+    store i8 %b, ptr %5, align 1
+    %9 = tail call { ptr, i20 } @llvm.aie2.add.2d(ptr nonnull %5, i20 0, i20 1, i20 2, i20 %4)
+    %10 = extractvalue { ptr, i20 } %9, 1
+    %11 = extractvalue { ptr, i20 } %9, 0
+    %load3 = load i8, ptr %8, align 1
+    store i8 %b, ptr %11, align 1
+    %sum1 = add i8 %load1, %sum0
+    %sum2 = add i8 %sum1, %load2
+    %sum3 = add i8 %sum2, %load3
+    %lsr.iv.next = add i32 %lsr.iv, -1
+    %exitcond.not = icmp eq i32 %lsr.iv.next, 0
+    br i1 %exitcond.not, label %for.cond.cleanup.loopexit, label %for.body
+  
+  for.cond.cleanup.loopexit:                        ; preds = %for.body
+    %12 = zext i8 %sum3 to i32
+    br label %for.cond.cleanup
+  
+  for.cond.cleanup:                                 ; preds = %for.cond.cleanup.loopexit, %entry
+    %retsum = phi i32 [ 0, %entry ], [ %12, %for.cond.cleanup.loopexit ]
+    ret i32 %retsum
+  }
+  
+  attributes #0 = { nofree nosync nounwind memory(none) }
+  attributes #1 = { nofree nosync nounwind memory(readwrite, inaccessiblemem: none) }
+
+...
+---
+name:            test
+alignment:       16
+legalized:       true
+regBankSelected: true
+selected:        true
+tracksRegLiveness: true
+tracksDebugUserValues: true
+registers:       []
+liveins:         []
+calleeSavedRegisters: [ '$lr', '$r16', '$r17', '$r18', '$r19', '$r20', 
+                        '$r21', '$r22', '$r23', '$p6', '$p7' ]
+
+body:             |
+  bb.0.entry (align 16):
+    successors: %bb.4(0x30000000), %bb.1(0x50000000)
+    liveins: $p0, $r1, $r2
+  
+    JZ renamable $r2, %bb.4
+    DelayedSchedBarrier
+  
+  bb.1.for.body.preheader:
+    successors: %bb.2(0x80000000)
+    liveins: $p0, $r1, $r2
+  
+    renamable $m0 = MOV_PD_imm10_pseudo 0
+    renamable $dj0 = MOV_PD_imm10_pseudo 1
+    renamable $dn0 = MOV_PD_imm10_pseudo 2
+    renamable $r0 = MOV_RLC_imm10_pseudo 0
+    $dc0 = MOV_mv_scl $m0
+    $dc1 = MOV_mv_scl $m0
+    $p1 = MOV_mv_scl $p0
+  
+  bb.2.for.body (align 16):
+    successors: %bb.3(0x04000000), %bb.2(0x7c000000)
+    liveins: $d0:0x0000000000000870, $d1:0x0000000000000010, $dc0, $dc1, $dj0, $dn0, $m0, $p0, $p1, $r0, $r1, $r2
+  
+    $r3, $p0, $dc0 = LDA_2D_S8_dmhb_lda killed $p0, $d0 :: (load (s8) from %ir.ptr_load)
+    $m1 = MOV_mv_scl $m0
+    $dn1 = MOV_mv_scl $dn0
+    $dj1 = MOV_mv_scl $dj0
+    $p1, $dc1 = ST_2D_S8 $r1, killed $p1, $d1 :: (store (s8) into %ir.ptr_store)
+    $r4, $p0, $dc0 = LDA_2D_S8_dmhb_lda killed $p0, $d0 :: (load (s8) from %ir.2)
+    $p1, $dc1 = ST_2D_S8 $r1, killed $p1, $d1 :: (store (s8) into %ir.5)
+    renamable $r5 = LDA_S8_ag_idx_imm renamable $p0, 0 :: (load (s8) from %ir.8)
+    ST_S8_ag_idx_imm renamable $r1, renamable $p1, 0 :: (store (s8) into %ir.11)
+    renamable $r0 = ADD killed renamable $r3, killed renamable $r0, implicit-def dead $srcarry
+    renamable $r0 = ADD killed renamable $r0, killed renamable $r4, implicit-def dead $srcarry
+    renamable $r2 = ADD_add_r_ri killed renamable $r2, -1, implicit-def dead $srcarry
+    renamable $r0 = ADD killed renamable $r0, killed renamable $r5, implicit-def dead $srcarry
+    JNZ renamable $r2, %bb.2
+    DelayedSchedBarrier
+  
+  bb.3.for.cond.cleanup.loopexit:
+    successors:
+    liveins: $r0
+  
+    renamable $r0 = EXTENDu8 killed renamable $r0
+    RET implicit $lr
+    DelayedSchedBarrier implicit $r0
+  
+  bb.4 (align 16):
+    renamable $r0 = MOV_RLC_imm10_pseudo 0
+    RET implicit $lr
+    DelayedSchedBarrier implicit $r0
+
+...
+)MIR";
+
+} // anonymous namespace


### PR DESCRIPTION
This is RFC. Soon we will need more AA support, and this PR tries to clear a bit the way.

Now we can disambiguate some cases where aie2_add_2d and aie2_add_3d are used to update pointers.

No QoR failures. 
Gains for Reduce* family up to 50% (instruction count). 
Average gain is ~2% (~350 benchmarks). 

Updated to include post-RA AA support.