### PR TITLE
[AIEX] Improve iterative scheduling convergence strategy

### DIFF
--- a/llvm/lib/Target/AIE/AIEHazardRecognizer.cpp
+++ b/llvm/lib/Target/AIE/AIEHazardRecognizer.cpp
@@ -475,8 +475,13 @@ bool AIEHazardRecognizer::checkConflict(
                                           MemoryBanks);
     for (auto Cycles : MemoryAccessCycles) {
       // MemoryAccessCycles starts counting from 1, so we need to subtract 1
-      if (MemoryBankAccessCycle.conflict(Scoreboard[DeltaCycles + Cycles - 1]))
+      int AccessCycle = DeltaCycles + Cycles - 1;
+      if (MemoryBankAccessCycle.conflict(Scoreboard[AccessCycle])) {
+        LLVM_DEBUG(dbgs() << "*** Memory bank conflict in cycle=" << AccessCycle
+                          << ":\n";
+                   MemoryBankAccessCycle.dump(); dbgs() << "\n");
         return true;
+      }
     }
   }
 
@@ -496,8 +501,9 @@ bool AIEHazardRecognizer::checkConflict(
       assert(StageCycle < Scoreboard.getDepth());
 
       if (ThisCycle.conflict(Scoreboard[StageCycle])) {
-        LLVM_DEBUG(dbgs() << "*** Hazard in execution cycle"
-                          << StageCycle - DeltaCycles << ", ");
+        LLVM_DEBUG(dbgs() << "*** Hazard in cycle=" << StageCycle
+                          << " EC=" << StageCycle - DeltaCycles << ":\n";
+                   ThisCycle.dump(); dbgs() << "\n");
         return true;
       }
     }

--- a/llvm/lib/Target/AIE/AIEInterBlockScheduling.cpp
+++ b/llvm/lib/Target/AIE/AIEInterBlockScheduling.cpp
@@ -121,13 +121,16 @@ checkResourceConflicts(const ResourceScoreboard<FuncUnitWrapper> &Scoreboard,
 
   int BottomUpCycle = 0;
   for (const MachineBundle &B : reverse(PredBundles)) {
+    if (BottomUpCycle >= HR.getConflictHorizon())
+      break;
     for (MachineInstr *MI : B.getInstrs()) {
-      if (BottomUpCycle >= HR.getConflictHorizon())
-        break;
       if (HR.getHazardType(Scoreboard, MI->getDesc(), HR.getMemoryBanks(MI),
                            MI->operands(), MI->getMF()->getRegInfo(),
-                           -BottomUpCycle))
+                           -BottomUpCycle)) {
+        DEBUG_LOOPAWARE(dbgs() << "Conflicting MI at Bottom-up cycle="
+                               << BottomUpCycle << ": " << *MI);
         return MI;
+      }
     }
     ++BottomUpCycle;
   }

--- a/llvm/lib/Target/AIE/AIEInterBlockScheduling.h
+++ b/llvm/lib/Target/AIE/AIEInterBlockScheduling.h
@@ -144,6 +144,7 @@ public:
   // Parameters of the loop-aware convergence
   int LatencyMargin = 0;
   SmallMapVector<MachineInstr *, int, 8> PerMILatencyMargin;
+  SmallMapVector<MachineInstr *, int, 8> PerMIExtraDepth;
   int ResourceMargin = 0;
   // The II of the modulo schedule we are trying.
   int II = 0;
