### PR TITLE
[AIE2] NFC : Refactor Address Space Code

### DIFF
--- a/llvm/lib/Target/AIE/AIE2AddrSpace.h
+++ b/llvm/lib/Target/AIE/AIE2AddrSpace.h
@@ -4,13 +4,16 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// (c) Copyright 2023-2024 Advanced Micro Devices, Inc. or its affiliates
+// (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
 //
 //===----------------------------------------------------------------------===//
 //
 // This file declares the AIEngine V2 Address Space and DM banks
 //
 //===----------------------------------------------------------------------===//
+
+#include "AIEBaseAddrSpaceInfo.h"
+#include <bitset>
 
 #ifndef LLVM_SUPPORT_AIE2ADDRSPACE_H
 #define LLVM_SUPPORT_AIE2ADDRSPACE_H
@@ -41,6 +44,73 @@ enum class AddressSpaces {
 enum class AIEBanks { A, B, C, D, TileMemory };
 
 } // end namespace AIE2
+
+class AIE2AddrSpaceInfo final : public AIEBaseAddrSpaceInfo {
+
+public:
+  MemoryBankBits getDefaultMemoryBank() const override {
+    std::bitset<32> MemoryBanks;
+    using namespace AIE2;
+    MemoryBanks.set(static_cast<unsigned>(AIEBanks::A))
+        .set(static_cast<unsigned>(AIEBanks::B))
+        .set(static_cast<unsigned>(AIEBanks::C))
+        .set(static_cast<unsigned>(AIEBanks::D));
+    return MemoryBanks.to_ulong();
+  }
+
+  MemoryBankBits
+  getMemoryBanksFromAddressSpace(unsigned AddrSpace) const override {
+    std::bitset<32> MemoryBanks;
+    using namespace AIE2;
+    switch (static_cast<AddressSpaces>(AddrSpace)) {
+    case AddressSpaces::a:
+      MemoryBanks.set(static_cast<unsigned>(AIEBanks::A));
+      break;
+    case AddressSpaces::b:
+      MemoryBanks.set(static_cast<unsigned>(AIEBanks::B));
+      break;
+    case AddressSpaces::c:
+      MemoryBanks.set(static_cast<unsigned>(AIEBanks::C));
+      break;
+    case AddressSpaces::d:
+      MemoryBanks.set(static_cast<unsigned>(AIEBanks::D));
+      break;
+    case AddressSpaces::ab:
+      MemoryBanks.set(static_cast<unsigned>(AIEBanks::A))
+          .set(static_cast<unsigned>(AIEBanks::B));
+      break;
+    case AddressSpaces::ac:
+      MemoryBanks.set(static_cast<unsigned>(AIEBanks::A))
+          .set(static_cast<unsigned>(AIEBanks::C));
+      break;
+    case AddressSpaces::ad:
+      MemoryBanks.set(static_cast<unsigned>(AIEBanks::A))
+          .set(static_cast<unsigned>(AIEBanks::D));
+      break;
+    case AddressSpaces::bc:
+      MemoryBanks.set(static_cast<unsigned>(AIEBanks::B))
+          .set(static_cast<unsigned>(AIEBanks::C));
+      break;
+    case AddressSpaces::bd:
+      MemoryBanks.set(static_cast<unsigned>(AIEBanks::B))
+          .set(static_cast<unsigned>(AIEBanks::D));
+      break;
+    case AddressSpaces::cd:
+      MemoryBanks.set(static_cast<unsigned>(AIEBanks::C))
+          .set(static_cast<unsigned>(AIEBanks::D));
+      break;
+    case AddressSpaces::TM:
+      MemoryBanks.set(static_cast<unsigned>(AIEBanks::TileMemory));
+      break;
+    default:
+      MemoryBanks.set();
+      break;
+    }
+
+    return MemoryBanks.to_ulong();
+  }
+};
+
 } // end namespace llvm
 
 #endif // LLVM_SUPPORT_AIE2ADDRSPACE_H

--- a/llvm/lib/Target/AIE/AIE2Subtarget.cpp
+++ b/llvm/lib/Target/AIE/AIE2Subtarget.cpp
@@ -77,65 +77,6 @@ InstructionSelector *AIE2Subtarget::getInstructionSelector() const {
   return InstSelector.get();
 }
 
