### PR TITLE
[AIE2] Enable MOV scalar immediate and scalar register to use optimal itinerary 

### DIFF
--- a/llvm/lib/Target/AIE/AIE2GenInstrInfo.td
+++ b/llvm/lib/Target/AIE/AIE2GenInstrInfo.td
@@ -536,16 +536,22 @@ let Itinerary = II_PADD_3D in {
   }
 }
 
+// MOV & MOVXM instruction have identical itineraries, they differ only in slot usage 
 let Itinerary = II_MOV, isMoveImm = 1, isReMaterializable = 1 in {
-  // MOVXM is quite expensive in code size, and will block an extra slot, so we don't
-  // mark it as isAsCheapAsAMove
-  let isAsCheapAsAMove = 0 in {
-    def MOVXM_lng_cg : AIE2_lng_cg_lng< (outs OP_mMvSclDstCg:$mMvSclDstCg), 
-        (ins simm32:$i), "movxm", "$mMvSclDstCg, $i">;
-  }
-  let isAsCheapAsAMove = 1 in {  
-    def MOV_mv_cg : AIE2_mv_cg_inst_mv< (outs OP_mMvSclDstCg:$dst) , (ins simm10:$i),
-        "mov", "$dst, $i">;
+  let ItineraryRegPairs = [ItinRegClassPair<II_MOV_RS,eR>, ItinRegClassPair<II_MOV_P,eP>, 
+                          ItinRegClassPair<II_MOV_M,eM>, ItinRegClassPair<II_MOV_RS,eS>,
+                          ItinRegClassPair<II_MOV_DC,eDC>, ItinRegClassPair<II_MOV_DJ,eDJ>,
+                          ItinRegClassPair<II_MOV_DN,eDN>] in {
+    // MOVXM is quite expensive in code size, and will block an extra slot, so we don't
+    // mark it as isAsCheapAsAMove
+    let isAsCheapAsAMove = 0 in {
+      def MOVXM_lng_cg : AIE2_lng_cg_lng< (outs OP_mMvSclDstCg:$mMvSclDstCg), 
+          (ins simm32:$i), "movxm", "$mMvSclDstCg, $i">;
+    }
+    let isAsCheapAsAMove = 1 in {  
+      def MOV_mv_cg : AIE2_mv_cg_inst_mv< (outs OP_mMvSclDstCg:$dst) , (ins simm10:$i),
+          "mov", "$dst, $i">;
+    }
   }
 }
 

--- a/llvm/lib/Target/AIE/AIE2GenInstrInfo.td
+++ b/llvm/lib/Target/AIE/AIE2GenInstrInfo.td
@@ -430,8 +430,12 @@ let Itinerary = II_JZ, hasDelaySlot = true in {
 }
 
 let Itinerary = II_MOVA, isMoveImm = 1, isReMaterializable = 1, isAsCheapAsAMove = 1 in {
-  def MOVA_lda_cg : AIE2_lda_cg_inst_lda<(outs OP_mLdaCg:$mLdaCg),
-      (ins simm11:$c11s), "mova", "$mLdaCg, $c11s">;
+  let ItineraryRegPairs = [ItinRegClassPair<II_MOVA_R,eR>, ItinRegClassPair<II_MOVA_P,eP>, 
+                           ItinRegClassPair<II_MOVA_M,eM>, ItinRegClassPair<II_MOVA_DC,eDC>,
+                           ItinRegClassPair<II_MOVA_DJ,eDJ>, ItinRegClassPair<II_MOVA_DN,eDN>] in {  
+    def MOVA_lda_cg : AIE2_lda_cg_inst_lda<(outs OP_mLdaCg:$mLdaCg),
+        (ins simm11:$c11s), "mova", "$mLdaCg, $c11s">;
+  }
 }
 
 let Itinerary = II_MOV_SS, Defs = [srSS0],

--- a/llvm/lib/Target/AIE/AIE2GenInstrInfo.td
+++ b/llvm/lib/Target/AIE/AIE2GenInstrInfo.td
@@ -532,16 +532,17 @@ let Itinerary = II_PADD_3D in {
   }
 }
 
