### PR TITLE
[AIE2] Combine 2D/3D post-increments for 512-bit load/stores

### DIFF
--- a/llvm/lib/Target/AIE/AIE2InstrInfo.cpp
+++ b/llvm/lib/Target/AIE/AIE2InstrInfo.cpp
@@ -242,7 +242,7 @@ std::optional<unsigned> AIE2InstrInfo::getCombinedPostIncOpcode(
   case TargetOpcode::G_INTRINSIC:
     switch (cast<GIntrinsic>(PostIncI).getIntrinsicID()) {
     case Intrinsic::aie2_add_2d:
-      if (Size >= 512)
+      if (Size >= 1024)
         return {};
       switch (BaseMemI.getOpcode()) {
       case TargetOpcode::G_STORE:
@@ -256,7 +256,7 @@ std::optional<unsigned> AIE2InstrInfo::getCombinedPostIncOpcode(
       }
       break;
     case Intrinsic::aie2_add_3d:
-      if (Size >= 512)
+      if (Size >= 1024)
         return {};
       switch (BaseMemI.getOpcode()) {
       case TargetOpcode::G_STORE:

--- a/llvm/test/CodeGen/AIE/GlobalISel/combine-loads-stores.mir
+++ b/llvm/test/CodeGen/AIE/GlobalISel/combine-loads-stores.mir
@@ -1473,6 +1473,52 @@ body: |
 ...
 
 ---
+name: vector_512_combine_postinc_2d
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: vector_512_combine_postinc_2d
+    ; CHECK: [[COPY:%[0-9]+]]:_(p0) = COPY $p0
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(p0) = COPY $p1
+    ; CHECK-NEXT: [[C:%[0-9]+]]:_(s20) = G_CONSTANT i20 64
+    ; CHECK-NEXT: [[AIE_POSTINC_2D_LOAD:%[0-9]+]]:_(<32 x s16>), [[AIE_POSTINC_2D_LOAD1:%[0-9]+]]:_(p0), [[AIE_POSTINC_2D_LOAD2:%[0-9]+]]:_(s20) = G_AIE_POSTINC_2D_LOAD [[COPY]], [[C]], [[C]], [[C]], [[C]] :: (load (<32 x s16>))
+    ; CHECK-NEXT: [[AIE_POSTINC_2D_STORE:%[0-9]+]]:_(p0), [[AIE_POSTINC_2D_STORE1:%[0-9]+]]:_(s20) = G_AIE_POSTINC_2D_STORE [[AIE_POSTINC_2D_LOAD]](<32 x s16>), [[COPY1]], [[C]], [[C]], [[C]], [[C]] :: (store (<32 x s16>))
+    ; CHECK-NEXT: $p0 = COPY [[AIE_POSTINC_2D_LOAD1]](p0)
+    ; CHECK-NEXT: $p1 = COPY [[AIE_POSTINC_2D_STORE]](p0)
+      %0:_(p0) = COPY $p0
+      %6:_(p0) = COPY $p1
+      %1:_(s20) = G_CONSTANT i20 64
+      %4:_(<32 x s16>) = G_LOAD %0(p0) :: (load (<32 x s16>))
+      G_STORE %4, %6 :: (store (<32 x s16>))
+      %3:_(p0), %8:_(s20) = G_INTRINSIC intrinsic(@llvm.aie2.add.2d), %0:_(p0), %1:_(s20), %1:_(s20), %1:_(s20), %1:_(s20)
+      $p0 = COPY %3
+      %7:_(p0), %9:_(s20) = G_INTRINSIC intrinsic(@llvm.aie2.add.2d), %6:_(p0), %1:_(s20), %1:_(s20), %1:_(s20), %1:_(s20)
+      $p1 = COPY %7
+...
+
+---
+name: vector_512_combine_postinc_3d
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: vector_512_combine_postinc_3d
+    ; CHECK: [[COPY:%[0-9]+]]:_(p0) = COPY $p0
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(p0) = COPY $p1
+    ; CHECK-NEXT: [[C:%[0-9]+]]:_(s20) = G_CONSTANT i20 64
+    ; CHECK-NEXT: [[AIE_POSTINC_3D_LOAD:%[0-9]+]]:_(<32 x s16>), [[AIE_POSTINC_3D_LOAD1:%[0-9]+]]:_(p0), [[AIE_POSTINC_3D_LOAD2:%[0-9]+]]:_(s20), [[AIE_POSTINC_3D_LOAD3:%[0-9]+]]:_ = G_AIE_POSTINC_3D_LOAD [[COPY]], [[C]], [[C]], [[C]], [[C]], [[C]], [[C]], [[C]] :: (load (<32 x s16>))
+    ; CHECK-NEXT: [[AIE_POSTINC_3D_STORE:%[0-9]+]]:_(p0), [[AIE_POSTINC_3D_STORE1:%[0-9]+]]:_(s20), [[AIE_POSTINC_3D_STORE2:%[0-9]+]]:_ = G_AIE_POSTINC_3D_STORE [[AIE_POSTINC_3D_LOAD]](<32 x s16>), [[COPY1]], [[C]], [[C]], [[C]], [[C]], [[C]], [[C]], [[C]] :: (store (<32 x s16>))
+    ; CHECK-NEXT: $p0 = COPY [[AIE_POSTINC_3D_LOAD1]](p0)
+    ; CHECK-NEXT: $p1 = COPY [[AIE_POSTINC_3D_STORE]](p0)
+      %0:_(p0) = COPY $p0
+      %6:_(p0) = COPY $p1
+      %1:_(s20) = G_CONSTANT i20 64
+      %4:_(<32 x s16>) = G_LOAD %0(p0) :: (load (<32 x s16>))
+      G_STORE %4, %6 :: (store (<32 x s16>))
+      %3:_(p0), %8:_(s20), %9:_(s20) = G_INTRINSIC intrinsic(@llvm.aie2.add.3d), %0:_(p0), %1:_(s20), %1:_(s20), %1:_(s20), %1:_(s20), %1:_(s20), %1:_(s20), %1:_(s20)
+      $p0 = COPY %3
+      %7:_(p0), %10:_(s20), %11:_(s20) = G_INTRINSIC intrinsic(@llvm.aie2.add.3d), %6:_(p0), %1:_(s20), %1:_(s20), %1:_(s20), %1:_(s20), %1:_(s20), %1:_(s20), %1:_(s20)
+      $p1 = COPY %7
+...
+
+---
 name: no_vector_1024_combine_postinc_yet
 body: |
   bb.0:

--- a/llvm/test/CodeGen/AIE/aie2/end-to-end/Conv2D-red-swp.ll
+++ b/llvm/test/CodeGen/AIE/aie2/end-to-end/Conv2D-red-swp.ll
@@ -330,7 +330,7 @@ define dso_local void @conv2d.loop.nest(ptr %add.ptr6.i51, ptr %add.ptr5, ptr %c
 ; DCL-NEXT:    vldb wl10, [p1], #32; add r0, r10, #33; mov r10, p0; vmac cm3, cm3, x11, x6, r4 // Delay Slot 2
 ; DCL-NEXT:    vldb wh10, [p1], #32; and r10, r10, r9; vmov x8, x10; vmac cm7, cm7, x11, x8, r4 // Delay Slot 1
 ; DCL-NEXT:  // %bb.3: // in Loop: Header=BB0_1 Depth=1
-; DCL-NEXT:    nopa ; nopx ; vmov x11, x0
+; DCL-NEXT:    nopa ; nopb ; nopx ; vmov x11, x0
 ; DCL-NEXT:    vshuffle x0, x4, x2, r3
 ; DCL-NEXT:    vshuffle x11, x0, x11, r8
 ; DCL-NEXT:    vlda wl0, [sp, #-64] // 32-byte Folded Reload
@@ -367,7 +367,7 @@ define dso_local void @conv2d.loop.nest(ptr %add.ptr6.i51, ptr %add.ptr5, ptr %c
 ; DCL-NEXT:    vst.srs.s16.s32 bmh5, s3, [p3, #32]; mov m3, r14
 ; DCL-NEXT:    vst.srs.s16.s32 bml5, s3, [p3], #64; mov m1, r11
 ; DCL-NEXT:    padda.3d [p0], d1; vst.srs.s16.s32 bmh4, s3, [p3, #32]; mov m1, r24
-; DCL-NEXT:    padda.2d [p3], d7; vst.srs.s16.s32 bml4, s3, [p3, #0]; add r7, r7, #-1; mov dj7, r25
+; DCL-NEXT:    vst.2d.srs.s16.s32 bml4, s3, [p3], d7; add r7, r7, #-1; mov dj7, r25
 ; DCL-NEXT:    jnz r7, #.LBB0_1
 ; DCL-NEXT:    mov dn7, r26 // Delay Slot 5
 ; DCL-NEXT:    st dc7, [sp, #-84] // 4-byte Folded Spill Delay Slot 4
@@ -494,7 +494,7 @@ define dso_local void @conv2d.loop.nest(ptr %add.ptr6.i51, ptr %add.ptr5, ptr %c
 ; ZOL-NEXT:  .L_LEnd0:
 ; ZOL-NEXT:    vldb wh10, [p1], #32; nopa ; nops ; and r1, r1, r9; vmov x8, x10; vmac cm7, cm7, x11, x8, r4
 ; ZOL-NEXT:  // %bb.3: // in Loop: Header=BB0_1 Depth=1
-; ZOL-NEXT:    nopa ; nopx ; vmov x11, x0
+; ZOL-NEXT:    nopa ; nopb ; nopx ; vmov x11, x0
 ; ZOL-NEXT:    vshuffle x0, x4, x2, r3
 ; ZOL-NEXT:    vshuffle x11, x0, x11, r8
 ; ZOL-NEXT:    vlda wl0, [sp, #-64] // 32-byte Folded Reload
@@ -531,7 +531,7 @@ define dso_local void @conv2d.loop.nest(ptr %add.ptr6.i51, ptr %add.ptr5, ptr %c
 ; ZOL-NEXT:    vst.srs.s16.s32 bmh5, s3, [p3, #32]; mov m3, r13
 ; ZOL-NEXT:    vst.srs.s16.s32 bml5, s3, [p3], #64; mov m1, r10
 ; ZOL-NEXT:    padda.3d [p0], d1; vst.srs.s16.s32 bmh4, s3, [p3, #32]; mov m1, r15
-; ZOL-NEXT:    padda.2d [p3], d7; vst.srs.s16.s32 bml4, s3, [p3, #0]; add r7, r7, #-1; mov dj7, r24
+; ZOL-NEXT:    vst.2d.srs.s16.s32 bml4, s3, [p3], d7; add r7, r7, #-1; mov dj7, r24
 ; ZOL-NEXT:    jnz r7, #.LBB0_1
 ; ZOL-NEXT:    mov dn7, r25 // Delay Slot 5
 ; ZOL-NEXT:    st dc7, [sp, #-84] // 4-byte Folded Spill Delay Slot 4

--- a/llvm/test/CodeGen/AIE/aie2/end-to-end/Conv2D-red.ll
+++ b/llvm/test/CodeGen/AIE/aie2/end-to-end/Conv2D-red.ll
@@ -94,22 +94,22 @@ define dso_local void @conv2d.loop.nest(ptr %add.ptr6.i51, ptr %add.ptr5, ptr %c
 ; ASM-NEXT:  .LBB0_1: // %outer.loop.header
 ; ASM-NEXT:    // =>This Loop Header: Depth=1
 ; ASM-NEXT:    // Child Loop BB0_2 Depth 2
-; ASM-NEXT:    vlda.ups.s32.s16 bmh0, s0, [p2, #32]; mov m1, p4
-; ASM-NEXT:    vlda.ups.s32.s16 bml0, s0, [p2], m1
-; ASM-NEXT:    vlda.ups.s32.s16 bmh1, s0, [p2, #32]; mov m2, p5
-; ASM-NEXT:    vlda.ups.s32.s16 bml1, s0, [p2], m2
-; ASM-NEXT:    vlda.ups.s32.s16 bmh2, s0, [p2, #32]
-; ASM-NEXT:    vlda.ups.s32.s16 bml2, s0, [p2], m1
-; ASM-NEXT:    vlda.ups.s32.s16 bmh3, s0, [p2, #32]; mov m3, r15
-; ASM-NEXT:    vlda.ups.s32.s16 bml3, s0, [p2], m3
-; ASM-NEXT:    vlda.ups.s32.s16 bmh4, s0, [p2, #32]
-; ASM-NEXT:    vlda.ups.s32.s16 bml4, s0, [p2], m1
+; ASM-NEXT:    vlda.ups.s32.s16 bmh1, s0, [p2, #32]; mov m1, p4
+; ASM-NEXT:    vlda.ups.s32.s16 bml1, s0, [p2], m1
+; ASM-NEXT:    vlda.ups.s32.s16 bmh2, s0, [p2, #32]; mov m2, p5
+; ASM-NEXT:    vlda.ups.s32.s16 bml2, s0, [p2], m2
+; ASM-NEXT:    vlda.ups.s32.s16 bmh3, s0, [p2, #32]
+; ASM-NEXT:    vlda.ups.s32.s16 bml3, s0, [p2], m1
+; ASM-NEXT:    vlda.ups.s32.s16 bmh4, s0, [p2, #32]; mov m3, r15
+; ASM-NEXT:    vlda.ups.s32.s16 bml4, s0, [p2], m3
 ; ASM-NEXT:    vlda.ups.s32.s16 bmh5, s0, [p2, #32]
-; ASM-NEXT:    vlda.ups.s32.s16 bml5, s0, [p2], m2
+; ASM-NEXT:    vlda.ups.s32.s16 bml5, s0, [p2], m1
 ; ASM-NEXT:    vlda.ups.s32.s16 bmh6, s0, [p2, #32]
-; ASM-NEXT:    vlda.ups.s32.s16 bml6, s0, [p2], m1; mov r0, p0
-; ASM-NEXT:    vlda.ups.s32.s16 bmh7, s0, [p2, #32]; and r0, r0, r9
-; ASM-NEXT:    vlda.ups.s32.s16 bml7, s0, [p2, #0]; add r1, r0, #33; mov r0, r5
+; ASM-NEXT:    vlda.ups.s32.s16 bml6, s0, [p2], m2
+; ASM-NEXT:    vlda.ups.s32.s16 bmh7, s0, [p2, #32]
+; ASM-NEXT:    vlda.ups.s32.s16 bml7, s0, [p2], m1; mov r0, p0
+; ASM-NEXT:    vlda.ups.s32.s16 bmh0, s0, [p2, #32]; and r0, r0, r9
+; ASM-NEXT:    vlda.ups.s32.s16 bml0, s0, [p2, #0]; add r1, r0, #33; mov r0, r5
 ; ASM-NEXT:    .p2align 4
 ; ASM-NEXT:  .LBB0_2: // %inner.loop
 ; ASM-NEXT:    // Parent Loop BB0_1 Depth=1
@@ -127,32 +127,32 @@ define dso_local void @conv2d.loop.nest(ptr %add.ptr6.i51, ptr %add.ptr5, ptr %c
 ; ASM-NEXT:    vshift.align x2, x2, s1, x8, r1
 ; ASM-NEXT:    vshuffle x9, x4, x2, r2
 ; ASM-NEXT:    vshuffle x3, x4, x2, r3
-; ASM-NEXT:    vmac cm0, cm0, x9, x10, r4
-; ASM-NEXT:    add r0, r0, #-1; vshuffle x1, x9, x0, r8; vmac cm2, cm2, x3, x10, r4
-; ASM-NEXT:    jnz r0, #.LBB0_2; vmac cm4, cm4, x9, x7, r4
-; ASM-NEXT:    vshuffle x5, x3, x0, r8; vmac cm6, cm6, x3, x7, r4 // Delay Slot 5
-; ASM-NEXT:    vmac cm1, cm1, x1, x10, r4 // Delay Slot 4
-; ASM-NEXT:    mov r1, p0; vmac cm3, cm3, x5, x10, r4 // Delay Slot 3
-; ASM-NEXT:    and r1, r1, r9; vmac cm5, cm5, x1, x7, r4 // Delay Slot 2
-; ASM-NEXT:    add r1, r1, #33; vmac cm7, cm7, x5, x7, r4 // Delay Slot 1
+; ASM-NEXT:    vmac cm1, cm1, x9, x10, r4
+; ASM-NEXT:    add r0, r0, #-1; vshuffle x1, x9, x0, r8; vmac cm3, cm3, x3, x10, r4
+; ASM-NEXT:    jnz r0, #.LBB0_2; vmac cm5, cm5, x9, x7, r4
+; ASM-NEXT:    vshuffle x5, x3, x0, r8; vmac cm7, cm7, x3, x7, r4 // Delay Slot 5
+; ASM-NEXT:    vmac cm2, cm2, x1, x10, r4 // Delay Slot 4
+; ASM-NEXT:    mov r1, p0; vmac cm4, cm4, x5, x10, r4 // Delay Slot 3
+; ASM-NEXT:    and r1, r1, r9; vmac cm6, cm6, x1, x7, r4 // Delay Slot 2
+; ASM-NEXT:    add r1, r1, #33; vmac cm0, cm0, x5, x7, r4 // Delay Slot 1
 ; ASM-NEXT:  // %bb.3: // %outer.loop.latch
 ; ASM-NEXT:    // in Loop: Header=BB0_1 Depth=1
-; ASM-NEXT:    nopa ; nopb ; nopx ; mov s3, r6; vst.srs.s16.s32 bmh0, s2, [p3, #32]
-; ASM-NEXT:    vst.srs.s16.s32 bml0, s3, [p3], #64
-; ASM-NEXT:    vst.srs.s16.s32 bmh1, s3, [p3, #32]
-; ASM-NEXT:    vst.srs.s16.s32 bml1, s3, [p3], m4
+; ASM-NEXT:    nopb ; nopa ; vst.srs.s16.s32 bmh1, s2, [p3, #32]; nopx ; mov s3, r6; nopv
+; ASM-NEXT:    vst.srs.s16.s32 bml1, s3, [p3], #64
 ; ASM-NEXT:    vst.srs.s16.s32 bmh2, s3, [p3, #32]
-; ASM-NEXT:    vst.srs.s16.s32 bml2, s3, [p3], #64
+; ASM-NEXT:    vst.srs.s16.s32 bml2, s3, [p3], m4
 ; ASM-NEXT:    vst.srs.s16.s32 bmh3, s3, [p3, #32]
-; ASM-NEXT:    vst.srs.s16.s32 bml3, s3, [p3], m7
+; ASM-NEXT:    vst.srs.s16.s32 bml3, s3, [p3], #64
 ; ASM-NEXT:    vst.srs.s16.s32 bmh4, s3, [p3, #32]
-; ASM-NEXT:    vst.srs.s16.s32 bml4, s3, [p3], #64
-; ASM-NEXT:    vst.srs.s16.s32 bmh5, s3, [p3, #32]; mov dc5, r26
-; ASM-NEXT:    vst.srs.s16.s32 bml5, s3, [p3], m4; mov dn5, r27
-; ASM-NEXT:    vst.srs.s16.s32 bmh6, s3, [p3, #32]; mov dj5, r28
-; ASM-NEXT:    vst.srs.s16.s32 bml6, s3, [p3], #64; mov m1, r10
-; ASM-NEXT:    vst.srs.s16.s32 bmh7, s3, [p3, #32]; mov m2, r13
-; ASM-NEXT:    padda.2d [p3], d5; vst.srs.s16.s32 bml7, s3, [p3, #0]; mov dj5, r11
+; ASM-NEXT:    vst.srs.s16.s32 bml4, s3, [p3], m7
+; ASM-NEXT:    vst.srs.s16.s32 bmh5, s3, [p3, #32]
+; ASM-NEXT:    vst.srs.s16.s32 bml5, s3, [p3], #64
+; ASM-NEXT:    vst.srs.s16.s32 bmh6, s3, [p3, #32]; mov dc5, r26
+; ASM-NEXT:    vst.srs.s16.s32 bml6, s3, [p3], m4; mov dn5, r27
+; ASM-NEXT:    vst.srs.s16.s32 bmh7, s3, [p3, #32]; mov dj5, r28
+; ASM-NEXT:    vst.srs.s16.s32 bml7, s3, [p3], #64; mov m1, r10
+; ASM-NEXT:    vst.srs.s16.s32 bmh0, s3, [p3, #32]; mov m2, r13
+; ASM-NEXT:    vst.2d.srs.s16.s32 bml0, s3, [p3], d5; mov dj5, r11
 ; ASM-NEXT:    add r7, r7, #-1; mov dn5, r12
 ; ASM-NEXT:    jnz r7, #.LBB0_1
 ; ASM-NEXT:    mov r26, dc5 // Delay Slot 5


### PR DESCRIPTION
QoR results are mixed, but I believe this is a change in the right direction as this is simplifying the MIR. Those combines are also needed if we want to post-pipeline benchmarks.

```
| Core_Compute_Cycle_Count      | Mul2D_0      | Mul2D_1      | Conv2D_2x8_0 | Mul2d_bf16_0 | ReduceSumAxis_7_aie2_int8 | ReduceMeanAxis_7_aie2_int8 | Mul2d_bf16_1 | Add2D_bf16_1 | Add2D_bf16_0 | ReduceSumAxis_6_aie2_int8 | ReduceSumAxis_3_aie2_int8 | ReduceSumAxis_5_aie2_int8 | ReduceMeanAxis_6_aie2_int8 | ReduceMeanAxis_3_aie2_int8 | ReduceMeanAxis_5_aie2_int8 | InstanceNormPart1_aie2_bf16_0 | LayerNormC8Part1_aie2_bf16_0 | ReduceSumAxis_7_aie2_bf16 | InstanceNormPart2_aie2_bf16_0 | ReduceMeanAxis_7_aie2_bf16 | InstanceNormPart1_aie2_int8_0 | ReduceSumAxis_6_aie2_bf16 | ReduceSumAxis_3_aie2_bf16 | ReduceSumAxis_5_aie2_bf16 | ReduceMeanAxis_5_aie2_bf16 | ReduceMeanAxis_6_aie2_bf16 | ReduceProdAxis_6_aie2_bf16 | ReduceProdAxis_5_aie2_bf16 | ReduceProdAxis_3_aie2_bf16 | LayerNormC8Part2_aie2_bf16_0 | ReduceProdAxis_7_aie2_bf16 | ReduceSumAxis_4_aie2_int8 | ReduceSumAxis_1_aie2_int8 | ReduceMeanAxis_1_aie2_int8 | ReduceSumAxis_2_aie2_int8 | ReduceMeanAxis_4_aie2_int8 | Mish_aie2_bfloat16 | ReduceMeanAxis_2_aie2_int8 | LayerNormC8Part1_aie2_int8_0 | ReduceSumAxis_1_aie2_bf16 | ReduceSumAxis_2_aie2_bf16 | ReduceSumAxis_4_aie2_bf16 | ReduceMeanAxis_1_aie2_bf16 | ReduceMeanAxis_4_aie2_bf16 | ReduceMeanAxis_2_aie2_bf16 | Conv2D_bf16_0 | ReduceProdAxis_2_aie2_bf16 | ReduceProdAxis_1_aie2_bf16 | ReduceProdAxis_4_aie2_bf16 | Conv2D_bf16_1 | Conv2D_Transpose_AIE2_0 | Conv2D_2x8_1 |    ...    | Mish_aie2_int8 | BatchNorm2D_0 | Conv2D_ReLU_1 | Conv2D_FC_0  | DilatedConv2D_1 | Conv2D_FC_1  | Conv2D_0     | Conv2D_mixed_batch_1 | BilinearInterpolation_1 | GEMM_int8_0  | GEMM_int8_1  | BilinearInterpolation_0 | Average diff |
| ----------------------------- | ------------ | ------------ | ------------ | ------------ | ------------------------- | -------------------------- | ------------ | ------------ | ------------ | ------------------------- | ------------------------- | ------------------------- | -------------------------- | -------------------------- | -------------------------- | ----------------------------- | ---------------------------- | ------------------------- | ----------------------------- | -------------------------- | ----------------------------- | ------------------------- | ------------------------- | ------------------------- | -------------------------- | -------------------------- | -------------------------- | -------------------------- | -------------------------- | ---------------------------- | -------------------------- | ------------------------- | ------------------------- | -------------------------- | ------------------------- | -------------------------- | ------------------ | -------------------------- | ---------------------------- | ------------------------- | ------------------------- | ------------------------- | -------------------------- | -------------------------- | -------------------------- | ------------- | -------------------------- | -------------------------- | -------------------------- | ------------- | ----------------------- | ------------ |    ...    | -------------- | ------------- | ------------- | ------------ | --------------- | ------------ | ------------ | -------------------- | ----------------------- | ------------ | ------------ | ----------------------- | ------------ |
| Baseline                      | 451          | 451          | 1684         | 416          | 2071                      | 2111                       | 272          | 311          | 257          | 2855                      | 2879                      | 2882                      | 2928                       | 2932                       | 2949                       | 2838                          | 8780                         | 6686                      | 13040                         | 6737                       | 11108                         | 7450                      | 7464                      | 7467                      | 7613                       | 7620                       | 10509                      | 10526                      | 10527                      | 11710                        | 2252                       | 7211                      | 7149                      | 7438                       | 7190                      | 7465                       | 5661               | 7500                       | 7712                         | 12349                     | 12372                     | 12387                     | 13438                      | 13444                      | 13474                      | 25071         | 18747                      | 37320                      | 37349                      | 39569         | 64836                   | 3811         |    ...    | 9418           | 386           | 27951         | 2692         | 5510            | 1177         | 7967         | 22344                | 378                     | 3019         | 36178        | 724                     |              |
| This PR                       | 496          | 496          | 1819         | 448          | 2215                      | 2255                       | 288          | 329          | 269          | 2945                      | 2969                      | 2972                      | 3018                       | 3022                       | 3039                       | 2906                          | 8952                         | 6814                      | 13288                         | 6865                       | 11303                         | 7578                      | 7592                      | 7595                      | 7743                       | 7750                       | 10677                      | 10694                      | 10695                      | 11894                        | 2284                       | 7302                      | 7235                      | 7527                       | 7275                      | 7553                       | 5726               | 7586                       | 7798                         | 12477                     | 12500                     | 12515                     | 13566                      | 13572                      | 13602                      | 25197         | 18835                      | 37488                      | 37517                      | 39655         | 64976                   | 3819         |    ...    | 9417           | 385           | 27503         | 2644         | 5382            | 1140         | 7687         | 21504                | 361                     | 2815         | 33499        | 667                     | +0.25%       |
| Total diff                    | REGR(+9.98%) | REGR(+9.98%) | REGR(+8.02%) | REGR(+7.69%) | REGR(+6.95%)              | REGR(+6.82%)               | REGR(+5.88%) | REGR(+5.79%) | REGR(+4.67%) | REGR(+3.15%)              | REGR(+3.13%)              | REGR(+3.12%)              | REGR(+3.07%)               | REGR(+3.07%)               | REGR(+3.05%)               | REGR(+2.40%)                  | REGR(+1.96%)                 | REGR(+1.91%)              | REGR(+1.90%)                  | REGR(+1.90%)               | REGR(+1.76%)                  | REGR(+1.72%)              | REGR(+1.71%)              | REGR(+1.71%)              | REGR(+1.71%)               | REGR(+1.71%)               | REGR(+1.60%)               | REGR(+1.60%)               | REGR(+1.60%)               | REGR(+1.57%)                 | REGR(+1.42%)               | REGR(+1.26%)              | REGR(+1.20%)              | REGR(+1.20%)               | REGR(+1.18%)              | REGR(+1.18%)               | REGR(+1.15%)       | REGR(+1.15%)               | REGR(+1.12%)                 | REGR(+1.04%)              | REGR(+1.03%)              | REGR(+1.03%)              | REGR(+0.95%)               | REGR(+0.95%)               | REGR(+0.95%)               | REGR(+0.50%)  | REGR(+0.47%)               | REGR(+0.45%)               | REGR(+0.45%)               | REGR(+0.22%)  | REGR(+0.22%)            | REGR(+0.21%) |    ...    | SAME(-0.01%)   | IMPR(-0.26%)  | IMPR(-1.60%)  | IMPR(-1.78%) | IMPR(-2.32%)    | IMPR(-3.14%) | IMPR(-3.51%) | IMPR(-3.76%)         | IMPR(-4.50%)            | IMPR(-6.76%) | IMPR(-7.41%) | IMPR(-7.87%)            | +0.25%       |
```

Some notes on the regressions:
- Mul2D goes from II=9 to II=10. We are still missing VST.SRS combining. Once this is there, this should be a candidate for the newer pipeliner
- Add2D/Mul2D bf16 variants: we now introduce lots of pointer copies instead of re-using the same pointer and enforcing ordering. This should be investigated separately
- ReduceSum/Mean int8 variants: should be handled in the post-pipeliner to target II=4
- Conv2D_2x8_0 The regression is in the outer loop. We are changing the live ranges of our 2D/3D iterators and forcing a spill