-MemoryBankBits AIE2Subtarget::getDefaultMemoryBank() const {
-  using namespace AIE2;
-  std::bitset<32> MemoryBanks;
-  MemoryBanks.set(static_cast<unsigned>(AIEBanks::A))
-      .set(static_cast<unsigned>(AIEBanks::B))
-      .set(static_cast<unsigned>(AIEBanks::C))
-      .set(static_cast<unsigned>(AIEBanks::D));
-  return MemoryBanks.to_ulong();
-}
-
-MemoryBankBits
-AIE2Subtarget::getMemoryBanksFromAddressSpace(unsigned AddrSpace) const {
-  using namespace AIE2;
-  std::bitset<32> MemoryBanks;
-
-  switch (static_cast<AddressSpaces>(AddrSpace)) {
-  case AddressSpaces::a:
-    MemoryBanks.set(static_cast<unsigned>(AIEBanks::A));
-    break;
-  case AddressSpaces::b:
-    MemoryBanks.set(static_cast<unsigned>(AIEBanks::B));
-    break;
-  case AddressSpaces::c:
-    MemoryBanks.set(static_cast<unsigned>(AIEBanks::C));
-    break;
-  case AddressSpaces::d:
-    MemoryBanks.set(static_cast<unsigned>(AIEBanks::D));
-    break;
-  case AddressSpaces::ab:
-    MemoryBanks.set(static_cast<unsigned>(AIEBanks::A))
-        .set(static_cast<unsigned>(AIEBanks::B));
-    break;
-  case AddressSpaces::ac:
-    MemoryBanks.set(static_cast<unsigned>(AIEBanks::A))
-        .set(static_cast<unsigned>(AIEBanks::C));
-    break;
-  case AddressSpaces::ad:
-    MemoryBanks.set(static_cast<unsigned>(AIEBanks::A))
-        .set(static_cast<unsigned>(AIEBanks::D));
-    break;
-  case AddressSpaces::bc:
-    MemoryBanks.set(static_cast<unsigned>(AIEBanks::B))
-        .set(static_cast<unsigned>(AIEBanks::C));
-    break;
-  case AddressSpaces::bd:
-    MemoryBanks.set(static_cast<unsigned>(AIEBanks::B))
-        .set(static_cast<unsigned>(AIEBanks::D));
-    break;
-  case AddressSpaces::cd:
-    MemoryBanks.set(static_cast<unsigned>(AIEBanks::C))
-        .set(static_cast<unsigned>(AIEBanks::D));
-    break;
-  case AddressSpaces::TM:
-    MemoryBanks.set(static_cast<unsigned>(AIEBanks::TileMemory));
-    break;
-  default:
-    return getDefaultMemoryBank();
-    break;
-  }
-
-  return MemoryBanks.to_ulong();
+const AIEBaseAddrSpaceInfo &AIE2Subtarget::getAddrSpaceInfo() const {
+  return AddrSpaceInfo;
 }

--- a/llvm/lib/Target/AIE/AIE2Subtarget.h
+++ b/llvm/lib/Target/AIE/AIE2Subtarget.h
@@ -39,6 +39,7 @@ class StringRef;
 class AIE2Subtarget : public AIE2GenSubtargetInfo, public AIEBaseSubtarget {
   virtual void anchor();
   std::string CPUName;
+  AIE2AddrSpaceInfo AddrSpaceInfo;
   AIE2FrameLowering FrameLowering;
   AIE2InstrInfo InstrInfo;
   AIE2RegisterInfo RegInfo;
@@ -93,10 +94,6 @@ public:
     return &TSInfo;
   }
 
-  MemoryBankBits getDefaultMemoryBank() const override;
-  MemoryBankBits
-  getMemoryBanksFromAddressSpace(unsigned AddrSpace) const override;
-
   // Perform target-specific adjustments to the latency of a schedule
   // dependency.
   // If a pair of operands is associated with the schedule dependency, DefOpIdx
@@ -143,6 +140,7 @@ public:
   const LegalizerInfo *getLegalizerInfo() const override;
   const RegisterBankInfo *getRegBankInfo() const override;
   InstructionSelector *getInstructionSelector() const override;
+  const AIEBaseAddrSpaceInfo &getAddrSpaceInfo() const override;
 };
 } // namespace llvm
 