-// MOVXM is quite expensive in code size, and will block an extra slot, so we don't
-// mark it as isAsCheapAsAMove
-let Itinerary = II_MOVXM, isMoveImm = 1, isReMaterializable = 1, isAsCheapAsAMove = 0 in {
-  def MOVXM_lng_cg : AIE2_lng_cg_lng< (outs OP_mMvSclDstCg:$mMvSclDstCg), 
-      (ins simm32:$i), "movxm", "$mMvSclDstCg, $i">;
-}
-
-let Itinerary = II_MOV, isMoveImm = 1, isReMaterializable = 1, isAsCheapAsAMove = 1 in {
-  def MOV_mv_cg : AIE2_mv_cg_inst_mv< (outs OP_mMvSclDstCg:$dst) , (ins simm10:$i),
-      "mov", "$dst, $i">;
+let Itinerary = II_MOV, isMoveImm = 1, isReMaterializable = 1 in {
+  // MOVXM is quite expensive in code size, and will block an extra slot, so we don't
+  // mark it as isAsCheapAsAMove
+  let isAsCheapAsAMove = 0 in {
+    def MOVXM_lng_cg : AIE2_lng_cg_lng< (outs OP_mMvSclDstCg:$mMvSclDstCg), 
+        (ins simm32:$i), "movxm", "$mMvSclDstCg, $i">;
+  }
+  let isAsCheapAsAMove = 1 in {  
+    def MOV_mv_cg : AIE2_mv_cg_inst_mv< (outs OP_mMvSclDstCg:$dst) , (ins simm10:$i),
+        "mov", "$dst, $i">;
+  }
 }
 
 let Itinerary = II_MOV_SCL, isMoveReg = 1 in {

--- a/llvm/lib/Target/AIE/AIE2GenInstrInfo.td
+++ b/llvm/lib/Target/AIE/AIE2GenInstrInfo.td
@@ -545,8 +545,13 @@ let Itinerary = II_MOV, isMoveImm = 1, isReMaterializable = 1, isAsCheapAsAMove 
 }
 
 let Itinerary = II_MOV_SCL, isMoveReg = 1 in {
-  def MOV_mv_scl : AIE2_mv_scl_inst_mv<(outs OP_mMvSclDst:$mMvSclDst), 
-      (ins OP_mMvSclSrc:$mMvSclSrc  ), "mov", "$mMvSclDst, $mMvSclSrc">;
+  let ItineraryRegPairs = [ItinRegClassPair<II_MOV_SCL_RS,eR>, ItinRegClassPair<II_MOV_SCL_P,eP>, 
+                           ItinRegClassPair<II_MOV_SCL_M,eM>, ItinRegClassPair<II_MOV_SCL_RS,eS>,
+                           ItinRegClassPair<II_MOV_SCL_DC,eDC>, ItinRegClassPair<II_MOV_SCL_DJ,eDJ>,
+                           ItinRegClassPair<II_MOV_SCL_DN,eDN>] in {
+    def MOV_mv_scl : AIE2_mv_scl_inst_mv<(outs OP_mMvSclDst:$mMvSclDst), 
+        (ins OP_mMvSclSrc:$mMvSclSrc), "mov", "$mMvSclDst, $mMvSclSrc">;
+  }
 }
 
 let Itinerary = II_MUL in {

--- a/llvm/lib/Target/AIE/AIE2Schedule.td
+++ b/llvm/lib/Target/AIE/AIE2Schedule.td
@@ -190,6 +190,12 @@ def II_LT : InstrItinClass;
 def II_LTU : InstrItinClass;
 def II_MOV : InstrItinClass;
 def II_MOVA : InstrItinClass;
+def II_MOVA_DC : InstrItinClass;
+def II_MOVA_DJ : InstrItinClass;
+def II_MOVA_DN : InstrItinClass;
+def II_MOVA_M : InstrItinClass;
+def II_MOVA_P : InstrItinClass;
+def II_MOVA_R : InstrItinClass;
 def II_MOVX : InstrItinClass;
 def II_MOV_SCL : InstrItinClass;
 def II_MOV_SCL_DC : InstrItinClass;
@@ -446,6 +452,12 @@ InstrItinData<II_MOV, [PrefixCycle<P_WM_PORT>, PrefixCycle<M_WM_PORT>, PrefixCyc
                        PrefixCycle<DN_WM_PORT>, PrefixCycle<DC_WM_PORT>, SimpleCycle<RS_WM_PORT>], [1,1]>,
 InstrItinData<II_MOVA, [PrefixCycle<P_WM_PORT>, PrefixCycle<M_WM_PORT>, PrefixCycle<DJ_WM_PORT>,
                         PrefixCycle<DN_WM_PORT>, PrefixCycle<DC_WM_PORT>, SimpleCycle<R_WA_PORT>], [1,1]>,
+InstrItinData<II_MOVA_DC, [SimpleCycle<DC_WM_PORT>], [1,1]>,
+InstrItinData<II_MOVA_DJ, [SimpleCycle<DJ_WM_PORT>], [1,1]>,
+InstrItinData<II_MOVA_DN, [SimpleCycle<DN_WM_PORT>], [1,1]>,
+InstrItinData<II_MOVA_M, [SimpleCycle<M_WM_PORT>], [1,1]>,
+InstrItinData<II_MOVA_P, [SimpleCycle<P_WM_PORT>], [1,1]>,
+InstrItinData<II_MOVA_R, [SimpleCycle<R_WA_PORT>], [1,1]>,
 InstrItinData<II_MOVX, [SimpleCycle<R_WX_PORT>], [1,1]>,
 InstrItinData<II_MOV_SCL, [PrefixCycle<P_RM_PORT>, PrefixCycle<RS_WM_PORT>, PrefixCycle<P_WM_PORT>, PrefixCycle<M_WM_PORT>,
                            PrefixCycle<DJ_WM_PORT>, PrefixCycle<DN_WM_PORT>, SimpleCycle<DC_WM_PORT>],

--- a/llvm/lib/Target/AIE/AIE2Schedule.td
+++ b/llvm/lib/Target/AIE/AIE2Schedule.td
@@ -70,8 +70,8 @@ def EXEC_TRACE_UNIT : FuncUnit;
 
 // Reading (rv port)
 def R_RV_PORT : FuncUnit;
-// Writing (wm port)
-def R_WM_PORT : FuncUnit;
+// Writing (wm port), shared with S RegClass
+def RS_WM_PORT : FuncUnit;
 // Writing (wx port)
 def R_WX_PORT : FuncUnit;
 // Writing (wa port)
@@ -98,10 +98,9 @@ def DC_WM_PORT : FuncUnit;
 
 
 // 11.4 Other Scalar Register Ports
-
-// TESTME-VLIW: Conflict between VEXTRACT and other instructions
-// in the mov slot
-def S_WM_PORT : FuncUnit;
+// The S register is a separate register file, however, there is a common part between the 
+// R and S register file wm port which prevents them from being used in parallel.
+// RS_WM_PORT ports model the necessary behavior
 
 // 11.5 Vector Register Ports
 
@@ -362,9 +361,9 @@ def II_VMOV_D : InstrItinClass;
 
 def AIE2Itineraries : ProcessorItineraries<
 [EMPTY_FU,
- R_WX_PORT, R_WA_PORT, R_RV_PORT, R_WM_PORT,
+ R_WX_PORT, R_WA_PORT, R_RV_PORT, RS_WM_PORT,
  P_RM_PORT, P_WM_PORT,
- S_WM_PORT, M_WM_PORT, DC_WM_PORT, DJ_WM_PORT, DN_WM_PORT,
+ M_WM_PORT, DC_WM_PORT, DJ_WM_PORT, DN_WM_PORT,
  W_RS_PORT, W_WA_PORT, W_WM_PORT,
  CM_RM_PORT, CM_WA_PORT, CM_WM_PORT, PROC_BUS, PART_WORD_STORE,
  UPPER_SRS, STORE_UNIT, LOAD_UNIT_A, SEMAPHORE, UPS_UNIT, DONE_UNIT],
@@ -381,9 +380,9 @@ InstrItinData<II_ADC, [InstrStage<1,  [R_WX_PORT]>],
 InstrItinData<II_ADD, [InstrStage<1,  [R_WX_PORT]>],
               [1,1,1,/*def:srCarry*/1]>,
 InstrItinData<II_ADD_NC, [PrefixCycle<P_WM_PORT>, PrefixCycle<M_WM_PORT>, PrefixCycle<DJ_WM_PORT>,
-                         PrefixCycle<DN_WM_PORT>, PrefixCycle<DC_WM_PORT>, PrefixCycle<S_WM_PORT>,
-                         SimpleCycle<R_WM_PORT>], [1,1,1]>,
-InstrItinData<II_ADD_NC_GPR, [SimpleCycle<R_WM_PORT>], [1,1,1]>,
+                         PrefixCycle<DN_WM_PORT>, PrefixCycle<DC_WM_PORT>, SimpleCycle<RS_WM_PORT>],
+                         [1,1,1]>,
+InstrItinData<II_ADD_NC_GPR, [SimpleCycle<RS_WM_PORT>], [1,1,1]>,
 InstrItinData<II_AND, [InstrStage<1,  [R_WX_PORT]>], [1,1,1,1]>,
 InstrItinData<II_ASHL, [InstrStage<1,  [R_WX_PORT]>], [1,1,1,1]>,
 InstrItinData<II_CLB, [InstrStage<1,  [R_WX_PORT]>], [1,1,1]>,
@@ -438,23 +437,23 @@ MemInstrItinData<II_LDA_TM,
 InstrItinData<II_LSHL, [InstrStage<1,  [R_WX_PORT]>], [1,1,1,1]>,
 InstrItinData<II_LT, [InstrStage<1,  [R_WX_PORT]>], [1,1,1,1]>,
 InstrItinData<II_LTU, [InstrStage<1,  [R_WX_PORT]>], [1,1,1,1]>,
-InstrItinData<II_MOV, [PrefixCycle<P_WM_PORT>, PrefixCycle<S_WM_PORT>, PrefixCycle<M_WM_PORT>, PrefixCycle<DJ_WM_PORT>,
-                       PrefixCycle<DN_WM_PORT>, PrefixCycle<DC_WM_PORT>, SimpleCycle<R_WM_PORT>], [1,1]>,
+InstrItinData<II_MOV, [PrefixCycle<P_WM_PORT>, PrefixCycle<M_WM_PORT>, PrefixCycle<DJ_WM_PORT>,
+                       PrefixCycle<DN_WM_PORT>, PrefixCycle<DC_WM_PORT>, SimpleCycle<RS_WM_PORT>], [1,1]>,
 InstrItinData<II_MOVA, [PrefixCycle<P_WM_PORT>, PrefixCycle<M_WM_PORT>, PrefixCycle<DJ_WM_PORT>,
                         PrefixCycle<DN_WM_PORT>, PrefixCycle<DC_WM_PORT>, SimpleCycle<R_WA_PORT>], [1,1]>,
 InstrItinData<II_MOVX, [SimpleCycle<R_WX_PORT>], [1,1]>,
-InstrItinData<II_MOVXM, [PrefixCycle<P_WM_PORT>, PrefixCycle<S_WM_PORT>, PrefixCycle<M_WM_PORT>, PrefixCycle<DJ_WM_PORT>,
-                         PrefixCycle<DN_WM_PORT>, PrefixCycle<DC_WM_PORT>, SimpleCycle<R_WM_PORT>], [1,1]>,
-InstrItinData<II_MOV_SCL, [PrefixCycle<P_RM_PORT>, PrefixCycle<R_WM_PORT>, PrefixCycle<P_WM_PORT>, PrefixCycle<M_WM_PORT>,
-                           PrefixCycle<DJ_WM_PORT>, PrefixCycle<DN_WM_PORT>, PrefixCycle<DC_WM_PORT>, SimpleCycle<S_WM_PORT>],
+InstrItinData<II_MOVXM, [PrefixCycle<P_WM_PORT>, PrefixCycle<M_WM_PORT>, PrefixCycle<DJ_WM_PORT>,
+                         PrefixCycle<DN_WM_PORT>, PrefixCycle<DC_WM_PORT>, SimpleCycle<RS_WM_PORT>], [1,1]>,
+InstrItinData<II_MOV_SCL, [PrefixCycle<P_RM_PORT>, PrefixCycle<RS_WM_PORT>, PrefixCycle<P_WM_PORT>, PrefixCycle<M_WM_PORT>,
+                           PrefixCycle<DJ_WM_PORT>, PrefixCycle<DN_WM_PORT>, SimpleCycle<DC_WM_PORT>],
                            [1,1]>,
 InstrItinData<II_MOV_SS, [AvoidSemaphore<7>, EmptyCycles<6>, SimpleCycle<R_WA_PORT>], [7,/*def:srSS0*/8]>,
-InstrItinData<II_MOVd1, [SimpleCycle<P_RM_PORT>, SimpleCycle<R_WM_PORT>], [2,1]>,
-InstrItinData<II_MOVd2, [SimpleCycle<P_RM_PORT>, EmptyCycles<1>, SimpleCycle<R_WM_PORT>], [3,1]>,
-InstrItinData<II_MOVd3, [SimpleCycle<P_RM_PORT>, EmptyCycles<2>, SimpleCycle<R_WM_PORT>], [4,1]>,
-InstrItinData<II_MOVd4, [SimpleCycle<P_RM_PORT>, EmptyCycles<3>, SimpleCycle<R_WM_PORT>], [5,1]>,
-InstrItinData<II_MOVd5, [SimpleCycle<P_RM_PORT>, EmptyCycles<4>, SimpleCycle<R_WM_PORT>], [6,1]>,
-InstrItinData<II_MOVd6, [SimpleCycle<P_RM_PORT>, EmptyCycles<5>, SimpleCycle<R_WM_PORT>], [7,1]>,
+InstrItinData<II_MOVd1, [SimpleCycle<P_RM_PORT>, SimpleCycle<RS_WM_PORT>], [2,1]>,
+InstrItinData<II_MOVd2, [SimpleCycle<P_RM_PORT>, EmptyCycles<1>, SimpleCycle<RS_WM_PORT>], [3,1]>,
+InstrItinData<II_MOVd3, [SimpleCycle<P_RM_PORT>, EmptyCycles<2>, SimpleCycle<RS_WM_PORT>], [4,1]>,
+InstrItinData<II_MOVd4, [SimpleCycle<P_RM_PORT>, EmptyCycles<3>, SimpleCycle<RS_WM_PORT>], [5,1]>,
+InstrItinData<II_MOVd5, [SimpleCycle<P_RM_PORT>, EmptyCycles<4>, SimpleCycle<RS_WM_PORT>], [6,1]>,
+InstrItinData<II_MOVd6, [SimpleCycle<P_RM_PORT>, EmptyCycles<5>, SimpleCycle<RS_WM_PORT>], [7,1]>,
 InstrItinData<II_MUL, [EmptyCycles<1>, SimpleCycle<R_WX_PORT>], [2,1,1]>,
 InstrItinData<II_NE, [InstrStage<1,  [R_WX_PORT]>], [1,1,1,1]>,
 InstrItinData<II_NEZ, [InstrStage<1,  [R_WX_PORT]>], [1,1,1]>,
@@ -570,7 +569,7 @@ MemInstrItinData<II_STHB_3D,
     MemoryCycles<[5, 11]>>,
 InstrItinData<II_SUB, [InstrStage<1,  [R_WX_PORT]>],
               [1,1,1,/*def:srCarry*/1]>,
-InstrItinData<II_VABS_GTZ, [EmptyCycles<1>, PrefixCycle<W_WM_PORT>, SimpleCycle<R_WM_PORT>],
+InstrItinData<II_VABS_GTZ, [EmptyCycles<1>, PrefixCycle<W_WM_PORT>, SimpleCycle<RS_WM_PORT>],
               [2,2,1,/*crVaddSign*/1], [MOV_Bypass,NoBypass,MOV_Bypass]>,
 InstrItinData<II_VACC, [InstrStage<1, [R_RV_PORT]>, EmptyCycles<1>, InstrStage<1, [CM_RM_PORT]>,
               EmptyCycles<1>, InstrStage<1, [CM_WA_PORT]>],
@@ -607,13 +606,12 @@ InstrItinData<II_VBCST, [EmptyCycles<1>, InstrStage<1,  [W_WM_PORT]>],
               [2,1], [MOV_Bypass,NoBypass]>,
 InstrItinData<II_VBCSTSHFL, [EmptyCycles<1>, InstrStage<1,[W_WM_PORT],0>, InstrStage<1,[CM_WM_PORT],0>],
               [2,1,1], [MOV_Bypass,NoBypass,NoBypass]>,
-InstrItinData<II_VBNEG_LTZ, [EmptyCycles<1>, PrefixCycle<W_WM_PORT>, SimpleCycle<R_WM_PORT>],
+InstrItinData<II_VBNEG_LTZ, [EmptyCycles<1>, PrefixCycle<W_WM_PORT>, SimpleCycle<RS_WM_PORT>],
               [2,2,1], [MOV_Bypass,NoBypass,MOV_Bypass]>,
 InstrItinData<II_VEXTBCST, [EmptyCycles<1>, InstrStage<1,  [W_WM_PORT]>],
               [2,1,1], [MOV_Bypass,MOV_Bypass,NoBypass]>,
-InstrItinData<II_VEXTRACT, [EmptyCycles<1>, PrefixCycle<R_WM_PORT>, PrefixCycle<P_WM_PORT>, PrefixCycle<M_WM_PORT>,
-                            PrefixCycle<DJ_WM_PORT>, PrefixCycle<DN_WM_PORT>, PrefixCycle<DC_WM_PORT>,
-                            SimpleCycle<S_WM_PORT>],
+InstrItinData<II_VEXTRACT, [EmptyCycles<1>, PrefixCycle<RS_WM_PORT>, PrefixCycle<P_WM_PORT>, PrefixCycle<M_WM_PORT>,
+                            PrefixCycle<DJ_WM_PORT>, PrefixCycle<DN_WM_PORT>, SimpleCycle<DC_WM_PORT>],
               [2,1,1,/*crVaddSign*/1], [NoBypass,MOV_Bypass,NoBypass]>,
 InstrItinData<II_VINSERT, [EmptyCycles<1>, InstrStage<1,  [W_WM_PORT]>],
               [2,1,1,1], [MOV_Bypass,MOV_Bypass,NoBypass,NoBypass]>,
@@ -757,22 +755,22 @@ MemInstrItinData<II_LDA_3D_Q,
     MemoryCycles<[5]>>,
 InstrItinData<II_VMAC, [InstrStage<1, [R_RV_PORT]>, EmptyCycles<3>, InstrStage<1, [CM_WA_PORT]>],
               [5,3,1,1,1], [VEC_Bypass,VEC_Bypass,NoBypass,NoBypass]>,
-InstrItinData<II_VMAX_LT, [EmptyCycles<1>, PrefixCycle<W_WM_PORT>, SimpleCycle<R_WM_PORT>],
+InstrItinData<II_VMAX_LT, [EmptyCycles<1>, PrefixCycle<W_WM_PORT>, SimpleCycle<RS_WM_PORT>],
               [2,2,1,1,/*crVaddSign*/1], [MOV_Bypass,NoBypass,MOV_Bypass,MOV_Bypass]>,
-InstrItinData<II_VMIN_GE, [EmptyCycles<1>, PrefixCycle<W_WM_PORT>, SimpleCycle<R_WM_PORT>],
+InstrItinData<II_VMIN_GE, [EmptyCycles<1>, PrefixCycle<W_WM_PORT>, SimpleCycle<RS_WM_PORT>],
               [2,2,1,1,/*crVaddSign*/1], [MOV_Bypass,NoBypass,MOV_Bypass,MOV_Bypass]>,
-InstrItinData<II_VSUB_CMP, [EmptyCycles<1>, PrefixCycle<W_WM_PORT>, SimpleCycle<R_WM_PORT>],
+InstrItinData<II_VSUB_CMP, [EmptyCycles<1>, PrefixCycle<W_WM_PORT>, SimpleCycle<RS_WM_PORT>],
               [2,2,1,1,/*crVaddSign*/1], [MOV_Bypass,NoBypass,MOV_Bypass,MOV_Bypass]>,
-InstrItinData<II_VMAXDIFF_LT, [EmptyCycles<1>, PrefixCycle<W_WM_PORT>, SimpleCycle<R_WM_PORT>],
+InstrItinData<II_VMAXDIFF_LT, [EmptyCycles<1>, PrefixCycle<W_WM_PORT>, SimpleCycle<RS_WM_PORT>],
               [2,2,1,1,/*crVaddSign*/1], [MOV_Bypass,NoBypass,MOV_Bypass,MOV_Bypass]>,
 // We don't reserve the W_WM_PORT for VGE/VLT/VEQZ because they don't write to W or X register file.
-InstrItinData<II_VCMP, [EmptyCycles<1>, SimpleCycle<R_WM_PORT>],
+InstrItinData<II_VCMP, [EmptyCycles<1>, SimpleCycle<RS_WM_PORT>],
               [2,1,1,/*crVaddSign*/1], [NoBypass,MOV_Bypass,MOV_Bypass]>,
-InstrItinData<II_VEQZ, [EmptyCycles<1>, SimpleCycle<R_WM_PORT>],
+InstrItinData<II_VEQZ, [EmptyCycles<1>, SimpleCycle<RS_WM_PORT>],
               [2,1], [NoBypass,MOV_Bypass]>,
 InstrItinData<II_VMSC, [InstrStage<1, [R_RV_PORT]>, EmptyCycles<3>, InstrStage<1, [CM_WA_PORT]>],
               [5,3,1,1,1], [VEC_Bypass,VEC_Bypass,NoBypass,NoBypass]>,
-InstrItinData<II_VNEG_GTZ, [EmptyCycles<1>, PrefixCycle<W_WM_PORT>, SimpleCycle<R_WM_PORT>],
+InstrItinData<II_VNEG_GTZ, [EmptyCycles<1>, PrefixCycle<W_WM_PORT>, SimpleCycle<RS_WM_PORT>],
               [2,2,1], [MOV_Bypass,NoBypass,MOV_Bypass]>,
 InstrItinData<II_VNEGMAC, [InstrStage<1, [R_RV_PORT]>, EmptyCycles<3>, InstrStage<1, [CM_WA_PORT]>],
               [5,3,1,1,1], [VEC_Bypass,VEC_Bypass,NoBypass,NoBypass]>,

--- a/llvm/lib/Target/AIE/AIE2Schedule.td
+++ b/llvm/lib/Target/AIE/AIE2Schedule.td
@@ -193,6 +193,12 @@ def II_MOVA : InstrItinClass;
 def II_MOVX : InstrItinClass;
 def II_MOVXM : InstrItinClass;
 def II_MOV_SCL : InstrItinClass;
+def II_MOV_SCL_DC : InstrItinClass;
+def II_MOV_SCL_DJ : InstrItinClass;
+def II_MOV_SCL_DN : InstrItinClass;
+def II_MOV_SCL_M : InstrItinClass;
+def II_MOV_SCL_P : InstrItinClass;
+def II_MOV_SCL_RS : InstrItinClass;
 def II_MOV_SS : InstrItinClass;
 def II_MUL : InstrItinClass;
 def II_NE : InstrItinClass;
@@ -447,6 +453,12 @@ InstrItinData<II_MOVXM, [PrefixCycle<P_WM_PORT>, PrefixCycle<M_WM_PORT>, PrefixC
 InstrItinData<II_MOV_SCL, [PrefixCycle<P_RM_PORT>, PrefixCycle<RS_WM_PORT>, PrefixCycle<P_WM_PORT>, PrefixCycle<M_WM_PORT>,
                            PrefixCycle<DJ_WM_PORT>, PrefixCycle<DN_WM_PORT>, SimpleCycle<DC_WM_PORT>],
                            [1,1]>,
+InstrItinData<II_MOV_SCL_DC, [PrefixCycle<P_RM_PORT>, SimpleCycle<DC_WM_PORT>], [1,1]>,
+InstrItinData<II_MOV_SCL_DJ, [PrefixCycle<P_RM_PORT>, SimpleCycle<DJ_WM_PORT>], [1,1]>,
+InstrItinData<II_MOV_SCL_DN, [PrefixCycle<P_RM_PORT>, SimpleCycle<DN_WM_PORT>], [1,1]>,
+InstrItinData<II_MOV_SCL_M, [PrefixCycle<P_RM_PORT>, SimpleCycle<M_WM_PORT>], [1,1]>,
+InstrItinData<II_MOV_SCL_P, [PrefixCycle<P_RM_PORT>, SimpleCycle<P_WM_PORT>], [1,1]>,
+InstrItinData<II_MOV_SCL_RS, [PrefixCycle<P_RM_PORT>, SimpleCycle<RS_WM_PORT>], [1,1]>,
 InstrItinData<II_MOV_SS, [AvoidSemaphore<7>, EmptyCycles<6>, SimpleCycle<R_WA_PORT>], [7,/*def:srSS0*/8]>,
 InstrItinData<II_MOVd1, [SimpleCycle<P_RM_PORT>, SimpleCycle<RS_WM_PORT>], [2,1]>,
 InstrItinData<II_MOVd2, [SimpleCycle<P_RM_PORT>, EmptyCycles<1>, SimpleCycle<RS_WM_PORT>], [3,1]>,

--- a/llvm/lib/Target/AIE/AIE2Schedule.td
+++ b/llvm/lib/Target/AIE/AIE2Schedule.td
@@ -191,7 +191,6 @@ def II_LTU : InstrItinClass;
 def II_MOV : InstrItinClass;
 def II_MOVA : InstrItinClass;
 def II_MOVX : InstrItinClass;
-def II_MOVXM : InstrItinClass;
 def II_MOV_SCL : InstrItinClass;
 def II_MOV_SCL_DC : InstrItinClass;
 def II_MOV_SCL_DJ : InstrItinClass;
@@ -448,8 +447,6 @@ InstrItinData<II_MOV, [PrefixCycle<P_WM_PORT>, PrefixCycle<M_WM_PORT>, PrefixCyc
 InstrItinData<II_MOVA, [PrefixCycle<P_WM_PORT>, PrefixCycle<M_WM_PORT>, PrefixCycle<DJ_WM_PORT>,
                         PrefixCycle<DN_WM_PORT>, PrefixCycle<DC_WM_PORT>, SimpleCycle<R_WA_PORT>], [1,1]>,
 InstrItinData<II_MOVX, [SimpleCycle<R_WX_PORT>], [1,1]>,
-InstrItinData<II_MOVXM, [PrefixCycle<P_WM_PORT>, PrefixCycle<M_WM_PORT>, PrefixCycle<DJ_WM_PORT>,
-                         PrefixCycle<DN_WM_PORT>, PrefixCycle<DC_WM_PORT>, SimpleCycle<RS_WM_PORT>], [1,1]>,
 InstrItinData<II_MOV_SCL, [PrefixCycle<P_RM_PORT>, PrefixCycle<RS_WM_PORT>, PrefixCycle<P_WM_PORT>, PrefixCycle<M_WM_PORT>,
                            PrefixCycle<DJ_WM_PORT>, PrefixCycle<DN_WM_PORT>, SimpleCycle<DC_WM_PORT>],
                            [1,1]>,

--- a/llvm/lib/Target/AIE/AIE2Schedule.td
+++ b/llvm/lib/Target/AIE/AIE2Schedule.td
@@ -189,6 +189,12 @@ def II_LSHL : InstrItinClass;
 def II_LT : InstrItinClass;
 def II_LTU : InstrItinClass;
 def II_MOV : InstrItinClass;
+def II_MOV_DC : InstrItinClass;
+def II_MOV_DJ : InstrItinClass;
+def II_MOV_DN : InstrItinClass;
+def II_MOV_M : InstrItinClass;
+def II_MOV_P : InstrItinClass;
+def II_MOV_RS : InstrItinClass;
 def II_MOVA : InstrItinClass;
 def II_MOVA_DC : InstrItinClass;
 def II_MOVA_DJ : InstrItinClass;
@@ -450,6 +456,12 @@ InstrItinData<II_LT, [InstrStage<1,  [R_WX_PORT]>], [1,1,1,1]>,
 InstrItinData<II_LTU, [InstrStage<1,  [R_WX_PORT]>], [1,1,1,1]>,
 InstrItinData<II_MOV, [PrefixCycle<P_WM_PORT>, PrefixCycle<M_WM_PORT>, PrefixCycle<DJ_WM_PORT>,
                        PrefixCycle<DN_WM_PORT>, PrefixCycle<DC_WM_PORT>, SimpleCycle<RS_WM_PORT>], [1,1]>,
+InstrItinData<II_MOV_DC, [SimpleCycle<DC_WM_PORT>], [1,1]>,
+InstrItinData<II_MOV_DJ, [SimpleCycle<DJ_WM_PORT>], [1,1]>,
+InstrItinData<II_MOV_DN, [SimpleCycle<DN_WM_PORT>], [1,1]>,
+InstrItinData<II_MOV_M, [SimpleCycle<M_WM_PORT>], [1,1]>,
+InstrItinData<II_MOV_P, [SimpleCycle<P_WM_PORT>], [1,1]>,
+InstrItinData<II_MOV_RS, [SimpleCycle<RS_WM_PORT>], [1,1]>,
 InstrItinData<II_MOVA, [PrefixCycle<P_WM_PORT>, PrefixCycle<M_WM_PORT>, PrefixCycle<DJ_WM_PORT>,
                         PrefixCycle<DN_WM_PORT>, PrefixCycle<DC_WM_PORT>, SimpleCycle<R_WA_PORT>], [1,1]>,
 InstrItinData<II_MOVA_DC, [SimpleCycle<DC_WM_PORT>], [1,1]>,

--- a/llvm/test/CodeGen/AIE/aie2/brcc.ll
+++ b/llvm/test/CodeGen/AIE/aie2/brcc.ll
@@ -153,8 +153,8 @@ define i32 @br_diamond_complex_end(i32  %a, i32  %b, i32 %v, i32* nocapture writ
 ; CHECK-NEXT:    nop // Delay Slot 5
 ; CHECK-NEXT:    nop // Delay Slot 4
 ; CHECK-NEXT:    nop // Delay Slot 3
-; CHECK-NEXT:    mov r0, r16 // Delay Slot 2
-; CHECK-NEXT:    paddb [sp], #-32 // Delay Slot 1
+; CHECK-NEXT:    nop // Delay Slot 2
+; CHECK-NEXT:    paddb [sp], #-32; mov r0, r16 // Delay Slot 1
 entry:
   %cmp = icmp ugt i32 %a, %b
   br i1 %cmp, label %if.then, label %if.else

--- a/llvm/test/CodeGen/AIE/aie2/end-to-end/Add2D-red.ll
+++ b/llvm/test/CodeGen/AIE/aie2/end-to-end/Add2D-red.ll
@@ -35,7 +35,7 @@ define void @add2d(ptr noalias %params, ptr noalias %ifm1_data, ptr noalias %ifm
 ; ASM-LABEL: add2d:
 ; ASM:         .p2align 4
 ; ASM-NEXT:  // %bb.0: // %newFuncRoot
-; ASM-NEXT:    paddb [sp], #32; nopx
+; ASM-NEXT:    paddb [sp], #32
 ; ASM-NEXT:    st p7, [sp, #-32] // 4-byte Folded Spill
 ; ASM-NEXT:    paddb [p0], #40; st p6, [sp, #-28] // 4-byte Folded Spill
 ; ASM-NEXT:    lda m2, [p0], #-4
@@ -92,8 +92,8 @@ define void @add2d(ptr noalias %params, ptr noalias %ifm1_data, ptr noalias %ifm
 ; ASM-NEXT:    paddb [p0], #-92
 ; ASM-NEXT:    lda r13, [p0, #0]; mov p0, r8
 ; ASM-NEXT:    mova r6, #1; st dj4, [p0, #0]
-; ASM-NEXT:    mova r6, #3; ne r4, r4, r6; mov p0, r14
-; ASM-NEXT:    st dn0, [p0, #0]; add r7, r1, #-1
+; ASM-NEXT:    ne r4, r4, r6; mov p0, r14
+; ASM-NEXT:    st dn0, [p0, #0]; add r7, r1, #-1; mov r6, #3
 ; ASM-NEXT:    ltu r7, r7, r6; mov p0, r15
 ; ASM-NEXT:    jz r7, #.LBB0_2
 ; ASM-NEXT:    st dn4, [p7, #0]; nez r0, r0 // Delay Slot 5

--- a/llvm/test/CodeGen/AIE/aie2/end-to-end/Add2D-red.ll
+++ b/llvm/test/CodeGen/AIE/aie2/end-to-end/Add2D-red.ll
@@ -35,7 +35,7 @@ define void @add2d(ptr noalias %params, ptr noalias %ifm1_data, ptr noalias %ifm
 ; ASM-LABEL: add2d:
 ; ASM:         .p2align 4
 ; ASM-NEXT:  // %bb.0: // %newFuncRoot
-; ASM-NEXT:    paddb [sp], #32
+; ASM-NEXT:    paddb [sp], #32; nopx
 ; ASM-NEXT:    st p7, [sp, #-32] // 4-byte Folded Spill
 ; ASM-NEXT:    paddb [p0], #40; st p6, [sp, #-28] // 4-byte Folded Spill
 ; ASM-NEXT:    lda m2, [p0], #-4
@@ -90,9 +90,9 @@ define void @add2d(ptr noalias %params, ptr noalias %ifm1_data, ptr noalias %ifm
 ; ASM-NEXT:    lda r12, [p0, #0]
 ; ASM-NEXT:    mov p0, sp
 ; ASM-NEXT:    paddb [p0], #-92
-; ASM-NEXT:    lda r13, [p0, #0]; movx r6, #1; mov p0, r8
-; ASM-NEXT:    st dj4, [p0, #0]; ne r4, r4, r6
-; ASM-NEXT:    movx r6, #3; mov p0, r14
+; ASM-NEXT:    lda r13, [p0, #0]; mov p0, r8
+; ASM-NEXT:    mova r6, #1; st dj4, [p0, #0]
+; ASM-NEXT:    mova r6, #3; ne r4, r4, r6; mov p0, r14
 ; ASM-NEXT:    st dn0, [p0, #0]; add r7, r1, #-1
 ; ASM-NEXT:    ltu r7, r7, r6; mov p0, r15
 ; ASM-NEXT:    jz r7, #.LBB0_2

--- a/llvm/test/CodeGen/AIE/aie2/end-to-end/Conv2D-red-swp.ll
+++ b/llvm/test/CodeGen/AIE/aie2/end-to-end/Conv2D-red-swp.ll
@@ -224,10 +224,7 @@ define dso_local void @conv2d.loop.nest(ptr %add.ptr6.i51, ptr %add.ptr5, ptr %c
 ; DCL-LABEL: conv2d.loop.nest:
 ; DCL:         .p2align 4
 ; DCL-NEXT:  // %bb.0: // %newFuncRoot
-; DCL-NEXT:    mova dj3, #0
-; DCL-NEXT:    mov s0, r0
-; DCL-NEXT:    mov s1, r1
-; DCL-NEXT:    mov s2, r6
+; DCL-NEXT:    mova dj3, #0; nopb ; nopx
 ; DCL-NEXT:    mov dc0, dj3
 ; DCL-NEXT:    mov dc4, dj3
 ; DCL-NEXT:    mov dc1, dj3
@@ -240,58 +237,57 @@ define dso_local void @conv2d.loop.nest(ptr %add.ptr6.i51, ptr %add.ptr5, ptr %c
 ; DCL-NEXT:    mov p6, sp
 ; DCL-NEXT:    paddb [p6], #-292; mov dc3, dj3
 ; DCL-NEXT:    lda m0, [p6, #0]; mov p6, sp
-; DCL-NEXT:    paddb [p6], #-296; mov r28, dj3
+; DCL-NEXT:    paddb [p6], #-296; mov dc7, dj3
 ; DCL-NEXT:    lda dj0, [p6, #0]; mov p6, sp
 ; DCL-NEXT:    paddb [p6], #-300
-; DCL-NEXT:    lda dn0, [p6, #0]; mov p7, sp
-; DCL-NEXT:    paddb [p7], #-200; mov p6, sp
-; DCL-NEXT:    lda m6, [p7, #0]; paddb [p6], #-204
-; DCL-NEXT:    lda m0, [p6, #0]; mov p6, sp
+; DCL-NEXT:    lda dn0, [p6, #0]; mov p6, sp
+; DCL-NEXT:    paddb [p6], #-204; mov p7, sp
+; DCL-NEXT:    lda m0, [p6, #0]
+; DCL-NEXT:    mov p6, sp
 ; DCL-NEXT:    paddb [p6], #-208
 ; DCL-NEXT:    lda dj0, [p6, #0]; mov p6, sp
 ; DCL-NEXT:    paddb [p6], #-212
 ; DCL-NEXT:    lda dj4, [p6, #0]; mov p6, sp
 ; DCL-NEXT:    paddb [p6], #-216; st m0, [sp, #-96] // 4-byte Folded Spill
-; DCL-NEXT:    lda dn0, [p6, #0]
-; DCL-NEXT:    mov p6, sp
+; DCL-NEXT:    lda dn0, [p6, #0]; mov p6, sp
 ; DCL-NEXT:    paddb [p6], #-220; st dj0, [sp, #-88] // 4-byte Folded Spill
-; DCL-NEXT:    lda dn4, [p6, #0]; mov p6, sp
-; DCL-NEXT:    paddb [p6], #-228
+; DCL-NEXT:    lda dn4, [p6, #0]
+; DCL-NEXT:    paddb [p7], #-200; mov p6, sp
+; DCL-NEXT:    lda m6, [p7, #0]; paddb [p6], #-228
 ; DCL-NEXT:    lda r11, [p6, #0]; mov p6, sp
 ; DCL-NEXT:    paddb [p6], #-232; st dn0, [sp, #-92] // 4-byte Folded Spill
 ; DCL-NEXT:    lda dj1, [p6, #0]; mov p6, sp
-; DCL-NEXT:    paddb [p6], #-236; mov dc7, dj3
-; DCL-NEXT:    lda r12, [p6, #0]
-; DCL-NEXT:    mov p6, sp
+; DCL-NEXT:    paddb [p6], #-236
+; DCL-NEXT:    lda r12, [p6, #0]; mov p6, sp
 ; DCL-NEXT:    paddb [p6], #-240
-; DCL-NEXT:    lda dn1, [p6, #0]; mov p6, sp
+; DCL-NEXT:    lda dn1, [p6, #0]
+; DCL-NEXT:    mov p6, sp
 ; DCL-NEXT:    paddb [p6], #-244
 ; DCL-NEXT:    lda dn5, [p6, #0]; mov p6, sp
 ; DCL-NEXT:    paddb [p6], #-248
 ; DCL-NEXT:    lda r13, [p6, #0]; mov p6, sp
-; DCL-NEXT:    paddb [p6], #-252; mov p7, sp
-; DCL-NEXT:    lda dj2, [p6, #0]
+; DCL-NEXT:    paddb [p6], #-252
+; DCL-NEXT:    lda dj2, [p6, #0]; mov p6, sp
+; DCL-NEXT:    paddb [p6], #-256; mov p7, sp
+; DCL-NEXT:    lda dj6, [p6, #0]
 ; DCL-NEXT:    mov p6, sp
-; DCL-NEXT:    lda m7, [sp, #-96]; paddb [p6], #-256 // 4-byte Folded Reload
-; DCL-NEXT:    lda dj6, [p6, #0]; mov p6, sp
-; DCL-NEXT:    paddb [p6], #-260
+; DCL-NEXT:    lda m7, [sp, #-96]; paddb [p6], #-260 // 4-byte Folded Reload
 ; DCL-NEXT:    lda dn2, [p6, #0]; mov p6, sp
 ; DCL-NEXT:    paddb [p6], #-264
 ; DCL-NEXT:    lda dn6, [p6, #0]; mov p6, sp
-; DCL-NEXT:    paddb [p6], #-268
-; DCL-NEXT:    lda r14, [p6, #0]
-; DCL-NEXT:    vst wl0, [sp, #-64]; mov p6, sp // 32-byte Folded Spill
-; DCL-NEXT:    lda dj7, [sp, #-88]; paddb [p6], #-276 // 4-byte Folded Reload
-; DCL-NEXT:    lda dn3, [p6, #0]; mov p6, sp
-; DCL-NEXT:    paddb [p6], #-280; st dc7, [sp, #-84] // 4-byte Folded Spill
-; DCL-NEXT:    lda r26, [p6, #0]; mov p6, sp
-; DCL-NEXT:    lda dn7, [sp, #-92]; paddb [p6], #-196 // 4-byte Folded Reload
-; DCL-NEXT:    lda r15, [p6, #0]; paddb [p7], #-288; mov p6, sp
-; DCL-NEXT:    lda r27, [p7, #0]; paddb [p6], #-224
-; DCL-NEXT:    lda r24, [p6, #0]
+; DCL-NEXT:    paddb [p6], #-268; vst wl0, [sp, #-64] // 32-byte Folded Spill
+; DCL-NEXT:    lda r14, [p6, #0]; mov p6, sp
+; DCL-NEXT:    paddb [p6], #-276; st dc7, [sp, #-84] // 4-byte Folded Spill
+; DCL-NEXT:    lda dn3, [p6, #0]
 ; DCL-NEXT:    vst wh0, [sp, #-32]; mov p6, sp // 32-byte Folded Spill
+; DCL-NEXT:    lda dj7, [sp, #-88]; paddb [p6], #-280; mov s0, r0 // 4-byte Folded Reload
+; DCL-NEXT:    lda r26, [p6, #0]; mov p6, sp
+; DCL-NEXT:    lda dn7, [sp, #-92]; paddb [p6], #-196; mov s1, r1 // 4-byte Folded Reload
+; DCL-NEXT:    lda r15, [p6, #0]; paddb [p7], #-288; mov p6, sp
+; DCL-NEXT:    lda r27, [p7, #0]; paddb [p6], #-224; mov s2, r6
+; DCL-NEXT:    lda r24, [p6, #0]; mov p6, sp
 ; DCL-NEXT:    paddb [p6], #-284; st m7, [sp, #-96] // 4-byte Folded Spill
-; DCL-NEXT:    lda m4, [p6, #0]
+; DCL-NEXT:    lda m4, [p6, #0]; mov r28, dj3
 ; DCL-NEXT:    st dj7, [sp, #-88]; movx r8, #11 // 4-byte Folded Spill
 ; DCL-NEXT:    st dn7, [sp, #-92]; movx r9, #31 // 4-byte Folded Spill
 ; DCL-NEXT:    // implicit-def: $x4
@@ -404,10 +400,7 @@ define dso_local void @conv2d.loop.nest(ptr %add.ptr6.i51, ptr %add.ptr5, ptr %c
 ; ZOL-LABEL: conv2d.loop.nest:
 ; ZOL:         .p2align 4
 ; ZOL-NEXT:  // %bb.0: // %newFuncRoot
-; ZOL-NEXT:    mova dj3, #0
-; ZOL-NEXT:    mov s0, r0
-; ZOL-NEXT:    mov s1, r1
-; ZOL-NEXT:    mov s2, r6
+; ZOL-NEXT:    mova dj3, #0; nopb ; nopx
 ; ZOL-NEXT:    mov dc0, dj3
 ; ZOL-NEXT:    mov dc4, dj3
 ; ZOL-NEXT:    mov dc1, dj3
@@ -420,58 +413,57 @@ define dso_local void @conv2d.loop.nest(ptr %add.ptr6.i51, ptr %add.ptr5, ptr %c
 ; ZOL-NEXT:    mov p6, sp
 ; ZOL-NEXT:    paddb [p6], #-292; mov dc3, dj3
 ; ZOL-NEXT:    lda m0, [p6, #0]; mov p6, sp
-; ZOL-NEXT:    paddb [p6], #-296; mov r27, dj3
+; ZOL-NEXT:    paddb [p6], #-296; mov dc7, dj3
 ; ZOL-NEXT:    lda dj0, [p6, #0]; mov p6, sp
 ; ZOL-NEXT:    paddb [p6], #-300
-; ZOL-NEXT:    lda dn0, [p6, #0]; mov p7, sp
-; ZOL-NEXT:    paddb [p7], #-200; mov p6, sp
-; ZOL-NEXT:    lda m6, [p7, #0]; paddb [p6], #-204
-; ZOL-NEXT:    lda m0, [p6, #0]; mov p6, sp
+; ZOL-NEXT:    lda dn0, [p6, #0]; mov p6, sp
+; ZOL-NEXT:    paddb [p6], #-204; mov p7, sp
+; ZOL-NEXT:    lda m0, [p6, #0]
+; ZOL-NEXT:    mov p6, sp
 ; ZOL-NEXT:    paddb [p6], #-208
 ; ZOL-NEXT:    lda dj0, [p6, #0]; mov p6, sp
 ; ZOL-NEXT:    paddb [p6], #-212
 ; ZOL-NEXT:    lda dj4, [p6, #0]; mov p6, sp
 ; ZOL-NEXT:    paddb [p6], #-216; st m0, [sp, #-96] // 4-byte Folded Spill
-; ZOL-NEXT:    lda dn0, [p6, #0]
-; ZOL-NEXT:    mov p6, sp
+; ZOL-NEXT:    lda dn0, [p6, #0]; mov p6, sp
 ; ZOL-NEXT:    paddb [p6], #-220; st dj0, [sp, #-88] // 4-byte Folded Spill
-; ZOL-NEXT:    lda dn4, [p6, #0]; mov p6, sp
-; ZOL-NEXT:    paddb [p6], #-228
+; ZOL-NEXT:    lda dn4, [p6, #0]
+; ZOL-NEXT:    paddb [p7], #-200; mov p6, sp
+; ZOL-NEXT:    lda m6, [p7, #0]; paddb [p6], #-228
 ; ZOL-NEXT:    lda r10, [p6, #0]; mov p6, sp
 ; ZOL-NEXT:    paddb [p6], #-232; st dn0, [sp, #-92] // 4-byte Folded Spill
 ; ZOL-NEXT:    lda dj1, [p6, #0]; mov p6, sp
-; ZOL-NEXT:    paddb [p6], #-236; mov dc7, dj3
-; ZOL-NEXT:    lda r11, [p6, #0]
-; ZOL-NEXT:    mov p6, sp
+; ZOL-NEXT:    paddb [p6], #-236
+; ZOL-NEXT:    lda r11, [p6, #0]; mov p6, sp
 ; ZOL-NEXT:    paddb [p6], #-240
-; ZOL-NEXT:    lda dn1, [p6, #0]; mov p6, sp
+; ZOL-NEXT:    lda dn1, [p6, #0]
+; ZOL-NEXT:    mov p6, sp
 ; ZOL-NEXT:    paddb [p6], #-244
 ; ZOL-NEXT:    lda dn5, [p6, #0]; mov p6, sp
 ; ZOL-NEXT:    paddb [p6], #-248
 ; ZOL-NEXT:    lda r12, [p6, #0]; mov p6, sp
-; ZOL-NEXT:    paddb [p6], #-252; mov p7, sp
-; ZOL-NEXT:    lda dj2, [p6, #0]
+; ZOL-NEXT:    paddb [p6], #-252
+; ZOL-NEXT:    lda dj2, [p6, #0]; mov p6, sp
+; ZOL-NEXT:    paddb [p6], #-256; mov p7, sp
+; ZOL-NEXT:    lda dj6, [p6, #0]
 ; ZOL-NEXT:    mov p6, sp
-; ZOL-NEXT:    lda m7, [sp, #-96]; paddb [p6], #-256 // 4-byte Folded Reload
-; ZOL-NEXT:    lda dj6, [p6, #0]; mov p6, sp
-; ZOL-NEXT:    paddb [p6], #-260
+; ZOL-NEXT:    lda m7, [sp, #-96]; paddb [p6], #-260 // 4-byte Folded Reload
 ; ZOL-NEXT:    lda dn2, [p6, #0]; mov p6, sp
 ; ZOL-NEXT:    paddb [p6], #-264
 ; ZOL-NEXT:    lda dn6, [p6, #0]; mov p6, sp
-; ZOL-NEXT:    paddb [p6], #-268
-; ZOL-NEXT:    lda r13, [p6, #0]
-; ZOL-NEXT:    vst wl0, [sp, #-64]; mov p6, sp // 32-byte Folded Spill
-; ZOL-NEXT:    lda dj7, [sp, #-88]; paddb [p6], #-276 // 4-byte Folded Reload
-; ZOL-NEXT:    lda dn3, [p6, #0]; mov p6, sp
-; ZOL-NEXT:    paddb [p6], #-280; st dc7, [sp, #-84] // 4-byte Folded Spill
-; ZOL-NEXT:    lda r25, [p6, #0]; mov p6, sp
-; ZOL-NEXT:    lda dn7, [sp, #-92]; paddb [p6], #-196 // 4-byte Folded Reload
-; ZOL-NEXT:    lda r14, [p6, #0]; paddb [p7], #-288; mov p6, sp
-; ZOL-NEXT:    lda r26, [p7, #0]; paddb [p6], #-224
-; ZOL-NEXT:    lda r15, [p6, #0]
+; ZOL-NEXT:    paddb [p6], #-268; vst wl0, [sp, #-64] // 32-byte Folded Spill
+; ZOL-NEXT:    lda r13, [p6, #0]; mov p6, sp
+; ZOL-NEXT:    paddb [p6], #-276; st dc7, [sp, #-84] // 4-byte Folded Spill
+; ZOL-NEXT:    lda dn3, [p6, #0]
 ; ZOL-NEXT:    vst wh0, [sp, #-32]; mov p6, sp // 32-byte Folded Spill
+; ZOL-NEXT:    lda dj7, [sp, #-88]; paddb [p6], #-280; mov s0, r0 // 4-byte Folded Reload
+; ZOL-NEXT:    lda r25, [p6, #0]; mov p6, sp
+; ZOL-NEXT:    lda dn7, [sp, #-92]; paddb [p6], #-196; mov s1, r1 // 4-byte Folded Reload
+; ZOL-NEXT:    lda r14, [p6, #0]; paddb [p7], #-288; mov p6, sp
+; ZOL-NEXT:    lda r26, [p7, #0]; paddb [p6], #-224; mov s2, r6
+; ZOL-NEXT:    lda r15, [p6, #0]; mov p6, sp
 ; ZOL-NEXT:    paddb [p6], #-284; st m7, [sp, #-96] // 4-byte Folded Spill
-; ZOL-NEXT:    lda m4, [p6, #0]
+; ZOL-NEXT:    lda m4, [p6, #0]; mov r27, dj3
 ; ZOL-NEXT:    st dj7, [sp, #-88]; movx r8, #11 // 4-byte Folded Spill
 ; ZOL-NEXT:    st dn7, [sp, #-92]; movx r9, #31 // 4-byte Folded Spill
 ; ZOL-NEXT:    // implicit-def: $x4

--- a/llvm/test/CodeGen/AIE/aie2/end-to-end/Conv2D-red-swp.ll
+++ b/llvm/test/CodeGen/AIE/aie2/end-to-end/Conv2D-red-swp.ll
@@ -224,7 +224,7 @@ define dso_local void @conv2d.loop.nest(ptr %add.ptr6.i51, ptr %add.ptr5, ptr %c
 ; DCL-LABEL: conv2d.loop.nest:
 ; DCL:         .p2align 4
 ; DCL-NEXT:  // %bb.0: // %newFuncRoot
-; DCL-NEXT:    mova dj3, #0; nopb ; nopx
+; DCL-NEXT:    mova dj3, #0; nopx
 ; DCL-NEXT:    mov dc0, dj3
 ; DCL-NEXT:    mov dc4, dj3
 ; DCL-NEXT:    mov dc1, dj3
@@ -288,8 +288,8 @@ define dso_local void @conv2d.loop.nest(ptr %add.ptr6.i51, ptr %add.ptr5, ptr %c
 ; DCL-NEXT:    lda r24, [p6, #0]; mov p6, sp
 ; DCL-NEXT:    paddb [p6], #-284; st m7, [sp, #-96] // 4-byte Folded Spill
 ; DCL-NEXT:    lda m4, [p6, #0]; mov r28, dj3
-; DCL-NEXT:    st dj7, [sp, #-88]; movx r8, #11 // 4-byte Folded Spill
-; DCL-NEXT:    st dn7, [sp, #-92]; movx r9, #31 // 4-byte Folded Spill
+; DCL-NEXT:    st dj7, [sp, #-88] // 4-byte Folded Spill
+; DCL-NEXT:    st dn7, [sp, #-92]; movx r9, #31; mov r8, #11 // 4-byte Folded Spill
 ; DCL-NEXT:    // implicit-def: $x4
 ; DCL-NEXT:    // implicit-def: $x2
 ; DCL-NEXT:    .p2align 4
@@ -400,7 +400,7 @@ define dso_local void @conv2d.loop.nest(ptr %add.ptr6.i51, ptr %add.ptr5, ptr %c
 ; ZOL-LABEL: conv2d.loop.nest:
 ; ZOL:         .p2align 4
 ; ZOL-NEXT:  // %bb.0: // %newFuncRoot
-; ZOL-NEXT:    mova dj3, #0; nopb ; nopx
+; ZOL-NEXT:    mova dj3, #0; nopx
 ; ZOL-NEXT:    mov dc0, dj3
 ; ZOL-NEXT:    mov dc4, dj3
 ; ZOL-NEXT:    mov dc1, dj3
@@ -464,8 +464,8 @@ define dso_local void @conv2d.loop.nest(ptr %add.ptr6.i51, ptr %add.ptr5, ptr %c
 ; ZOL-NEXT:    lda r15, [p6, #0]; mov p6, sp
 ; ZOL-NEXT:    paddb [p6], #-284; st m7, [sp, #-96] // 4-byte Folded Spill
 ; ZOL-NEXT:    lda m4, [p6, #0]; mov r27, dj3
-; ZOL-NEXT:    st dj7, [sp, #-88]; movx r8, #11 // 4-byte Folded Spill
-; ZOL-NEXT:    st dn7, [sp, #-92]; movx r9, #31 // 4-byte Folded Spill
+; ZOL-NEXT:    st dj7, [sp, #-88] // 4-byte Folded Spill
+; ZOL-NEXT:    st dn7, [sp, #-92]; movx r9, #31; mov r8, #11 // 4-byte Folded Spill
 ; ZOL-NEXT:    // implicit-def: $x4
 ; ZOL-NEXT:    // implicit-def: $x2
 ; ZOL-NEXT:    .p2align 4

--- a/llvm/test/CodeGen/AIE/aie2/end-to-end/Conv2D-red.ll
+++ b/llvm/test/CodeGen/AIE/aie2/end-to-end/Conv2D-red.ll
@@ -37,26 +37,22 @@ define dso_local void @conv2d.loop.nest(ptr %add.ptr6.i51, ptr %add.ptr5, ptr %c
 ; ASM-LABEL: conv2d.loop.nest:
 ; ASM:         .p2align 4
 ; ASM-NEXT:  // %bb.0: // %newFuncRoot
-; ASM-NEXT:    nopx ; mov s0, r0
-; ASM-NEXT:    mov s1, r1
-; ASM-NEXT:    paddb [sp], #32; mov s2, r6
-; ASM-NEXT:    mova dj3, #0; st p7, [sp, #-32] // 4-byte Folded Spill
-; ASM-NEXT:    mov p7, sp
-; ASM-NEXT:    mov dc0, dj3
-; ASM-NEXT:    st p6, [sp, #-28] // 4-byte Folded Spill
+; ASM-NEXT:    nopa ; paddb [sp], #32; nopxm
+; ASM-NEXT:    st p7, [sp, #-32] // 4-byte Folded Spill
+; ASM-NEXT:    mova dj3, #0; st p6, [sp, #-28] // 4-byte Folded Spill
 ; ASM-NEXT:    mov p6, sp
-; ASM-NEXT:    paddb [p6], #-132; mov dc4, dj3
+; ASM-NEXT:    paddb [p6], #-132; mov p7, sp
 ; ASM-NEXT:    lda m5, [p6, #0]; mov p6, sp
-; ASM-NEXT:    paddb [p6], #-136; mov dc1, dj3
-; ASM-NEXT:    lda r28, [p6, #0]; mov r25, dj3
+; ASM-NEXT:    paddb [p6], #-136; mov dc0, dj3
+; ASM-NEXT:    lda r28, [p6, #0]; mov dc4, dj3
 ; ASM-NEXT:    mov p6, sp
-; ASM-NEXT:    paddb [p6], #-140; mov dc2, dj3
+; ASM-NEXT:    paddb [p6], #-140; mov dc1, dj3
 ; ASM-NEXT:    lda r27, [p6, #0]; mov p6, sp
 ; ASM-NEXT:    paddb [p6], #-44
 ; ASM-NEXT:    lda m0, [p6, #0]; mov p6, sp
 ; ASM-NEXT:    paddb [p6], #-48
 ; ASM-NEXT:    lda dj0, [p6, #0]; mov p6, sp
-; ASM-NEXT:    paddb [p6], #-52; mov dc6, dj3
+; ASM-NEXT:    paddb [p6], #-52; mov dc2, dj3
 ; ASM-NEXT:    lda dj4, [p6, #0]
 ; ASM-NEXT:    mov p6, sp
 ; ASM-NEXT:    paddb [p6], #-56
@@ -65,7 +61,7 @@ define dso_local void @conv2d.loop.nest(ptr %add.ptr6.i51, ptr %add.ptr5, ptr %c
 ; ASM-NEXT:    lda dn4, [p6, #0]; mov p6, sp
 ; ASM-NEXT:    paddb [p6], #-68
 ; ASM-NEXT:    lda r10, [p6, #0]; mov p6, sp
-; ASM-NEXT:    paddb [p6], #-72; mov dc3, dj3
+; ASM-NEXT:    paddb [p6], #-72; mov dc6, dj3
 ; ASM-NEXT:    lda dj1, [p6, #0]
 ; ASM-NEXT:    mov p6, sp
 ; ASM-NEXT:    paddb [p6], #-76
@@ -74,7 +70,7 @@ define dso_local void @conv2d.loop.nest(ptr %add.ptr6.i51, ptr %add.ptr5, ptr %c
 ; ASM-NEXT:    lda dn1, [p6, #0]; mov p6, sp
 ; ASM-NEXT:    paddb [p6], #-84
 ; ASM-NEXT:    lda r12, [p6, #0]; mov p6, sp
-; ASM-NEXT:    paddb [p6], #-88; mov dc7, dj3
+; ASM-NEXT:    paddb [p6], #-88; mov dc3, dj3
 ; ASM-NEXT:    lda r13, [p6, #0]
 ; ASM-NEXT:    mov p6, sp
 ; ASM-NEXT:    paddb [p6], #-92
@@ -83,7 +79,7 @@ define dso_local void @conv2d.loop.nest(ptr %add.ptr6.i51, ptr %add.ptr5, ptr %c
 ; ASM-NEXT:    lda dj6, [p6, #0]; mov p6, sp
 ; ASM-NEXT:    paddb [p6], #-100
 ; ASM-NEXT:    lda dn2, [p6, #0]; mov p6, sp
-; ASM-NEXT:    paddb [p6], #-104; mov r26, dj3
+; ASM-NEXT:    paddb [p6], #-104; mov dc7, dj3
 ; ASM-NEXT:    lda dn6, [p6, #0]
 ; ASM-NEXT:    mov p6, sp
 ; ASM-NEXT:    paddb [p6], #-108
@@ -96,13 +92,13 @@ define dso_local void @conv2d.loop.nest(ptr %add.ptr6.i51, ptr %add.ptr5, ptr %c
 ; ASM-NEXT:    lda r15, [p6, #0]
 ; ASM-NEXT:    paddb [p7], #-40; mov p6, sp
 ; ASM-NEXT:    lda m6, [p7, #0]; paddb [p6], #-64
-; ASM-NEXT:    lda r24, [p6, #0]
-; ASM-NEXT:    nop
+; ASM-NEXT:    lda r24, [p6, #0]; mov s0, r0
+; ASM-NEXT:    mov s1, r1
 ; ASM-NEXT:    mov p7, sp
-; ASM-NEXT:    nop
+; ASM-NEXT:    mov s2, r6
 ; ASM-NEXT:    paddb [p7], #-128; mov p6, sp
-; ASM-NEXT:    lda m7, [p7, #0]; paddb [p6], #-124; movx r8, #11
-; ASM-NEXT:    lda m4, [p6, #0]; movx r9, #31
+; ASM-NEXT:    lda m7, [p7, #0]; paddb [p6], #-124; movx r8, #11; mov r25, dj3
+; ASM-NEXT:    lda m4, [p6, #0]; movx r9, #31; mov r26, dj3
 ; ASM-NEXT:    // implicit-def: $x4
 ; ASM-NEXT:    // implicit-def: $x2
 ; ASM-NEXT:    .p2align 4

--- a/llvm/test/CodeGen/AIE/aie2/end-to-end/Conv2D-red.ll
+++ b/llvm/test/CodeGen/AIE/aie2/end-to-end/Conv2D-red.ll
@@ -37,11 +37,11 @@ define dso_local void @conv2d.loop.nest(ptr %add.ptr6.i51, ptr %add.ptr5, ptr %c
 ; ASM-LABEL: conv2d.loop.nest:
 ; ASM:         .p2align 4
 ; ASM-NEXT:  // %bb.0: // %newFuncRoot
-; ASM-NEXT:    nopa ; paddb [sp], #32; nopxm
+; ASM-NEXT:    paddb [sp], #32; nopxm
 ; ASM-NEXT:    st p7, [sp, #-32] // 4-byte Folded Spill
-; ASM-NEXT:    mova dj3, #0; st p6, [sp, #-28] // 4-byte Folded Spill
+; ASM-NEXT:    st p6, [sp, #-28] // 4-byte Folded Spill
 ; ASM-NEXT:    mov p6, sp
-; ASM-NEXT:    paddb [p6], #-132; mov p7, sp
+; ASM-NEXT:    mova dj3, #0; paddb [p6], #-132; mov p7, sp
 ; ASM-NEXT:    lda m5, [p6, #0]; mov p6, sp
 ; ASM-NEXT:    paddb [p6], #-136; mov dc0, dj3
 ; ASM-NEXT:    lda r28, [p6, #0]; mov dc4, dj3

--- a/llvm/test/CodeGen/AIE/aie2/end-to-end/Memops.ll
+++ b/llvm/test/CodeGen/AIE/aie2/end-to-end/Memops.ll
@@ -210,9 +210,9 @@ define dso_local void @lowerMemcpyUsingAlignedWordCall() local_unnamed_addr #0 {
 ; CHECK-NEXT:    jl #memcpy
 ; CHECK-NEXT:    nop // Delay Slot 5
 ; CHECK-NEXT:    paddb [sp], #32 // Delay Slot 4
-; CHECK-NEXT:    st lr, [sp, #-32]; movxm p1, #buffer1 // 4-byte Folded Spill Delay Slot 3
-; CHECK-NEXT:    movxm p2, #buffer2 // Delay Slot 2
-; CHECK-NEXT:    mova r0, #256 // Delay Slot 1
+; CHECK-NEXT:    st lr, [sp, #-32] // 4-byte Folded Spill Delay Slot 3
+; CHECK-NEXT:    movxm p1, #buffer1 // Delay Slot 2
+; CHECK-NEXT:    mova r0, #256; movxm p2, #buffer2 // Delay Slot 1
 ; CHECK-NEXT:    lda lr, [sp, #-32] // 4-byte Folded Reload
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
@@ -259,9 +259,8 @@ define dso_local void @lowerMemsetUsingWordByte() local_unnamed_addr #2 {
 ; CHECK-LABEL: lowerMemsetUsingWordByte:
 ; CHECK:         .p2align 4
 ; CHECK-NEXT:  // %bb.0: // %entry
-; CHECK-NEXT:    nopb ; nopa ; nops ; movxm p0, #(buffer1+4); nopv
-; CHECK-NEXT:    mova r0, #0; nopb ; nopx
-; CHECK-NEXT:    st r0, [p0, #-4]
+; CHECK-NEXT:    nopb ; mova r0, #0; nops ; movxm p0, #(buffer1+4); nopv
+; CHECK-NEXT:    nopa ; nopb ; nopx ; st r0, [p0, #-4]
 ; CHECK-NEXT:    st.s8 r0, [p0, #0]
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    ret lr

--- a/llvm/test/CodeGen/AIE/aie2/end-to-end/Mul2D.ll
+++ b/llvm/test/CodeGen/AIE/aie2/end-to-end/Mul2D.ll
@@ -73,13 +73,13 @@ define void @mul2d(ptr noalias %in_ptr0, ptr noalias %in_ptr1, ptr noalias %out_
 ; CHECK-NEXT:    lda dn0, [p3, #0]; mov p3, sp
 ; CHECK-NEXT:    paddb [p3], #-20
 ; CHECK-NEXT:    lda dn4, [p3, #0]; mov p3, sp
-; CHECK-NEXT:    mova r2, #1; paddb [p3], #-24
-; CHECK-NEXT:    lda m0, [p3, #0]; movx r3, #0
+; CHECK-NEXT:    paddb [p3], #-24
+; CHECK-NEXT:    lda m0, [p3, #0]
 ; CHECK-NEXT:    mova dc0, #0; extend.u8 r5, r5
-; CHECK-NEXT:    movx r4, #-1; mov s0, r5
-; CHECK-NEXT:    lshl r1, r1, r4; mov dc4, dc0
+; CHECK-NEXT:    movx r2, #1; mov s0, r5
+; CHECK-NEXT:    mova r4, #-1; movx r3, #0; mov dc4, dc0
 ; CHECK-NEXT:    ne r2, r0, r2; vbcst.8 x0, r3
-; CHECK-NEXT:    movx r0, #808; mov crSRSSign, r2
+; CHECK-NEXT:    mova r0, #808; lshl r1, r1, r4; mov crSRSSign, r2
 ; CHECK-NEXT:    .p2align 4
 ; CHECK-NEXT:  .LBB0_2: // %for.body
 ; CHECK-NEXT:    // =>This Inner Loop Header: Depth=1

--- a/llvm/test/CodeGen/AIE/aie2/end-to-end/Mul2D.ll
+++ b/llvm/test/CodeGen/AIE/aie2/end-to-end/Mul2D.ll
@@ -73,10 +73,10 @@ define void @mul2d(ptr noalias %in_ptr0, ptr noalias %in_ptr1, ptr noalias %out_
 ; CHECK-NEXT:    lda dn0, [p3, #0]; mov p3, sp
 ; CHECK-NEXT:    paddb [p3], #-20
 ; CHECK-NEXT:    lda dn4, [p3, #0]; mov p3, sp
-; CHECK-NEXT:    mova dc0, #0; paddb [p3], #-24; movx r2, #1
-; CHECK-NEXT:    lda m0, [p3, #0]; extend.u8 r5, r5
-; CHECK-NEXT:    movx r3, #0; mov s0, r5
-; CHECK-NEXT:    movx r4, #-1
+; CHECK-NEXT:    mova r2, #1; paddb [p3], #-24
+; CHECK-NEXT:    lda m0, [p3, #0]; movx r3, #0
+; CHECK-NEXT:    mova dc0, #0; extend.u8 r5, r5
+; CHECK-NEXT:    movx r4, #-1; mov s0, r5
 ; CHECK-NEXT:    lshl r1, r1, r4; mov dc4, dc0
 ; CHECK-NEXT:    ne r2, r0, r2; vbcst.8 x0, r3
 ; CHECK-NEXT:    movx r0, #808; mov crSRSSign, r2

--- a/llvm/test/CodeGen/AIE/aie2/fadd.ll
+++ b/llvm/test/CodeGen/AIE/aie2/fadd.ll
@@ -12,9 +12,8 @@ define bfloat @test_fadd_bfloat(bfloat %a, bfloat %b) {
 ; CHECK-LABEL: test_fadd_bfloat:
 ; CHECK:         .p2align 4
 ; CHECK-NEXT:  // %bb.0: // %entry
-; CHECK-NEXT:    nopa ; nopb ; nopx ; mov r3, r16
-; CHECK-NEXT:    mova r16, #0; movx r0, #16
-; CHECK-NEXT:    lshl r1, r1, r0; mov r29, r16
+; CHECK-NEXT:    nopb ; mova r16, #0; nops ; movx r0, #16; mov r3, r16; nopv
+; CHECK-NEXT:    nopa ; lshl r1, r1, r0; mov r29, r16
 ; CHECK-NEXT:    lshl r0, r2, r0; vinsert.32 x0, x0, r29, r1
 ; CHECK-NEXT:    vinsert.32 x2, x0, r29, r0
 ; CHECK-NEXT:    mova r0, #28; vmov bmh0, x0

--- a/llvm/test/CodeGen/AIE/aie2/float_to_bfloat16.ll
+++ b/llvm/test/CodeGen/AIE/aie2/float_to_bfloat16.ll
@@ -11,8 +11,7 @@ define bfloat @float_to_bf16_test(float %v) {
 ; CHECK-LABEL: float_to_bf16_test:
 ; CHECK:         .p2align 4
 ; CHECK-NEXT:  // %bb.0:
-; CHECK-NEXT:    nopa ; nopb ; nopx ; mov r2, r16
-; CHECK-NEXT:    mova r16, #0
+; CHECK-NEXT:    nopb ; mova r16, #0; nops ; nopx ; mov r2, r16; nopv
 ; CHECK-NEXT:    mov r29, r16
 ; CHECK-NEXT:    vinsert.32 x0, x0, r29, r1
 ; CHECK-NEXT:    vmov bmh0, x0

--- a/llvm/test/CodeGen/AIE/aie2/fsub.ll
+++ b/llvm/test/CodeGen/AIE/aie2/fsub.ll
@@ -12,9 +12,8 @@ define bfloat @test_fsub_bfloat(bfloat %a, bfloat %b) {
 ; CHECK-LABEL: test_fsub_bfloat:
 ; CHECK:         .p2align 4
 ; CHECK-NEXT:  // %bb.0: // %entry
-; CHECK-NEXT:    nopa ; nopb ; nopx ; mov r3, r16
-; CHECK-NEXT:    mova r16, #0; movx r0, #16
-; CHECK-NEXT:    lshl r1, r1, r0; mov r29, r16
+; CHECK-NEXT:    nopb ; mova r16, #0; nops ; movx r0, #16; mov r3, r16; nopv
+; CHECK-NEXT:    nopa ; lshl r1, r1, r0; mov r29, r16
 ; CHECK-NEXT:    lshl r0, r2, r0; vinsert.32 x0, x0, r29, r1
 ; CHECK-NEXT:    vinsert.32 x2, x0, r29, r0
 ; CHECK-NEXT:    mova r0, #28; vmov bmh0, x0

--- a/llvm/test/CodeGen/AIE/aie2/hardware-loops/loop-with-call.ll
+++ b/llvm/test/CodeGen/AIE/aie2/hardware-loops/loop-with-call.ll
@@ -82,17 +82,17 @@ define dso_local void @_Z5test4i(i32 noundef %n) {
 ; CHECK-NEXT:  .LBB1_2: // %for.body
 ; CHECK-NEXT:    // =>This Inner Loop Header: Depth=1
 ; CHECK-NEXT:    nopb ; nopa ; nops ; jl #_Z16addToSymbolTablePKci; nopv
-; CHECK-NEXT:    nop // Delay Slot 5
+; CHECK-NEXT:    nopx // Delay Slot 5
 ; CHECK-NEXT:    nop // Delay Slot 4
 ; CHECK-NEXT:    nop // Delay Slot 3
 ; CHECK-NEXT:    nop // Delay Slot 2
-; CHECK-NEXT:    movx r0, #0; mov p0, p6 // Delay Slot 1
+; CHECK-NEXT:    mova r0, #0; mov p0, p6 // Delay Slot 1
 ; CHECK-NEXT:    nopb ; nopa ; nops ; jl #_Z16addToSymbolTablePKci; nopv
-; CHECK-NEXT:    nop // Delay Slot 5
+; CHECK-NEXT:    nopx // Delay Slot 5
 ; CHECK-NEXT:    nop // Delay Slot 4
 ; CHECK-NEXT:    nop // Delay Slot 3
 ; CHECK-NEXT:    nop // Delay Slot 2
-; CHECK-NEXT:    movx r0, #1; mov p0, p7 // Delay Slot 1
+; CHECK-NEXT:    mova r0, #1; mov p0, p7 // Delay Slot 1
 ; CHECK-NEXT:    nopb ; nopa ; nops ; add r16, r16, #-1; nopm ; nopv
 ; CHECK-NEXT:    jnz r16, #.LBB1_2
 ; CHECK-NEXT:    nop // Delay Slot 5

--- a/llvm/test/CodeGen/AIE/aie2/hardware-loops/noduplication.mir
+++ b/llvm/test/CodeGen/AIE/aie2/hardware-loops/noduplication.mir
@@ -39,9 +39,6 @@ body:             |
   ; CHECK-NEXT:   frame-setup BUNDLE implicit-def $sp, implicit $sp {
   ; CHECK-NEXT:     frame-setup PADDB_sp_imm 32, implicit-def $sp, implicit $sp
   ; CHECK-NEXT:   }
-  ; CHECK-NEXT:   BUNDLE implicit killed $r17, implicit $sp {
-  ; CHECK-NEXT:     ST_dms_spill killed $r17, -24, implicit $sp :: (store (s32) into %stack.2)
-  ; CHECK-NEXT:   }
   ; CHECK-NEXT:   BUNDLE implicit-def $p6, implicit $sp {
   ; CHECK-NEXT:     renamable $p6 = MOVA_lda_cg 0
   ; CHECK-NEXT:     ST_dms_spill internal $p6, -32, implicit $sp :: (store (s32) into %stack.4)
@@ -52,8 +49,8 @@ body:             |
   ; CHECK-NEXT:   BUNDLE implicit killed $r16, implicit $sp {
   ; CHECK-NEXT:     ST_dms_spill killed $r16, -20, implicit $sp :: (store (s32) into %stack.1)
   ; CHECK-NEXT:   }
-  ; CHECK-NEXT:   BUNDLE implicit-def $r16, implicit killed $r1 {
-  ; CHECK-NEXT:     $r16 = MOV_mv_scl killed $r1
+  ; CHECK-NEXT:   BUNDLE implicit killed $r17, implicit $sp {
+  ; CHECK-NEXT:     ST_dms_spill killed $r17, -24, implicit $sp :: (store (s32) into %stack.2)
   ; CHECK-NEXT:   }
   ; CHECK-NEXT:   BUNDLE implicit-def $p0, implicit $lr, implicit $sp {
   ; CHECK-NEXT:     $p0 = MOVA_lda_cg 0
@@ -63,9 +60,10 @@ body:             |
   ; CHECK-NEXT:     $p1 = MOVA_lda_cg 0
   ; CHECK-NEXT:     ST_dms_spill killed $r18, -28, implicit $sp :: (store (s32) into %stack.3)
   ; CHECK-NEXT:   }
-  ; CHECK-NEXT:   BUNDLE implicit-def $r18, implicit-def $r17 {
+  ; CHECK-NEXT:   BUNDLE implicit-def $r18, implicit-def $r17, implicit-def $r16, implicit killed $r1 {
   ; CHECK-NEXT:     renamable $r18 = MOVA_lda_cg 1
   ; CHECK-NEXT:     renamable $r17 = MOVX_alu_cg 0
+  ; CHECK-NEXT:     $r16 = MOV_mv_scl killed $r1
   ; CHECK-NEXT:   }
   ; CHECK-NEXT:   DelayedSchedBarrier csr_aie2, implicit killed $p0, implicit killed $p1, implicit-def dead $r0
   ; CHECK-NEXT:   BUNDLE implicit-def $r0, implicit killed $r16, implicit killed $r18 {

--- a/llvm/test/CodeGen/AIE/aie2/intrinsics-shufflevec.ll
+++ b/llvm/test/CodeGen/AIE/aie2/intrinsics-shufflevec.ll
@@ -18,27 +18,20 @@ define <8 x i32> @test_extract_vector(<16 x i32> noundef %a, i32 noundef %idx) {
 ; CHECK-NEXT:    nop // Delay Slot 2
 ; CHECK-NEXT:    mov r8, r16 // Delay Slot 1
 ; CHECK-NEXT:  // %bb.1: // %if.end
-; CHECK-NEXT:    mova r16, #8; nopb ; nopxm ; nops
+; CHECK-NEXT:    mova r16, #8; nopb ; nopxm
 ; CHECK-NEXT:    vextract.s32 r0, x2, r16
-; CHECK-NEXT:    nop
 ; CHECK-NEXT:    mova r16, #9
 ; CHECK-NEXT:    vextract.s32 r1, x2, r16
-; CHECK-NEXT:    nop
 ; CHECK-NEXT:    mova r16, #10
 ; CHECK-NEXT:    vextract.s32 r2, x2, r16
-; CHECK-NEXT:    nop
 ; CHECK-NEXT:    mova r16, #11
 ; CHECK-NEXT:    vextract.s32 r3, x2, r16
-; CHECK-NEXT:    nop
 ; CHECK-NEXT:    mova r16, #12
 ; CHECK-NEXT:    vextract.s32 r4, x2, r16
-; CHECK-NEXT:    nop
 ; CHECK-NEXT:    mova r16, #13
 ; CHECK-NEXT:    vextract.s32 r5, x2, r16
-; CHECK-NEXT:    nop
 ; CHECK-NEXT:    mova r16, #15
 ; CHECK-NEXT:    vextract.s32 r6, x2, r16
-; CHECK-NEXT:    nop
 ; CHECK-NEXT:    mova r16, #14
 ; CHECK-NEXT:    vextract.s32 r7, x2, r16
 ; CHECK-NEXT:    vpush.lo.32 x0, r6, x0
@@ -53,27 +46,20 @@ define <8 x i32> @test_extract_vector(<16 x i32> noundef %a, i32 noundef %idx) {
 ; CHECK-NEXT:    mov r16, r8 // Delay Slot 1
 ; CHECK-NEXT:    .p2align 4
 ; CHECK-NEXT:  .LBB0_2: // %if.then
-; CHECK-NEXT:    mova r16, #0; nopb ; nopxm ; nops
+; CHECK-NEXT:    mova r16, #0; nopb ; nopxm
 ; CHECK-NEXT:    vextract.s32 r0, x2, r16
-; CHECK-NEXT:    nop
 ; CHECK-NEXT:    mova r16, #1
 ; CHECK-NEXT:    vextract.s32 r1, x2, r16
-; CHECK-NEXT:    nop
 ; CHECK-NEXT:    mova r16, #2
 ; CHECK-NEXT:    vextract.s32 r2, x2, r16
-; CHECK-NEXT:    nop
 ; CHECK-NEXT:    mova r16, #3
 ; CHECK-NEXT:    vextract.s32 r3, x2, r16
-; CHECK-NEXT:    nop
 ; CHECK-NEXT:    mova r16, #4
 ; CHECK-NEXT:    vextract.s32 r4, x2, r16
-; CHECK-NEXT:    nop
 ; CHECK-NEXT:    mova r16, #5
 ; CHECK-NEXT:    vextract.s32 r5, x2, r16
-; CHECK-NEXT:    nop
 ; CHECK-NEXT:    mova r16, #7
 ; CHECK-NEXT:    vextract.s32 r6, x2, r16
-; CHECK-NEXT:    nop
 ; CHECK-NEXT:    mova r16, #6
 ; CHECK-NEXT:    vextract.s32 r7, x2, r16
 ; CHECK-NEXT:    vpush.lo.32 x0, r6, x0
@@ -107,27 +93,24 @@ define <16 x i32> @test_insert_vector(<16 x i32> noundef %a, i32 noundef %idx, <
 ; CHECK-LABEL: test_insert_vector:
 ; CHECK:         .p2align 4
 ; CHECK-NEXT:  // %bb.0: // %entry
-; CHECK-NEXT:    nopx ; mov r25, r17
+; CHECK-NEXT:    nopa ; nopb ; nopx ; mov r24, r16; nops
+; CHECK-NEXT:    mov r25, r17
 ; CHECK-NEXT:    mov r26, r18
 ; CHECK-NEXT:    mov r27, r19
 ; CHECK-NEXT:    mova r19, #0
 ; CHECK-NEXT:    mova r18, #1
-; CHECK-NEXT:    mov r24, r16
+; CHECK-NEXT:    mova r17, #2
 ; CHECK-NEXT:    mova r16, #3
 ; CHECK-NEXT:    vextract.s32 r4, x4, r16
-; CHECK-NEXT:    movx r17, #2
 ; CHECK-NEXT:    mova r16, #4
 ; CHECK-NEXT:    vextract.s32 r1, x4, r19
 ; CHECK-NEXT:    vextract.s32 r2, x4, r18
 ; CHECK-NEXT:    vextract.s32 r3, x4, r17
 ; CHECK-NEXT:    vextract.s32 r5, x4, r16
-; CHECK-NEXT:    nop
 ; CHECK-NEXT:    mova r16, #5
 ; CHECK-NEXT:    vextract.s32 r6, x4, r16
-; CHECK-NEXT:    nop
 ; CHECK-NEXT:    mova r16, #7
 ; CHECK-NEXT:    vextract.s32 r7, x4, r16
-; CHECK-NEXT:    nop
 ; CHECK-NEXT:    mova r16, #6
 ; CHECK-NEXT:    vextract.s32 r8, x4, r16
 ; CHECK-NEXT:    vpush.lo.32 x0, r7, x0
@@ -140,8 +123,8 @@ define <16 x i32> @test_insert_vector(<16 x i32> noundef %a, i32 noundef %idx, <
 ; CHECK-NEXT:    vpush.lo.32 x0, r2, x0 // Delay Slot 2
 ; CHECK-NEXT:    vpush.lo.32 x0, r1, x0 // Delay Slot 1
 ; CHECK-NEXT:  // %bb.1: // %if.end
-; CHECK-NEXT:    nopb ; mova r16, #3; nops ; nopxm ; nopv
-; CHECK-NEXT:    nopa ; vextract.s32 r0, x2, r19
+; CHECK-NEXT:    mova r16, #3; nopxm
+; CHECK-NEXT:    vextract.s32 r0, x2, r19
 ; CHECK-NEXT:    vextract.s32 r1, x0, r19
 ; CHECK-NEXT:    vextract.s32 r2, x2, r18
 ; CHECK-NEXT:    vextract.s32 r3, x0, r18
@@ -149,19 +132,15 @@ define <16 x i32> @test_insert_vector(<16 x i32> noundef %a, i32 noundef %idx, <
 ; CHECK-NEXT:    vextract.s32 r5, x0, r17
 ; CHECK-NEXT:    vextract.s32 r6, x2, r16
 ; CHECK-NEXT:    vextract.s32 r7, x0, r16
-; CHECK-NEXT:    nop
 ; CHECK-NEXT:    mova r16, #4
 ; CHECK-NEXT:    vextract.s32 r8, x2, r16
 ; CHECK-NEXT:    vextract.s32 r9, x0, r16
-; CHECK-NEXT:    nop
 ; CHECK-NEXT:    mova r16, #5
 ; CHECK-NEXT:    vextract.s32 r10, x2, r16
 ; CHECK-NEXT:    vextract.s32 r11, x0, r16
-; CHECK-NEXT:    nop
 ; CHECK-NEXT:    mova r16, #7
 ; CHECK-NEXT:    vextract.s32 r12, x2, r16
 ; CHECK-NEXT:    vextract.s32 r13, x0, r16
-; CHECK-NEXT:    nop
 ; CHECK-NEXT:    mova r16, #6
 ; CHECK-NEXT:    vextract.s32 r14, x2, r16
 ; CHECK-NEXT:    vextract.s32 r15, x0, r16
@@ -184,7 +163,7 @@ define <16 x i32> @test_insert_vector(<16 x i32> noundef %a, i32 noundef %idx, <
 ; CHECK-NEXT:    vpush.lo.32 x0, r0, x0 // Delay Slot 1
 ; CHECK-NEXT:    .p2align 4
 ; CHECK-NEXT:  .LBB1_2: // %if.then
-; CHECK-NEXT:    mova r16, #3; nopb ; nopx
+; CHECK-NEXT:    nopb ; mova r16, #3; nops ; nopxm ; nopv
 ; CHECK-NEXT:    vextract.s32 r0, x0, r19
 ; CHECK-NEXT:    vextract.s32 r1, x2, r19
 ; CHECK-NEXT:    vextract.s32 r2, x0, r18
@@ -193,19 +172,15 @@ define <16 x i32> @test_insert_vector(<16 x i32> noundef %a, i32 noundef %idx, <
 ; CHECK-NEXT:    vextract.s32 r5, x2, r17
 ; CHECK-NEXT:    vextract.s32 r6, x0, r16
 ; CHECK-NEXT:    vextract.s32 r7, x2, r16
-; CHECK-NEXT:    nop
 ; CHECK-NEXT:    mova r16, #4
 ; CHECK-NEXT:    vextract.s32 r8, x0, r16
 ; CHECK-NEXT:    vextract.s32 r9, x2, r16
-; CHECK-NEXT:    nop
 ; CHECK-NEXT:    mova r16, #5
 ; CHECK-NEXT:    vextract.s32 r10, x0, r16
 ; CHECK-NEXT:    vextract.s32 r11, x2, r16
-; CHECK-NEXT:    nop
 ; CHECK-NEXT:    mova r16, #7
 ; CHECK-NEXT:    vextract.s32 r12, x0, r16
 ; CHECK-NEXT:    vextract.s32 r13, x2, r16
-; CHECK-NEXT:    nop
 ; CHECK-NEXT:    mova r16, #6
 ; CHECK-NEXT:    vextract.s32 r14, x0, r16
 ; CHECK-NEXT:    vextract.s32 r15, x2, r16
@@ -255,35 +230,28 @@ define <16 x i32> @test_concat_vector(<8 x i32> noundef %a, <8 x i32> noundef %b
 ; CHECK-LABEL: test_concat_vector:
 ; CHECK:         .p2align 4
 ; CHECK-NEXT:  // %bb.0: // %entry
-; CHECK-NEXT:    nopa ; nopx ; mov r24, r16
+; CHECK-NEXT:    nopx ; mov r24, r16
 ; CHECK-NEXT:    mova r16, #0
 ; CHECK-NEXT:    vextract.s32 r0, x2, r16
 ; CHECK-NEXT:    vextract.s32 r1, x4, r16
-; CHECK-NEXT:    nop
 ; CHECK-NEXT:    mova r16, #1
 ; CHECK-NEXT:    vextract.s32 r2, x2, r16
 ; CHECK-NEXT:    vextract.s32 r3, x4, r16
-; CHECK-NEXT:    nop
 ; CHECK-NEXT:    mova r16, #2
 ; CHECK-NEXT:    vextract.s32 r4, x2, r16
 ; CHECK-NEXT:    vextract.s32 r5, x4, r16
-; CHECK-NEXT:    nop
 ; CHECK-NEXT:    mova r16, #3
 ; CHECK-NEXT:    vextract.s32 r6, x2, r16
 ; CHECK-NEXT:    vextract.s32 r7, x4, r16
-; CHECK-NEXT:    nop
 ; CHECK-NEXT:    mova r16, #4
 ; CHECK-NEXT:    vextract.s32 r8, x2, r16
 ; CHECK-NEXT:    vextract.s32 r9, x4, r16
-; CHECK-NEXT:    nop
 ; CHECK-NEXT:    mova r16, #5
 ; CHECK-NEXT:    vextract.s32 r10, x2, r16
 ; CHECK-NEXT:    vextract.s32 r11, x4, r16
-; CHECK-NEXT:    nop
 ; CHECK-NEXT:    mova r16, #7
 ; CHECK-NEXT:    vextract.s32 r12, x2, r16
 ; CHECK-NEXT:    vextract.s32 r13, x4, r16
-; CHECK-NEXT:    nop
 ; CHECK-NEXT:    mova r16, #6
 ; CHECK-NEXT:    vextract.s32 r14, x2, r16
 ; CHECK-NEXT:    vextract.s32 r15, x4, r16
@@ -314,28 +282,22 @@ define <16 x i32> @test_set_vector(i32 noundef %idx, <8 x i32> noundef %a) {
 ; CHECK-LABEL: test_set_vector:
 ; CHECK:         .p2align 4
 ; CHECK-NEXT:  // %bb.0: // %entry
-; CHECK-NEXT:    nopb ; nopa ; nops ; nopx ; mov r9, r16; nopv
+; CHECK-NEXT:    nopa ; nopb ; nopx ; mov r9, r16
 ; CHECK-NEXT:    mova r16, #0
+; CHECK-NEXT:    eqz r0, r0
 ; CHECK-NEXT:    vextract.s32 r1, x2, r16
-; CHECK-NEXT:    nop
 ; CHECK-NEXT:    mova r16, #1
 ; CHECK-NEXT:    vextract.s32 r2, x2, r16
-; CHECK-NEXT:    nop
 ; CHECK-NEXT:    mova r16, #2
 ; CHECK-NEXT:    vextract.s32 r3, x2, r16
-; CHECK-NEXT:    nop
 ; CHECK-NEXT:    mova r16, #3
 ; CHECK-NEXT:    vextract.s32 r4, x2, r16
-; CHECK-NEXT:    nop
 ; CHECK-NEXT:    mova r16, #4
 ; CHECK-NEXT:    vextract.s32 r5, x2, r16
-; CHECK-NEXT:    nop
 ; CHECK-NEXT:    mova r16, #5
 ; CHECK-NEXT:    vextract.s32 r6, x2, r16
-; CHECK-NEXT:    nop
 ; CHECK-NEXT:    mova r16, #7
 ; CHECK-NEXT:    vextract.s32 r7, x2, r16
-; CHECK-NEXT:    eqz r0, r0
 ; CHECK-NEXT:    mova r16, #6
 ; CHECK-NEXT:    vextract.s32 r8, x2, r16
 ; CHECK-NEXT:    add r16, r0, #-1

--- a/llvm/test/CodeGen/AIE/aie2/schedule/mov.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/mov.mir
@@ -28,11 +28,11 @@ alignment:       16
 body:             |
   bb.0.entry:
     ; CHECK-LABEL: name: multi_slot_sched
-    ; CHECK: BUNDLE implicit-def $r1, implicit-def $r2 {
+    ; CHECK: BUNDLE implicit-def $r1, implicit-def $r2, implicit-def $r3 {
     ; CHECK-NEXT:   $r1 = MOVA_lda_cg 0
     ; CHECK-NEXT:   $r2 = MOVX_alu_cg 1
+    ; CHECK-NEXT:   $r3 = MOV_mv_cg 2
     ; CHECK-NEXT: }
-    ; CHECK-NEXT: $r3 = MOVA_lda_cg 2
     $r1 = MOV_RLC_imm10_pseudo 0
     $r2 = MOV_RLC_imm10_pseudo 1
     $r3 = MOV_RLC_imm10_pseudo 2
@@ -44,11 +44,11 @@ alignment:       16
 body:             |
   bb.0.entry:
     ; CHECK-LABEL: name: multi_slot_sched_MOVA_first
-    ; CHECK: BUNDLE implicit-def $r1, implicit-def $r2 {
+    ; CHECK: BUNDLE implicit-def $r1, implicit-def $r2, implicit-def $r3 {
     ; CHECK-NEXT:   $r1 = MOVA_lda_cg 0
     ; CHECK-NEXT:   $r2 = MOVX_alu_cg 1
+    ; CHECK-NEXT:   $r3 = MOV_mv_cg 2
     ; CHECK-NEXT: }
-    ; CHECK-NEXT: $r3 = MOVA_lda_cg 2
     $r1 = MOVA_lda_cg 0
     $r2 = MOV_RLC_imm10_pseudo 1
     $r3 = MOV_RLC_imm10_pseudo 2
@@ -60,11 +60,11 @@ alignment:       16
 body:             |
   bb.0.entry:
     ; CHECK-LABEL: name: multi_slot_sched_MOVX_first
-    ; CHECK: BUNDLE implicit-def $r2, implicit-def $r1 {
+    ; CHECK: BUNDLE implicit-def $r2, implicit-def $r1, implicit-def $r3 {
     ; CHECK-NEXT:   $r2 = MOVA_lda_cg 1
     ; CHECK-NEXT:   $r1 = MOVX_alu_cg 0
+    ; CHECK-NEXT:   $r3 = MOV_mv_cg 2
     ; CHECK-NEXT: }
-    ; CHECK-NEXT: $r3 = MOVA_lda_cg 2
     $r1 = MOVX_alu_cg 0
     $r2 = MOV_RLC_imm10_pseudo 1
     $r3 = MOV_RLC_imm10_pseudo 2
@@ -76,11 +76,11 @@ alignment:       16
 body:             |
   bb.0.entry:
     ; CHECK-LABEL: name: multi_slot_sched_MOV_first
-    ; CHECK: BUNDLE implicit-def $r2, implicit-def $r1 {
-    ; CHECK-NEXT:   $r2 = MOVX_alu_cg 1
+    ; CHECK: BUNDLE implicit-def $r2, implicit-def $r3, implicit-def $r1 {
+    ; CHECK-NEXT:   $r2 = MOVA_lda_cg 1
+    ; CHECK-NEXT:   $r3 = MOVX_alu_cg 2
     ; CHECK-NEXT:   $r1 = MOV_mv_cg 0
     ; CHECK-NEXT: }
-    ; CHECK-NEXT: $r3 = MOVA_lda_cg 2
     $r1 = MOV_mv_cg 0
     $r2 = MOV_RLC_imm10_pseudo 1
     $r3 = MOV_RLC_imm10_pseudo 2
@@ -92,11 +92,11 @@ alignment:       16
 body:             |
   bb.0.entry:
     ; CHECK-LABEL: name: multi_slot_sched_MOVXM_first
-    ; CHECK: $r1 = MOVXM_lng_cg 0
-    ; CHECK-NEXT: BUNDLE implicit-def $r2, implicit-def $r3 {
+    ; CHECK: BUNDLE implicit-def $r2, implicit-def $r1 {
     ; CHECK-NEXT:   $r2 = MOVA_lda_cg 1
-    ; CHECK-NEXT:   $r3 = MOVX_alu_cg 2
+    ; CHECK-NEXT:   $r1 = MOVXM_lng_cg 0
     ; CHECK-NEXT: }
+    ; CHECK-NEXT: $r3 = MOVA_lda_cg 2
     $r1 = MOVXM_lng_cg 0
     $r2 = MOV_RLC_imm10_pseudo 1
     $r3 = MOV_RLC_imm10_pseudo 2
@@ -124,11 +124,11 @@ alignment:       16
 body:             |
   bb.0.entry:
     ; CHECK-LABEL: name: multi_slot_sched_MOVX_second
-    ; CHECK: BUNDLE implicit-def $r1, implicit-def $r2 {
+    ; CHECK: BUNDLE implicit-def $r1, implicit-def $r2, implicit-def $r3 {
     ; CHECK-NEXT:   $r1 = MOVA_lda_cg 0
     ; CHECK-NEXT:   $r2 = MOVX_alu_cg 1
+    ; CHECK-NEXT:   $r3 = MOV_mv_cg 2
     ; CHECK-NEXT: }
-    ; CHECK-NEXT: $r3 = MOVA_lda_cg 2
     $r1 = MOV_RLC_imm10_pseudo 0
     $r2 = MOVX_alu_cg 1
     $r3 = MOV_RLC_imm10_pseudo 2
@@ -140,11 +140,11 @@ alignment:       16
 body:             |
   bb.0.entry:
     ; CHECK-LABEL: name: multi_slot_sched_MOV_second
-    ; CHECK: BUNDLE implicit-def $r1, implicit-def $r3 {
+    ; CHECK: BUNDLE implicit-def $r1, implicit-def $r3, implicit-def $r2 {
     ; CHECK-NEXT:   $r1 = MOVA_lda_cg 0
     ; CHECK-NEXT:   $r3 = MOVX_alu_cg 2
+    ; CHECK-NEXT:   $r2 = MOV_mv_cg 1
     ; CHECK-NEXT: }
-    ; CHECK-NEXT: $r2 = MOV_mv_cg 1
     $r1 = MOV_RLC_imm10_pseudo 0
     $r2 = MOV_mv_cg 1
     $r3 = MOV_RLC_imm10_pseudo 2
@@ -156,11 +156,11 @@ alignment:       16
 body:             |
   bb.0.entry:
     ; CHECK-LABEL: name: multi_slot_sched_MOVXM_second
-    ; CHECK: BUNDLE implicit-def $r1, implicit-def $r3 {
+    ; CHECK: BUNDLE implicit-def $r1, implicit-def $r2 {
     ; CHECK-NEXT:   $r1 = MOVA_lda_cg 0
-    ; CHECK-NEXT:   $r3 = MOVX_alu_cg 2
+    ; CHECK-NEXT:   $r2 = MOVXM_lng_cg 1
     ; CHECK-NEXT: }
-    ; CHECK-NEXT: $r2 = MOVXM_lng_cg 1
+    ; CHECK-NEXT: $r3 = MOVA_lda_cg 2
     $r1 = MOV_RLC_imm10_pseudo 0
     $r2 = MOVXM_lng_cg 1
     $r3 = MOV_RLC_imm10_pseudo 2
@@ -188,8 +188,10 @@ alignment:       16
 body:             |
   bb.0.entry:
     ; CHECK-LABEL: name: multi_slot_sched_s20_MOVA_first
-    ; CHECK: $r1 = MOVA_lda_cg 0
-    ; CHECK-NEXT: $m0 = MOVA_lda_cg 1
+    ; CHECK: BUNDLE implicit-def $r1, implicit-def $m0 {
+    ; CHECK-NEXT:   $r1 = MOVA_lda_cg 0
+    ; CHECK-NEXT:   $m0 = MOV_mv_cg 1
+    ; CHECK-NEXT: }
     ; CHECK-NEXT: $p0 = MOVA_lda_cg 2
     $r1 = MOVA_lda_cg 0
     $m0 = MOV_PD_imm10_pseudo 1
@@ -248,8 +250,10 @@ body:             |
   bb.0.entry:
     ; CHECK-LABEL: name: multi_slot_sched_s20_MOVA_second
     ; CHECK: $p1 = MOVA_lda_cg 0
-    ; CHECK-NEXT: $r2 = MOVA_lda_cg 1
-    ; CHECK-NEXT: $m3 = MOVA_lda_cg 2
+    ; CHECK-NEXT: BUNDLE implicit-def $r2, implicit-def $m3 {
+    ; CHECK-NEXT:   $r2 = MOVA_lda_cg 1
+    ; CHECK-NEXT:   $m3 = MOV_mv_cg 2
+    ; CHECK-NEXT: }
     $p1 = MOV_PD_imm10_pseudo 0
     $r2 = MOVA_lda_cg 1
     $m3 = MOV_PD_imm10_pseudo 2
@@ -307,11 +311,11 @@ alignment:       16
 body:             |
   bb.0.entry:
     ; CHECK-LABEL: name: multi_slot_sched_slot_alloc_order
-    ; CHECK: BUNDLE implicit-def $r2, implicit-def $s1 {
-    ; CHECK-NEXT:   $r2 = MOVX_alu_cg 1
+    ; CHECK: BUNDLE implicit-def $r2, implicit-def $r3, implicit-def $s1 {
+    ; CHECK-NEXT:   $r2 = MOVA_lda_cg 1
+    ; CHECK-NEXT:   $r3 = MOVX_alu_cg 2
     ; CHECK-NEXT:   $s1 = MOV_mv_cg 0
     ; CHECK-NEXT: }
-    ; CHECK-NEXT: $r3 = MOVA_lda_cg 2
     $s1 = MOV_S_imm10_pseudo 0
     $r2 = MOV_RLC_imm10_pseudo 1
     $r3 = MOV_RLC_imm10_pseudo 2

--- a/llvm/test/CodeGen/AIE/aie2/schedule/mov.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/mov.mir
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
 # (c) Copyright 2023-2024 Advanced Micro Devices, Inc. or its affiliates
-# RUN: llc -march=aie2 -run-pass=postmisched %s %topdown-multi -o - | FileCheck %s
+# RUN: llc -mtriple=aie2 -run-pass=postmisched %s %topdown-multi -o - | FileCheck %s
 
 ---
 name:            latency
@@ -166,16 +166,16 @@ body:             |
     $r3 = MOV_RLC_imm10_pseudo 2
 ...
 
-# Lot of cases down are not bundling the INSTR together, because we reserve P_WM_PORT for any kind of D or P reg type. The ISA suggests every register file has its own writeport, which is selected. Once we are able to do that we would start seeing better bundling.
-
 ---
 name:            multi_slot_sched_s20
 alignment:       16
 body:             |
   bb.0.entry:
     ; CHECK-LABEL: name: multi_slot_sched_s20
-    ; CHECK: $dc1 = MOVA_lda_cg 0
-    ; CHECK-NEXT: $m0 = MOVA_lda_cg 1
+    ; CHECK: BUNDLE implicit-def $dc1, implicit-def $m0 {
+    ; CHECK-NEXT:   $dc1 = MOVA_lda_cg 0
+    ; CHECK-NEXT:   $m0 = MOV_mv_cg 1
+    ; CHECK-NEXT: }
     ; CHECK-NEXT: $p0 = MOVA_lda_cg 2
     $dc1 = MOV_PD_imm10_pseudo 0
     $m0 = MOV_PD_imm10_pseudo 1
@@ -204,11 +204,11 @@ alignment:       16
 body:             |
   bb.0.entry:
     ; CHECK-LABEL: name: multi_slot_sched_s20_MOVX_first
-    ; CHECK: BUNDLE implicit-def $m0, implicit-def $r1 {
+    ; CHECK: BUNDLE implicit-def $m0, implicit-def $r1, implicit-def $p0 {
     ; CHECK-NEXT:   $m0 = MOVA_lda_cg 1
     ; CHECK-NEXT:   $r1 = MOVX_alu_cg 0
+    ; CHECK-NEXT:   $p0 = MOV_mv_cg 2
     ; CHECK-NEXT: }
-    ; CHECK-NEXT: $p0 = MOVA_lda_cg 2
     $r1 = MOVX_alu_cg 0
     $m0 = MOV_PD_imm10_pseudo 1
     $p0 = MOV_PD_imm10_pseudo 2
@@ -220,8 +220,10 @@ alignment:       16
 body:             |
   bb.0.entry:
     ; CHECK-LABEL: name: multi_slot_sched_s20_MOV_first
-    ; CHECK: $r1 = MOV_mv_cg 0
-    ; CHECK-NEXT: $m0 = MOVA_lda_cg 1
+    ; CHECK: BUNDLE implicit-def $m0, implicit-def $r1 {
+    ; CHECK-NEXT:   $m0 = MOVA_lda_cg 1
+    ; CHECK-NEXT:   $r1 = MOV_mv_cg 0
+    ; CHECK-NEXT: }
     ; CHECK-NEXT: $p0 = MOVA_lda_cg 2
     $r1 = MOV_mv_cg 0
     $m0 = MOV_PD_imm10_pseudo 1
@@ -234,8 +236,10 @@ alignment:       16
 body:             |
   bb.0.entry:
     ; CHECK-LABEL: name: multi_slot_sched_s20_MOVXM_first
-    ; CHECK: $r1 = MOVXM_lng_cg 0
-    ; CHECK-NEXT: $m0 = MOVA_lda_cg 1
+    ; CHECK: BUNDLE implicit-def $m0, implicit-def $r1 {
+    ; CHECK-NEXT:   $m0 = MOVA_lda_cg 1
+    ; CHECK-NEXT:   $r1 = MOVXM_lng_cg 0
+    ; CHECK-NEXT: }
     ; CHECK-NEXT: $p0 = MOVA_lda_cg 2
     $r1 = MOVXM_lng_cg 0
     $m0 = MOV_PD_imm10_pseudo 1
@@ -249,11 +253,11 @@ alignment:       16
 body:             |
   bb.0.entry:
     ; CHECK-LABEL: name: multi_slot_sched_s20_MOVA_second
-    ; CHECK: $p1 = MOVA_lda_cg 0
-    ; CHECK-NEXT: BUNDLE implicit-def $r2, implicit-def $m3 {
-    ; CHECK-NEXT:   $r2 = MOVA_lda_cg 1
+    ; CHECK: BUNDLE implicit-def $p1, implicit-def $m3 {
+    ; CHECK-NEXT:   $p1 = MOVA_lda_cg 0
     ; CHECK-NEXT:   $m3 = MOV_mv_cg 2
     ; CHECK-NEXT: }
+    ; CHECK-NEXT: $r2 = MOVA_lda_cg 1
     $p1 = MOV_PD_imm10_pseudo 0
     $r2 = MOVA_lda_cg 1
     $m3 = MOV_PD_imm10_pseudo 2
@@ -266,11 +270,11 @@ alignment:       16
 body:             |
   bb.0.entry:
     ; CHECK-LABEL: name: multi_slot_sched_s20_MOVX_second
-    ; CHECK: BUNDLE implicit-def $p1, implicit-def $r2 {
+    ; CHECK: BUNDLE implicit-def $p1, implicit-def $r2, implicit-def $m3 {
     ; CHECK-NEXT:   $p1 = MOVA_lda_cg 0
     ; CHECK-NEXT:   $r2 = MOVX_alu_cg 1
+    ; CHECK-NEXT:   $m3 = MOV_mv_cg 2
     ; CHECK-NEXT: }
-    ; CHECK-NEXT: $m3 = MOVA_lda_cg 2
     $p1 = MOV_PD_imm10_pseudo 0
     $r2 = MOVX_alu_cg 1
     $m3 = MOV_PD_imm10_pseudo 2
@@ -282,8 +286,10 @@ alignment:       16
 body:             |
   bb.0.entry:
     ; CHECK-LABEL: name: multi_slot_sched_s20_MOV_second
-    ; CHECK: $p1 = MOVA_lda_cg 0
-    ; CHECK-NEXT: $r2 = MOV_mv_cg 1
+    ; CHECK: BUNDLE implicit-def $p1, implicit-def $r2 {
+    ; CHECK-NEXT:   $p1 = MOVA_lda_cg 0
+    ; CHECK-NEXT:   $r2 = MOV_mv_cg 1
+    ; CHECK-NEXT: }
     ; CHECK-NEXT: $m3 = MOVA_lda_cg 2
     $p1 = MOV_PD_imm10_pseudo 0
     $r2 = MOV_mv_cg 1
@@ -297,8 +303,10 @@ alignment:       16
 body:             |
   bb.0.entry:
     ; CHECK-LABEL: name: multi_slot_sched_s20_MOVXM_second
-    ; CHECK: $p1 = MOVA_lda_cg 0
-    ; CHECK-NEXT: $r2 = MOVXM_lng_cg 1
+    ; CHECK: BUNDLE implicit-def $p1, implicit-def $r2 {
+    ; CHECK-NEXT:   $p1 = MOVA_lda_cg 0
+    ; CHECK-NEXT:   $r2 = MOVXM_lng_cg 1
+    ; CHECK-NEXT: }
     ; CHECK-NEXT: $m3 = MOVA_lda_cg 2
     $p1 = MOV_PD_imm10_pseudo 0
     $r2 = MOVXM_lng_cg 1

--- a/llvm/test/CodeGen/AIE/aie2/schedule/pre_ra/multi-slot-scoreboard.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/pre_ra/multi-slot-scoreboard.mir
@@ -50,12 +50,12 @@ body: |
     ; CHECK-LABEL: name: MOVs_A_slot_taken
     ; CHECK: liveins: $p0, $p1, $m1, $r1, $s1
     ; CHECK-NEXT: {{  $}}
-    ; CHECK-NEXT: dead [[MOV_RLC_imm10_pseudo:%[0-9]+]]:er = MOV_RLC_imm10_pseudo 1
     ; CHECK-NEXT: dead [[MOVA_lda_cg:%[0-9]+]]:er = MOVA_lda_cg 1
     ; CHECK-NEXT: CYCLE_SEPARATOR
-    ; CHECK-NEXT: dead [[MOV_RLC_imm10_pseudo1:%[0-9]+]]:er = MOV_RLC_imm10_pseudo 2
+    ; CHECK-NEXT: dead [[MOV_RLC_imm10_pseudo:%[0-9]+]]:er = MOV_RLC_imm10_pseudo 1
     ; CHECK-NEXT: dead [[MOVA_lda_cg1:%[0-9]+]]:er = MOVA_lda_cg 2
     ; CHECK-NEXT: CYCLE_SEPARATOR
+    ; CHECK-NEXT: dead [[MOV_RLC_imm10_pseudo1:%[0-9]+]]:er = MOV_RLC_imm10_pseudo 2
     ; CHECK-NEXT: dead [[MOV_RLC_imm10_pseudo2:%[0-9]+]]:er = MOV_RLC_imm10_pseudo 3
     ; CHECK-NEXT: dead [[MOVA_lda_cg2:%[0-9]+]]:er = MOVA_lda_cg 3
     ; CHECK-NEXT: CYCLE_SEPARATOR
@@ -76,12 +76,12 @@ body: |
     ; CHECK-LABEL: name: MOVs_M_slot_taken
     ; CHECK: liveins: $p0, $p1, $m1, $r1, $s1
     ; CHECK-NEXT: {{  $}}
-    ; CHECK-NEXT: dead [[MOV_RLC_imm10_pseudo:%[0-9]+]]:er = MOV_RLC_imm10_pseudo 1
     ; CHECK-NEXT: dead [[MOV_mv_cg:%[0-9]+]]:er = MOV_mv_cg 1
     ; CHECK-NEXT: CYCLE_SEPARATOR
-    ; CHECK-NEXT: dead [[MOV_RLC_imm10_pseudo1:%[0-9]+]]:er = MOV_RLC_imm10_pseudo 2
+    ; CHECK-NEXT: dead [[MOV_RLC_imm10_pseudo:%[0-9]+]]:er = MOV_RLC_imm10_pseudo 1
     ; CHECK-NEXT: dead [[MOV_mv_cg1:%[0-9]+]]:er = MOV_mv_cg 2
     ; CHECK-NEXT: CYCLE_SEPARATOR
+    ; CHECK-NEXT: dead [[MOV_RLC_imm10_pseudo1:%[0-9]+]]:er = MOV_RLC_imm10_pseudo 2
     ; CHECK-NEXT: dead [[MOV_RLC_imm10_pseudo2:%[0-9]+]]:er = MOV_RLC_imm10_pseudo 3
     ; CHECK-NEXT: dead [[MOV_mv_cg2:%[0-9]+]]:er = MOV_mv_cg 3
     ; CHECK-NEXT: CYCLE_SEPARATOR
@@ -103,7 +103,6 @@ body: |
     ; CHECK: liveins: $x4, $r19
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: dead [[VEXTRACT_S32_:%[0-9]+]]:er = VEXTRACT_S32 $x4, $r19
-    ; CHECK-NEXT: CYCLE_SEPARATOR
     ; CHECK-NEXT: CYCLE_SEPARATOR
     ; CHECK-NEXT: dead [[MOV_RLC_imm10_pseudo:%[0-9]+]]:er = MOV_RLC_imm10_pseudo 2
     ; CHECK-NEXT: dead [[MOV_RLC_imm10_pseudo1:%[0-9]+]]:er = MOV_RLC_imm10_pseudo 3

--- a/llvm/test/CodeGen/AIE/aie2/schedule/resource/dc_wm.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/resource/dc_wm.mir
@@ -208,3 +208,35 @@ body:             |
     $r1 = MOVX_alu_cg 0
     $dc0 = MOV_mv_scl $r4
 ...
+
+---
+name:            mova_with_mov_scl_to_DC
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: mova_with_mov_scl_to_DC
+    ; CHECK: BUNDLE implicit-def $r2, implicit-def $r1, implicit-def $dc0, implicit killed $r4 {
+    ; CHECK-NEXT:   $r2 = MOVA_lda_cg 0
+    ; CHECK-NEXT:   $r1 = MOVX_alu_cg 0
+    ; CHECK-NEXT:   $dc0 = MOV_mv_scl killed $r4
+    ; CHECK-NEXT: }
+    $r2 = MOVA_lda_cg 0
+    $r1 = MOVX_alu_cg 0
+    $dc0 = MOV_mv_scl $r4
+...
+
+---
+name:            mova_to_DC
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: mova_to_DC
+    ; CHECK: BUNDLE implicit-def $dc1, implicit-def $r1, implicit-def $r2, implicit killed $r4 {
+    ; CHECK-NEXT:   $dc1 = MOVA_lda_cg 0
+    ; CHECK-NEXT:   $r1 = MOVX_alu_cg 0
+    ; CHECK-NEXT:   $r2 = MOV_mv_scl killed $r4
+    ; CHECK-NEXT: }
+    $dc1 = MOVA_lda_cg 0
+    $r1 = MOVX_alu_cg 0
+    $r2 = MOV_mv_scl $r4
+...

--- a/llvm/test/CodeGen/AIE/aie2/schedule/resource/dc_wm.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/resource/dc_wm.mir
@@ -5,8 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
 # (c) Copyright 2023-2024 Advanced Micro Devices, Inc. or its affiliates
-# RUN: llc -march=aie2 %topdown-single -run-pass=postmisched %s -o - \
-# RUN:   | FileCheck %s
+# RUN: llc -mtriple=aie2 -run-pass=postmisched %s %topdown-multi -o - | FileCheck %s
 
 # Conflict on dc reg file in mov slot
 ---
@@ -61,9 +60,11 @@ body:             |
   bb.0.entry:
 
     ; CHECK-LABEL: name: E1_MOVA_E2_VEXTRACT
-    ; CHECK: $dc0 = VEXTRACT_S16 killed $x1, killed $r16
+    ; CHECK: BUNDLE implicit-def $dc1, implicit-def $dc0, implicit killed $x1, implicit killed $r16 {
+    ; CHECK-NEXT:   $dc1 = MOVA_lda_cg 2
+    ; CHECK-NEXT:   $dc0 = VEXTRACT_S16 killed $x1, killed $r16
+    ; CHECK-NEXT: }
     ; CHECK-NEXT: NOP
-    ; CHECK-NEXT: $dc1 = MOVA_lda_cg 2
     ; CHECK-NEXT: $dc2 = MOVA_lda_cg 2
   $dc0 = VEXTRACT_S16 killed $x1, killed $r16
   $dc1 = MOVA_lda_cg 2
@@ -164,4 +165,46 @@ body:             |
   $dc1 = MOVA_lda_cg 2
   $dc1 = MOVA_lda_cg 2
   $dc1 = MOVA_lda_cg 2
+...
+
+# Once Load use Reg base initinary we expect no NOP
+---
+name:            load_to_M_and_move_R_to_DC
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: load_to_M_and_move_R_to_DC
+    ; CHECK: BUNDLE implicit-def $m0, implicit-def $dc0, implicit killed $p7, implicit $r0 {
+    ; CHECK-NEXT:   $m0 = LDA_dms_lda_idx_imm killed $p7, 0
+    ; CHECK-NEXT:   $dc0 = MOV_mv_scl $r0
+    ; CHECK-NEXT: }
+    ; CHECK-NEXT: $dc0 = MOV_mv_scl $r0
+    ; CHECK-NEXT: $dc0 = MOV_mv_scl $r0
+    ; CHECK-NEXT: $dc0 = MOV_mv_scl $r0
+    ; CHECK-NEXT: $dc0 = MOV_mv_scl $r0
+    ; CHECK-NEXT: $dc0 = MOV_mv_scl $r0
+    ; CHECK-NEXT: NOP
+    ; CHECK-NEXT: $dc0 = MOV_mv_scl killed $r0
+    $m0 = LDA_dms_lda_idx_imm killed $p7, 0
+    $dc0 = MOV_mv_scl $r0
+    $dc0 = MOV_mv_scl $r0
+    $dc0 = MOV_mv_scl $r0
+    $dc0 = MOV_mv_scl $r0
+    $dc0 = MOV_mv_scl $r0
+    $dc0 = MOV_mv_scl $r0
+    $dc0 = MOV_mv_scl $r0
+...
+
+---
+name:            mov_SCL_to_DC
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: mov_SCL_to_DC
+    ; CHECK: BUNDLE implicit-def $r1, implicit-def $dc0, implicit killed $r4 {
+    ; CHECK-NEXT:   $r1 = MOVX_alu_cg 0
+    ; CHECK-NEXT:   $dc0 = MOV_mv_scl killed $r4
+    ; CHECK-NEXT: }
+    $r1 = MOVX_alu_cg 0
+    $dc0 = MOV_mv_scl $r4
 ...

--- a/llvm/test/CodeGen/AIE/aie2/schedule/resource/dc_wm.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/resource/dc_wm.mir
@@ -240,3 +240,217 @@ body:             |
     $r1 = MOVX_alu_cg 0
     $r2 = MOV_mv_scl $r4
 ...
+
+---
+name:            mov_to_DC
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: mov_to_DC
+    ; CHECK: BUNDLE implicit-def $r1, implicit-def $dc1 {
+    ; CHECK-NEXT:   $r1 = MOVA_lda_cg 0
+    ; CHECK-NEXT:   $dc1 = MOV_mv_cg 0
+    ; CHECK-NEXT: }
+    $dc1 = MOV_mv_cg 0
+    $r1 = MOVA_lda_cg 0
+...
+
+---
+name:            mova_to_dc_mov_to_DC
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: mova_to_dc_mov_to_DC
+    ; CHECK: $dc0 = MOV_mv_cg 0
+    ; CHECK-NEXT: $dc1 = MOVA_lda_cg 0
+    $dc0 = MOV_mv_cg 0
+    $dc1 = MOVA_lda_cg 0
+...
+
+---
+name:            mova_to_dj_mov_to_DC
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: mova_to_dj_mov_to_DC
+    ; CHECK: BUNDLE implicit-def $dj1, implicit-def $dc1 {
+    ; CHECK-NEXT:   $dj1 = MOVA_lda_cg 0
+    ; CHECK-NEXT:   $dc1 = MOV_mv_cg 0
+    ; CHECK-NEXT: }
+    $dc1 = MOV_mv_cg 0
+    $dj1 = MOVA_lda_cg 0
+...
+
+---
+name:            mova_to_dn_mov_to_DC
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: mova_to_dn_mov_to_DC
+    ; CHECK: BUNDLE implicit-def $dn1, implicit-def $dc1 {
+    ; CHECK-NEXT:   $dn1 = MOVA_lda_cg 0
+    ; CHECK-NEXT:   $dc1 = MOV_mv_cg 0
+    ; CHECK-NEXT: }
+    $dc1 = MOV_mv_cg 0
+    $dn1 = MOVA_lda_cg 0
+...
+
+---
+name:            mova_to_p_mov_to_DC
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: mova_to_p_mov_to_DC
+    ; CHECK: BUNDLE implicit-def $p0, implicit-def $dc1 {
+    ; CHECK-NEXT:   $p0 = MOVA_lda_cg 0
+    ; CHECK-NEXT:   $dc1 = MOV_mv_cg 0
+    ; CHECK-NEXT: }
+    $dc1 = MOV_mv_cg 0
+    $p0 = MOVA_lda_cg 0
+...
+
+---
+name:            movx_to_R_mov_to_DC
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: movx_to_R_mov_to_DC
+    ; CHECK: BUNDLE implicit-def $r1, implicit-def $r2, implicit-def $dc1 {
+    ; CHECK-NEXT:   $r1 = MOVA_lda_cg 0
+    ; CHECK-NEXT:   $r2 = MOVX_alu_cg 1
+    ; CHECK-NEXT:   $dc1 = MOV_mv_cg 0
+    ; CHECK-NEXT: }
+    $dc1 = MOV_mv_cg 0
+    $r2 = MOVX_alu_cg 1
+    $r1 = MOVA_lda_cg 0
+...
+
+---
+name:            mova_to_dc_movx_to_R_mov_to_DC
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: mova_to_dc_movx_to_R_mov_to_DC
+    ; CHECK: BUNDLE implicit-def $r2, implicit-def $dc0 {
+    ; CHECK-NEXT:   $r2 = MOVX_alu_cg 1
+    ; CHECK-NEXT:   $dc0 = MOV_mv_cg 0
+    ; CHECK-NEXT: }
+    ; CHECK-NEXT: $dc1 = MOVA_lda_cg 0
+    $dc0 = MOV_mv_cg 0
+    $r2 = MOVX_alu_cg 1
+    $dc1 = MOVA_lda_cg 0
+...
+
+---
+name:            mova_to_dj_movx_to_R_mov_to_M
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: mova_to_dj_movx_to_R_mov_to_M
+    ; CHECK: BUNDLE implicit-def $dj1, implicit-def $m1 {
+    ; CHECK-NEXT:   $dj1 = MOVA_lda_cg 0
+    ; CHECK-NEXT:   $m1 = MOV_mv_cg 0
+    ; CHECK-NEXT: }
+    $m1 = MOV_mv_cg 0
+    $dj1 = MOVA_lda_cg 0
+...
+
+---
+name:            mova_to_dn_movx_to_R_mov_to_DC
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: mova_to_dn_movx_to_R_mov_to_DC
+    ; CHECK: BUNDLE implicit-def $dn1, implicit-def $r2, implicit-def $dc1 {
+    ; CHECK-NEXT:   $dn1 = MOVA_lda_cg 0
+    ; CHECK-NEXT:   $r2 = MOVX_alu_cg 1
+    ; CHECK-NEXT:   $dc1 = MOV_mv_cg 0
+    ; CHECK-NEXT: }
+    $dc1 = MOV_mv_cg 0
+    $r2 = MOVX_alu_cg 1
+    $dn1 = MOVA_lda_cg 0
+...
+
+---
+name:            mova_to_p_movx_to_R_mov_to_DC
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: mova_to_p_movx_to_R_mov_to_DC
+    ; CHECK: BUNDLE implicit-def $p0, implicit-def $r2, implicit-def $dc1 {
+    ; CHECK-NEXT:   $p0 = MOVA_lda_cg 0
+    ; CHECK-NEXT:   $r2 = MOVX_alu_cg 1
+    ; CHECK-NEXT:   $dc1 = MOV_mv_cg 0
+    ; CHECK-NEXT: }
+    $dc1 = MOV_mv_cg 0
+    $r2 = MOVX_alu_cg 1
+    $p0 = MOVA_lda_cg 0
+...
+
+---
+name:            mova_to_p_movxm_to_DC
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: mova_to_p_movxm_to_DC
+    ; CHECK: BUNDLE implicit-def $p0, implicit-def $dc1 {
+    ; CHECK-NEXT:   $p0 = MOVA_lda_cg 0
+    ; CHECK-NEXT:   $dc1 = MOVXM_lng_cg 0
+    ; CHECK-NEXT: }
+    $dc1 = MOVXM_lng_cg 0
+    $p0 = MOVA_lda_cg 0
+...
+
+---
+name:            mova_to_dn_movxm_to_DC
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: mova_to_dn_movxm_to_DC
+    ; CHECK: BUNDLE implicit-def $dn1, implicit-def $dc1 {
+    ; CHECK-NEXT:   $dn1 = MOVA_lda_cg 0
+    ; CHECK-NEXT:   $dc1 = MOVXM_lng_cg 0
+    ; CHECK-NEXT: }
+    $dc1 = MOVXM_lng_cg 0
+    $dn1 = MOVA_lda_cg 0
+...
+
+---
+name:            mova_to_dj_movxm_to_DC
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: mova_to_dj_movxm_to_DC
+    ; CHECK: BUNDLE implicit-def $dj1, implicit-def $dc1 {
+    ; CHECK-NEXT:   $dj1 = MOVA_lda_cg 0
+    ; CHECK-NEXT:   $dc1 = MOVXM_lng_cg 0
+    ; CHECK-NEXT: }
+    $dc1 = MOVXM_lng_cg 0
+    $dj1 = MOVA_lda_cg 0
+...
+
+---
+name:            mova_to_dc_movxm_to_DC
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: mova_to_dc_movxm_to_DC
+    ; CHECK: $dc1 = MOVXM_lng_cg 0
+    ; CHECK-NEXT: $dc0 = MOVA_lda_cg 0
+    $dc1 = MOVXM_lng_cg 0
+    $dc0 = MOVA_lda_cg 0
+...
+
+---
+name:            movxm_to_DC
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: movxm_to_DC
+    ; CHECK: BUNDLE implicit-def $r1, implicit-def $dc1 {
+    ; CHECK-NEXT:   $r1 = MOVA_lda_cg 0
+    ; CHECK-NEXT:   $dc1 = MOVXM_lng_cg 0
+    ; CHECK-NEXT: }
+    $dc1 = MOVXM_lng_cg 0
+    $r1 = MOVA_lda_cg 0
+...

--- a/llvm/test/CodeGen/AIE/aie2/schedule/resource/dj_wm.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/resource/dj_wm.mir
@@ -175,3 +175,35 @@ body:             |
     $r1 = MOVX_alu_cg 0
     $dj0 = MOV_mv_scl $r4
 ...
+
+---
+name:            mova_with_mov_scl_to_DJ
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: mova_with_mov_scl_to_DJ
+    ; CHECK: BUNDLE implicit-def $dn1, implicit-def $r1, implicit-def $dj2, implicit killed $r4 {
+    ; CHECK-NEXT:   $dn1 = MOVA_lda_cg 0
+    ; CHECK-NEXT:   $r1 = MOVX_alu_cg 0
+    ; CHECK-NEXT:   $dj2 = MOV_mv_scl killed $r4
+    ; CHECK-NEXT: }
+    $dn1 = MOVA_lda_cg 0
+    $r1 = MOVX_alu_cg 0
+    $dj2 = MOV_mv_scl $r4
+...
+
+---
+name:            mova_to_DJ
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: mova_to_DJ
+    ; CHECK: BUNDLE implicit-def $dj1, implicit-def $r1, implicit-def $r2, implicit killed $r4 {
+    ; CHECK-NEXT:   $dj1 = MOVA_lda_cg 0
+    ; CHECK-NEXT:   $r1 = MOVX_alu_cg 0
+    ; CHECK-NEXT:   $r2 = MOV_mv_scl killed $r4
+    ; CHECK-NEXT: }
+    $dj1 = MOVA_lda_cg 0
+    $r1 = MOVX_alu_cg 0
+    $r2 = MOV_mv_scl $r4
+...

--- a/llvm/test/CodeGen/AIE/aie2/schedule/resource/dj_wm.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/resource/dj_wm.mir
@@ -5,8 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
 # (c) Copyright 2023-2024 Advanced Micro Devices, Inc. or its affiliates
-# RUN: llc -march=aie2 %topdown-single -run-pass=postmisched %s -o - \
-# RUN:   | FileCheck %s
+# RUN: llc -mtriple=aie2 -run-pass=postmisched %s %topdown-multi -o - | FileCheck %s
 
 # Conflict on dj reg file in mov slot
 ---
@@ -57,9 +56,11 @@ alignment:       16
 body:             |
   bb.0.entry:
     ; CHECK-LABEL: name: E1_MOVA_E2_VEXTRACT
-    ; CHECK: $dj0 = VEXTRACT_S16 killed $x1, killed $r16
+    ; CHECK: BUNDLE implicit-def $dj1, implicit-def $dj0, implicit killed $x1, implicit killed $r16 {
+    ; CHECK-NEXT:   $dj1 = MOVA_lda_cg 2
+    ; CHECK-NEXT:   $dj0 = VEXTRACT_S16 killed $x1, killed $r16
+    ; CHECK-NEXT: }
     ; CHECK-NEXT: NOP
-    ; CHECK-NEXT: $dj1 = MOVA_lda_cg 2
     ; CHECK-NEXT: $dj2 = MOVA_lda_cg 2
   $dj0 = VEXTRACT_S16 killed $x1, killed $r16
   $dj1 = MOVA_lda_cg 2
@@ -159,4 +160,18 @@ body:             |
   $dj4 = MOVA_lda_cg 2
   $dj5 = MOVA_lda_cg 2
   $dj6 = MOVA_lda_cg 2
+...
+
+---
+name:            mov_SCL_to_DJ
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: mov_SCL_to_DJ
+    ; CHECK: BUNDLE implicit-def $r1, implicit-def $dj0, implicit killed $r4 {
+    ; CHECK-NEXT:   $r1 = MOVX_alu_cg 0
+    ; CHECK-NEXT:   $dj0 = MOV_mv_scl killed $r4
+    ; CHECK-NEXT: }
+    $r1 = MOVX_alu_cg 0
+    $dj0 = MOV_mv_scl $r4
 ...

--- a/llvm/test/CodeGen/AIE/aie2/schedule/resource/dj_wm.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/resource/dj_wm.mir
@@ -207,3 +207,219 @@ body:             |
     $r1 = MOVX_alu_cg 0
     $r2 = MOV_mv_scl $r4
 ...
+
+---
+name:            mov_to_DJ
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: mov_to_DJ
+    ; CHECK: BUNDLE implicit-def $r1, implicit-def $dj1 {
+    ; CHECK-NEXT:   $r1 = MOVA_lda_cg 0
+    ; CHECK-NEXT:   $dj1 = MOV_mv_cg 0
+    ; CHECK-NEXT: }
+    $dj1 = MOV_mv_cg 0
+    $r1 = MOVA_lda_cg 0
+...
+
+---
+name:            mova_to_dc_mov_to_DJ
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: mova_to_dc_mov_to_DJ
+    ; CHECK: BUNDLE implicit-def $dc1, implicit-def $dj1 {
+    ; CHECK-NEXT:   $dc1 = MOVA_lda_cg 0
+    ; CHECK-NEXT:   $dj1 = MOV_mv_cg 0
+    ; CHECK-NEXT: }
+    $dj1 = MOV_mv_cg 0
+    $dc1 = MOVA_lda_cg 0
+...
+
+---
+name:            mova_to_dj_mov_to_DJ
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: mova_to_dj_mov_to_DJ
+    ; CHECK: $dj0 = MOV_mv_cg 0
+    ; CHECK-NEXT: $dj1 = MOVA_lda_cg 0
+    $dj0 = MOV_mv_cg 0
+    $dj1 = MOVA_lda_cg 0
+...
+
+---
+name:            mova_to_dn_mov_to_DJ
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: mova_to_dn_mov_to_DJ
+    ; CHECK: BUNDLE implicit-def $dn1, implicit-def $dj1 {
+    ; CHECK-NEXT:   $dn1 = MOVA_lda_cg 0
+    ; CHECK-NEXT:   $dj1 = MOV_mv_cg 0
+    ; CHECK-NEXT: }
+    $dj1 = MOV_mv_cg 0
+    $dn1 = MOVA_lda_cg 0
+...
+
+---
+name:            mova_to_p_mov_to_DJ
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: mova_to_p_mov_to_DJ
+    ; CHECK: BUNDLE implicit-def $p0, implicit-def $dj1 {
+    ; CHECK-NEXT:   $p0 = MOVA_lda_cg 0
+    ; CHECK-NEXT:   $dj1 = MOV_mv_cg 0
+    ; CHECK-NEXT: }
+    $dj1 = MOV_mv_cg 0
+    $p0 = MOVA_lda_cg 0
+...
+
+---
+name:            movx_to_R_mov_to_DJ
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: movx_to_R_mov_to_DJ
+    ; CHECK: BUNDLE implicit-def $r1, implicit-def $r2, implicit-def $dj1 {
+    ; CHECK-NEXT:   $r1 = MOVA_lda_cg 0
+    ; CHECK-NEXT:   $r2 = MOVX_alu_cg 1
+    ; CHECK-NEXT:   $dj1 = MOV_mv_cg 0
+    ; CHECK-NEXT: }
+    $dj1 = MOV_mv_cg 0
+    $r2 = MOVX_alu_cg 1
+    $r1 = MOVA_lda_cg 0
+...
+
+---
+name:            mova_to_dc_movx_to_R_mov_to_DJ
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: mova_to_dc_movx_to_R_mov_to_DJ
+    ; CHECK: BUNDLE implicit-def $dc1, implicit-def $r2, implicit-def $dj1 {
+    ; CHECK-NEXT:   $dc1 = MOVA_lda_cg 0
+    ; CHECK-NEXT:   $r2 = MOVX_alu_cg 1
+    ; CHECK-NEXT:   $dj1 = MOV_mv_cg 0
+    ; CHECK-NEXT: }
+    $dj1 = MOV_mv_cg 0
+    $r2 = MOVX_alu_cg 1
+    $dc1 = MOVA_lda_cg 0
+...
+
+---
+name:            mova_to_dj_movx_to_R_mov_to_DJ
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: mova_to_dj_movx_to_R_mov_to_DJ
+    ; CHECK: BUNDLE implicit-def $r2, implicit-def $dj1 {
+    ; CHECK-NEXT:   $r2 = MOVX_alu_cg 1
+    ; CHECK-NEXT:   $dj1 = MOV_mv_cg 0
+    ; CHECK-NEXT: }
+    ; CHECK-NEXT: $dj2 = MOVA_lda_cg 0
+    $dj1 = MOV_mv_cg 0
+    $r2 = MOVX_alu_cg 1
+    $dj2 = MOVA_lda_cg 0
+...
+
+---
+name:            mova_to_dn_movx_to_R_mov_to_DJ
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: mova_to_dn_movx_to_R_mov_to_DJ
+    ; CHECK: BUNDLE implicit-def $dn1, implicit-def $r2, implicit-def $dj1 {
+    ; CHECK-NEXT:   $dn1 = MOVA_lda_cg 0
+    ; CHECK-NEXT:   $r2 = MOVX_alu_cg 1
+    ; CHECK-NEXT:   $dj1 = MOV_mv_cg 0
+    ; CHECK-NEXT: }
+    $dj1 = MOV_mv_cg 0
+    $r2 = MOVX_alu_cg 1
+    $dn1 = MOVA_lda_cg 0
+...
+
+---
+name:            mova_to_p_movx_to_R_mov_to_DJ
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: mova_to_p_movx_to_R_mov_to_DJ
+    ; CHECK: BUNDLE implicit-def $p0, implicit-def $r2, implicit-def $dj1 {
+    ; CHECK-NEXT:   $p0 = MOVA_lda_cg 0
+    ; CHECK-NEXT:   $r2 = MOVX_alu_cg 1
+    ; CHECK-NEXT:   $dj1 = MOV_mv_cg 0
+    ; CHECK-NEXT: }
+    $dj1 = MOV_mv_cg 0
+    $r2 = MOVX_alu_cg 1
+    $p0 = MOVA_lda_cg 0
+...
+
+---
+name:            movxm_to_DJ
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: movxm_to_DJ
+    ; CHECK: BUNDLE implicit-def $r1, implicit-def $dj1 {
+    ; CHECK-NEXT:   $r1 = MOVA_lda_cg 0
+    ; CHECK-NEXT:   $dj1 = MOVXM_lng_cg 0
+    ; CHECK-NEXT: }
+    $dj1 = MOVXM_lng_cg 0
+    $r1 = MOVA_lda_cg 0
+...
+
+---
+name:            mova_to_dc_movxm_to_DJ
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: mova_to_dc_movxm_to_DJ
+    ; CHECK: BUNDLE implicit-def $dc1, implicit-def $dj1 {
+    ; CHECK-NEXT:   $dc1 = MOVA_lda_cg 0
+    ; CHECK-NEXT:   $dj1 = MOVXM_lng_cg 0
+    ; CHECK-NEXT: }
+    $dj1 = MOVXM_lng_cg 0
+    $dc1 = MOVA_lda_cg 0
+...
+
+---
+name:            mova_to_dj_movxm_to_DJ
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: mova_to_dj_movxm_to_DJ
+    ; CHECK: $dj1 = MOVXM_lng_cg 0
+    ; CHECK-NEXT: $dj0 = MOVA_lda_cg 0
+    $dj1 = MOVXM_lng_cg 0
+    $dj0 = MOVA_lda_cg 0
+...
+
+---
+name:            mova_to_dn_movxm_to_DJ
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: mova_to_dn_movxm_to_DJ
+    ; CHECK: BUNDLE implicit-def $dn1, implicit-def $dj1 {
+    ; CHECK-NEXT:   $dn1 = MOVA_lda_cg 0
+    ; CHECK-NEXT:   $dj1 = MOVXM_lng_cg 0
+    ; CHECK-NEXT: }
+    $dj1 = MOVXM_lng_cg 0
+    $dn1 = MOVA_lda_cg 0
+...
+
+---
+name:            mova_to_p_movxm_to_DJ
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: mova_to_p_movxm_to_DJ
+    ; CHECK: BUNDLE implicit-def $p0, implicit-def $dj1 {
+    ; CHECK-NEXT:   $p0 = MOVA_lda_cg 0
+    ; CHECK-NEXT:   $dj1 = MOVXM_lng_cg 0
+    ; CHECK-NEXT: }
+    $dj1 = MOVXM_lng_cg 0
+    $p0 = MOVA_lda_cg 0
+...

--- a/llvm/test/CodeGen/AIE/aie2/schedule/resource/dn_wm.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/resource/dn_wm.mir
@@ -183,3 +183,35 @@ body:             |
     $r1 = MOVX_alu_cg 0
     $dn0 = MOV_mv_scl $r4
 ...
+
+---
+name:            mova_with_mov_scl_to_DN
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: mova_with_mov_scl_to_DN
+    ; CHECK: BUNDLE implicit-def $dj1, implicit-def $r1, implicit-def $dn1, implicit killed $r4 {
+    ; CHECK-NEXT:   $dj1 = MOVA_lda_cg 0
+    ; CHECK-NEXT:   $r1 = MOVX_alu_cg 0
+    ; CHECK-NEXT:   $dn1 = MOV_mv_scl killed $r4
+    ; CHECK-NEXT: }
+    $dj1 = MOVA_lda_cg 0
+    $r1 = MOVX_alu_cg 0
+    $dn1 = MOV_mv_scl $r4
+...
+
+---
+name:            mova_to_DN
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: mova_to_DN
+    ; CHECK: BUNDLE implicit-def $dn1, implicit-def $r1, implicit-def $r2, implicit killed $r4 {
+    ; CHECK-NEXT:   $dn1 = MOVA_lda_cg 0
+    ; CHECK-NEXT:   $r1 = MOVX_alu_cg 0
+    ; CHECK-NEXT:   $r2 = MOV_mv_scl killed $r4
+    ; CHECK-NEXT: }
+    $dn1 = MOVA_lda_cg 0
+    $r1 = MOVX_alu_cg 0
+    $r2 = MOV_mv_scl $r4
+...

--- a/llvm/test/CodeGen/AIE/aie2/schedule/resource/dn_wm.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/resource/dn_wm.mir
@@ -215,3 +215,219 @@ body:             |
     $r1 = MOVX_alu_cg 0
     $r2 = MOV_mv_scl $r4
 ...
+
+---
+name:            mov_to_DN
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: mov_to_DN
+    ; CHECK: BUNDLE implicit-def $r1, implicit-def $dn1 {
+    ; CHECK-NEXT:   $r1 = MOVA_lda_cg 0
+    ; CHECK-NEXT:   $dn1 = MOV_mv_cg 0
+    ; CHECK-NEXT: }
+    $dn1 = MOV_mv_cg 0
+    $r1 = MOVA_lda_cg 0
+...
+
+---
+name:            mova_to_dc_mov_to_DN
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: mova_to_dc_mov_to_DN
+    ; CHECK: BUNDLE implicit-def $dc1, implicit-def $dn1 {
+    ; CHECK-NEXT:   $dc1 = MOVA_lda_cg 0
+    ; CHECK-NEXT:   $dn1 = MOV_mv_cg 0
+    ; CHECK-NEXT: }
+    $dn1 = MOV_mv_cg 0
+    $dc1 = MOVA_lda_cg 0
+...
+
+---
+name:            mova_to_dj_mov_to_DN
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: mova_to_dj_mov_to_DN
+    ; CHECK: BUNDLE implicit-def $dj1, implicit-def $dn1 {
+    ; CHECK-NEXT:   $dj1 = MOVA_lda_cg 0
+    ; CHECK-NEXT:   $dn1 = MOV_mv_cg 0
+    ; CHECK-NEXT: }
+    $dn1 = MOV_mv_cg 0
+    $dj1 = MOVA_lda_cg 0
+...
+
+---
+name:            mova_to_dn_mov_to_DN
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: mova_to_dn_mov_to_DN
+    ; CHECK: $dn0 = MOV_mv_cg 0
+    ; CHECK-NEXT: $dn1 = MOVA_lda_cg 0
+    $dn0 = MOV_mv_cg 0
+    $dn1 = MOVA_lda_cg 0
+...
+
+---
+name:            mova_to_p_mov_to_DN
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: mova_to_p_mov_to_DN
+    ; CHECK: BUNDLE implicit-def $p0, implicit-def $dn1 {
+    ; CHECK-NEXT:   $p0 = MOVA_lda_cg 0
+    ; CHECK-NEXT:   $dn1 = MOV_mv_cg 0
+    ; CHECK-NEXT: }
+    $dn1 = MOV_mv_cg 0
+    $p0 = MOVA_lda_cg 0
+...
+
+---
+name:            movx_to_R_mov_to_DN
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: movx_to_R_mov_to_DN
+    ; CHECK: BUNDLE implicit-def $r1, implicit-def $r2, implicit-def $dn1 {
+    ; CHECK-NEXT:   $r1 = MOVA_lda_cg 0
+    ; CHECK-NEXT:   $r2 = MOVX_alu_cg 1
+    ; CHECK-NEXT:   $dn1 = MOV_mv_cg 0
+    ; CHECK-NEXT: }
+    $dn1 = MOV_mv_cg 0
+    $r2 = MOVX_alu_cg 1
+    $r1 = MOVA_lda_cg 0
+...
+
+---
+name:            mova_to_dc_movx_to_R_mov_to_DN
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: mova_to_dc_movx_to_R_mov_to_DN
+    ; CHECK: BUNDLE implicit-def $dc1, implicit-def $r2, implicit-def $dn1 {
+    ; CHECK-NEXT:   $dc1 = MOVA_lda_cg 0
+    ; CHECK-NEXT:   $r2 = MOVX_alu_cg 1
+    ; CHECK-NEXT:   $dn1 = MOV_mv_cg 0
+    ; CHECK-NEXT: }
+    $dn1 = MOV_mv_cg 0
+    $r2 = MOVX_alu_cg 1
+    $dc1 = MOVA_lda_cg 0
+...
+
+---
+name:            mova_to_dj_movx_to_R_mov_to_DN
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: mova_to_dj_movx_to_R_mov_to_DN
+    ; CHECK: BUNDLE implicit-def $dj1, implicit-def $r2, implicit-def $dn1 {
+    ; CHECK-NEXT:   $dj1 = MOVA_lda_cg 0
+    ; CHECK-NEXT:   $r2 = MOVX_alu_cg 1
+    ; CHECK-NEXT:   $dn1 = MOV_mv_cg 0
+    ; CHECK-NEXT: }
+    $dn1 = MOV_mv_cg 0
+    $r2 = MOVX_alu_cg 1
+    $dj1 = MOVA_lda_cg 0
+...
+
+---
+name:            mova_to_dn_movx_to_R_mov_to_DN
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: mova_to_dn_movx_to_R_mov_to_DN
+    ; CHECK: BUNDLE implicit-def $r2, implicit-def $dn1 {
+    ; CHECK-NEXT:   $r2 = MOVX_alu_cg 1
+    ; CHECK-NEXT:   $dn1 = MOV_mv_cg 0
+    ; CHECK-NEXT: }
+    ; CHECK-NEXT: $dn2 = MOVA_lda_cg 0
+    $dn1 = MOV_mv_cg 0
+    $r2 = MOVX_alu_cg 1
+    $dn2 = MOVA_lda_cg 0
+...
+
+---
+name:            mova_to_p_movx_to_R_mov_to_DN
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: mova_to_p_movx_to_R_mov_to_DN
+    ; CHECK: BUNDLE implicit-def $p0, implicit-def $r2, implicit-def $dn1 {
+    ; CHECK-NEXT:   $p0 = MOVA_lda_cg 0
+    ; CHECK-NEXT:   $r2 = MOVX_alu_cg 1
+    ; CHECK-NEXT:   $dn1 = MOV_mv_cg 0
+    ; CHECK-NEXT: }
+    $dn1 = MOV_mv_cg 0
+    $r2 = MOVX_alu_cg 1
+    $p0 = MOVA_lda_cg 0
+...
+
+---
+name:            movxm_to_DN
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: movxm_to_DN
+    ; CHECK: BUNDLE implicit-def $r1, implicit-def $dn1 {
+    ; CHECK-NEXT:   $r1 = MOVA_lda_cg 0
+    ; CHECK-NEXT:   $dn1 = MOVXM_lng_cg 0
+    ; CHECK-NEXT: }
+    $dn1 = MOVXM_lng_cg 0
+    $r1 = MOVA_lda_cg 0
+...
+
+---
+name:            mova_to_dc_movxm_to_DN
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: mova_to_dc_movxm_to_DN
+    ; CHECK: BUNDLE implicit-def $dc1, implicit-def $dn1 {
+    ; CHECK-NEXT:   $dc1 = MOVA_lda_cg 0
+    ; CHECK-NEXT:   $dn1 = MOVXM_lng_cg 0
+    ; CHECK-NEXT: }
+    $dn1 = MOVXM_lng_cg 0
+    $dc1 = MOVA_lda_cg 0
+...
+
+---
+name:            mova_to_dj_movxm_to_DN
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: mova_to_dj_movxm_to_DN
+    ; CHECK: BUNDLE implicit-def $dj1, implicit-def $dn1 {
+    ; CHECK-NEXT:   $dj1 = MOVA_lda_cg 0
+    ; CHECK-NEXT:   $dn1 = MOVXM_lng_cg 0
+    ; CHECK-NEXT: }
+    $dn1 = MOVXM_lng_cg 0
+    $dj1 = MOVA_lda_cg 0
+...
+
+---
+name:            mova_to_dn_movxm_to_DN
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: mova_to_dn_movxm_to_DN
+    ; CHECK: $dn1 = MOVXM_lng_cg 0
+    ; CHECK-NEXT: $dn0 = MOVA_lda_cg 0
+    $dn1 = MOVXM_lng_cg 0
+    $dn0 = MOVA_lda_cg 0
+...
+
+---
+name:            mova_to_p_movxm_to_DN
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: mova_to_p_movxm_to_DN
+    ; CHECK: BUNDLE implicit-def $p0, implicit-def $dn1 {
+    ; CHECK-NEXT:   $p0 = MOVA_lda_cg 0
+    ; CHECK-NEXT:   $dn1 = MOVXM_lng_cg 0
+    ; CHECK-NEXT: }
+    $dn1 = MOVXM_lng_cg 0
+    $p0 = MOVA_lda_cg 0
+...

--- a/llvm/test/CodeGen/AIE/aie2/schedule/resource/dn_wm.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/resource/dn_wm.mir
@@ -5,8 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
 # (c) Copyright 2023-2024 Advanced Micro Devices, Inc. or its affiliates
-# RUN: llc -march=aie2 %topdown-single -run-pass=postmisched %s -o - \
-# RUN:   | FileCheck %s
+# RUN: llc -mtriple=aie2 -run-pass=postmisched %s %topdown-multi -o - | FileCheck %s
 
 # Conflict on dn reg file in mov slot
 ---
@@ -61,9 +60,11 @@ body:             |
   bb.0.entry:
 
     ; CHECK-LABEL: name: E1_MOVA_E2_VEXTRACT
-    ; CHECK: $dn0 = VEXTRACT_S16 killed $x1, killed $r16
+    ; CHECK: BUNDLE implicit-def $dn1, implicit-def $dn0, implicit killed $x1, implicit killed $r16 {
+    ; CHECK-NEXT:   $dn1 = MOVA_lda_cg 2
+    ; CHECK-NEXT:   $dn0 = VEXTRACT_S16 killed $x1, killed $r16
+    ; CHECK-NEXT: }
     ; CHECK-NEXT: NOP
-    ; CHECK-NEXT: $dn1 = MOVA_lda_cg 2
     ; CHECK-NEXT: $dn2 = MOVA_lda_cg 2
   $dn0 = VEXTRACT_S16 killed $x1, killed $r16
   $dn1 = MOVA_lda_cg 2
@@ -167,4 +168,18 @@ body:             |
   $dn1 = MOVA_lda_cg 2
   $dn1 = MOVA_lda_cg 2
   $dn1 = MOVA_lda_cg 2
+...
+
+---
+name:            mov_SCL_to_DN
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: mov_SCL_to_DN
+    ; CHECK: BUNDLE implicit-def $r1, implicit-def $dn0, implicit killed $r4 {
+    ; CHECK-NEXT:   $r1 = MOVX_alu_cg 0
+    ; CHECK-NEXT:   $dn0 = MOV_mv_scl killed $r4
+    ; CHECK-NEXT: }
+    $r1 = MOVX_alu_cg 0
+    $dn0 = MOV_mv_scl $r4
 ...

--- a/llvm/test/CodeGen/AIE/aie2/schedule/resource/m_wm.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/resource/m_wm.mir
@@ -185,13 +185,15 @@ body:             |
 ...
 
 ---
-name:            mov_to_M
+name:            movscl_to_M_mova_to_R
 alignment:       16
 body:             |
   bb.0.entry:
-    ; CHECK-LABEL: name: mov_to_M
-    ; CHECK: $r1 = MOVA_lda_cg 0
-    ; CHECK-NEXT: $m0 = MOV_mv_scl killed $r4
+    ; CHECK-LABEL: name: movscl_to_M_mova_to_R
+    ; CHECK: BUNDLE implicit-def $r1, implicit-def $m0, implicit killed $r4 {
+    ; CHECK-NEXT:   $r1 = MOVA_lda_cg 0
+    ; CHECK-NEXT:   $m0 = MOV_mv_scl killed $r4
+    ; CHECK-NEXT: }
     $r1 = MOVA_lda_cg 0
     $m0 = MOV_mv_scl $r4
 ...
@@ -226,4 +228,222 @@ body:             |
     $m1 = MOVA_lda_cg 0
     $r1 = MOVX_alu_cg 0
     $dc0 = MOV_mv_scl $r4
+...
+
+---
+name:            mov_to_M_mova_to_R
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: mov_to_M_mova_to_R
+    ; CHECK: BUNDLE implicit-def $r1, implicit-def $m1 {
+    ; CHECK-NEXT:   $r1 = MOVA_lda_cg 0
+    ; CHECK-NEXT:   $m1 = MOV_mv_cg 0
+    ; CHECK-NEXT: }
+    $m1 = MOV_mv_cg 0
+    $r1 = MOVA_lda_cg 0
+...
+
+---
+name:            mova_to_dc_mov_to_M
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: mova_to_dc_mov_to_M
+    ; CHECK: BUNDLE implicit-def $dc1, implicit-def $m1 {
+    ; CHECK-NEXT:   $dc1 = MOVA_lda_cg 0
+    ; CHECK-NEXT:   $m1 = MOV_mv_cg 0
+    ; CHECK-NEXT: }
+    $m1 = MOV_mv_cg 0
+    $dc1 = MOVA_lda_cg 0
+...
+
+---
+name:            mova_to_dj_mov_to_M
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: mova_to_dj_mov_to_M
+    ; CHECK: BUNDLE implicit-def $dj1, implicit-def $m1 {
+    ; CHECK-NEXT:   $dj1 = MOVA_lda_cg 0
+    ; CHECK-NEXT:   $m1 = MOV_mv_cg 0
+    ; CHECK-NEXT: }
+    $m1 = MOV_mv_cg 0
+    $dj1 = MOVA_lda_cg 0
+...
+
+---
+name:            mova_to_dn_mov_to_M
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: mova_to_dn_mov_to_M
+    ; CHECK: BUNDLE implicit-def $dn1, implicit-def $m1 {
+    ; CHECK-NEXT:   $dn1 = MOVA_lda_cg 0
+    ; CHECK-NEXT:   $m1 = MOV_mv_cg 0
+    ; CHECK-NEXT: }
+    $m1 = MOV_mv_cg 0
+    $dn1 = MOVA_lda_cg 0
+...
+
+---
+name:            mova_to_p_mov_to_M
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: mova_to_p_mov_to_M
+    ; CHECK: BUNDLE implicit-def $p0, implicit-def $m1 {
+    ; CHECK-NEXT:   $p0 = MOVA_lda_cg 0
+    ; CHECK-NEXT:   $m1 = MOV_mv_cg 0
+    ; CHECK-NEXT: }
+    $m1 = MOV_mv_cg 0
+    $p0 = MOVA_lda_cg 0
+...
+
+---
+name:            movx_to_R_mov_to_M
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: movx_to_R_mov_to_M
+    ; CHECK: BUNDLE implicit-def $r1, implicit-def $r2, implicit-def $m1 {
+    ; CHECK-NEXT:   $r1 = MOVA_lda_cg 0
+    ; CHECK-NEXT:   $r2 = MOVX_alu_cg 1
+    ; CHECK-NEXT:   $m1 = MOV_mv_cg 0
+    ; CHECK-NEXT: }
+    $m1 = MOV_mv_cg 0
+    $r2 = MOVX_alu_cg 1
+    $r1 = MOVA_lda_cg 0
+...
+
+---
+name:            mova_to_dc_movx_to_R_mov_to_M
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: mova_to_dc_movx_to_R_mov_to_M
+    ; CHECK: BUNDLE implicit-def $dc1, implicit-def $r2, implicit-def $m1 {
+    ; CHECK-NEXT:   $dc1 = MOVA_lda_cg 0
+    ; CHECK-NEXT:   $r2 = MOVX_alu_cg 1
+    ; CHECK-NEXT:   $m1 = MOV_mv_cg 0
+    ; CHECK-NEXT: }
+    $m1 = MOV_mv_cg 0
+    $r2 = MOVX_alu_cg 1
+    $dc1 = MOVA_lda_cg 0
+...
+
+---
+name:            mova_to_dj_movx_to_R_mov_to_M
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: mova_to_dj_movx_to_R_mov_to_M
+    ; CHECK: BUNDLE implicit-def $dj1, implicit-def $m1 {
+    ; CHECK-NEXT:   $dj1 = MOVA_lda_cg 0
+    ; CHECK-NEXT:   $m1 = MOV_mv_cg 0
+    ; CHECK-NEXT: }
+    $m1 = MOV_mv_cg 0
+    $dj1 = MOVA_lda_cg 0
+...
+
+---
+name:            mova_to_dn_movx_to_R_mov_to_M
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: mova_to_dn_movx_to_R_mov_to_M
+    ; CHECK: BUNDLE implicit-def $dn1, implicit-def $r2, implicit-def $m1 {
+    ; CHECK-NEXT:   $dn1 = MOVA_lda_cg 0
+    ; CHECK-NEXT:   $r2 = MOVX_alu_cg 1
+    ; CHECK-NEXT:   $m1 = MOV_mv_cg 0
+    ; CHECK-NEXT: }
+    $m1 = MOV_mv_cg 0
+    $r2 = MOVX_alu_cg 1
+    $dn1 = MOVA_lda_cg 0
+...
+
+---
+name:            mova_to_p_movx_to_R_mov_to_M
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: mova_to_p_movx_to_R_mov_to_M
+    ; CHECK: BUNDLE implicit-def $p0, implicit-def $r2, implicit-def $m1 {
+    ; CHECK-NEXT:   $p0 = MOVA_lda_cg 0
+    ; CHECK-NEXT:   $r2 = MOVX_alu_cg 1
+    ; CHECK-NEXT:   $m1 = MOV_mv_cg 0
+    ; CHECK-NEXT: }
+    $m1 = MOV_mv_cg 0
+    $r2 = MOVX_alu_cg 1
+    $p0 = MOVA_lda_cg 0
+...
+
+---
+name:            movxm_to_M
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: movxm_to_M
+    ; CHECK: BUNDLE implicit-def $r1, implicit-def $m1 {
+    ; CHECK-NEXT:   $r1 = MOVA_lda_cg 0
+    ; CHECK-NEXT:   $m1 = MOVXM_lng_cg 0
+    ; CHECK-NEXT: }
+    $m1 = MOVXM_lng_cg 0
+    $r1 = MOVA_lda_cg 0
+...
+
+---
+name:            mova_to_dc_movxm_to_M
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: mova_to_dc_movxm_to_M
+    ; CHECK: BUNDLE implicit-def $dc1, implicit-def $m1 {
+    ; CHECK-NEXT:   $dc1 = MOVA_lda_cg 0
+    ; CHECK-NEXT:   $m1 = MOVXM_lng_cg 0
+    ; CHECK-NEXT: }
+    $m1 = MOVXM_lng_cg 0
+    $dc1 = MOVA_lda_cg 0
+...
+
+---
+name:            mova_to_dj_movxm_to_M
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: mova_to_dj_movxm_to_M
+    ; CHECK: BUNDLE implicit-def $dj1, implicit-def $m1 {
+    ; CHECK-NEXT:   $dj1 = MOVA_lda_cg 0
+    ; CHECK-NEXT:   $m1 = MOVXM_lng_cg 0
+    ; CHECK-NEXT: }
+    $m1 = MOVXM_lng_cg 0
+    $dj1 = MOVA_lda_cg 0
+...
+
+---
+name:            mova_to_dn_movxm_to_M
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: mova_to_dn_movxm_to_M
+    ; CHECK: BUNDLE implicit-def $dn1, implicit-def $m1 {
+    ; CHECK-NEXT:   $dn1 = MOVA_lda_cg 0
+    ; CHECK-NEXT:   $m1 = MOVXM_lng_cg 0
+    ; CHECK-NEXT: }
+    $m1 = MOVXM_lng_cg 0
+    $dn1 = MOVA_lda_cg 0
+...
+
+---
+name:            mova_to_p_movxm_to_M
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: mova_to_p_movxm_to_M
+    ; CHECK: BUNDLE implicit-def $p0, implicit-def $m1 {
+    ; CHECK-NEXT:   $p0 = MOVA_lda_cg 0
+    ; CHECK-NEXT:   $m1 = MOVXM_lng_cg 0
+    ; CHECK-NEXT: }
+    $m1 = MOVXM_lng_cg 0
+    $p0 = MOVA_lda_cg 0
 ...

--- a/llvm/test/CodeGen/AIE/aie2/schedule/resource/m_wm.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/resource/m_wm.mir
@@ -5,8 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
 # (c) Copyright 2023-2024 Advanced Micro Devices, Inc. or its affiliates
-# RUN: llc -march=aie2 %topdown-single -run-pass=postmisched %s -o - \
-# RUN:   | FileCheck %s
+# RUN: llc -mtriple=aie2 -run-pass=postmisched %s %topdown-multi -o - | FileCheck %s
 
 # Conflict on writing m register file in mov slot
 ---
@@ -61,9 +60,11 @@ body:             |
   bb.0.entry:
 
     ; CHECK-LABEL: name: E1_MOVA_E2_VEXTRACT
-    ; CHECK: $m0 = VEXTRACT_S16 killed $x1, killed $r16
+    ; CHECK: BUNDLE implicit-def $m1, implicit-def $m0, implicit killed $x1, implicit killed $r16 {
+    ; CHECK-NEXT:   $m1 = MOVA_lda_cg 2
+    ; CHECK-NEXT:   $m0 = VEXTRACT_S16 killed $x1, killed $r16
+    ; CHECK-NEXT: }
     ; CHECK-NEXT: NOP
-    ; CHECK-NEXT: $m1 = MOVA_lda_cg 2
     ; CHECK-NEXT: $m2 = MOVA_lda_cg 2
   $m0 = VEXTRACT_S16 killed $x1, killed $r16
   $m1 = MOVA_lda_cg 2
@@ -167,4 +168,30 @@ body:             |
   $m2 = MOVA_lda_cg 2
   $m2 = MOVA_lda_cg 2
   $m2 = MOVA_lda_cg 2
+...
+
+---
+name:            mov_SCL_to_M
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: mov_SCL_to_M
+    ; CHECK: BUNDLE implicit-def $r1, implicit-def $m0, implicit killed $r4 {
+    ; CHECK-NEXT:   $r1 = MOVX_alu_cg 0
+    ; CHECK-NEXT:   $m0 = MOV_mv_scl killed $r4
+    ; CHECK-NEXT: }
+    $r1 = MOVX_alu_cg 0
+    $m0 = MOV_mv_scl $r4
+...
+
+---
+name:            mov_to_M
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: mov_to_M
+    ; CHECK: $r1 = MOVA_lda_cg 0
+    ; CHECK-NEXT: $m0 = MOV_mv_scl killed $r4
+    $r1 = MOVA_lda_cg 0
+    $m0 = MOV_mv_scl $r4
 ...

--- a/llvm/test/CodeGen/AIE/aie2/schedule/resource/m_wm.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/resource/m_wm.mir
@@ -195,3 +195,35 @@ body:             |
     $r1 = MOVA_lda_cg 0
     $m0 = MOV_mv_scl $r4
 ...
+
+---
+name:            mova_with_mov_scl_to_M
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: mova_with_mov_scl_to_M
+    ; CHECK: BUNDLE implicit-def $dj0, implicit-def $r1, implicit-def $m0, implicit killed $r4 {
+    ; CHECK-NEXT:   $dj0 = MOVA_lda_cg 0
+    ; CHECK-NEXT:   $r1 = MOVX_alu_cg 0
+    ; CHECK-NEXT:   $m0 = MOV_mv_scl killed $r4
+    ; CHECK-NEXT: }
+    $dj0 = MOVA_lda_cg 0
+    $r1 = MOVX_alu_cg 0
+    $m0 = MOV_mv_scl $r4
+...
+
+---
+name:            mova_to_M
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: mova_to_M
+    ; CHECK: BUNDLE implicit-def $m1, implicit-def $r1, implicit-def $dc0, implicit killed $r4 {
+    ; CHECK-NEXT:   $m1 = MOVA_lda_cg 0
+    ; CHECK-NEXT:   $r1 = MOVX_alu_cg 0
+    ; CHECK-NEXT:   $dc0 = MOV_mv_scl killed $r4
+    ; CHECK-NEXT: }
+    $m1 = MOVA_lda_cg 0
+    $r1 = MOVX_alu_cg 0
+    $dc0 = MOV_mv_scl $r4
+...

--- a/llvm/test/CodeGen/AIE/aie2/schedule/resource/p_rm.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/resource/p_rm.mir
@@ -570,3 +570,19 @@ body:             |
   MOV_NB_mv_cph2ms_doTlast_reg $m1, 1, 2, $r2, $r28, implicit-def $srms0
   $r1 = MOV_mv_scl $m0
 ...
+
+---
+name:            mova_to_dj_movx_to_R_mov_to_P
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: mova_to_dj_movx_to_R_mov_to_P
+    ; CHECK: BUNDLE implicit-def $dj1, implicit-def $r2, implicit-def $p0 {
+    ; CHECK-NEXT:   $dj1 = MOVA_lda_cg 0
+    ; CHECK-NEXT:   $r2 = MOVX_alu_cg 1
+    ; CHECK-NEXT:   $p0 = MOV_mv_cg 0
+    ; CHECK-NEXT: }
+    $p0 = MOV_mv_cg 0
+    $r2 = MOVX_alu_cg 1
+    $dj1 = MOVA_lda_cg 0
+...

--- a/llvm/test/CodeGen/AIE/aie2/schedule/resource/p_wm.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/resource/p_wm.mir
@@ -5,8 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
 # (c) Copyright 2023-2024 Advanced Micro Devices, Inc. or its affiliates
-# RUN: llc -march=aie2 %topdown-single -run-pass=postmisched %s -o - \
-# RUN:   | FileCheck %s
+# RUN: llc -mtriple=aie2 -run-pass=postmisched %s %topdown-multi -o - | FileCheck %s
 
 # Conflict on p register file in mov slot
 ---
@@ -61,9 +60,11 @@ body:             |
   bb.0.entry:
 
     ; CHECK-LABEL: name: E1_MOVA_E2_VEXTRACT
-    ; CHECK: $p0 = VEXTRACT_S16 killed $x1, killed $r16
+    ; CHECK: BUNDLE implicit-def $p1, implicit-def $p0, implicit killed $x1, implicit killed $r16 {
+    ; CHECK-NEXT:   $p1 = MOVA_lda_cg 2
+    ; CHECK-NEXT:   $p0 = VEXTRACT_S16 killed $x1, killed $r16
+    ; CHECK-NEXT: }
     ; CHECK-NEXT: NOP
-    ; CHECK-NEXT: $p1 = MOVA_lda_cg 2
     ; CHECK-NEXT: $p2 = MOVA_lda_cg 2
   $p0 = VEXTRACT_S16 killed $x1, killed $r16
   $p1 = MOVA_lda_cg 2
@@ -179,4 +180,18 @@ body:             |
   $p0 = VEXTRACT_S16 killed $x1, killed $r16
   $p1 = ADD_NC $r1, 20
   $p2 = ADD_NC $r2, -32
+...
+
+---
+name:            mov_SCL_to_P
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: mov_SCL_to_P
+    ; CHECK: BUNDLE implicit-def $r1, implicit-def $p0, implicit killed $r4 {
+    ; CHECK-NEXT:   $r1 = MOVX_alu_cg 0
+    ; CHECK-NEXT:   $p0 = MOV_mv_scl killed $r4
+    ; CHECK-NEXT: }
+    $r1 = MOVX_alu_cg 0
+    $p0 = MOV_mv_scl $r4
 ...

--- a/llvm/test/CodeGen/AIE/aie2/schedule/resource/p_wm.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/resource/p_wm.mir
@@ -195,3 +195,35 @@ body:             |
     $r1 = MOVX_alu_cg 0
     $p0 = MOV_mv_scl $r4
 ...
+
+---
+name:            mova_with_mov_scl_to_P
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: mova_with_mov_scl_to_P
+    ; CHECK: BUNDLE implicit-def $dc0, implicit-def $r1, implicit-def $p0, implicit killed $r4 {
+    ; CHECK-NEXT:   $dc0 = MOVA_lda_cg 0
+    ; CHECK-NEXT:   $r1 = MOVX_alu_cg 0
+    ; CHECK-NEXT:   $p0 = MOV_mv_scl killed $r4
+    ; CHECK-NEXT: }
+    $dc0 = MOVA_lda_cg 0
+    $r1 = MOVX_alu_cg 0
+    $p0 = MOV_mv_scl $r4
+...
+
+---
+name:            mova_to_P
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: mova_to_P
+    ; CHECK: BUNDLE implicit-def $p0, implicit-def $r1, implicit-def $dc0, implicit killed $r4 {
+    ; CHECK-NEXT:   $p0 = MOVA_lda_cg 0
+    ; CHECK-NEXT:   $r1 = MOVX_alu_cg 0
+    ; CHECK-NEXT:   $dc0 = MOV_mv_scl killed $r4
+    ; CHECK-NEXT: }
+    $p0 = MOVA_lda_cg 0
+    $r1 = MOVX_alu_cg 0
+    $dc0 = MOV_mv_scl $r4
+...

--- a/llvm/test/CodeGen/AIE/aie2/schedule/resource/p_wm.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/resource/p_wm.mir
@@ -227,3 +227,160 @@ body:             |
     $r1 = MOVX_alu_cg 0
     $dc0 = MOV_mv_scl $r4
 ...
+
+---
+name:            mov_to_P
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: mov_to_P
+    ; CHECK: BUNDLE implicit-def $r1, implicit-def $p0 {
+    ; CHECK-NEXT:   $r1 = MOVA_lda_cg 0
+    ; CHECK-NEXT:   $p0 = MOV_mv_cg 0
+    ; CHECK-NEXT: }
+    $p0 = MOV_mv_cg 0
+    $r1 = MOVA_lda_cg 0
+...
+
+---
+name:            mova_to_dj_mov_to_P
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: mova_to_dj_mov_to_P
+    ; CHECK: BUNDLE implicit-def $dj1, implicit-def $p0 {
+    ; CHECK-NEXT:   $dj1 = MOVA_lda_cg 0
+    ; CHECK-NEXT:   $p0 = MOV_mv_cg 0
+    ; CHECK-NEXT: }
+    $p0 = MOV_mv_cg 0
+    $dj1 = MOVA_lda_cg 0
+...
+
+
+---
+name:            mova_to_dn_mov_to_P
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: mova_to_dn_mov_to_P
+    ; CHECK: BUNDLE implicit-def $dn1, implicit-def $p0 {
+    ; CHECK-NEXT:   $dn1 = MOVA_lda_cg 0
+    ; CHECK-NEXT:   $p0 = MOV_mv_cg 0
+    ; CHECK-NEXT: }
+    $p0 = MOV_mv_cg 0
+    $dn1 = MOVA_lda_cg 0
+...
+
+---
+name:            mova_to_p_mov_to_P
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: mova_to_p_mov_to_P
+    ; CHECK: $p0 = MOV_mv_cg 0
+    ; CHECK-NEXT: $p1 = MOVA_lda_cg 0
+    $p0 = MOV_mv_cg 0
+    $p1 = MOVA_lda_cg 0
+...
+
+---
+name:            movx_to_R_mov_to_P
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: movx_to_R_mov_to_P
+    ; CHECK: BUNDLE implicit-def $r1, implicit-def $r2, implicit-def $p0 {
+    ; CHECK-NEXT:   $r1 = MOVA_lda_cg 0
+    ; CHECK-NEXT:   $r2 = MOVX_alu_cg 1
+    ; CHECK-NEXT:   $p0 = MOV_mv_cg 0
+    ; CHECK-NEXT: }
+    $p0 = MOV_mv_cg 0
+    $r2 = MOVX_alu_cg 1
+    $r1 = MOVA_lda_cg 0
+...
+
+---
+name:            mova_to_dn_movx_to_R_mov_to_P
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: mova_to_dn_movx_to_R_mov_to_P
+    ; CHECK: BUNDLE implicit-def $dn1, implicit-def $r2, implicit-def $p0 {
+    ; CHECK-NEXT:   $dn1 = MOVA_lda_cg 0
+    ; CHECK-NEXT:   $r2 = MOVX_alu_cg 1
+    ; CHECK-NEXT:   $p0 = MOV_mv_cg 0
+    ; CHECK-NEXT: }
+    $p0 = MOV_mv_cg 0
+    $r2 = MOVX_alu_cg 1
+    $dn1 = MOVA_lda_cg 0
+...
+
+---
+name:            mova_to_p_movx_to_R_mov_to_P
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: mova_to_p_movx_to_R_mov_to_P
+    ; CHECK: BUNDLE implicit-def $r2, implicit-def $p0 {
+    ; CHECK-NEXT:   $r2 = MOVX_alu_cg 1
+    ; CHECK-NEXT:   $p0 = MOV_mv_cg 0
+    ; CHECK-NEXT: }
+    ; CHECK-NEXT: $p1 = MOVA_lda_cg 0
+    $p0 = MOV_mv_cg 0
+    $r2 = MOVX_alu_cg 1
+    $p1 = MOVA_lda_cg 0
+...
+
+---
+name:            mova_to_p_movxm_to_P
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: mova_to_p_movxm_to_P
+    ; CHECK: $p0 = MOVXM_lng_cg 0
+    ; CHECK-NEXT: $p1 = MOVA_lda_cg 0
+    $p0 = MOVXM_lng_cg 0
+    $p1 = MOVA_lda_cg 0
+...
+
+---
+name:            mova_to_dn_movxm_to_P
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: mova_to_dn_movxm_to_P
+    ; CHECK: BUNDLE implicit-def $dn1, implicit-def $p0 {
+    ; CHECK-NEXT:   $dn1 = MOVA_lda_cg 0
+    ; CHECK-NEXT:   $p0 = MOVXM_lng_cg 0
+    ; CHECK-NEXT: }
+    $p0 = MOVXM_lng_cg 0
+    $dn1 = MOVA_lda_cg 0
+...
+
+---
+name:            mova_to_dj_movxm_to_P
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: mova_to_dj_movxm_to_P
+    ; CHECK: BUNDLE implicit-def $dj1, implicit-def $p0 {
+    ; CHECK-NEXT:   $dj1 = MOVA_lda_cg 0
+    ; CHECK-NEXT:   $p0 = MOVXM_lng_cg 0
+    ; CHECK-NEXT: }
+    $p0 = MOVXM_lng_cg 0
+    $dj1 = MOVA_lda_cg 0
+...
+
+---
+name:            movxm_to_P
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: movxm_to_P
+    ; CHECK: BUNDLE implicit-def $r1, implicit-def $p0 {
+    ; CHECK-NEXT:   $r1 = MOVA_lda_cg 0
+    ; CHECK-NEXT:   $p0 = MOVXM_lng_cg 0
+    ; CHECK-NEXT: }
+    $p0 = MOVXM_lng_cg 0
+    $r1 = MOVA_lda_cg 0
+...

--- a/llvm/test/CodeGen/AIE/aie2/schedule/resource/r_wa.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/resource/r_wa.mir
@@ -198,3 +198,35 @@ body:             |
     $r5 = MOVA_lda_cg 5
     $r6 = MOVA_lda_cg 6
 ...
+
+---
+name:            mova_with_mov_scl_to_R
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: mova_with_mov_scl_to_R
+    ; CHECK: BUNDLE implicit-def $dc3, implicit-def $r1, implicit-def $r3, implicit killed $r4 {
+    ; CHECK-NEXT:   $dc3 = MOVA_lda_cg 0
+    ; CHECK-NEXT:   $r1 = MOVX_alu_cg 0
+    ; CHECK-NEXT:   $r3 = MOV_mv_scl killed $r4
+    ; CHECK-NEXT: }
+    $dc3 = MOVA_lda_cg 0
+    $r1 = MOVX_alu_cg 0
+    $r3 = MOV_mv_scl $r4
+...
+
+---
+name:            mova_to_R
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: mova_to_R
+    ; CHECK: BUNDLE implicit-def $r3, implicit-def $r1, implicit-def $dc0, implicit killed $r4 {
+    ; CHECK-NEXT:   $r3 = MOVA_lda_cg 0
+    ; CHECK-NEXT:   $r1 = MOVX_alu_cg 0
+    ; CHECK-NEXT:   $dc0 = MOV_mv_scl killed $r4
+    ; CHECK-NEXT: }
+    $r3 = MOVA_lda_cg 0
+    $r1 = MOVX_alu_cg 0
+    $dc0 = MOV_mv_scl $r4
+...

--- a/llvm/test/CodeGen/AIE/aie2/schedule/resource/r_wa.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/resource/r_wa.mir
@@ -230,3 +230,17 @@ body:             |
     $r1 = MOVX_alu_cg 0
     $dc0 = MOV_mv_scl $r4
 ...
+
+---
+name:            mova_to_p_mov_to_R
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: mova_to_p_mov_to_R
+    ; CHECK: BUNDLE implicit-def $p0, implicit-def $r3 {
+    ; CHECK-NEXT:   $p0 = MOVA_lda_cg 0
+    ; CHECK-NEXT:   $r3 = MOV_mv_cg 0
+    ; CHECK-NEXT: }
+    $r3 = MOV_mv_cg 0
+    $p0 = MOVA_lda_cg 0
+...

--- a/llvm/test/CodeGen/AIE/aie2/schedule/resource/r_wm.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/resource/r_wm.mir
@@ -260,3 +260,46 @@ body:             |
   $dc0 = VEXTRACT_S16 killed $x1, killed $r16
   $dc0 = VEXTRACT_S16 killed $x1, killed $r16
 ...
+
+# expected to not be in the same bundle
+---
+name:            mov_P_to_R_and_store_DJ
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: mov_P_to_R_and_store_DJ
+    ; CHECK: ST_dms_sts_idx_imm killed $dj0, $p0, 0
+    ; CHECK-NEXT: $r3 = MOV_mv_scl killed $p0
+    ST_dms_sts_idx_imm $dj0, $p0, 0
+    $r3 = MOV_mv_scl $p0
+...
+
+---
+name:            mov_to_R
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: mov_to_R
+    ; CHECK: BUNDLE implicit-def $r1, implicit-def $r2, implicit-def $r3, implicit killed $r4 {
+    ; CHECK-NEXT:   $r1 = MOVA_lda_cg 0
+    ; CHECK-NEXT:   $r2 = MOVX_alu_cg 1
+    ; CHECK-NEXT:   $r3 = MOV_mv_scl killed $r4
+    ; CHECK-NEXT: }
+    $r1 = MOVA_lda_cg 0
+    $r2 = MOVX_alu_cg 1
+    $r3 = MOV_mv_scl $r4
+...
+
+---
+name:            mov_SCL_to_R
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: mov_SCL_to_R
+    ; CHECK: BUNDLE implicit-def $r1, implicit-def $r0, implicit killed $r4 {
+    ; CHECK-NEXT:   $r1 = MOVX_alu_cg 0
+    ; CHECK-NEXT:   $r0 = MOV_mv_scl killed $r4
+    ; CHECK-NEXT: }
+    $r1 = MOVX_alu_cg 0
+    $r0 = MOV_mv_scl $r4
+...

--- a/llvm/test/CodeGen/AIE/aie2/schedule/resource/r_wm.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/resource/r_wm.mir
@@ -303,3 +303,95 @@ body:             |
     $r1 = MOVX_alu_cg 0
     $r0 = MOV_mv_scl $r4
 ...
+
+---
+name:            mova_to_dj_mov_to_R
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: mova_to_dj_mov_to_R
+    ; CHECK: BUNDLE implicit-def $dj1, implicit-def $r3 {
+    ; CHECK-NEXT:   $dj1 = MOVA_lda_cg 0
+    ; CHECK-NEXT:   $r3 = MOV_mv_cg 0
+    ; CHECK-NEXT: }
+    $r3 = MOV_mv_cg 0
+    $dj1 = MOVA_lda_cg 0
+...
+
+---
+name:            mova_to_dn_mov_to_R
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: mova_to_dn_mov_to_R
+    ; CHECK: BUNDLE implicit-def $dn1, implicit-def $r3 {
+    ; CHECK-NEXT:   $dn1 = MOVA_lda_cg 0
+    ; CHECK-NEXT:   $r3 = MOV_mv_cg 0
+    ; CHECK-NEXT: }
+    $r3 = MOV_mv_cg 0
+    $dn1 = MOVA_lda_cg 0
+...
+
+---
+name:            movx_to_R_mov_to_R
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: movx_to_R_mov_to_R
+    ; CHECK: BUNDLE implicit-def $r1, implicit-def $r2, implicit-def $r3 {
+    ; CHECK-NEXT:   $r1 = MOVA_lda_cg 0
+    ; CHECK-NEXT:   $r2 = MOVX_alu_cg 1
+    ; CHECK-NEXT:   $r3 = MOV_mv_cg 0
+    ; CHECK-NEXT: }
+    $r3 = MOV_mv_cg 0
+    $r2 = MOVX_alu_cg 1
+    $r1 = MOVA_lda_cg 0
+...
+
+---
+name:            mova_to_dj_movx_to_R_mov_to_R
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: mova_to_dj_movx_to_R_mov_to_R
+    ; CHECK: BUNDLE implicit-def $dj1, implicit-def $r2, implicit-def $r3 {
+    ; CHECK-NEXT:   $dj1 = MOVA_lda_cg 0
+    ; CHECK-NEXT:   $r2 = MOVX_alu_cg 1
+    ; CHECK-NEXT:   $r3 = MOV_mv_cg 0
+    ; CHECK-NEXT: }
+    $r3 = MOV_mv_cg 0
+    $r2 = MOVX_alu_cg 1
+    $dj1 = MOVA_lda_cg 0
+...
+
+---
+name:            mova_to_dn_movx_to_R_mov_to_R
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: mova_to_dn_movx_to_R_mov_to_R
+    ; CHECK: BUNDLE implicit-def $dn1, implicit-def $r2, implicit-def $r3 {
+    ; CHECK-NEXT:   $dn1 = MOVA_lda_cg 0
+    ; CHECK-NEXT:   $r2 = MOVX_alu_cg 1
+    ; CHECK-NEXT:   $r3 = MOV_mv_cg 0
+    ; CHECK-NEXT: }
+    $r3 = MOV_mv_cg 0
+    $r2 = MOVX_alu_cg 1
+    $dn1 = MOVA_lda_cg 0
+...
+
+---
+name:            mova_to_p_movx_to_R_mov_to_R
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: mova_to_p_movx_to_R_mov_to_R
+    ; CHECK: BUNDLE implicit-def $p0, implicit-def $r2, implicit-def $r3 {
+    ; CHECK-NEXT:   $p0 = MOVA_lda_cg 0
+    ; CHECK-NEXT:   $r2 = MOVX_alu_cg 1
+    ; CHECK-NEXT:   $r3 = MOV_mv_cg 0
+    ; CHECK-NEXT: }
+    $r3 = MOV_mv_cg 0
+    $r2 = MOVX_alu_cg 1
+    $p0 = MOVA_lda_cg 0
+...

--- a/llvm/test/CodeGen/AIE/aie2/schedule/resource/r_wx.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/resource/r_wx.mir
@@ -43,3 +43,59 @@ body:             |
     $r4 = MOV_mv_scl $r6
     $r3, $r31 = DIVS  $r31, $r4, $r5
 ...
+
+---
+name:            movxm_to_R
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: movxm_to_R
+    ; CHECK: BUNDLE implicit-def $r1, implicit-def $r3 {
+    ; CHECK-NEXT:   $r1 = MOVA_lda_cg 0
+    ; CHECK-NEXT:   $r3 = MOVXM_lng_cg 0
+    ; CHECK-NEXT: }
+    $r3 = MOVXM_lng_cg 0
+    $r1 = MOVA_lda_cg 0
+...
+
+---
+name:            mova_to_dj_movxm_to_R
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: mova_to_dj_movxm_to_R
+    ; CHECK: BUNDLE implicit-def $dj1, implicit-def $r3 {
+    ; CHECK-NEXT:   $dj1 = MOVA_lda_cg 0
+    ; CHECK-NEXT:   $r3 = MOVXM_lng_cg 0
+    ; CHECK-NEXT: }
+    $r3 = MOVXM_lng_cg 0
+    $dj1 = MOVA_lda_cg 0
+...
+
+---
+name:            mova_to_dn_movxm_to_R
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: mova_to_dn_movxm_to_R
+    ; CHECK: BUNDLE implicit-def $dn1, implicit-def $r3 {
+    ; CHECK-NEXT:   $dn1 = MOVA_lda_cg 0
+    ; CHECK-NEXT:   $r3 = MOVXM_lng_cg 0
+    ; CHECK-NEXT: }
+    $r3 = MOVXM_lng_cg 0
+    $dn1 = MOVA_lda_cg 0
+...
+
+---
+name:            mova_to_p_movxm_to_R
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: mova_to_p_movxm_to_R
+    ; CHECK: BUNDLE implicit-def $p0, implicit-def $r3 {
+    ; CHECK-NEXT:   $p0 = MOVA_lda_cg 0
+    ; CHECK-NEXT:   $r3 = MOVXM_lng_cg 0
+    ; CHECK-NEXT: }
+    $r3 = MOVXM_lng_cg 0
+    $p0 = MOVA_lda_cg 0
+...

--- a/llvm/test/CodeGen/AIE/aie2/schedule/resource/s_wm.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/resource/s_wm.mir
@@ -38,3 +38,17 @@ body:             |
     $s1 = ADD_NC $r2, 20
     $s2 = ADD_NC $r3, -31
 ...
+
+---
+name:            mov_SCL_to_S
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: mov_SCL_to_S
+    ; CHECK: BUNDLE implicit-def $r1, implicit-def $s0, implicit killed $r4 {
+    ; CHECK-NEXT:   $r1 = MOVX_alu_cg 0
+    ; CHECK-NEXT:   $s0 = MOV_mv_scl killed $r4
+    ; CHECK-NEXT: }
+    $r1 = MOVX_alu_cg 0
+    $s0 = MOV_mv_scl $r4
+...

--- a/llvm/test/CodeGen/AIE/aie2/schedule/resource/s_wm.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/resource/s_wm.mir
@@ -52,3 +52,33 @@ body:             |
     $r1 = MOVX_alu_cg 0
     $s0 = MOV_mv_scl $r4
 ...
+
+---
+name:            mov_to_S
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: mov_to_S
+    ; CHECK: BUNDLE implicit-def $r1, implicit-def $s1 {
+    ; CHECK-NEXT:   $r1 = MOVA_lda_cg 0
+    ; CHECK-NEXT:   $s1 = MOV_mv_cg 0
+    ; CHECK-NEXT: }
+    $s1 = MOV_mv_cg 0
+    $r1 = MOVA_lda_cg 0
+...
+
+---
+name:            movx_to_R_mov_to_S
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: movx_to_R_mov_to_S
+    ; CHECK: BUNDLE implicit-def $r1, implicit-def $r2, implicit-def $s1 {
+    ; CHECK-NEXT:   $r1 = MOVA_lda_cg 0
+    ; CHECK-NEXT:   $r2 = MOVX_alu_cg 1
+    ; CHECK-NEXT:   $s1 = MOV_mv_cg 0
+    ; CHECK-NEXT: }
+    $s1 = MOV_mv_cg 0
+    $r2 = MOVX_alu_cg 1
+    $r1 = MOVA_lda_cg 0
+...

--- a/llvm/test/CodeGen/AIE/aie2/schedule/schedregionfill.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/schedregionfill.mir
@@ -30,8 +30,11 @@ body:             |
   ; CHECK-NEXT:   NOP
   ; CHECK-NEXT:   NOP
   ; CHECK-NEXT:   NOP
-  ; CHECK-NEXT:   $r13 = MOVXM_lng_cg 12345
-  ; CHECK-NEXT:   $r2 = MOVA_lda_cg 2
+  ; CHECK-NEXT:   NOP
+  ; CHECK-NEXT:   BUNDLE implicit-def $r2, implicit-def $r13 {
+  ; CHECK-NEXT:     $r2 = MOVA_lda_cg 2
+  ; CHECK-NEXT:     $r13 = MOVXM_lng_cg 12345
+  ; CHECK-NEXT:   }
   ; CHECK-NEXT:   DelayedSchedBarrier
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT: bb.1:

--- a/llvm/test/CodeGen/AIE/aie2/schedule/swp/doloop-stage0.ll
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/swp/doloop-stage0.ll
@@ -27,9 +27,8 @@ define dso_local i32 @dot(ptr nocapture readonly %a, ptr nocapture readonly %b, 
 ; CHECK-NEXT:    padda [p1], #2044 // Delay Slot 2
 ; CHECK-NEXT:    mova r0, #0 // Delay Slot 1
 ; CHECK-NEXT:  // %bb.1: // %do.body
-; CHECK-NEXT:    lda r1, [p0, #0]; nopx
-; CHECK-NEXT:    lda r4, [p1, #0]; add r5, r5, #-1
-; CHECK-NEXT:    jz r5, #.LBB0_4
+; CHECK-NEXT:    lda r4, [p1, #0]; nopb ; add r5, r5, #-1
+; CHECK-NEXT:    lda r1, [p0, #0]; jz r5, #.LBB0_4
 ; CHECK-NEXT:    nop // Delay Slot 5
 ; CHECK-NEXT:    nop // Delay Slot 4
 ; CHECK-NEXT:    nop // Delay Slot 3

--- a/llvm/test/CodeGen/AIE/aie2/schedule/swp/stage0.ll
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/swp/stage0.ll
@@ -35,9 +35,8 @@ define dso_local i32 @dot(ptr nocapture readonly %a, ptr nocapture readonly %b, 
 ; CHECK-NEXT:    padda [p0], #2044 // Delay Slot 2
 ; CHECK-NEXT:    padda [p1], #2044 // Delay Slot 1
 ; CHECK-NEXT:  // %bb.2: // %for.body
-; CHECK-NEXT:    lda r1, [p0, #0]; nopx
-; CHECK-NEXT:    lda r4, [p1, #0]; add r5, r5, #-1
-; CHECK-NEXT:    jz r5, #.LBB0_5
+; CHECK-NEXT:    lda r4, [p1, #0]; nopb ; add r5, r5, #-1
+; CHECK-NEXT:    lda r1, [p0, #0]; jz r5, #.LBB0_5
 ; CHECK-NEXT:    nop // Delay Slot 5
 ; CHECK-NEXT:    nop // Delay Slot 4
 ; CHECK-NEXT:    nop // Delay Slot 3

--- a/llvm/test/CodeGen/AIE/aie2/switch.ll
+++ b/llvm/test/CodeGen/AIE/aie2/switch.ll
@@ -28,8 +28,8 @@ define  i32 @test(i8 signext %i) noinline nounwind optnone {
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
+; CHECK-NEXT:    mova r2, #15
 ; CHECK-NEXT:    movxm r1, #1048575
-; CHECK-NEXT:    movx r2, #15
 ; CHECK-NEXT:    add r0, r0, #-1
 ; CHECK-NEXT:    and r1, r0, r1
 ; CHECK-NEXT:    ltu r1, r2, r1

--- a/llvm/test/CodeGen/AIE/aie2/vaddsub.ll
+++ b/llvm/test/CodeGen/AIE/aie2/vaddsub.ll
@@ -44,8 +44,8 @@ define dso_local noundef <64 x i8> @test_vaddsub_s8_zeroinit_from_s32(<64 x i8> 
 ; CHECK-NEXT:  // %bb.0: // %entry
 ; CHECK-NEXT:    nopb ; nopa ; nops ; ret lr ; nopm ; nopv
 ; CHECK-NEXT:    nop // Delay Slot 5
-; CHECK-NEXT:    mov r24, r0 // Delay Slot 4
-; CHECK-NEXT:    mova r25, #0 // Delay Slot 3
+; CHECK-NEXT:    nop // Delay Slot 4
+; CHECK-NEXT:    mova r25, #0; mov r24, r0 // Delay Slot 3
 ; CHECK-NEXT:    vaddsub.8 x0, x2, x4, r25:r24 // Delay Slot 2
 ; CHECK-NEXT:    nop // Delay Slot 1
 entry:

--- a/llvm/test/CodeGen/AIE/aie2/vextract.ll
+++ b/llvm/test/CodeGen/AIE/aie2/vextract.ll
@@ -424,8 +424,8 @@ define dso_local noundef signext i8 @_Z5test1Dv128_a(<128 x i8> noundef %vec)  {
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
-; CHECK-NEXT:    mova r1, #0
 ; CHECK-NEXT:    mov r3, r16
+; CHECK-NEXT:    mova r1, #0
 ; CHECK-NEXT:    movx r2, #64
 ; CHECK-NEXT:    lt r27, r0, r2
 ; CHECK-NEXT:    sel.nez r1, r1, r2, r27
@@ -454,9 +454,9 @@ define dso_local noundef signext i16 @_Z5test2Dv64_s(<64 x i16> noundef %vec)  {
 ; CHECK-NEXT:    lda r0, [p0, #0]
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
-; CHECK-NEXT:    mova r1, #0
 ; CHECK-NEXT:    mov r3, r16
 ; CHECK-NEXT:    mov r4, r17
+; CHECK-NEXT:    mova r1, #0
 ; CHECK-NEXT:    movx r2, #32
 ; CHECK-NEXT:    lt r27, r0, r2
 ; CHECK-NEXT:    sel.nez r1, r1, r2, r27
@@ -485,9 +485,9 @@ define dso_local noundef i32 @_Z5test3Dv32_i(<32 x i32> noundef %vec)  {
 ; CHECK-NEXT:    lda r0, [p0, #0]
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
-; CHECK-NEXT:    mova r1, #0
 ; CHECK-NEXT:    mov r3, r16
 ; CHECK-NEXT:    mov r4, r17
+; CHECK-NEXT:    mova r1, #0
 ; CHECK-NEXT:    movx r2, #16
 ; CHECK-NEXT:    lt r27, r0, r2
 ; CHECK-NEXT:    sel.nez r1, r1, r2, r27
@@ -525,8 +525,8 @@ define dso_local noundef signext i8 @_Z16extract_8bit_256Dv32_a(<32 x i8> nounde
 ; CHECK-NEXT:    nop // Delay Slot 5
 ; CHECK-NEXT:    nop // Delay Slot 4
 ; CHECK-NEXT:    nop // Delay Slot 3
-; CHECK-NEXT:    mov r16, r1 // Delay Slot 2
-; CHECK-NEXT:    paddb [sp], #-32 // Delay Slot 1
+; CHECK-NEXT:    paddb [sp], #-32 // Delay Slot 2
+; CHECK-NEXT:    mov r16, r1 // Delay Slot 1
 entry:
   %ret = alloca i8, align 4
   %vecext = extractelement <32 x i8> %vec, i64 5
@@ -554,8 +554,8 @@ define dso_local noundef zeroext i16 @_Z17extract_16bit_256Dv16_t(<16 x i16> nou
 ; CHECK-NEXT:    nop // Delay Slot 5
 ; CHECK-NEXT:    nop // Delay Slot 4
 ; CHECK-NEXT:    nop // Delay Slot 3
-; CHECK-NEXT:    mov r16, r1 // Delay Slot 2
-; CHECK-NEXT:    paddb [sp], #-32 // Delay Slot 1
+; CHECK-NEXT:    paddb [sp], #-32 // Delay Slot 2
+; CHECK-NEXT:    mov r16, r1 // Delay Slot 1
 entry:
   %ret = alloca i16, align 4
   %vecext = extractelement <16 x i16> %vec, i64 15
@@ -583,8 +583,8 @@ define dso_local noundef signext i8 @_Z16extract_8bit_512Dv64_a(<64 x i8> nounde
 ; CHECK-NEXT:    nop // Delay Slot 5
 ; CHECK-NEXT:    nop // Delay Slot 4
 ; CHECK-NEXT:    nop // Delay Slot 3
-; CHECK-NEXT:    mov r16, r1 // Delay Slot 2
-; CHECK-NEXT:    paddb [sp], #-32 // Delay Slot 1
+; CHECK-NEXT:    paddb [sp], #-32 // Delay Slot 2
+; CHECK-NEXT:    mov r16, r1 // Delay Slot 1
 entry:
   %ret = alloca i8, align 4
   %vecext = extractelement <64 x i8> %vec, i64 63
@@ -612,8 +612,8 @@ define dso_local noundef zeroext i16 @_Z17extract_16bit_512Dv32_t(<32 x i16> nou
 ; CHECK-NEXT:    nop // Delay Slot 5
 ; CHECK-NEXT:    nop // Delay Slot 4
 ; CHECK-NEXT:    nop // Delay Slot 3
-; CHECK-NEXT:    mov r16, r1 // Delay Slot 2
-; CHECK-NEXT:    paddb [sp], #-32 // Delay Slot 1
+; CHECK-NEXT:    paddb [sp], #-32 // Delay Slot 2
+; CHECK-NEXT:    mov r16, r1 // Delay Slot 1
 entry:
   %ret = alloca i16, align 4
   %vecext = extractelement <32 x i16> %vec, i64 15
@@ -642,8 +642,8 @@ define dso_local noundef signext i8 @_Z17extract_8bit_1024Dv128_a(<128 x i8> nou
 ; CHECK-NEXT:    nop // Delay Slot 5
 ; CHECK-NEXT:    nop // Delay Slot 4
 ; CHECK-NEXT:    nop // Delay Slot 3
-; CHECK-NEXT:    mov r16, r1 // Delay Slot 2
-; CHECK-NEXT:    paddb [sp], #-32 // Delay Slot 1
+; CHECK-NEXT:    paddb [sp], #-32 // Delay Slot 2
+; CHECK-NEXT:    mov r16, r1 // Delay Slot 1
 entry:
   %ret = alloca i8, align 4
   %vecext = extractelement <128 x i8> %vec, i64 127
@@ -672,8 +672,8 @@ define dso_local noundef zeroext i16 @_Z18extract_16bit_1024Dv64_t(<64 x i16> no
 ; CHECK-NEXT:    nop // Delay Slot 5
 ; CHECK-NEXT:    nop // Delay Slot 4
 ; CHECK-NEXT:    nop // Delay Slot 3
-; CHECK-NEXT:    mov r16, r1 // Delay Slot 2
-; CHECK-NEXT:    paddb [sp], #-32 // Delay Slot 1
+; CHECK-NEXT:    paddb [sp], #-32 // Delay Slot 2
+; CHECK-NEXT:    mov r16, r1 // Delay Slot 1
 entry:
   %ret = alloca i16, align 4
   %vecext = extractelement <64 x i16> %vec, i64 63

--- a/llvm/test/CodeGen/AIE/aie2/vsel.ll
+++ b/llvm/test/CodeGen/AIE/aie2/vsel.ll
@@ -44,8 +44,8 @@ define dso_local noundef <64 x i8> @test_vsel_s8_zeroinit_from_s32(<64 x i8> nou
 ; CHECK-NEXT:  // %bb.0: // %entry
 ; CHECK-NEXT:    nopb ; nopa ; nops ; ret lr ; nopm ; nopv
 ; CHECK-NEXT:    nop // Delay Slot 5
-; CHECK-NEXT:    mov r24, r0 // Delay Slot 4
-; CHECK-NEXT:    mova r25, #0 // Delay Slot 3
+; CHECK-NEXT:    nop // Delay Slot 4
+; CHECK-NEXT:    mova r25, #0; mov r24, r0 // Delay Slot 3
 ; CHECK-NEXT:    vsel.8 x0, x2, x4, r25:r24 // Delay Slot 2
 ; CHECK-NEXT:    nop // Delay Slot 1
 entry:


### PR DESCRIPTION
Follow up work for #144 
This PR updates Schedule & Instruction for MOV scalar immediate and scalar register allowing the Hazard Recognizer to select itinerary/FU based on reg type used. 

Will create sperate PR for 
1. LOAD 1D,2D,3D : #169 
2. VEXTRACT, ADD.NC : #171 