### PR TITLE
[AIE2P] Remove unused ePSRFLd's decoder table

### DIFF
--- a/llvm/lib/Target/AIE/Disassembler/AIE2PDisassembler.cpp
+++ b/llvm/lib/Target/AIE/Disassembler/AIE2PDisassembler.cpp
@@ -53,8 +53,6 @@ MCDisassembler *createAIE2PDisassembler(const Target &T,
 // Include generated operand decoder tables and methods.
 #include "AIE2PDisassembler.inc"
 
-static const unsigned ePSRFLdFDecoderTable[] = {plfr0, plfr1};
-
 SLOTDECODERDecl(Lda);
 SLOTDECODERDecl(Ldb);
 SLOTDECODERDecl(Alu);


### PR DESCRIPTION
Since this https://github.com/Xilinx/llvm-aie/pull/266, `ePSRFLd` class's registers are not used to encode/decode any instructions which leads to its decoder table triggering a warning during build. This removes the no-longer-used decoder table.