### PR TITLE
Fix for some problems related to loops

### DIFF
--- a/llvm/lib/Target/AIE/AIEBasePipelinerLoopInfo.cpp
+++ b/llvm/lib/Target/AIE/AIEBasePipelinerLoopInfo.cpp
@@ -726,7 +726,8 @@ std::optional<bool> ZeroOverheadLoop::createTripCountGreaterCondition(
 
 void ZeroOverheadLoop::adjustTripCount(int TripCountAdjust) {
   LLVM_DEBUG(dbgs() << "TripCountAdjust =  " << TripCountAdjust << "\n");
-  if (DefTripCount->getOperand(1).isImm()) {
+  if (DefTripCount->getOperand(1).isImm() &&
+      MRI.hasOneUse(DefTripCount->getOperand(0).getReg())) {
     // If we have a constant here, just update the value.
     const int64_t InitVal = DefTripCount->getOperand(1).getImm();
     DefTripCount->getOperand(1).setImm(InitVal + TripCountAdjust);

--- a/llvm/lib/Target/AIE/AIEInterBlockScheduling.cpp
+++ b/llvm/lib/Target/AIE/AIEInterBlockScheduling.cpp
@@ -485,9 +485,12 @@ int InterBlockScheduling::getCyclesToRespectTiming(
     for (auto &Bundle : R.Bundles) {
       for (MachineInstr *MI : Bundle.getInstrs()) {
         DistancesFromLoopEntry[MI] = DistFromLoopEntry;
-        Edges.addNode(MI);
       }
       ++DistFromLoopEntry;
+    }
+    // Here we need to iterate using semantic order.
+    for (MachineInstr *MI : R) {
+      Edges.addNode(MI);
     }
   };
 

--- a/llvm/test/CodeGen/AIE/aie2/schedule/loopaware/loop-epilogue.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/loopaware/loop-epilogue.mir
@@ -613,3 +613,72 @@ body:             |
     RET implicit $lr
     DelayedSchedBarrier implicit $r3
 ...
+
+# Test 10: the goal here is to test if we can handle negative latencies
+# correctly. In this, case we need to be sure that we are constructing the
+# DAG with the semantic order.
+
+---
+name:            negativeLatLoop
+alignment:       16
+tracksRegLiveness: true
+body:             |
+  ; CHECK-LABEL: name: negativeLatLoop
+  ; CHECK: bb.0:
+  ; CHECK-NEXT:   successors: %bb.1(0x80000000)
+  ; CHECK-NEXT:   liveins: $p0
+  ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT: bb.1:
+  ; CHECK-NEXT:   successors: %bb.2(0x40000000), %bb.1(0x40000000)
+  ; CHECK-NEXT:   liveins: $p0, $r0, $r1, $r2, $r3, $r4
+  ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT:   JNZ $r0, %bb.1
+  ; CHECK-NEXT:   NOP
+  ; CHECK-NEXT:   $dj0 = MOV_mv_scl $r2
+  ; CHECK-NEXT:   $r1 = LDA_dms_lda_idx $p0, killed $dj0
+  ; CHECK-NEXT:   $r1 = OR $r2, killed $r3
+  ; CHECK-NEXT:   $r3 = AND $r1, $r4
+  ; CHECK-NEXT:   DelayedSchedBarrier
+  ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT: bb.2:
+  ; CHECK-NEXT:   successors: %bb.3(0x80000000)
+  ; CHECK-NEXT:   liveins: $r1, $r3
+  ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT:   NOP
+  ; CHECK-NEXT:   NOP
+  ; CHECK-NEXT:   NOP
+  ; CHECK-NEXT:   NOP
+  ; CHECK-NEXT:   $r2 = nsw ADD_add_r_ri killed $r1, -1, implicit-def $srcarry
+  ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT: bb.3:
+  ; CHECK-NEXT:   liveins: $r3
+  ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT:   RET implicit $lr
+  ; CHECK-NEXT:   NOP
+  ; CHECK-NEXT:   NOP
+  ; CHECK-NEXT:   NOP
+  ; CHECK-NEXT:   NOP
+  ; CHECK-NEXT:   NOP
+  ; CHECK-NEXT:   DelayedSchedBarrier implicit killed $r3
+  bb.0:
+    successors: %bb.1
+    liveins: $p0
+  bb.1:
+    successors: %bb.2, %bb.1
+    liveins: $p0, $r0, $r1, $r2, $r3, $r4
+    $dj0 = MOV_mv_scl $r2
+    $r1 = OR $r2, $r3
+    $r3 = AND $r1, $r4
+    $r1 = LDA_dms_lda_idx $p0, $dj0
+    JNZ $r0, %bb.1
+    DelayedSchedBarrier
+  bb.2:
+    successors: %bb.3
+    liveins: $r1, $r3
+    $r2 = nsw ADD_add_r_ri $r1, -1, implicit-def $srcarry
+  bb.3:
+    successors:
+    liveins: $r3
+    RET implicit $lr
+    DelayedSchedBarrier implicit $r3
+...

--- a/llvm/test/CodeGen/AIE/aie2/schedule/swp/swp-zoloop.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/swp/swp-zoloop.mir
@@ -168,3 +168,50 @@ body:             |
     PseudoRET implicit $lr, implicit $r0
 
 ...
+
+# Test 4: LoopStart uses a register defined by mov
+# immediate, but we cannot update the immediate value
+# because LoopStart is not the only user of the result
+
+...
+---
+name:            maxCanonMOV_RLC_imm10_2_users
+alignment:       16
+tracksRegLiveness: true
+debugInstrRef:   false
+liveins:         []
+body:             |
+  ; CHECK-LABEL: name: maxCanonMOV_RLC_imm10
+  ; CHECK: [[INIT:%[0-9]+]]:er = MOV_RLC_imm10_pseudo 4
+  ; CHECK: [[COPY:%[0-9]+]]:em = COPY [[INIT]]
+  ; CHECK: [[MOV:%[0-9]+]]:er = MOV_RLC_imm11_pseudo 0
+  ; CHECK: [[MOV1:%[0-9]+]]:er = MOV_RLC_imm10_pseudo 16
+  ; CHECK: [[LDEC:%[0-9]+]]:er = ADD_NC_GPR [[MOV1]], -3 
+  ; CHECK: LoopStart [[LDEC]]
+  bb.1:
+    liveins: $p0, $p1
+    %1:ep = COPY $p0
+    %2:ep = COPY $p1
+    %26:er = MOV_RLC_imm10_pseudo 4
+    %29:em = COPY %26
+    %17:er = MOV_RLC_imm11_pseudo 0
+    %19:er = MOV_RLC_imm10_pseudo 16
+    LoopStart %19:er
+
+  bb.3:
+    %4:ep = PHI %1, %bb.1, %8, %bb.3
+    %5:er = PHI %17, %bb.1, %0, %bb.3
+    %9:er = LDA_dms_lda_idx_imm %4, 0
+    %8:ep = PADD_mod_pseudo  %4, %29
+    %14:er = ABS %9, implicit-def $srcarry
+    %24:er27 = LT %5, %14
+    %0:er = SELNEZ %14, %5, %24
+    PseudoLoopEnd <mcsymbol .L_LEnd0>, %bb.3
+    PseudoJ_jump_imm %bb.2
+
+  bb.2:
+    $r0 = COPY %0
+    $r1 = COPY %19
+    PseudoRET implicit $lr, implicit $r0, implicit $r1
+
+...


### PR DESCRIPTION
With this PR we remove 9 from 11 failures from QoR when using `-fno-unroll-loops`.