### PR TITLE
Use last known good LLVM Docker build container image

### DIFF
--- a/.github/workflows/llvm-project-tests.yml
+++ b/.github/workflows/llvm-project-tests.yml
@@ -67,7 +67,7 @@ jobs:
     name: Lit Tests
     runs-on: ${{ matrix.os }}
     container:
-      image: ${{(startsWith(matrix.os, 'ubuntu') && 'ghcr.io/llvm/ci-ubuntu-22.04:latest') || null}}
+      image: ${{(startsWith(matrix.os, 'ubuntu') && 'ghcr.io/llvm/ci-ubuntu-22.04:1734381129') || null}}
       volumes:
         - /mnt/:/mnt/
     strategy:


### PR DESCRIPTION
Pinning last known good version of the `ci-ubuntu-22.04` image (Dec 16 2024) to resolve errors with `setup ccache` like seen here: https://github.com/Xilinx/llvm-aie/actions/runs/12581321418/job/35195137449?pr=233

The latest version of `ci-ubuntu-22.04` (Jan 3 2025) broke that action.

Release history for the container image:
https://github.com/llvm/llvm-project/pkgs/container/ci-ubuntu-22.04

Ticket tracking task to bring back compatibility with latest: https://jira.xilinx.com/browse/APRO-1001