### PR TITLE
relocate fix for aie2p-none-unknown-elf arch

### DIFF
--- a/lld/ELF/Arch/AIE.cpp
+++ b/lld/ELF/Arch/AIE.cpp
@@ -370,6 +370,7 @@ void AIE::relocate(uint8_t *Loc, const Relocation &rel, uint64_t Val) const {
     relocateAIE1(Loc, rel, Val);
     break;
   case 2:
+  case 3:
     relocateAIE2(Loc, rel, Val);
     break;
   default:


### PR DESCRIPTION
This solves "Unknown AIE version in EFLAGS"
error when test application is build for the
triplet aie2p-none-unknown-elf target.
For this target the EFLAGS is 3.

fixes: https://github.com/Xilinx/llvm-aie/issues/258