### PR TITLE
Extend ZOL to recognize static bounded loops

### DIFF
--- a/llvm/include/llvm/Transforms/Utils/LoopUtils.h
+++ b/llvm/include/llvm/Transforms/Utils/LoopUtils.h
@@ -287,7 +287,8 @@ MDNode *updateIterCounts(LLVMContext &Context, MDNode *LoopID,
 std::optional<int64_t> getMinTripCount(const MDNode *LoopID);
 
 /// Get Minimum Trip Count of the Loop
-std::optional<int64_t> getMinTripCount(const Loop *L);
+std::optional<int64_t> getMinTripCount(const Loop *L,
+                                       ScalarEvolution *SE = nullptr);
 
 /// Look for the loop attribute that disables all transformation heuristic.
 bool hasDisableAllTransformsHint(const Loop *L);

--- a/llvm/lib/Target/AIE/AIE2TargetTransformInfo.cpp
+++ b/llvm/lib/Target/AIE/AIE2TargetTransformInfo.cpp
@@ -119,19 +119,14 @@ bool AIE2TTIImpl::isHardwareLoopProfitable(Loop *L, ScalarEvolution &SE,
     return false;
 
   if (!ForceHLGeneration) {
-    if (const MDNode *LoopID = L->getLoopID()) {
-      std::optional<int64_t> MinTripCount = getMinTripCount(LoopID);
-      if (MinTripCount) {
-        // Reject HL for this case.
-        if (*MinTripCount <= MinIterCountHLReject) {
-          return false;
-        }
-      } else {
-        // We have metadata, but not iteration information.
+    std::optional<int64_t> MinTripCount = getMinTripCount(L, &SE);
+    if (MinTripCount) {
+      // Reject HL for this case.
+      if (*MinTripCount <= MinIterCountHLReject) {
         return false;
       }
     } else {
-      // We don't have metadata.
+      // We have metadata, but not iteration information.
       return false;
     }
   }

--- a/llvm/lib/Transforms/Utils/LoopUtils.cpp
+++ b/llvm/lib/Transforms/Utils/LoopUtils.cpp
@@ -447,7 +447,15 @@ std::optional<int64_t> llvm::getMinTripCount(const MDNode *LoopID) {
   return std::nullopt;
 }
 
-std::optional<int64_t> llvm::getMinTripCount(const Loop *L) {
+std::optional<int64_t> llvm::getMinTripCount(const Loop *L,
+                                             ScalarEvolution *SE) {
+  if (SE && L->isRotatedForm()) {
+    if (SE->hasLoopInvariantBackedgeTakenCount(L)) {
+      const SCEV *BackedgeTakenCount = SE->getBackedgeTakenCount(L);
+      if (const SCEVConstant *CT = dyn_cast<SCEVConstant>(BackedgeTakenCount))
+        return CT->getValue()->getSExtValue() + 1;
+    }
+  }
   return getMinTripCount(L->getLoopID());
 }
 

--- a/llvm/test/CodeGen/AIE/aie2/hardware-loops/zol-loop.ll
+++ b/llvm/test/CodeGen/AIE/aie2/hardware-loops/zol-loop.ll
@@ -72,3 +72,45 @@ for.body:                                         ; preds = %entry, %for.body
   %exitcond.not = icmp eq i32 %inc, %n
   br i1 %exitcond.not, label %for.cond.cleanup, label %for.body
 }
+
+define i32 @static_bounded_loop(i32 %num) {
+; CHECK-LABEL: static_bounded_loop:
+; CHECK:         .p2align 4
+; CHECK-NEXT:  // %bb.0: // %entry
+; CHECK-NEXT:    nopb ; nopa ; nops ; movxm ls, #.LBB1_1; nopv
+; CHECK-NEXT:    mova r2, #64; nopb ; movxm le, #.L_LEnd1
+; CHECK-NEXT:    add.nc lc, r2, #0
+; CHECK-NEXT:    nopb ; nopa ; nops ; nopxm ; nopv
+; CHECK-NEXT:    nopb ; nopa ; nops ; nopxm ; nopv
+; CHECK-NEXT:    nopb ; nopa ; nops ; nopxm ; nopv
+; CHECK-NEXT:    nopb ; nopa ; nops ; nopxm ; nopv
+; CHECK-NEXT:    nopb ; nopa ; nops ; nopxm ; nopv
+; CHECK-NEXT:    nopb ; nopa ; nops ; nopxm ; nopv
+; CHECK-NEXT:    nopb ; nopa ; nops ; nopx ; mov r0, r1; nopv
+; CHECK-NEXT:    .p2align 4
+; CHECK-NEXT:  .LBB1_1: // %for.body
+; CHECK-NEXT:    // =>This Inner Loop Header: Depth=1
+; CHECK-NEXT:    nopb ; nopa ; nops ; mul r0, r0, r0; nopm ; nopv
+; CHECK-NEXT:  .L_LEnd1:
+; CHECK-NEXT:    nopb ; nopa ; nops ; nopxm ; nopv
+; CHECK-NEXT:  // %bb.2: // %for.cond.cleanup
+; CHECK-NEXT:    nopa ; ret lr
+; CHECK-NEXT:    nop // Delay Slot 5
+; CHECK-NEXT:    nop // Delay Slot 4
+; CHECK-NEXT:    nop // Delay Slot 3
+; CHECK-NEXT:    nop // Delay Slot 2
+; CHECK-NEXT:    nop // Delay Slot 1
+entry:
+  br label %for.body
+
+for.cond.cleanup:                                 ; preds = %for.body
+  ret i32 %mul
+
+for.body:                                         ; preds = %entry, %for.body
+  %i.05 = phi i32 [ 0, %entry ], [ %inc, %for.body ]
+  %x.04 = phi i32 [ %num, %entry ], [ %mul, %for.body ]
+  %mul = mul nsw i32 %x.04, %x.04
+  %inc = add nuw nsw i32 %i.05, 1
+  %exitcond.not = icmp eq i32 %inc, 64
+  br i1 %exitcond.not, label %for.cond.cleanup, label %for.body
+}

--- a/llvm/test/CodeGen/AIE/aie2/hardware-loops/zol-loop.mir
+++ b/llvm/test/CodeGen/AIE/aie2/hardware-loops/zol-loop.mir
@@ -80,3 +80,51 @@ body:             |
     PseudoRET implicit $lr
 
 ...
+
+---
+name:            static_bounded_loop
+tracksRegLiveness: true
+body:             |
+  ; CHECK-LABEL: name: static_bounded_loop
+  ; CHECK: bb.0.entry (align 16):
+  ; CHECK-NEXT:   successors: %bb.1(0x80000000)
+  ; CHECK-NEXT:   liveins: $r1
+  ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT:   renamable $r2 = MOV_RLC_imm10_pseudo 64
+  ; CHECK-NEXT:   $r0 = MOV_SCL_pseudo $r1
+  ; CHECK-NEXT:   $lc = ADD_NC $r2, 0
+  ; CHECK-NEXT:   $ls = MOVXM_lng_cg %bb.1
+  ; CHECK-NEXT:   $le = MOVXM_lng_cg <mcsymbol .L_LEnd0>
+  ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT: bb.1 (align 16):
+  ; CHECK-NEXT:   successors: %bb.1(0x7c000000), %bb.2(0x04000000)
+  ; CHECK-NEXT:   liveins: $r0
+  ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT:   renamable $r0 = nsw MUL_mul_r_rr killed renamable $r0, renamable $r0
+  ; CHECK-NEXT:   PseudoLoopEnd <mcsymbol .L_LEnd0>, %bb.1
+  ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT: bb.2:
+  ; CHECK-NEXT:   liveins: $r0
+  ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT:   PseudoRET implicit $lr, implicit $r0
+  bb.0.entry (align 16):
+    successors: %bb.1(0x80000000)
+    liveins: $r1
+
+    renamable $r2 = MOV_RLC_imm10_pseudo 64
+    $r0 = MOV_SCL_pseudo $r1
+    LoopStart killed renamable $r2, 0
+
+  bb.1 (align 16):
+    successors: %bb.1(0x7c000000), %bb.2(0x04000000)
+    liveins: $r0
+
+    renamable $r0 = nsw MUL_mul_r_rr killed renamable $r0, renamable $r0
+    PseudoLoopEnd <mcsymbol .L_LEnd0>, %bb.1
+
+  bb.2:
+    liveins: $r0
+
+    PseudoRET implicit $lr, implicit $r0
+
+...


### PR DESCRIPTION
Extended existing `std::optional<int64_t> getMinTripCount(const Loop *L)` to get iteration count using Scalar Evolution analysis. 