### PR TITLE
[AIE2P] Fix PLFR spill alignment and fix warning in RegBankSelect

### DIFF
--- a/llvm/lib/Target/AIE/aie2p/AIE2PInstrInfo.cpp
+++ b/llvm/lib/Target/AIE/aie2p/AIE2PInstrInfo.cpp
@@ -943,8 +943,8 @@ AIE2PInstrInfo::getSpillPseudoExpandInfo(const MachineInstr &MI) const {
     return {{AIE2P::VST_dmx_sts_fifohl_spill, AIE2P::sub_lo_fifo},
             {AIE2P::VST_dmx_sts_fifohl_spill, AIE2P::sub_hi_fifo}};
   case AIE2P::VST_PLFR_SPILL:
-    return {{AIE2P::ST_dms_sts_spill, AIE2P::sub_ptr},
-            {AIE2P::VST_FIFO_SPILL, AIE2P::sub_fifo},
+    return {{AIE2P::VST_FIFO_SPILL, AIE2P::sub_fifo},
+            {AIE2P::ST_dms_sts_spill, AIE2P::sub_ptr},
             {AIE2P::ST_dms_sts_spill, AIE2P::sub_avail}};
 
   case AIE2P::VST_DM_SPILL:
@@ -978,9 +978,11 @@ AIE2PInstrInfo::getSpillPseudoExpandInfo(const MachineInstr &MI) const {
     return {{AIE2P::VLDA_dmx_lda_fifohl_spill, AIE2P::sub_lo_fifo},
             {AIE2P::VLDA_dmx_lda_fifohl_spill, AIE2P::sub_hi_fifo}};
   case AIE2P::VLDA_PLFR_SPILL:
-    return {{AIE2P::LDA_dms_lda_spill, AIE2P::sub_ptr},
-            {AIE2P::VLDA_FIFO_SPILL, AIE2P::sub_fifo},
-            {AIE2P::LDA_dms_lda_spill, AIE2P::sub_avail}};
+    return {
+        {AIE2P::VLDA_FIFO_SPILL, AIE2P::sub_fifo},
+        {AIE2P::LDA_dms_lda_spill, AIE2P::sub_avail},
+        {AIE2P::LDA_dms_lda_spill, AIE2P::sub_ptr},
+    };
   case AIE2P::VLDA_DM_SPILL:
     return {{AIE2P::VLDA_CM_SPILL, AIE2P::sub_1024_acc_lo},
             {AIE2P::VLDA_CM_SPILL, AIE2P::sub_1024_acc_hi}};

--- a/llvm/lib/Target/AIE/aie2p/AIE2PRegisterBankInfo.cpp
+++ b/llvm/lib/Target/AIE/aie2p/AIE2PRegisterBankInfo.cpp
@@ -772,7 +772,6 @@ AIE2PRegisterBankInfo::getInstrMapping(const MachineInstr &MI) const {
     Register VReg = MI.getOperand(0).getReg();
     if (!VReg)
       break;
-    LLT Type = MRI.getType(VReg);
     auto DefRegBank = getRegBank(VReg, MRI, TRI);
     if (DefRegBank == &AIE2P::AccRegBank) {
       OpRegBankIdx[0] = getAccPartialMappingIdx(MRI.getType(VReg));

--- a/llvm/lib/Target/AIE/aie2p/AIE2PRegisterInfo.td
+++ b/llvm/lib/Target/AIE/aie2p/AIE2PRegisterInfo.td
@@ -957,7 +957,7 @@ foreach RC = [eP, eM, eDN, eDJ, eDC, eSP, eSpecial20] in
     def RC # _as_32Bit : AIE2PScalarRegisterClass<(add RC)>;
 
 class AIE2PVector1076FifoRegisterClass<dag reglist> :
-    AIE2PRegisterClass<1088, 256, [i32], reglist> {
+    AIE2PRegisterClass<1088, 512, [i32], reglist> {
   let hasCompleteDecoder = 0;
 }
 def sub_ptr : SubRegIndex<20,  0>;

--- a/llvm/test/CodeGen/AIE/aie2p/postrapseudos/vld_spill.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/postrapseudos/vld_spill.mir
@@ -106,10 +106,10 @@ body:             |
   bb.0 (align 16):
 
     ; CHECK-LABEL: name: test_fifo_plfr
-    ; CHECK: $p0 = LDA_dms_lda_spill -136, implicit $sp :: (load (s32) from %stack.0, align 64)
-    ; CHECK-NEXT: $lfl0 = VLDA_dmx_lda_fifohl_spill -132, implicit $sp :: (load (s512) from %stack.0 + 4, align 4, basealign 64)
-    ; CHECK-NEXT: $lfh0 = VLDA_dmx_lda_fifohl_spill -68, implicit $sp :: (load (s512) from %stack.0 + 68, align 4, basealign 64)
-    ; CHECK-NEXT: $r24 = LDA_dms_lda_spill -4, implicit $sp :: (load (s32) from %stack.0 + 132, basealign 64)
+    ; CHECK: $lfl0 = VLDA_dmx_lda_fifohl_spill -136, implicit $sp :: (load (s512) from %stack.0)
+    ; CHECK-NEXT: $lfh0 = VLDA_dmx_lda_fifohl_spill -72, implicit $sp :: (load (s512) from %stack.0 + 64)
+    ; CHECK-NEXT: $r24 = LDA_dms_lda_spill -8, implicit $sp :: (load (s32) from %stack.0 + 128, align 64)
+    ; CHECK-NEXT: $p0 = LDA_dms_lda_spill -4, implicit $sp :: (load (s32) from %stack.0 + 132, basealign 64)
     $plfr0 = VLDA_PLFR_SPILL -136, implicit $sp :: (load (s1088) from %stack.0, align 64)
 ...
 

--- a/llvm/test/CodeGen/AIE/aie2p/postrapseudos/vst_spill.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/postrapseudos/vst_spill.mir
@@ -106,10 +106,11 @@ body:             |
   bb.0 (align 16):
 
     ; CHECK-LABEL: name: test_fifo_plfr
-    ; CHECK: ST_dms_sts_spill $p0, -136, implicit $sp :: (store (s32) into %stack.0, align 64)
-    ; CHECK-NEXT: VST_dmx_sts_fifohl_spill $lfl0, -132, implicit $sp :: (store (s512) into %stack.0 + 4, align 4, basealign 64)
-    ; CHECK-NEXT: VST_dmx_sts_fifohl_spill $lfh0, -68, implicit $sp :: (store (s512) into %stack.0 + 68, align 4, basealign 64)
+    ; CHECK: VST_dmx_sts_fifohl_spill $lfl0, -136, implicit $sp :: (store (s512) into %stack.0)
+    ; CHECK-NEXT: VST_dmx_sts_fifohl_spill $lfh0, -72, implicit $sp :: (store (s512) into %stack.0 + 64)
+    ; CHECK-NEXT: ST_dms_sts_spill $p0, -8, implicit $sp :: (store (s32) into %stack.0 + 128, align 64)
     ; CHECK-NEXT: ST_dms_sts_spill $r24, -4, implicit $sp :: (store (s32) into %stack.0 + 132, basealign 64)
     VST_PLFR_SPILL $plfr0, -136, implicit $sp :: (store (s1076) into %stack.0, align 64)
 ...
+
 

--- a/llvm/test/CodeGen/AIE/aie2p/spill/spill-reload-fifo.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/spill/spill-reload-fifo.mir
@@ -176,9 +176,9 @@ body:             |
     ; CHECK-LABEL: name: test_plfr_fifo_caller_saved
     ; CHECK: liveins: $plfr0
     ; CHECK-NEXT: {{  $}}
-    ; CHECK-NEXT: VST_PLFR_SPILL $plfr0, %stack.0, implicit $sp :: (store (s1088) into %stack.0, align 32)
+    ; CHECK-NEXT: VST_PLFR_SPILL $plfr0, %stack.0, implicit $sp :: (store (s1088) into %stack.0, align 64)
     ; CHECK-NEXT: PseudoJL 32, csr_aie2p, implicit-def $lr
-    ; CHECK-NEXT: renamable $plfr0 = VLDA_PLFR_SPILL %stack.0, implicit $sp :: (load (s1088) from %stack.0, align 32)
+    ; CHECK-NEXT: renamable $plfr0 = VLDA_PLFR_SPILL %stack.0, implicit $sp :: (load (s1088) from %stack.0, align 64)
     ; CHECK-NEXT: PseudoRET implicit $lr, implicit killed renamable $plfr0
     %0:epsrfldf = COPY $plfr0
     PseudoJL 32, csr_aie2p, implicit-def $lr
@@ -200,10 +200,10 @@ body:             |
     ; CHECK: liveins: $bmll0, $p0, $plfr1, $r0
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: renamable $plfr0 = COPY $bmll0
-    ; CHECK-NEXT: VST_PLFR_SPILL killed renamable $plfr0, %stack.0, implicit $sp :: (store (s1088) into %stack.0, align 32)
+    ; CHECK-NEXT: VST_PLFR_SPILL killed renamable $plfr0, %stack.0, implicit $sp :: (store (s1088) into %stack.0, align 64)
     ; CHECK-NEXT: $plfr0 = COPY $plfr1
     ; CHECK-NEXT: ST_dms_sts_idx_imm $r0, $p0, 0, implicit $plfr0, implicit $plfr1
-    ; CHECK-NEXT: renamable $plfr0 = VLDA_PLFR_SPILL %stack.0, implicit $sp :: (load (s1088) from %stack.0, align 32)
+    ; CHECK-NEXT: renamable $plfr0 = VLDA_PLFR_SPILL %stack.0, implicit $sp :: (load (s1088) from %stack.0, align 64)
     ; CHECK-NEXT: PseudoRET implicit $lr, implicit killed renamable $plfr0
     %0:epsrfldf = COPY $bmll0 ; -> only $plfr0 is available
 


### PR DESCRIPTION
AIE2P vectors require 64-byte spill alignment. 

PLFR composite registers which are made of scalars and fifo vector registers are spilled and reloaded using pseudos.
This fixes this requirement for the PLFR register class and changes the spilling order of its sub-registers to make sure the fifo vector spill is properly aligned.  