### PR TITLE
Prune all Python versions from hosted tool cache prior to building

### DIFF
--- a/.github/workflows/llvm-project-tests.yml
+++ b/.github/workflows/llvm-project-tests.yml
@@ -80,6 +80,10 @@ jobs:
         uses: llvm/actions/setup-windows@main
         with:
           arch: amd64
+      - name: Remove Python in hosted tool cache
+        if: runner.os == 'Linux'
+        run: |
+          rm -Rf ${RUNNER_TOOL_CACHE}/Python
       # On Windows, starting with win19/20220814.1, cmake choose the 32-bit
       # python3.10.6 libraries instead of the 64-bit libraries when building
       # lldb.  Using this setup-python action to make 3.10 the default


### PR DESCRIPTION
In #256 we were seeing the following build failure:

```
CMake Error at /usr/share/cmake-3.22/Modules/FindPackageHandleStandardArgs.cmake:230 (message):
  Could NOT find Python3 (missing: Interpreter) (Required is at least version
  "3.6")

      Reason given by package: 
          Interpreter: Cannot run the interpreter "/__t/Python/3.11.11/x64/bin/python3"
```

It turned out, that the problem is coming from Python requiring a newer GLIBC version inside the container.

```
/__t/Python/3.11.11/x64/bin/python3: /lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.38' not found (required by /__t/Python/3.11.11/x64/lib/libpython3.11.so.1.0)
```

However, spawning the container locally and downloading the used Python 3.11.11 from GitHub's own [Python release list](https://github.com/actions/python-versions/), I wasn't able to reproduce this problem. It turned out, that the hosted tool cache, for some reasons, holds a distribution which is linked against the newer GLIBC and the `setup-python` action would not recognize that and (re-)fetch the Python package. 

This PR effectively disables the caching by pruning all previously fetched Python versions from the hosted tool cache.