@@ -311,7 +312,10 @@ class InterBlockScheduling {
 
   /// Return one instruction that needs to be moved higher to avoid a resource
   /// conflict, or nullptr if all resources converged.
-  MachineInstr *resourcesConverged(BlockState &BS) const;
+  /// \param FindInBottomRegion Whether the conflicting instruction is searched
+  ///        in the Bottom or Top region of \p BS.
+  MachineInstr *resourcesConverged(BlockState &BS,
+                                   bool FindInBottomRegion = true) const;
 
   /// Return one instruction that needs a higher latency cap, or nullptr if all
   /// latencies converged.

--- a/llvm/test/CodeGen/AIE/aie2/end-to-end/Add2D-red.ll
+++ b/llvm/test/CodeGen/AIE/aie2/end-to-end/Add2D-red.ll
@@ -98,58 +98,58 @@ define void @add2d(ptr noalias %params, ptr noalias %ifm1_data, ptr noalias %ifm
 ; ASM-NEXT:    mova r0, #0 // Delay Slot 1
 ; ASM-NEXT:    .p2align 4
 ; ASM-NEXT:  .LBB0_2: // %entry.new
-; ASM-NEXT:    vlda.ups.s32.d8 cm0, s1, [p1], m1; nopb ; nopx ; mov dc0, #0; nops
+; ASM-NEXT:    vlda.ups.s32.d8 cm1, s1, [p1], m1; nopx ; mov dc0, #0
 ; ASM-NEXT:    vlda.ups.s32.d8 cm2, s1, [p1], m1; mov dc4, dc0
-; ASM-NEXT:    vlda.3d.ups.s32.d8 cm1, s1, [p2], d0
-; ASM-NEXT:    vlda.ups.s32.d8 cm3, s1, [p1], m1
-; ASM-NEXT:    vlda.3d.ups.s32.d8 cm4, s1, [p2], d0; mov crUPSSign, r4
-; ASM-NEXT:    vlda.3d.ups.s32.d8 cm5, s1, [p2], d0; mov s1, r2
-; ASM-NEXT:    vlda.ups.s32.d8 cm0, s1, [p1], m1
-; ASM-NEXT:    vlda.3d.ups.s32.d8 cm1, s1, [p2], d0
-; ASM-NEXT:    vlda.ups.s32.d8 cm2, s1, [p1], m1
-; ASM-NEXT:    vlda.3d.ups.s32.d8 cm8, s1, [p2], d0
+; ASM-NEXT:    vlda.3d.ups.s32.d8 cm4, s1, [p2], d0
 ; ASM-NEXT:    vlda.ups.s32.d8 cm5, s1, [p1], m1
-; ASM-NEXT:    vlda.3d.ups.s32.d8 cm6, s1, [p2], d0
-; ASM-NEXT:    vlda.3d.ups.s32.d8 cm4, s1, [p2], d0; vadd cm6, cm1, cm0, r0
+; ASM-NEXT:    vlda.3d.ups.s32.d8 cm6, s1, [p2], d0; mov crUPSSign, r4
+; ASM-NEXT:    vlda.ups.s32.d8 cm0, s1, [p1], m1; mov s1, r2
+; ASM-NEXT:    vlda.3d.ups.s32.d8 cm7, s1, [p2], d0
+; ASM-NEXT:    vlda.3d.ups.s32.d8 cm3, s1, [p2], d0
+; ASM-NEXT:    vlda.ups.s32.d8 cm2, s1, [p1], m1
+; ASM-NEXT:    vlda.3d.ups.s32.d8 cm5, s1, [p2], d0
+; ASM-NEXT:    vlda.3d.ups.s32.d8 cm7, s1, [p2], d0
+; ASM-NEXT:    vlda.ups.s32.d8 cm4, s1, [p1], m1
 ; ASM-NEXT:    vlda.ups.s32.d8 cm3, s1, [p1], m1
-; ASM-NEXT:    vlda.3d.ups.s32.d8 cm1, s1, [p2], d0; movx r6, #-4; vadd cm4, cm4, cm2, r0
-; ASM-NEXT:    vlda.ups.s32.d8 cm0, s1, [p1], m1; and r1, r1, r6; vadd cm3, cm5, cm3, r0
-; ASM-NEXT:    add r1, r1, #-4; mov crSRSSign, r3
-; ASM-NEXT:    add r1, r1, #-4; mov s0, r5
-; ASM-NEXT:    vst.srs.d8.s32 cm6, s0, [p3], #32; jz r1, #.LBB0_5
-; ASM-NEXT:    vst.srs.d8.s32 cm4, s0, [p3], #32; vadd cm8, cm8, cm2, r0 // Delay Slot 5
-; ASM-NEXT:    vst.srs.d8.s32 cm3, s0, [p3], #32; vadd cm7, cm1, cm0, r0 // Delay Slot 4
-; ASM-NEXT:    nop // Delay Slot 3
-; ASM-NEXT:    nop // Delay Slot 2
+; ASM-NEXT:    vlda.3d.ups.s32.d8 cm6, s1, [p2], d0; movx r6, #-4; vadd cm4, cm4, cm1, r0
+; ASM-NEXT:    vlda.ups.s32.d8 cm0, s1, [p1], m1; and r1, r1, r6; vadd cm6, cm6, cm2, r0
+; ASM-NEXT:    vlda.3d.ups.s32.d8 cm1, s1, [p2], d0; add r1, r1, #-4; vadd cm1, cm7, cm5, r0
+; ASM-NEXT:    add r1, r1, #-4; mov crSRSSign, r3; vadd cm8, cm3, cm0, r0
+; ASM-NEXT:    jz r1, #.LBB0_5
+; ASM-NEXT:    mov s0, r5 // Delay Slot 5
+; ASM-NEXT:    vst.srs.d8.s32 cm4, s0, [p3], #32 // Delay Slot 4
+; ASM-NEXT:    vst.srs.d8.s32 cm6, s0, [p3], #32 // Delay Slot 3
+; ASM-NEXT:    vst.srs.d8.s32 cm1, s0, [p3], #32 // Delay Slot 2
 ; ASM-NEXT:    nop // Delay Slot 1
 ; ASM-NEXT:    .p2align 4
 ; ASM-NEXT:  .LBB0_3: // %for.body
 ; ASM-NEXT:    // =>This Inner Loop Header: Depth=1
-; ASM-NEXT:    nopb ; vlda.ups.s32.d8 cm2, s1, [p1], m1; nops ; nopxm ; nopv
-; ASM-NEXT:    vlda.3d.ups.s32.d8 cm6, s1, [p2], d0; nopx ; vadd cm5, cm6, cm5, r0
-; ASM-NEXT:    vlda.ups.s32.d8 cm5, s1, [p1], m1
-; ASM-NEXT:    vlda.3d.ups.s32.d8 cm6, s1, [p2], d0; add r1, r1, #-4
-; ASM-NEXT:    vst.srs.d8.s32 cm7, s0, [p3], #32; jnz r1, #.LBB0_3; vadd cm3, cm4, cm3, r0
-; ASM-NEXT:    vlda.ups.s32.d8 cm3, s1, [p1], m1; vst.srs.d8.s32 cm8, s0, [p3], #32 // Delay Slot 5
-; ASM-NEXT:    vlda.3d.ups.s32.d8 cm4, s1, [p2], d0 // Delay Slot 4
-; ASM-NEXT:    vst.srs.d8.s32 cm5, s0, [p3], #32 // Delay Slot 3
-; ASM-NEXT:    vlda.ups.s32.d8 cm0, s1, [p1], m1; vadd cm7, cm1, cm0, r0 // Delay Slot 2
-; ASM-NEXT:    vlda.3d.ups.s32.d8 cm1, s1, [p2], d0; vst.srs.d8.s32 cm3, s0, [p3], #32; vadd cm8, cm6, cm2, r0 // Delay Slot 1
+; ASM-NEXT:    nopb ; nopa ; nops ; nopxm ; vadd cm5, cm5, cm2, r0
+; ASM-NEXT:    vlda.3d.ups.s32.d8 cm5, s1, [p2], d0; vadd cm2, cm7, cm4, r0
+; ASM-NEXT:    vlda.ups.s32.d8 cm2, s1, [p1], m1; vadd cm3, cm6, cm3, r0
+; ASM-NEXT:    vlda.3d.ups.s32.d8 cm7, s1, [p2], d0
+; ASM-NEXT:    vlda.ups.s32.d8 cm4, s1, [p1], m1; add r1, r1, #-4
+; ASM-NEXT:    vlda.3d.ups.s32.d8 cm6, s1, [p2], d0; vst.srs.d8.s32 cm8, s0, [p3], #32; jnz r1, #.LBB0_3
+; ASM-NEXT:    vlda.ups.s32.d8 cm3, s1, [p1], m1; vst.srs.d8.s32 cm5, s0, [p3], #32 // Delay Slot 5
+; ASM-NEXT:    vst.srs.d8.s32 cm2, s0, [p3], #32 // Delay Slot 4
+; ASM-NEXT:    nop // Delay Slot 3
+; ASM-NEXT:    vlda.3d.ups.s32.d8 cm1, s1, [p2], d0; vst.srs.d8.s32 cm3, s0, [p3], #32 // Delay Slot 2
+; ASM-NEXT:    vlda.ups.s32.d8 cm0, s1, [p1], m1; vadd cm8, cm1, cm0, r0 // Delay Slot 1
 ; ASM-NEXT:  // %bb.4:
-; ASM-NEXT:    nopa ; nopxm
-; ASM-NEXT:    nop
+; ASM-NEXT:    nopa ; nopb ; nopxm
 ; ASM-NEXT:    nop
 ; ASM-NEXT:    nop
 ; ASM-NEXT:    .p2align 4
 ; ASM-NEXT:  .LBB0_5:
-; ASM-NEXT:    nopb ; nopa ; nops ; nopxm ; vadd cm5, cm6, cm5, r0
-; ASM-NEXT:    vadd cm3, cm4, cm3, r0
+; ASM-NEXT:    nopa ; nopb ; nopx ; vadd cm4, cm7, cm4, r0
+; ASM-NEXT:    vadd cm3, cm6, cm3, r0
+; ASM-NEXT:    vadd cm2, cm5, cm2, r0
 ; ASM-NEXT:    vadd cm0, cm1, cm0, r0
 ; ASM-NEXT:    nop
 ; ASM-NEXT:    nop
-; ASM-NEXT:    vst.srs.d8.s32 cm7, s0, [p3], #32
 ; ASM-NEXT:    vst.srs.d8.s32 cm8, s0, [p3], #32
-; ASM-NEXT:    vst.srs.d8.s32 cm5, s0, [p3], #32
+; ASM-NEXT:    vst.srs.d8.s32 cm2, s0, [p3], #32
+; ASM-NEXT:    vst.srs.d8.s32 cm4, s0, [p3], #32
 ; ASM-NEXT:    vst.srs.d8.s32 cm3, s0, [p3], #32; mov crUPSSign, #0
 ; ASM-NEXT:    vst.srs.d8.s32 cm0, s0, [p3], #32; mov r6, dc0
 ; ASM-NEXT:    mov r0, dc4

--- a/llvm/test/CodeGen/AIE/aie2/end-to-end/Add2D-red.ll
+++ b/llvm/test/CodeGen/AIE/aie2/end-to-end/Add2D-red.ll
@@ -98,7 +98,7 @@ define void @add2d(ptr noalias %params, ptr noalias %ifm1_data, ptr noalias %ifm
 ; ASM-NEXT:    mova r0, #0 // Delay Slot 1
 ; ASM-NEXT:    .p2align 4
 ; ASM-NEXT:  .LBB0_2: // %entry.new
-; ASM-NEXT:    vlda.ups.s32.d8 cm1, s1, [p1], m1; nopx ; mov dc0, #0
+; ASM-NEXT:    vlda.ups.s32.d8 cm1, s1, [p1], m1; mov dc0, #0
 ; ASM-NEXT:    vlda.ups.s32.d8 cm2, s1, [p1], m1; mov dc4, dc0
 ; ASM-NEXT:    vlda.3d.ups.s32.d8 cm4, s1, [p2], d0
 ; ASM-NEXT:    vlda.ups.s32.d8 cm5, s1, [p1], m1
@@ -111,30 +111,30 @@ define void @add2d(ptr noalias %params, ptr noalias %ifm1_data, ptr noalias %ifm
 ; ASM-NEXT:    vlda.3d.ups.s32.d8 cm7, s1, [p2], d0
 ; ASM-NEXT:    vlda.ups.s32.d8 cm4, s1, [p1], m1
 ; ASM-NEXT:    vlda.ups.s32.d8 cm3, s1, [p1], m1
-; ASM-NEXT:    vlda.3d.ups.s32.d8 cm6, s1, [p2], d0; movx r6, #-4; vadd cm4, cm4, cm1, r0
-; ASM-NEXT:    vlda.ups.s32.d8 cm0, s1, [p1], m1; and r1, r1, r6; vadd cm6, cm6, cm2, r0
-; ASM-NEXT:    vlda.3d.ups.s32.d8 cm1, s1, [p2], d0; add r1, r1, #-4; vadd cm1, cm7, cm5, r0
+; ASM-NEXT:    vlda.3d.ups.s32.d8 cm6, s1, [p2], d0; vadd cm4, cm4, cm1, r0
+; ASM-NEXT:    vlda.ups.s32.d8 cm0, s1, [p1], m1; movx r6, #-4; vadd cm6, cm6, cm2, r0
+; ASM-NEXT:    vlda.3d.ups.s32.d8 cm1, s1, [p2], d0; and r1, r1, r6; vadd cm1, cm7, cm5, r0
 ; ASM-NEXT:    add r1, r1, #-4; mov crSRSSign, r3; vadd cm8, cm3, cm0, r0
+; ASM-NEXT:    add r1, r1, #-4; mov s0, r5
 ; ASM-NEXT:    jz r1, #.LBB0_5
-; ASM-NEXT:    mov s0, r5 // Delay Slot 5
-; ASM-NEXT:    vst.srs.d8.s32 cm4, s0, [p3], #32 // Delay Slot 4
-; ASM-NEXT:    vst.srs.d8.s32 cm6, s0, [p3], #32 // Delay Slot 3
-; ASM-NEXT:    vst.srs.d8.s32 cm1, s0, [p3], #32 // Delay Slot 2
+; ASM-NEXT:    vst.srs.d8.s32 cm4, s0, [p3], #32 // Delay Slot 5
+; ASM-NEXT:    vst.srs.d8.s32 cm6, s0, [p3], #32 // Delay Slot 4
+; ASM-NEXT:    vst.srs.d8.s32 cm1, s0, [p3], #32 // Delay Slot 3
+; ASM-NEXT:    nop // Delay Slot 2
 ; ASM-NEXT:    nop // Delay Slot 1
 ; ASM-NEXT:    .p2align 4
 ; ASM-NEXT:  .LBB0_3: // %for.body
 ; ASM-NEXT:    // =>This Inner Loop Header: Depth=1
-; ASM-NEXT:    nopb ; nopa ; nops ; nopxm ; vadd cm5, cm5, cm2, r0
-; ASM-NEXT:    vlda.3d.ups.s32.d8 cm5, s1, [p2], d0; vadd cm2, cm7, cm4, r0
+; ASM-NEXT:    nopb ; vlda.3d.ups.s32.d8 cm5, s1, [p2], d0; nops ; nopxm ; vadd cm5, cm5, cm2, r0
+; ASM-NEXT:    vlda.3d.ups.s32.d8 cm7, s1, [p2], d0; nopb ; nopx ; vadd cm2, cm7, cm4, r0
 ; ASM-NEXT:    vlda.ups.s32.d8 cm2, s1, [p1], m1; vadd cm3, cm6, cm3, r0
-; ASM-NEXT:    vlda.3d.ups.s32.d8 cm7, s1, [p2], d0
-; ASM-NEXT:    vlda.ups.s32.d8 cm4, s1, [p1], m1; add r1, r1, #-4
-; ASM-NEXT:    vlda.3d.ups.s32.d8 cm6, s1, [p2], d0; vst.srs.d8.s32 cm8, s0, [p3], #32; jnz r1, #.LBB0_3
-; ASM-NEXT:    vlda.ups.s32.d8 cm3, s1, [p1], m1; vst.srs.d8.s32 cm5, s0, [p3], #32 // Delay Slot 5
-; ASM-NEXT:    vst.srs.d8.s32 cm2, s0, [p3], #32 // Delay Slot 4
+; ASM-NEXT:    vlda.3d.ups.s32.d8 cm6, s1, [p2], d0; add r1, r1, #-4
+; ASM-NEXT:    vlda.ups.s32.d8 cm4, s1, [p1], m1; jnz r1, #.LBB0_3
+; ASM-NEXT:    vlda.ups.s32.d8 cm3, s1, [p1], m1; vst.srs.d8.s32 cm8, s0, [p3], #32 // Delay Slot 5
+; ASM-NEXT:    vst.srs.d8.s32 cm5, s0, [p3], #32 // Delay Slot 4
 ; ASM-NEXT:    nop // Delay Slot 3
-; ASM-NEXT:    vlda.3d.ups.s32.d8 cm1, s1, [p2], d0; vst.srs.d8.s32 cm3, s0, [p3], #32 // Delay Slot 2
-; ASM-NEXT:    vlda.ups.s32.d8 cm0, s1, [p1], m1; vadd cm8, cm1, cm0, r0 // Delay Slot 1
+; ASM-NEXT:    vlda.3d.ups.s32.d8 cm1, s1, [p2], d0; vst.srs.d8.s32 cm2, s0, [p3], #32 // Delay Slot 2
+; ASM-NEXT:    vlda.ups.s32.d8 cm0, s1, [p1], m1; vst.srs.d8.s32 cm3, s0, [p3], #32; vadd cm8, cm1, cm0, r0 // Delay Slot 1
 ; ASM-NEXT:  // %bb.4:
 ; ASM-NEXT:    nopa ; nopb ; nopxm
 ; ASM-NEXT:    nop

--- a/llvm/test/CodeGen/AIE/aie2/schedule/loopaware/Add2D-like.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/loopaware/Add2D-like.mir
@@ -47,12 +47,12 @@ body:             |
   ; CHECK-NEXT:   successors: %bb.1(0x40000000), %bb.2(0x40000000)
   ; CHECK-NEXT:   liveins: $cm0, $cm4, $dc0, $dc4, $dj0, $dj4, $dn0, $dn4, $m0, $m1, $p1, $p2, $p3, $r0, $r1, $s0, $s1, $d0_3d:0x000000000001C870
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT:   BUNDLE implicit-def $cm0, implicit-def $bml0, implicit-def $amll0, implicit-def $amlh0, implicit-def $bmh0, implicit-def $amhl0, implicit-def $amhh0, implicit-def $p1, implicit-def $srups_of, implicit-def $cm8, implicit-def $bml8, implicit-def $amll8, implicit-def $amlh8, implicit-def $bmh8, implicit-def $amhl8, implicit-def $amhh8, implicit $s1, implicit killed $p1, implicit $m1, implicit $crsat, implicit $crupssign, implicit killed $cm4, implicit $r0 {
-  ; CHECK-NEXT:     renamable $cm0, renamable $p1 = VLDA_UPS_S32_D8_ag_pstm_nrm renamable $s1, killed renamable $p1, renamable $m1, implicit-def $srups_of, implicit $crsat, implicit $crupssign :: (load (<32 x s8>) from stack - 32)
-  ; CHECK-NEXT:     renamable $cm8 = VADD killed renamable $cm4, internal renamable $cm0, renamable $r0
-  ; CHECK-NEXT:   }
-  ; CHECK-NEXT:   BUNDLE implicit-def $cm4, implicit-def $bml4, implicit-def $amll4, implicit-def $amlh4, implicit-def $bmh4, implicit-def $amhl4, implicit-def $amhh4, implicit-def $p2, implicit-def $dc0, implicit-def $dc4, implicit-def $srups_of, implicit-def $r1, implicit-def dead $srcarry, implicit $s1, implicit killed $p2, implicit $d0_3d, implicit $crsat, implicit $crupssign, implicit killed $r1 {
+  ; CHECK-NEXT:   BUNDLE implicit-def $cm4, implicit-def $bml4, implicit-def $amll4, implicit-def $amlh4, implicit-def $bmh4, implicit-def $amhl4, implicit-def $amhh4, implicit-def $p2, implicit-def $dc0, implicit-def $dc4, implicit-def $srups_of, implicit-def $cm8, implicit-def $bml8, implicit-def $amll8, implicit-def $amlh8, implicit-def $bmh8, implicit-def $amhl8, implicit-def $amhh8, implicit $s1, implicit killed $p2, implicit $d0_3d, implicit $crsat, implicit $crupssign, implicit killed $cm0, implicit $r0 {
   ; CHECK-NEXT:     $cm4, $p2, $dc0, $dc4 = VLDA_3D_UPS_S32_D8 $s1, killed $p2, $d0_3d, implicit-def $srups_of, implicit $crsat, implicit $crupssign :: (load (<32 x s8>) from stack - 64)
+  ; CHECK-NEXT:     renamable $cm8 = VADD internal renamable $cm4, killed renamable $cm0, renamable $r0
+  ; CHECK-NEXT:   }
+  ; CHECK-NEXT:   BUNDLE implicit-def $cm0, implicit-def $bml0, implicit-def $amll0, implicit-def $amlh0, implicit-def $bmh0, implicit-def $amhl0, implicit-def $amhh0, implicit-def $p1, implicit-def $srups_of, implicit-def $r1, implicit-def dead $srcarry, implicit $s1, implicit killed $p1, implicit $m1, implicit $crsat, implicit $crupssign, implicit killed $r1 {
+  ; CHECK-NEXT:     renamable $cm0, renamable $p1 = VLDA_UPS_S32_D8_ag_pstm_nrm renamable $s1, killed renamable $p1, renamable $m1, implicit-def $srups_of, implicit $crsat, implicit $crupssign :: (load (<32 x s8>) from stack - 32)
   ; CHECK-NEXT:     renamable $r1 = ADD_add_r_ri killed renamable $r1, -4, implicit-def dead $srcarry
   ; CHECK-NEXT:   }
   ; CHECK-NEXT:   JNZ renamable $r1, %bb.1


### PR DESCRIPTION
This brings a new convergence strategy that can bias the depth of some SUnits. Doing so can shift part of the schedule up or down in the scoreboard and avoid resource conflicts without necessarily increasing the latency of the whole region.

Looking at Add2D, this helps us place the VLD instructions better and avoid bank conflicts with the next iteration of the loop. We can then disable the heuristic in `WAWStickyRegistersEdges` and more aggressively remove WAW edges on status registers. This is what the first commit does.

QoR is fine, there are still major regressions coming from `Neg_aie2_1` and `HardSigmoidTemplated_int8_0` (same as already mentioned in https://github.com/Xilinx/llvm-aie/pull/183#discussion_r1793032655), but other regressions are avoided.
And those two benchmarks are expected to be tackled in the new post-pipeliner soon.

```
| Core_Compute_Cycle_Count   | Neg_aie2_1    | HardSigmoidTemplated_int8_0 |     | Add2D_0      | Add2D_Standalone_0 | Add2D_Standalone_1 |     | Shrink_aie2_0 | Tanh_int8_0  | TanhTemplated_aie2_int8 | Tanh_int8_1  | Add2D_1      | HardSigmoidTemplated_bf16_0 | Average diff |
| -------------------------- | ------------- | --------------------------- | --- | ------------ | ------------------ | ------------------ | --- | ------------- | ------------ | ----------------------- | ------------ | ------------ | --------------------------- | ------------ |
| Baseline                   | 343(+0.00%)   | 257(+0.00%)                 | ... | 217(+0.00%)  | 322(+0.00%)        | 482(+0.00%)        | ... | 672(+0.00%)   | 349(+0.00%)  | 310(+0.00%)             | 421(+0.00%)  | 466(+0.00%)  | 617(+0.00%)                 | +0.00%       |
| Disabling heursitics       | 463(+34.99%)  | 284(+10.51%)                | ... | 230(+5.99%)  | 335(+4.04%)        | 511(+6.02%)        | ... | 672(+0.00%)   | 339(-2.87%)  | 300(-3.23%)             | 407(-3.33%)  | 466(+0.00%)  | 556(-9.89%)                 | +0.12%       |
| New convergence heuristic  | 462(-0.22%)   | 284(+0.00%)                 |     | 217(-5.65%)  | 322(-3.88%)        | 482(-5.68%)        |     | 658(-2.08%)   | 339(+0.00%)  | 300(+0.00%)             | 407(+0.00%)  | 434(-6.87%)  | 556(+0.00%)                 | -0.07%       |
| Overall diff               | REGR(+34.69%) | REGR(+10.51%)               |     | SAME(+0.00%) | SAME(+0.00%)       | SAME(+0.00%)       |     | IMPR(-2.08%)  | IMPR(-2.87%) | IMPR(-3.23%)            | IMPR(-3.33%) | IMPR(-6.87%) | IMPR(-9.89%)                | +0.05%       |
```

Better review commit by commit :)