### PR TITLE
[AIE2P] Remove redundant check for G_STORE in RegBankSelect

### DIFF
--- a/llvm/lib/Target/AIE/aie2p/AIE2PRegisterBankInfo.cpp
+++ b/llvm/lib/Target/AIE/aie2p/AIE2PRegisterBankInfo.cpp
@@ -774,10 +774,7 @@ AIE2PRegisterBankInfo::getInstrMapping(const MachineInstr &MI) const {
       break;
     LLT Type = MRI.getType(VReg);
     auto DefRegBank = getRegBank(VReg, MRI, TRI);
-    // Add an additional typesize check to avoid matching the following case.
-    // %3:_(<16 x s64>), %4:_(s32) = llvm.aie2p.scd.expand.ACC1024.incr),
-    // %1(s32) G_STORE %4(s32), %2(p0) :: (store (s32))
-    if (DefRegBank == &AIE2P::AccRegBank && Type.getSizeInBits() > 256) {
+    if (DefRegBank == &AIE2P::AccRegBank) {
       OpRegBankIdx[0] = getAccPartialMappingIdx(MRI.getType(VReg));
       OpRegBankIdx[1] = PMI_PTR;
       return AIEBaseRegisterBankInfo::getInstrMappingFinal(MI, Cost, OpSize,


### PR DESCRIPTION
The type check is not needed anymore now that https://github.com/Xilinx/llvm-aie/pull/264 fixed the bug mentioned in the removed comment.

Without the check and as we were looking at the operand at index 0 instead of VReg (before https://github.com/Xilinx/llvm-aie/pull/264), we would be assigning the accumulator bank to a store of a scalar in this case:
```
    // %3:_(<16 x s64>), %4:_(s32) = llvm.aie2p.scd.expand.ACC1024.incr),
    // %1(s32) G_STORE %4(s32), %2(p0) :: (store (s32))
```
Now we are looking at the correct def used by the store %4(s32) instead of `%3:_(<16 x s64>)` and it won't have the accumulator bank assigned which means we will return AIEBaseRegisterBankInfo::getInstrMapping(MI); exactly as we expect.