### PR TITLE
[AIE2] Fix VMOV instruction itinerary

### DIFF
--- a/llvm/lib/Target/AIE/AIE2GenFixupInstrInfo.td
+++ b/llvm/lib/Target/AIE/AIE2GenFixupInstrInfo.td
@@ -762,7 +762,9 @@ let Itinerary = II_VMOV_W in {
                            ItinRegClassPair<II_VMOV_W_WMH_WML,[OperandRegClass<0, eWH>, OperandRegClass<1, eWL>]>,						   
                            ItinRegClassPair<II_VMOV_W_WML_WMH,[OperandRegClass<0, eWL>, OperandRegClass<1, eWH>]>,
                            ItinRegClassPair<II_VMOV_W_WML_Q, [OperandRegClass<0, eWL>, OperandRegClass<1, mQQm>]>,
-                           ItinRegClassPair<II_VMOV_W_WMH_Q, [OperandRegClass<0, eWH>, OperandRegClass<1, mQQm>]>] in {	
+                           ItinRegClassPair<II_VMOV_W_WMH_Q, [OperandRegClass<0, eWH>, OperandRegClass<1, mQQm>]>,
+                           ItinRegClassPair<II_VMOV_W_Q_WML, [OperandRegClass<0, mQQm>, OperandRegClass<1, eWL>]>,
+                           ItinRegClassPair<II_VMOV_W_Q_WMH, [OperandRegClass<0, mQQm>, OperandRegClass<1, eWH>]>] in {	
 	def VMOV_mv_w : AIE2_mv_w_inst_mv< (outs OP_mMvAMWQDst:$dst), (ins OP_mMvAMWQSrc:$src),
 		"vmov", "$dst, $src">;
   }

--- a/llvm/lib/Target/AIE/AIE2GenFixupInstrInfo.td
+++ b/llvm/lib/Target/AIE/AIE2GenFixupInstrInfo.td
@@ -760,7 +760,9 @@ let Itinerary = II_VMOV_W in {
                            ItinRegClassPair<II_VMOV_W_WMH_WMH,[OperandRegClass<0, eWH>, OperandRegClass<1, eWH>]>,
                            ItinRegClassPair<II_VMOV_W_WML_WML,[OperandRegClass<0, eWL>, OperandRegClass<1, eWL>]>,
                            ItinRegClassPair<II_VMOV_W_WMH_WML,[OperandRegClass<0, eWH>, OperandRegClass<1, eWL>]>,						   
-                           ItinRegClassPair<II_VMOV_W_WML_WMH,[OperandRegClass<0, eWL>, OperandRegClass<1, eWH>]>] in {	
+                           ItinRegClassPair<II_VMOV_W_WML_WMH,[OperandRegClass<0, eWL>, OperandRegClass<1, eWH>]>,
+                           ItinRegClassPair<II_VMOV_W_WML_Q, [OperandRegClass<0, eWL>, OperandRegClass<1, mQQm>]>,
+                           ItinRegClassPair<II_VMOV_W_WMH_Q, [OperandRegClass<0, eWH>, OperandRegClass<1, mQQm>]>] in {	
 	def VMOV_mv_w : AIE2_mv_w_inst_mv< (outs OP_mMvAMWQDst:$dst), (ins OP_mMvAMWQSrc:$src),
 		"vmov", "$dst, $src">;
   }

--- a/llvm/lib/Target/AIE/AIE2Schedule.td
+++ b/llvm/lib/Target/AIE/AIE2Schedule.td
@@ -348,6 +348,8 @@ def II_VMOV_W_WMH_WMH : InstrItinClass;
 def II_VMOV_W_WML_WMH : InstrItinClass;
 def II_VMOV_W_WMH_WML : InstrItinClass;
 def II_VMOV_W_WML_WML : InstrItinClass;
+def II_VMOV_W_WML_Q : InstrItinClass;
+def II_VMOV_W_WMH_Q : InstrItinClass;
 def II_VMOV_X : InstrItinClass;
 def II_VMOV_X_BM_BM : InstrItinClass;
 def II_VMOV_X_BM_XM : InstrItinClass;
@@ -993,6 +995,10 @@ InstrItinData<II_VMOV_W_WMH_WML, [EmptyCycles<1>, SimpleCycle<W_WM_PORT>],
               [2,1], [NoBypass, MOV_Bypass]>,
 InstrItinData<II_VMOV_W_WML_WML, [EmptyCycles<1>, SimpleCycle<W_WM_PORT>],
               [2,1], [MOV_Bypass, MOV_Bypass]>,
