### PR TITLE
[AIE2] NFC: Fix missing "override" compile warning

### DIFF
--- a/llvm/lib/Target/AIE/AIE2InstrInfo.h
+++ b/llvm/lib/Target/AIE/AIE2InstrInfo.h
@@ -108,7 +108,7 @@ public:
   virtual unsigned
   getSchedClass(const MCInstrDesc &Desc,
                 iterator_range<const MachineOperand *> Operands,
-                const MachineRegisterInfo &MRI) const;
+                const MachineRegisterInfo &MRI) const override;
 
   SmallVector<TiedRegOperands, 4>
   getTiedRegInfo(unsigned Opcode) const override;


### PR DESCRIPTION
Missed when reviewing #144 