--- a/llvm/lib/Target/AIE/AIEBaseAddrSpaceInfo.h
+++ b/llvm/lib/Target/AIE/AIEBaseAddrSpaceInfo.h
@@ -1,0 +1,40 @@
+//===-- AIEBaseAddrSpaceInfo.h - Define Base AddressSpace Class  -*- C++-*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+//
+//===----------------------------------------------------------------------===//
+//
+// This file declares the AIEngine Base Address Space class.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_SUPPORT_AIEBASEADDRSPACEINFO_H
+#define LLVM_SUPPORT_AIEBASEADDRSPACEINFO_H
+
+#include <cstdint>
+
+namespace llvm {
+
+using MemoryBankBits = uint64_t;
+
+class AIEBaseAddrSpaceInfo {
+public:
+  virtual MemoryBankBits getDefaultMemoryBank() const {
+    // By default assume conflicts.
+    return ~0;
+  }
+
+  virtual MemoryBankBits
+  getMemoryBanksFromAddressSpace(unsigned AddrSpace) const {
+    // By default assume conflicts.
+    return ~0;
+  }
+};
+
+} // end namespace llvm
+
+#endif // LLVM_SUPPORT_AIEBASEADDRSPACEINFO_H

--- a/llvm/lib/Target/AIE/AIEBaseSubtarget.cpp
+++ b/llvm/lib/Target/AIE/AIEBaseSubtarget.cpp
@@ -146,17 +146,6 @@ const AIEBaseSubtarget &AIEBaseSubtarget::get(const MachineFunction &MF) {
     llvm_unreachable("Unknown subtarget");
 }
 