+InstrItinData<II_VMOV_W_WML_Q, [EmptyCycles<1>, SimpleCycle<W_WM_PORT>],
+              [2,1], [MOV_Bypass, NoBypass]>,
+InstrItinData<II_VMOV_W_WMH_Q, [EmptyCycles<1>, SimpleCycle<W_WM_PORT>],
+              [2,1], [NoBypass, NoBypass]>,
 InstrItinData<II_VMOV_X, [SimpleCycle<CM_RM_PORT>, PrefixCycle<W_WM_PORT>, SimpleCycle<CM_WM_PORT>],
               [2,1], [NoBypass, NoBypass]>,
 InstrItinData<II_VMOV_X_BM_BM, [SimpleCycle<CM_RM_PORT>, SimpleCycle<CM_WM_PORT>],

--- a/llvm/lib/Target/AIE/AIE2Schedule.td
+++ b/llvm/lib/Target/AIE/AIE2Schedule.td
@@ -350,6 +350,8 @@ def II_VMOV_W_WMH_WML : InstrItinClass;
 def II_VMOV_W_WML_WML : InstrItinClass;
 def II_VMOV_W_WML_Q : InstrItinClass;
 def II_VMOV_W_WMH_Q : InstrItinClass;
+def II_VMOV_W_Q_WML : InstrItinClass;
+def II_VMOV_W_Q_WMH : InstrItinClass;
 def II_VMOV_X : InstrItinClass;
 def II_VMOV_X_BM_BM : InstrItinClass;
 def II_VMOV_X_BM_XM : InstrItinClass;
@@ -998,6 +1000,10 @@ InstrItinData<II_VMOV_W_WML_WML, [EmptyCycles<1>, SimpleCycle<W_WM_PORT>],
 InstrItinData<II_VMOV_W_WML_Q, [EmptyCycles<1>, SimpleCycle<W_WM_PORT>],
               [2,1], [MOV_Bypass, NoBypass]>,
 InstrItinData<II_VMOV_W_WMH_Q, [EmptyCycles<1>, SimpleCycle<W_WM_PORT>],
+              [2,1], [NoBypass, NoBypass]>,
+InstrItinData<II_VMOV_W_Q_WML, [EmptyCycles<1>, SimpleCycle<W_WM_PORT>],
+              [2,1], [NoBypass, MOV_Bypass]>,
+InstrItinData<II_VMOV_W_Q_WMH, [EmptyCycles<1>, SimpleCycle<W_WM_PORT>],
               [2,1], [NoBypass, NoBypass]>,
 InstrItinData<II_VMOV_X, [SimpleCycle<CM_RM_PORT>, PrefixCycle<W_WM_PORT>, SimpleCycle<CM_WM_PORT>],
               [2,1], [NoBypass, NoBypass]>,

--- a/llvm/test/CodeGen/AIE/aie2/schedule/mov_bypass.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/mov_bypass.mir
@@ -149,6 +149,33 @@ body:             |
 ...
 
 ---
+name:            bypass_q_wl
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: bypass_q_wl
+    ; CHECK: $wl1 = VMOV_mv_w killed $wl0
+    ; CHECK-NEXT: $q0 = VMOV_mv_w killed $wl1
+    ; CHECK-NEXT: NOP
+    $wl1 = VMOV_mv_w $wl0
+    $q0 = VMOV_mv_w $wl1
+...
+
+---
+name:            no_bypass_q_wh
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: no_bypass_q_wh
+    ; CHECK: $wh1 = VMOV_mv_w killed $wl0
+    ; CHECK-NEXT: NOP
+    ; CHECK-NEXT: $q0 = VMOV_mv_w killed $wh1
+    ; CHECK-NEXT: NOP
+    $wh1 = VMOV_mv_w $wl0
+    $q0 = VMOV_mv_w $wh1
+...
+
+---
 name:            bypass_x
 alignment:       16
 body:             |

--- a/llvm/test/CodeGen/AIE/aie2/schedule/mov_bypass.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/mov_bypass.mir
@@ -122,6 +122,33 @@ body:             |
 ...
 
 ---
+name:            bypass_wl_q
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: bypass_wl_q
+    ; CHECK: $wl1 = VMOV_mv_w killed $q0
+    ; CHECK-NEXT: $wl0 = VMOV_mv_w killed $wl1
+    ; CHECK-NEXT: NOP
+    $wl1 = VMOV_mv_w $q0
+    $wl0 = VMOV_mv_w $wl1
+...
+
+---
+name:            no_bypass_wh_q
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: no_bypass_wh_q
+    ; CHECK: $wh1 = VMOV_mv_w killed $q0
+    ; CHECK-NEXT: NOP
+    ; CHECK-NEXT: $wl0 = VMOV_mv_w killed $wh1
+    ; CHECK-NEXT: NOP
+    $wh1 = VMOV_mv_w $q0
+    $wl0 = VMOV_mv_w $wh1
+...
+
+---
 name:            bypass_x
 alignment:       16
 body:             |
