### PR TITLE
[AIEX] Fix `reserved-reg-licm` pass

### DIFF
--- a/llvm/lib/Target/AIE/ReservedRegsLICM.cpp
+++ b/llvm/lib/Target/AIE/ReservedRegsLICM.cpp
@@ -109,13 +109,13 @@ static MCRegister getSinglePhysRegDef(const MachineInstr &MI) {
 }
 
 CandidateInfo *Candidates::getInfo(const MachineInstr &MI) {
-  const MachineRegisterInfo &MRI = MI.getMF()->getRegInfo();
+  const TargetRegisterInfo &TRI = *MI.getMF()->getSubtarget().getRegisterInfo();
   if (MCRegister Reg = getSinglePhysRegDef(MI)) {
     auto It = Candidates.find(Reg);
     if (It != Candidates.end()) {
       return &It->second;
     }
-    if (MRI.canSimplifyPhysReg(Reg)) {
+    if (TRI.isSimplifiableReservedReg(Reg)) {
       // Only consider "simplifiable" reserved regs in this pass.
       return &Candidates.try_emplace(Reg, Reg).first->second;
     }

--- a/llvm/test/CodeGen/AIE/aie2/GlobalISel/post-select-licm-reserved.mir
+++ b/llvm/test/CodeGen/AIE/aie2/GlobalISel/post-select-licm-reserved.mir
@@ -385,3 +385,44 @@ body:             |
     PseudoJNZ %0, %bb.2
     PseudoJ_jump_imm %bb.1
 ...
+
+# Verify that non-reserved physical registers aren't considered for LICM
+---
+name:            test_is_simplifiable_reserved_reg
+tracksRegLiveness: true
+body:             |
+  ; CHECK-LABEL: name: test_is_simplifiable_reserved_reg
+  ; CHECK: bb.0:
+  ; CHECK-NEXT:   successors: %bb.2(0x80000000)
+  ; CHECK-NEXT:   liveins: $r0, $x0
+  ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT:   [[COPY:%[0-9]+]]:er = COPY $r0
+  ; CHECK-NEXT:   [[COPY1:%[0-9]+]]:vec512 = COPY $x0
+  ; CHECK-NEXT:   PseudoJ_jump_imm %bb.2
+  ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT: bb.1:
+  ; CHECK-NEXT:   PseudoRET implicit $lr
+  ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT: bb.2:
+  ; CHECK-NEXT:   successors: %bb.2(0x7c000000), %bb.1(0x04000000)
+  ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT:   $x0 = COPY [[COPY1]]
+  ; CHECK-NEXT:   PseudoJNZ [[COPY]], %bb.2
+  ; CHECK-NEXT:   PseudoJ_jump_imm %bb.1
+  bb.0:
+    successors: %bb.2(0x80000000)
+    liveins: $r0, $x0
+    %0:er = COPY $r0
+    %1:vec512 = COPY $x0
+    PseudoJ_jump_imm %bb.2
+
+  bb.1:
+    PseudoRET implicit $lr
+
+  bb.2:
+    successors: %bb.2(0x7c000000), %bb.1(0x04000000)
+    $x0 = COPY %1
+    PseudoJNZ %0, %bb.2
+    PseudoJ_jump_imm %bb.1
+...
+


### PR DESCRIPTION
This PR fixes an assertion being triggered in the `reserved-reg-licm` pass.

The pass was not correctly checking for reserved registers and in some call paths it tries moving instructions involving physical registers that are not reserved. I was able to trigger this bug by calling a function that takes a 512-bit register as an input from inside a loop. The ABI introduces a copy of the 512-bit register into a physical register before the jump and link and the pass was trying to move that precise copy. The actual assert being triggered is a sanity check that makes sure that the physical register involved in the moved instruction only contains one register unit, which is the case for all reserved registers but not for the 512-bit vector register.
TLDR: a pre-condition was not being checked properly