-MemoryBankBits
-AIEBaseSubtarget::getMemoryBanksFromAddressSpace(unsigned AddrSpace) const {
-  // By default assume there are no conflicts.
-  return 0;
-}
-
-MemoryBankBits AIEBaseSubtarget::getDefaultMemoryBank() const {
-  // By default assume there are no conflicts.
-  return 0;
-}
-
 namespace {
 
 // Set latency and declare height/depth dirty if it changes

--- a/llvm/lib/Target/AIE/AIEBaseSubtarget.h
+++ b/llvm/lib/Target/AIE/AIEBaseSubtarget.h
@@ -15,13 +15,13 @@
 #ifndef LLVM_LIB_TARGET_AIE_AIEBASESUBTARGET_H
 #define LLVM_LIB_TARGET_AIE_AIEBASESUBTARGET_H
 
+#include "AIEBaseAddrSpaceInfo.h"
 #include "AIEBaseInstrInfo.h"
 #include "Utils/AIEBaseInfo.h"
 #include "llvm/CodeGen/ScheduleDAGMutation.h"
 #include "llvm/CodeGenTypes/MachineValueType.h"
 #include "llvm/MC/MCInstrItineraries.h"
 #include "llvm/TargetParser/Triple.h"
-#include <bitset>
 
 namespace llvm {
 
@@ -33,8 +33,6 @@ class InstrItineraryData;
 class ScheduleDAGMutation;
 class SUnit;
 class SDep;
-
-using MemoryBankBits = uint64_t;
 
 class AIEBaseSubtarget {
 private:
@@ -48,6 +46,7 @@ public:
   virtual const TargetRegisterInfo *getRegisterInfo() const = 0;
   virtual const TargetFrameLowering *getFrameLowering() const = 0;
   virtual const AIEBaseInstrInfo *getInstrInfo() const = 0;
+  virtual const AIEBaseAddrSpaceInfo &getAddrSpaceInfo() const = 0;
   AIEABI::ABI getTargetABI() const { return TargetABI; }
   bool isAIE1() const { return (TargetTriple.isAIE1()); }
   bool isAIE2() const { return (TargetTriple.isAIE2()); }
@@ -69,10 +68,6 @@ public:
   void adjustSchedDependency(const InstrItineraryData &Itineraries, SUnit *Def,
                              int DefOpIdx, SUnit *Use, int UseOpIdx,
                              SDep &Dep) const;
-
-  virtual MemoryBankBits
-  getMemoryBanksFromAddressSpace(unsigned AddrSpace) const;
-  virtual MemoryBankBits getDefaultMemoryBank() const;
 
   /// Required DAG mutations during Post-RA scheduling.
   static std::vector<std::unique_ptr<ScheduleDAGMutation>>

--- a/llvm/lib/Target/AIE/AIEHazardRecognizer.cpp
+++ b/llvm/lib/Target/AIE/AIEHazardRecognizer.cpp
@@ -619,10 +619,11 @@ AIEHazardRecognizer::getMemoryBanks(const MachineInstr *MI) const {
     return ~0;
 
   const AIEBaseSubtarget &STI = AIEBaseSubtarget::get(*MI->getMF());
-  MemoryBankBits MemoryBankUsed = STI.getDefaultMemoryBank();
+  const AIEBaseAddrSpaceInfo &ASI = STI.getAddrSpaceInfo();
+  MemoryBankBits MemoryBankUsed = ASI.getDefaultMemoryBank();
   for (auto &MMO : MI->memoperands()) {
     MemoryBankBits MemoryBank =
-        STI.getMemoryBanksFromAddressSpace(MMO->getAddrSpace());
+        ASI.getMemoryBanksFromAddressSpace(MMO->getAddrSpace());
     MemoryBankUsed &= MemoryBank;
   }
   return MemoryBankUsed;

--- a/llvm/lib/Target/AIE/AIEHazardRecognizer.h
+++ b/llvm/lib/Target/AIE/AIEHazardRecognizer.h
@@ -13,6 +13,7 @@
 #ifndef LLVM_LIB_TARGET_AIE_AIEHAZARDRECOGNIZER_H
 #define LLVM_LIB_TARGET_AIE_AIEHAZARDRECOGNIZER_H
 
+#include "AIEBaseAddrSpaceInfo.h"
 #include "AIEBaseSubtarget.h"
 #include "AIEBundle.h"
 #include "MCTargetDesc/AIEMCFormats.h"

--- a/llvm/lib/Target/AIE/AIESubtarget.cpp
+++ b/llvm/lib/Target/AIE/AIESubtarget.cpp
@@ -47,7 +47,7 @@ AIESubtarget::AIESubtarget(const Triple &TT, StringRef CPU, StringRef TuneCPU,
     : AIEGenSubtargetInfo(TT, CPU, TuneCPU, FS), AIEBaseSubtarget(TT),
       FrameLowering(initializeSubtargetDependencies(TT, CPU, FS, ABIName)),
       InstrInfo(), RegInfo(getHwMode()), TLInfo(TM, *this),
-      InstrItins(getInstrItineraryForCPU(StringRef(CPU))) { // CPUName)) {
+      InstrItins(getInstrItineraryForCPU(StringRef(CPU))) {
   LLVM_DEBUG(dbgs() << "CPU:" << CPU << "." << CPUName << "." << FS << "."
                     << ABIName << "\n");
 
@@ -74,4 +74,8 @@ const RegisterBankInfo *AIESubtarget::getRegBankInfo() const {
 
 InstructionSelector *AIESubtarget::getInstructionSelector() const {
   return InstSelector.get();
+}
+
+const AIEBaseAddrSpaceInfo &AIESubtarget::getAddrSpaceInfo() const {
+  return AddrSpaceInfo;
 }

--- a/llvm/lib/Target/AIE/AIESubtarget.h
+++ b/llvm/lib/Target/AIE/AIESubtarget.h
@@ -37,6 +37,7 @@ class StringRef;
 class AIESubtarget final : public AIEGenSubtargetInfo, public AIEBaseSubtarget {
   virtual void anchor();
   std::string CPUName;
+  AIEBaseAddrSpaceInfo AddrSpaceInfo;
   AIEFrameLowering FrameLowering;
   AIEInstrInfo InstrInfo;
   AIERegisterInfo RegInfo;
@@ -117,6 +118,7 @@ public:
   const LegalizerInfo *getLegalizerInfo() const override;
   const RegisterBankInfo *getRegBankInfo() const override;
   InstructionSelector *getInstructionSelector() const override;
+  const AIEBaseAddrSpaceInfo &getAddrSpaceInfo() const override;
 };
 } // namespace llvm
 


### PR DESCRIPTION
The PR would allow to use a single architecture agnostic AA pass which can do AA using addresspace info.  
Kindly refer #173 to see the use case. 

Note : AA using addresspace info is guarded by a CMD line option. 