@@ -176,11 +203,11 @@ body:             |
 ...
 
 ---
-name:            bypass_wh_vconv
+name:            no_bypass_wh_vconv
 alignment:       16
 body:             |
   bb.0.entry:
-    ; CHECK-LABEL: name: bypass_wh_vconv
+    ; CHECK-LABEL: name: no_bypass_wh_vconv
     ; CHECK: $wh1 = VMOV_mv_w killed $wh0
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: $bmh0 = VCONV_FP32_BF16 killed $wh1

--- a/llvm/test/CodeGen/AIE/aie2/schedule/resource/w_wm.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/resource/w_wm.mir
@@ -275,3 +275,42 @@ body:             |
     $wl3 = VSRSM_D16_S32 $bmh0, $s0, implicit-def $srsrs_of, implicit $crsat, implicit $crrnd, implicit $crsrssign
     $wl3 = VSRSM_D16_S32 $bmh0, $s0, implicit-def $srsrs_of, implicit $crsat, implicit $crrnd, implicit $crsrssign
 ...
+
+# VSRSM accesses vector WM write port in cycle 4, VMOV in cycle 2 when writing to eWL/eWH register class
+---
+name:            E4_VSRSM_E2_VMOV_WL_Q
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: E4_VSRSM_E2_VMOV_WL_Q
+    ; CHECK: $wl3 = VSRSM_D16_S32 $bmh0, $s0, implicit-def $srsrs_of, implicit $crsat, implicit $crrnd, implicit $crsrssign
+    ; CHECK-NEXT: $wl3 = VSRSM_D16_S32 $bmh0, $s0, implicit-def $srsrs_of, implicit $crsat, implicit $crrnd, implicit $crsrssign
+    ; CHECK-NEXT: $wl3 = VSRSM_D16_S32 killed $bmh0, killed $s0, implicit-def $srsrs_of, implicit $crsat, implicit $crrnd, implicit $crsrssign
+    ; CHECK-NEXT: NOP
+    ; CHECK-NEXT: NOP
+    ; CHECK-NEXT: $wl0 = VMOV_mv_w killed $q0
+    ; CHECK-NEXT: NOP
+    $wl0  = VMOV_mv_w  $q0
+    $wl3 = VSRSM_D16_S32 $bmh0, $s0, implicit-def $srsrs_of, implicit $crsat, implicit $crrnd, implicit $crsrssign
+    $wl3 = VSRSM_D16_S32 $bmh0, $s0, implicit-def $srsrs_of, implicit $crsat, implicit $crrnd, implicit $crsrssign
+    $wl3 = VSRSM_D16_S32 $bmh0, $s0, implicit-def $srsrs_of, implicit $crsat, implicit $crrnd, implicit $crsrssign
+...
+
+---
+name:            E4_VSRSM_E2_VMOV_WH_Q
+alignment:       16
+body:             |
+  bb.0.entry:
+    ; CHECK-LABEL: name: E4_VSRSM_E2_VMOV_WH_Q
+    ; CHECK: $wl3 = VSRSM_D16_S32 $bmh0, $s0, implicit-def $srsrs_of, implicit $crsat, implicit $crrnd, implicit $crsrssign
+    ; CHECK-NEXT: $wl3 = VSRSM_D16_S32 $bmh0, $s0, implicit-def $srsrs_of, implicit $crsat, implicit $crrnd, implicit $crsrssign
+    ; CHECK-NEXT: $wl3 = VSRSM_D16_S32 killed $bmh0, killed $s0, implicit-def $srsrs_of, implicit $crsat, implicit $crrnd, implicit $crsrssign
+    ; CHECK-NEXT: NOP
+    ; CHECK-NEXT: NOP
+    ; CHECK-NEXT: $wh0 = VMOV_mv_w killed $q0
+    ; CHECK-NEXT: NOP
+    $wh0  = VMOV_mv_w  $q0
+    $wl3 = VSRSM_D16_S32 $bmh0, $s0, implicit-def $srsrs_of, implicit $crsat, implicit $crrnd, implicit $crsrssign
+    $wl3 = VSRSM_D16_S32 $bmh0, $s0, implicit-def $srsrs_of, implicit $crsat, implicit $crrnd, implicit $crsrssign
+    $wl3 = VSRSM_D16_S32 $bmh0, $s0, implicit-def $srsrs_of, implicit $crsat, implicit $crrnd, implicit $crsrssign
+...


### PR DESCRIPTION
Changes done in this PR were identified by @konstantinschwarz for fixing the DIFF issue in FullyConnect_aie2_bf16

ISSUE : In a specific case the compiler was assuming that VMOV has a latency of 2, i.e. it can still use the old value of $wlX when written from $qX reg, but since the DST reg was of $wlX type which uses the bypass path and overwrites the value one cycle earlier, leading to wrong value being read. 