### PR TITLE
[AMD] avoid using upstream ci container

### DIFF
--- a/.github/workflows/llvm-project-tests.yml
+++ b/.github/workflows/llvm-project-tests.yml
@@ -67,7 +67,8 @@ jobs:
     name: Lit Tests
     runs-on: ${{ matrix.os }}
     container:
-      image: ${{(startsWith(matrix.os, 'ubuntu') && 'ghcr.io/llvm/ci-ubuntu-22.04:1734381129') || null}}
+      # Avoid using the llvm container image, since it needs to be consistent with the runner
+      # image: ${{(startsWith(matrix.os, 'ubuntu') && 'ghcr.io/llvm/ci-ubuntu-22.04:1734381129') || null}}
       volumes:
         - /mnt/:/mnt/
     strategy:

--- a/.github/workflows/llvm-project-tests.yml
+++ b/.github/workflows/llvm-project-tests.yml
@@ -69,6 +69,7 @@ jobs:
     container:
       # Avoid using the llvm container image, since it needs to be consistent with the runner
       # image: ${{(startsWith(matrix.os, 'ubuntu') && 'ghcr.io/llvm/ci-ubuntu-22.04:1734381129') || null}}
+      image: null
       volumes:
         - /mnt/:/mnt/
     strategy:

--- a/.github/workflows/llvm-project-tests.yml
+++ b/.github/workflows/llvm-project-tests.yml
@@ -69,7 +69,7 @@ jobs:
     container:
       # Avoid using the llvm container image, since it needs to be consistent with the runner
       # image: ${{(startsWith(matrix.os, 'ubuntu') && 'ghcr.io/llvm/ci-ubuntu-22.04:1734381129') || null}}
-      image: null
+      image: ${{ null }}
       volumes:
         - /mnt/:/mnt/
     strategy:


### PR DESCRIPTION
This container needs to be synchronized with the runner image, but we'd like to test on a number of different targets.