### PR TITLE
[AIE2P] Fix VLDA.UPS combine

### DIFF
--- a/llvm/lib/Target/AIE/aie2p/AIE2PInstructionSelector.cpp
+++ b/llvm/lib/Target/AIE/aie2p/AIE2PInstructionSelector.cpp
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+// (c) Copyright 2024-2025 Advanced Micro Devices, Inc. or its affiliates
 //
 //===----------------------------------------------------------------------===//
 /// \file
@@ -2660,12 +2660,12 @@ AIE2PInstructionSelector::getCombinedOpcodeSRSUPS(
                                   /*OffsetOpcode=*/{}};
         case Intrinsic::aie2p_acc32_v64_I512_ups:
         case Intrinsic::aie2p_acc64_v32_I512_ups:
-          FitsImmediateRange =
-              checkImmediateRangeSplitting<4, 64, 64>(Immediate);
-          return LoadStoreOpcodes{
-              /*ISelOpcode=*/AIE2P::
-                  VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign1,
-              FitsImmediateRange, /*OffsetOpcode=*/{}};
+          FitsImmediateRange = checkImmediateRange<4, 64>(Immediate);
+          ISelOpcode = FitsImmediateRange
+                           ? AIE2P::VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign1
+                           : AIE2P::VLDA_UPS_4x_dmx_lda_ups_x2d_idx_upsSign1;
+          return LoadStoreOpcodes{ISelOpcode, FitsImmediateRange,
+                                  /*OffsetOpcode=*/{}};
         }
       } else { // getLoadStoreSize(MemOp) == 256
         switch (cast<GIntrinsic>(CombOp).getIntrinsicID()) {
@@ -2701,8 +2701,7 @@ AIE2PInstructionSelector::getCombinedOpcodeSRSUPS(
                                   /*OffsetOpcode=*/{}};
         case Intrinsic::aie2p_acc32_v64_I512_ups:
         case Intrinsic::aie2p_acc64_v32_I512_ups:
-          FitsImmediateRange =
-              checkImmediateRangeSplitting<4, 64, 64>(Immediate);
+          FitsImmediateRange = checkImmediateRange<4, 64>(Immediate);
           ISelOpcode =
               FitsImmediateRange
                   ? AIE2P::VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign1
@@ -2752,14 +2751,12 @@ AIE2PInstructionSelector::getCombinedOpcodeSRSUPS(
         case Intrinsic::aie2p_acc64_v8_I256_ups:
           return LoadStoreOpcodes{
               /*ISelOpcode=*/AIE2P::VLDA_2D_UPS_2x_dmw_lda_ups_w2b_upsSign1,
-              NoImmediate,
-              /*OffsetOpcode=*/{}};
+              NoImmediate, /*OffsetOpcode=*/{}};
         case Intrinsic::aie2p_acc32_v32_I256_ups:
         case Intrinsic::aie2p_acc64_v16_I256_ups:
           return LoadStoreOpcodes{
               /*ISelOpcode=*/AIE2P::VLDA_2D_UPS_4x_dmw_lda_ups_w2c_upsSign1,
-              NoImmediate,
-              /*OffsetOpcode=*/{}};
+              NoImmediate, /*OffsetOpcode=*/{}};
         }
       }
     case AIE2P::G_AIE_POSTINC_3D_LOAD:
@@ -2839,12 +2836,12 @@ AIE2PInstructionSelector::getCombinedOpcodeSRSUPS(
                                   /*OffsetOpcode=*/{}};
         case Intrinsic::aie2p_acc32_v64_I512_ups:
         case Intrinsic::aie2p_acc64_v32_I512_ups:
-          FitsImmediateRange =
-              checkImmediateRangeSplitting<4, 64, 64>(Immediate);
-          return LoadStoreOpcodes{
-              /*ISelOpcode=*/AIE2P::
-                  VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0,
-              FitsImmediateRange, /*OffsetOpcode=*/{}};
+          FitsImmediateRange = checkImmediateRange<4, 64>(Immediate);
+          ISelOpcode = FitsImmediateRange
+                           ? AIE2P::VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0
+                           : AIE2P::VLDA_UPS_4x_dmx_lda_ups_x2d_idx_upsSign0;
+          return LoadStoreOpcodes{ISelOpcode, FitsImmediateRange,
+                                  /*OffsetOpcode=*/{}};
         }
       } else { // getLoadStoreSize(MemOp) == 256
         switch (cast<GIntrinsic>(CombOp).getIntrinsicID()) {
@@ -2880,8 +2877,7 @@ AIE2PInstructionSelector::getCombinedOpcodeSRSUPS(
                                   /*OffsetOpcode=*/{}};
         case Intrinsic::aie2p_acc32_v64_I512_ups:
         case Intrinsic::aie2p_acc64_v32_I512_ups:
-          FitsImmediateRange =
-              checkImmediateRangeSplitting<4, 64, 64>(Immediate);
+          FitsImmediateRange = checkImmediateRange<4, 64>(Immediate);
           ISelOpcode =
               FitsImmediateRange
                   ? AIE2P::VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign0

--- a/llvm/lib/Target/AIE/aie2p/AIE2PInstructionSelector.cpp
+++ b/llvm/lib/Target/AIE/aie2p/AIE2PInstructionSelector.cpp
@@ -124,6 +124,8 @@ private:
   std::optional<LoadStoreOpcodes>
   getCombinedOpcodeSRSUPS(const MachineInstr &MemOp, const MachineInstr &CombOp,
                           std::optional<APInt> Immediate, bool IsSigned);
+  bool canCombineUPS(MachineInstr &LoadOp, MachineInstr &UPSI,
+                     MachineRegisterInfo &MRI);
 
   const AIE2PInstrInfo &TII;
   const AIE2PRegisterInfo &TRI;
@@ -1273,8 +1275,10 @@ bool AIE2PInstructionSelector::selectG_AIE_LOAD_UPS(MachineInstr &UPSI,
   if (!canDelayMemOp(*LoadOp, UPSI, MRI))
     return false;
 
-  if (LoadOp->getParent() != UPSI.getParent() || !MRI.hasOneUse(LoadResult))
+  if (!canCombineUPS(*LoadOp, UPSI, MRI))
     return false;
+
+  assert(getLoadStoreSize(*LoadOp) == 256 || getLoadStoreSize(*LoadOp) == 512);
 
   std::optional<AddressingModeInfo> AMI =
       getOrDefineAddressingRegister(*LoadOp, MRI);
@@ -1294,8 +1298,7 @@ bool AIE2PInstructionSelector::selectG_AIE_LOAD_UPS(MachineInstr &UPSI,
       *LoadOp, UPSI, AMI->ImmediateOffset,
       ConstantSign ? SignVal.value().Value == 0x1 : false);
 
-  if (!LSO.has_value())
-    return false;
+  assert(LSO && "Unexpected VLDA.UPS combine failure");
 
   unsigned MemOpLoadStoreSize = getLoadStoreSize(*LoadOp);
   TypeSize DstRegSize = MRI.getType(DstReg).getSizeInBits();
@@ -2607,8 +2610,7 @@ AIE2PInstructionSelector::getCombinedOpcodeSRSUPS(
        IntrinsicID != Intrinsic::aie2p_acc32_v16_I256_ups &&
        IntrinsicID != Intrinsic::aie2p_acc64_v8_I256_ups &&
        IntrinsicID != Intrinsic::aie2p_acc32_v32_I256_ups &&
-       IntrinsicID != Intrinsic::aie2p_acc64_v16_I256_ups) ||
-      (getLoadStoreSize(MemOp) != 256 && getLoadStoreSize(MemOp) != 512))
+       IntrinsicID != Intrinsic::aie2p_acc64_v16_I256_ups))
     return {};
 
   unsigned ISelOpcode;
@@ -2967,6 +2969,19 @@ AIE2PInstructionSelector::getCombinedOpcodeSRSUPS(
     }
   }
   return {};
+}
+
+bool AIE2PInstructionSelector::canCombineUPS(MachineInstr &LoadOp,
+                                             MachineInstr &UPSI,
+                                             MachineRegisterInfo &MRI) {
+  Register LoadResult = (std::next(UPSI.uses().begin()))->getReg();
+  if (LoadOp.getParent() != UPSI.getParent() || !MRI.hasOneUse(LoadResult)) {
+    return false;
+  }
+  const std::optional<APInt> NoImmediate = {};
+  const bool IsSigned = true;
+  return getCombinedOpcodeSRSUPS(LoadOp, UPSI, NoImmediate, IsSigned)
+      .has_value();
 }
 
 namespace llvm {

--- a/llvm/test/CodeGen/AIE/aie2p/GlobalIsel/inst-select-indexed-vlda_ups.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/GlobalIsel/inst-select-indexed-vlda_ups.mir
@@ -4,23 +4,24 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2024-2025 Advanced Micro Devices, Inc. or its affiliates
 # RUN: llc -mtriple aie2p -run-pass=instruction-select %s -verify-machineinstrs -o - | FileCheck %s
 
 ---
-name:            VST_UPS_2x_BM_v16_acc32_signed
+name:            VLDA_UPS_2x_acc32_v16_signed
 alignment:       16
 legalized:       true
 regBankSelected: true
 body:             |
   bb.1.entry:
     liveins: $bmll0, $p0, $r0, $r1
-    ; CHECK-LABEL: name: VST_UPS_2x_BM_v16_acc32_signed
+    ; CHECK-LABEL: name: VLDA_UPS_2x_acc32_v16_signed
     ; CHECK: liveins: $bmll0, $p0, $r0, $r1
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
     ; CHECK-NEXT: [[COPY1:%[0-9]+]]:edj = COPY $m0
     ; CHECK-NEXT: [[MOV_PD_imm11_pseudo:%[0-9]+]]:edj = MOV_PD_imm11_pseudo 16
+    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo1:%[0-9]+]]:edj = MOV_PD_imm11_pseudo 256
     ; CHECK-NEXT: [[COPY2:%[0-9]+]]:er = COPY $r1
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: [[COPY3:%[0-9]+]]:es = COPY [[COPY2]]
@@ -33,21 +34,21 @@ body:             |
     ; CHECK-NEXT: [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_upsSign1_1:%[0-9]+]]:acc512 = VLDA_UPS_2x_dmw_lda_ups_w2b_idx_upsSign1 [[COPY5]], [[COPY]], [[MOV_PD_imm11_pseudo]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign1 :: (load (<16 x s16>))
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: [[COPY6:%[0-9]+]]:es = COPY [[COPY2]]
-    ; CHECK-NEXT: [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign1_1:%[0-9]+]]:acc512 = VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign1 [[COPY6]], [[COPY]], -128, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign1 :: (load (<16 x s16>))
+    ; CHECK-NEXT: [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign1_1:%[0-9]+]]:acc512 = VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign1 [[COPY6]], [[COPY]], -256, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign1 :: (load (<16 x s16>))
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: [[COPY7:%[0-9]+]]:es = COPY [[COPY2]]
-    ; CHECK-NEXT: [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign1_2:%[0-9]+]]:acc512 = VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign1 [[COPY7]], [[COPY]], 96, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign1 :: (load (<16 x s16>))
+    ; CHECK-NEXT: [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign1_2:%[0-9]+]]:acc512 = VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign1 [[COPY7]], [[COPY]], 224, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign1 :: (load (<16 x s16>))
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: [[COPY8:%[0-9]+]]:es = COPY [[COPY2]]
-    ; CHECK-NEXT: [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign1_3:%[0-9]+]]:acc512 = VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign1 [[COPY8]], [[COPY]], 128, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign1 :: (load (<16 x s16>))
-    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_upsSign1_]], implicit [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign1_]], implicit [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_upsSign1_1]], implicit [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign1_1]], implicit [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign1_2]], implicit [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign1_3]]
+    ; CHECK-NEXT: [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_upsSign1_2:%[0-9]+]]:acc512 = VLDA_UPS_2x_dmw_lda_ups_w2b_idx_upsSign1 [[COPY8]], [[COPY]], [[MOV_PD_imm11_pseudo1]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign1 :: (load (<16 x s16>))
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_upsSign1_]], implicit [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign1_]], implicit [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_upsSign1_1]], implicit [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign1_1]], implicit [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign1_2]], implicit [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_upsSign1_2]]
     %0:ptrregbank(p0) = COPY $p0
     %7:modregbank(s20) = COPY $m0
     %8:modregbank(s20) = G_CONSTANT i20 0
     %9:modregbank(s20) = G_CONSTANT i20 16
-    %10:modregbank(s20) = G_CONSTANT i20 -128
-    %11:modregbank(s20) = G_CONSTANT i20 96
-    %12:modregbank(s20) = G_CONSTANT i20 128
+    %10:modregbank(s20) = G_CONSTANT i20 -256
+    %11:modregbank(s20) = G_CONSTANT i20 224
+    %12:modregbank(s20) = G_CONSTANT i20 256
     %101:gprregbank(s32) = COPY $r1
     %102:gprregbank(s32) = G_CONSTANT i32 1
     %25:vregbank(<16 x s16>) = G_AIE_OFFSET_LOAD %0, %7 :: (load (<16 x s16>))
@@ -66,19 +67,20 @@ body:             |
 ...
 
 ---
-name:            VST_UPS_2x_BM_v8_acc64_signed
+name:            VLDA_UPS_2x_acc64_v8_signed
 alignment:       16
 legalized:       true
 regBankSelected: true
 body:             |
   bb.1.entry:
     liveins: $bmll0, $p0, $r0, $r1
-    ; CHECK-LABEL: name: VST_UPS_2x_BM_v8_acc64_signed
+    ; CHECK-LABEL: name: VLDA_UPS_2x_acc64_v8_signed
     ; CHECK: liveins: $bmll0, $p0, $r0, $r1
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
     ; CHECK-NEXT: [[COPY1:%[0-9]+]]:edj = COPY $m0
     ; CHECK-NEXT: [[MOV_PD_imm11_pseudo:%[0-9]+]]:edj = MOV_PD_imm11_pseudo 16
+    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo1:%[0-9]+]]:edj = MOV_PD_imm11_pseudo 256
     ; CHECK-NEXT: [[COPY2:%[0-9]+]]:er = COPY $r1
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 1
     ; CHECK-NEXT: [[COPY3:%[0-9]+]]:es = COPY [[COPY2]]
@@ -91,21 +93,21 @@ body:             |
     ; CHECK-NEXT: [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_upsSign1_1:%[0-9]+]]:acc512 = VLDA_UPS_2x_dmw_lda_ups_w2b_idx_upsSign1 [[COPY5]], [[COPY]], [[MOV_PD_imm11_pseudo]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign1 :: (load (<16 x s16>))
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 1
     ; CHECK-NEXT: [[COPY6:%[0-9]+]]:es = COPY [[COPY2]]
-    ; CHECK-NEXT: [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign1_1:%[0-9]+]]:acc512 = VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign1 [[COPY6]], [[COPY]], -128, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign1 :: (load (<16 x s16>))
+    ; CHECK-NEXT: [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign1_1:%[0-9]+]]:acc512 = VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign1 [[COPY6]], [[COPY]], -256, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign1 :: (load (<16 x s16>))
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 1
     ; CHECK-NEXT: [[COPY7:%[0-9]+]]:es = COPY [[COPY2]]
-    ; CHECK-NEXT: [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign1_2:%[0-9]+]]:acc512 = VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign1 [[COPY7]], [[COPY]], 96, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign1 :: (load (<16 x s16>))
+    ; CHECK-NEXT: [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign1_2:%[0-9]+]]:acc512 = VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign1 [[COPY7]], [[COPY]], 224, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign1 :: (load (<16 x s16>))
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 1
     ; CHECK-NEXT: [[COPY8:%[0-9]+]]:es = COPY [[COPY2]]
-    ; CHECK-NEXT: [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign1_3:%[0-9]+]]:acc512 = VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign1 [[COPY8]], [[COPY]], 128, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign1 :: (load (<16 x s16>))
-    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_upsSign1_]], implicit [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign1_]], implicit [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_upsSign1_1]], implicit [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign1_1]], implicit [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign1_2]], implicit [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign1_3]]
+    ; CHECK-NEXT: [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_upsSign1_2:%[0-9]+]]:acc512 = VLDA_UPS_2x_dmw_lda_ups_w2b_idx_upsSign1 [[COPY8]], [[COPY]], [[MOV_PD_imm11_pseudo1]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign1 :: (load (<16 x s16>))
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_upsSign1_]], implicit [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign1_]], implicit [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_upsSign1_1]], implicit [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign1_1]], implicit [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign1_2]], implicit [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_upsSign1_2]]
     %0:ptrregbank(p0) = COPY $p0
     %7:modregbank(s20) = COPY $m0
     %8:modregbank(s20) = G_CONSTANT i20 0
     %9:modregbank(s20) = G_CONSTANT i20 16
-    %10:modregbank(s20) = G_CONSTANT i20 -128
-    %11:modregbank(s20) = G_CONSTANT i20 96
-    %12:modregbank(s20) = G_CONSTANT i20 128
+    %10:modregbank(s20) = G_CONSTANT i20 -256
+    %11:modregbank(s20) = G_CONSTANT i20 224
+    %12:modregbank(s20) = G_CONSTANT i20 256
     %101:gprregbank(s32) = COPY $r1
     %102:gprregbank(s32) = G_CONSTANT i32 1
     %25:vregbank(<16 x s16>) = G_AIE_OFFSET_LOAD %0, %7 :: (load (<16 x s16>))
@@ -124,19 +126,20 @@ body:             |
 ...
 
 ---
-name:            VST_UPS_4x_CM_v16_acc64_signed
+name:            VLDA_UPS_4x_acc64_v16_signed
 alignment:       16
 legalized:       true
 regBankSelected: true
 body:             |
   bb.1.entry:
     liveins: $bmll0, $p0, $r0, $r1
-    ; CHECK-LABEL: name: VST_UPS_4x_CM_v16_acc64_signed
+    ; CHECK-LABEL: name: VLDA_UPS_4x_acc64_v16_signed
     ; CHECK: liveins: $bmll0, $p0, $r0, $r1
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
     ; CHECK-NEXT: [[COPY1:%[0-9]+]]:edj = COPY $m0
     ; CHECK-NEXT: [[MOV_PD_imm11_pseudo:%[0-9]+]]:edj = MOV_PD_imm11_pseudo 16
+    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo1:%[0-9]+]]:edj = MOV_PD_imm11_pseudo 256
     ; CHECK-NEXT: [[COPY2:%[0-9]+]]:er = COPY $r1
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 1
     ; CHECK-NEXT: [[COPY3:%[0-9]+]]:es = COPY [[COPY2]]
@@ -149,21 +152,21 @@ body:             |
     ; CHECK-NEXT: [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_upsSign1_1:%[0-9]+]]:acc1024 = VLDA_UPS_4x_dmw_lda_ups_w2c_idx_upsSign1 [[COPY5]], [[COPY]], [[MOV_PD_imm11_pseudo]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign1 :: (load (<16 x s16>))
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 1
     ; CHECK-NEXT: [[COPY6:%[0-9]+]]:es = COPY [[COPY2]]
-    ; CHECK-NEXT: [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign1_1:%[0-9]+]]:acc1024 = VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign1 [[COPY6]], [[COPY]], -128, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign1 :: (load (<16 x s16>))
+    ; CHECK-NEXT: [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign1_1:%[0-9]+]]:acc1024 = VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign1 [[COPY6]], [[COPY]], -256, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign1 :: (load (<16 x s16>))
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 1
     ; CHECK-NEXT: [[COPY7:%[0-9]+]]:es = COPY [[COPY2]]
-    ; CHECK-NEXT: [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign1_2:%[0-9]+]]:acc1024 = VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign1 [[COPY7]], [[COPY]], 96, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign1 :: (load (<16 x s16>))
+    ; CHECK-NEXT: [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign1_2:%[0-9]+]]:acc1024 = VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign1 [[COPY7]], [[COPY]], 224, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign1 :: (load (<16 x s16>))
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 1
     ; CHECK-NEXT: [[COPY8:%[0-9]+]]:es = COPY [[COPY2]]
-    ; CHECK-NEXT: [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign1_3:%[0-9]+]]:acc1024 = VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign1 [[COPY8]], [[COPY]], 128, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign1 :: (load (<16 x s16>))
-    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_upsSign1_]], implicit [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign1_]], implicit [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_upsSign1_1]], implicit [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign1_1]], implicit [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign1_2]], implicit [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign1_3]]
+    ; CHECK-NEXT: [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_upsSign1_2:%[0-9]+]]:acc1024 = VLDA_UPS_4x_dmw_lda_ups_w2c_idx_upsSign1 [[COPY8]], [[COPY]], [[MOV_PD_imm11_pseudo1]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign1 :: (load (<16 x s16>))
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_upsSign1_]], implicit [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign1_]], implicit [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_upsSign1_1]], implicit [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign1_1]], implicit [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign1_2]], implicit [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_upsSign1_2]]
     %0:ptrregbank(p0) = COPY $p0
     %7:modregbank(s20) = COPY $m0
     %8:modregbank(s20) = G_CONSTANT i20 0
     %9:modregbank(s20) = G_CONSTANT i20 16
-    %10:modregbank(s20) = G_CONSTANT i20 -128
-    %11:modregbank(s20) = G_CONSTANT i20 96
-    %12:modregbank(s20) = G_CONSTANT i20 128
+    %10:modregbank(s20) = G_CONSTANT i20 -256
+    %11:modregbank(s20) = G_CONSTANT i20 224
+    %12:modregbank(s20) = G_CONSTANT i20 256
     %101:gprregbank(s32) = COPY $r1
     %102:gprregbank(s32) = G_CONSTANT i32 1
     %25:vregbank(<16 x s16>) = G_AIE_OFFSET_LOAD %0, %7 :: (load (<16 x s16>))
@@ -182,19 +185,20 @@ body:             |
 ...
 
 ---
-name:            VST_UPS_4x_CM_v32_acc32_signed
+name:            VLDA_UPS_4x_acc32_v32_signed
 alignment:       16
 legalized:       true
 regBankSelected: true
 body:             |
   bb.1.entry:
     liveins: $bmll0, $p0, $r0, $r1
-    ; CHECK-LABEL: name: VST_UPS_4x_CM_v32_acc32_signed
+    ; CHECK-LABEL: name: VLDA_UPS_4x_acc32_v32_signed
     ; CHECK: liveins: $bmll0, $p0, $r0, $r1
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
     ; CHECK-NEXT: [[COPY1:%[0-9]+]]:edj = COPY $m0
     ; CHECK-NEXT: [[MOV_PD_imm11_pseudo:%[0-9]+]]:edj = MOV_PD_imm11_pseudo 16
+    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo1:%[0-9]+]]:edj = MOV_PD_imm11_pseudo 256
     ; CHECK-NEXT: [[COPY2:%[0-9]+]]:er = COPY $r1
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: [[COPY3:%[0-9]+]]:es = COPY [[COPY2]]
@@ -207,21 +211,21 @@ body:             |
     ; CHECK-NEXT: [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_upsSign1_1:%[0-9]+]]:acc1024 = VLDA_UPS_4x_dmw_lda_ups_w2c_idx_upsSign1 [[COPY5]], [[COPY]], [[MOV_PD_imm11_pseudo]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign1 :: (load (<16 x s16>))
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: [[COPY6:%[0-9]+]]:es = COPY [[COPY2]]
-    ; CHECK-NEXT: [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign1_1:%[0-9]+]]:acc1024 = VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign1 [[COPY6]], [[COPY]], -128, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign1 :: (load (<16 x s16>))
+    ; CHECK-NEXT: [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign1_1:%[0-9]+]]:acc1024 = VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign1 [[COPY6]], [[COPY]], -256, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign1 :: (load (<16 x s16>))
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: [[COPY7:%[0-9]+]]:es = COPY [[COPY2]]
-    ; CHECK-NEXT: [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign1_2:%[0-9]+]]:acc1024 = VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign1 [[COPY7]], [[COPY]], 96, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign1 :: (load (<16 x s16>))
+    ; CHECK-NEXT: [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign1_2:%[0-9]+]]:acc1024 = VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign1 [[COPY7]], [[COPY]], 224, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign1 :: (load (<16 x s16>))
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: [[COPY8:%[0-9]+]]:es = COPY [[COPY2]]
-    ; CHECK-NEXT: [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign1_3:%[0-9]+]]:acc1024 = VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign1 [[COPY8]], [[COPY]], 128, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign1 :: (load (<16 x s16>))
-    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_upsSign1_]], implicit [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign1_]], implicit [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_upsSign1_1]], implicit [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign1_1]], implicit [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign1_2]], implicit [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign1_3]]
+    ; CHECK-NEXT: [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_upsSign1_2:%[0-9]+]]:acc1024 = VLDA_UPS_4x_dmw_lda_ups_w2c_idx_upsSign1 [[COPY8]], [[COPY]], [[MOV_PD_imm11_pseudo1]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign1 :: (load (<16 x s16>))
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_upsSign1_]], implicit [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign1_]], implicit [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_upsSign1_1]], implicit [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign1_1]], implicit [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign1_2]], implicit [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_upsSign1_2]]
     %0:ptrregbank(p0) = COPY $p0
     %7:modregbank(s20) = COPY $m0
     %8:modregbank(s20) = G_CONSTANT i20 0
     %9:modregbank(s20) = G_CONSTANT i20 16
-    %10:modregbank(s20) = G_CONSTANT i20 -128
-    %11:modregbank(s20) = G_CONSTANT i20 96
-    %12:modregbank(s20) = G_CONSTANT i20 128
+    %10:modregbank(s20) = G_CONSTANT i20 -256
+    %11:modregbank(s20) = G_CONSTANT i20 224
+    %12:modregbank(s20) = G_CONSTANT i20 256
     %101:gprregbank(s32) = COPY $r1
     %102:gprregbank(s32) = G_CONSTANT i32 1
     %25:vregbank(<16 x s16>) = G_AIE_OFFSET_LOAD %0, %7 :: (load (<16 x s16>))
@@ -240,20 +244,20 @@ body:             |
 ...
 
 ---
-name:            VST_UPS_2x_CM_v32_acc32_signed
+name:            VLDA_UPS_2x_acc32_v32_signed
 alignment:       16
 legalized:       true
 regBankSelected: true
 body:             |
   bb.1.entry:
     liveins: $bmll0, $p0, $r0, $r1
-    ; CHECK-LABEL: name: VST_UPS_2x_CM_v32_acc32_signed
+    ; CHECK-LABEL: name: VLDA_UPS_2x_acc32_v32_signed
     ; CHECK: liveins: $bmll0, $p0, $r0, $r1
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
     ; CHECK-NEXT: [[COPY1:%[0-9]+]]:edj = COPY $m0
-    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo:%[0-9]+]]:edj = MOV_PD_imm11_pseudo 16
-    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo1:%[0-9]+]]:edj = MOV_PD_imm11_pseudo 96
+    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo:%[0-9]+]]:edj = MOV_PD_imm11_pseudo 32
+    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo1:%[0-9]+]]:edj = MOV_PD_imm11_pseudo 512
     ; CHECK-NEXT: [[COPY2:%[0-9]+]]:er = COPY $r1
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: [[COPY3:%[0-9]+]]:es = COPY [[COPY2]]
@@ -266,21 +270,21 @@ body:             |
     ; CHECK-NEXT: [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_upsSign1_1:%[0-9]+]]:acc1024 = VLDA_UPS_2x_dmx_lda_ups_x2c_idx_upsSign1 [[COPY5]], [[COPY]], [[MOV_PD_imm11_pseudo]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign1 :: (load (<16 x s32>))
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: [[COPY6:%[0-9]+]]:es = COPY [[COPY2]]
-    ; CHECK-NEXT: [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_imm_upsSign1_1:%[0-9]+]]:acc1024 = VLDA_UPS_2x_dmx_lda_ups_x2c_idx_imm_upsSign1 [[COPY6]], [[COPY]], -128, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign1 :: (load (<16 x s32>))
+    ; CHECK-NEXT: [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_imm_upsSign1_1:%[0-9]+]]:acc1024 = VLDA_UPS_2x_dmx_lda_ups_x2c_idx_imm_upsSign1 [[COPY6]], [[COPY]], -512, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign1 :: (load (<16 x s32>))
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: [[COPY7:%[0-9]+]]:es = COPY [[COPY2]]
-    ; CHECK-NEXT: [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_upsSign1_2:%[0-9]+]]:acc1024 = VLDA_UPS_2x_dmx_lda_ups_x2c_idx_upsSign1 [[COPY7]], [[COPY]], [[MOV_PD_imm11_pseudo1]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign1 :: (load (<16 x s32>))
+    ; CHECK-NEXT: [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_imm_upsSign1_2:%[0-9]+]]:acc1024 = VLDA_UPS_2x_dmx_lda_ups_x2c_idx_imm_upsSign1 [[COPY7]], [[COPY]], 448, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign1 :: (load (<16 x s32>))
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: [[COPY8:%[0-9]+]]:es = COPY [[COPY2]]
-    ; CHECK-NEXT: [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_imm_upsSign1_2:%[0-9]+]]:acc1024 = VLDA_UPS_2x_dmx_lda_ups_x2c_idx_imm_upsSign1 [[COPY8]], [[COPY]], 128, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign1 :: (load (<16 x s32>))
-    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_upsSign1_]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_imm_upsSign1_]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_upsSign1_1]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_imm_upsSign1_1]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_upsSign1_2]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_imm_upsSign1_2]]
+    ; CHECK-NEXT: [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_upsSign1_2:%[0-9]+]]:acc1024 = VLDA_UPS_2x_dmx_lda_ups_x2c_idx_upsSign1 [[COPY8]], [[COPY]], [[MOV_PD_imm11_pseudo1]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign1 :: (load (<16 x s32>))
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_upsSign1_]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_imm_upsSign1_]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_upsSign1_1]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_imm_upsSign1_1]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_imm_upsSign1_2]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_upsSign1_2]]
     %0:ptrregbank(p0) = COPY $p0
     %7:modregbank(s20) = COPY $m0
     %8:modregbank(s20) = G_CONSTANT i20 0
-    %9:modregbank(s20) = G_CONSTANT i20 16
-    %10:modregbank(s20) = G_CONSTANT i20 -128
-    %11:modregbank(s20) = G_CONSTANT i20 96
-    %12:modregbank(s20) = G_CONSTANT i20 128
+    %9:modregbank(s20) = G_CONSTANT i20 32
+    %10:modregbank(s20) = G_CONSTANT i20 -512
+    %11:modregbank(s20) = G_CONSTANT i20 448
+    %12:modregbank(s20) = G_CONSTANT i20 512
     %101:gprregbank(s32) = COPY $r1
     %102:gprregbank(s32) = G_CONSTANT i32 1
     %25:vregbank(<16 x s32>) = G_AIE_OFFSET_LOAD %0, %7 :: (load (<16 x s32>))
@@ -299,20 +303,20 @@ body:             |
 ...
 
 ---
-name:            VST_UPS_2x_CM_v16_acc64_signed
+name:            VLDA_UPS_2x_acc64_v16_signed
 alignment:       16
 legalized:       true
 regBankSelected: true
 body:             |
   bb.1.entry:
     liveins: $bmll0, $p0, $r0, $r1
-    ; CHECK-LABEL: name: VST_UPS_2x_CM_v16_acc64_signed
+    ; CHECK-LABEL: name: VLDA_UPS_2x_acc64_v16_signed
     ; CHECK: liveins: $bmll0, $p0, $r0, $r1
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
     ; CHECK-NEXT: [[COPY1:%[0-9]+]]:edj = COPY $m0
-    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo:%[0-9]+]]:edj = MOV_PD_imm11_pseudo 16
-    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo1:%[0-9]+]]:edj = MOV_PD_imm11_pseudo 96
+    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo:%[0-9]+]]:edj = MOV_PD_imm11_pseudo 32
+    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo1:%[0-9]+]]:edj = MOV_PD_imm11_pseudo 512
     ; CHECK-NEXT: [[COPY2:%[0-9]+]]:er = COPY $r1
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 1
     ; CHECK-NEXT: [[COPY3:%[0-9]+]]:es = COPY [[COPY2]]
@@ -325,21 +329,21 @@ body:             |
     ; CHECK-NEXT: [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_upsSign1_1:%[0-9]+]]:acc1024 = VLDA_UPS_2x_dmx_lda_ups_x2c_idx_upsSign1 [[COPY5]], [[COPY]], [[MOV_PD_imm11_pseudo]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign1 :: (load (<16 x s32>))
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 1
     ; CHECK-NEXT: [[COPY6:%[0-9]+]]:es = COPY [[COPY2]]
-    ; CHECK-NEXT: [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_imm_upsSign1_1:%[0-9]+]]:acc1024 = VLDA_UPS_2x_dmx_lda_ups_x2c_idx_imm_upsSign1 [[COPY6]], [[COPY]], -128, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign1 :: (load (<16 x s32>))
+    ; CHECK-NEXT: [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_imm_upsSign1_1:%[0-9]+]]:acc1024 = VLDA_UPS_2x_dmx_lda_ups_x2c_idx_imm_upsSign1 [[COPY6]], [[COPY]], -512, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign1 :: (load (<16 x s32>))
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 1
     ; CHECK-NEXT: [[COPY7:%[0-9]+]]:es = COPY [[COPY2]]
-    ; CHECK-NEXT: [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_upsSign1_2:%[0-9]+]]:acc1024 = VLDA_UPS_2x_dmx_lda_ups_x2c_idx_upsSign1 [[COPY7]], [[COPY]], [[MOV_PD_imm11_pseudo1]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign1 :: (load (<16 x s32>))
+    ; CHECK-NEXT: [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_imm_upsSign1_2:%[0-9]+]]:acc1024 = VLDA_UPS_2x_dmx_lda_ups_x2c_idx_imm_upsSign1 [[COPY7]], [[COPY]], 448, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign1 :: (load (<16 x s32>))
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 1
     ; CHECK-NEXT: [[COPY8:%[0-9]+]]:es = COPY [[COPY2]]
-    ; CHECK-NEXT: [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_imm_upsSign1_2:%[0-9]+]]:acc1024 = VLDA_UPS_2x_dmx_lda_ups_x2c_idx_imm_upsSign1 [[COPY8]], [[COPY]], 128, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign1 :: (load (<16 x s32>))
-    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_upsSign1_]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_imm_upsSign1_]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_upsSign1_1]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_imm_upsSign1_1]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_upsSign1_2]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_imm_upsSign1_2]]
+    ; CHECK-NEXT: [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_upsSign1_2:%[0-9]+]]:acc1024 = VLDA_UPS_2x_dmx_lda_ups_x2c_idx_upsSign1 [[COPY8]], [[COPY]], [[MOV_PD_imm11_pseudo1]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign1 :: (load (<16 x s32>))
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_upsSign1_]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_imm_upsSign1_]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_upsSign1_1]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_imm_upsSign1_1]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_imm_upsSign1_2]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_upsSign1_2]]
     %0:ptrregbank(p0) = COPY $p0
     %7:modregbank(s20) = COPY $m0
     %8:modregbank(s20) = G_CONSTANT i20 0
-    %9:modregbank(s20) = G_CONSTANT i20 16
-    %10:modregbank(s20) = G_CONSTANT i20 -128
-    %11:modregbank(s20) = G_CONSTANT i20 96
-    %12:modregbank(s20) = G_CONSTANT i20 128
+    %9:modregbank(s20) = G_CONSTANT i20 32
+    %10:modregbank(s20) = G_CONSTANT i20 -512
+    %11:modregbank(s20) = G_CONSTANT i20 448
+    %12:modregbank(s20) = G_CONSTANT i20 512
     %101:gprregbank(s32) = COPY $r1
     %102:gprregbank(s32) = G_CONSTANT i32 1
     %25:vregbank(<16 x s32>) = G_AIE_OFFSET_LOAD %0, %7 :: (load (<16 x s32>))
@@ -358,47 +362,47 @@ body:             |
 ...
 
 ---
-name:            VST_UPS_4x_DM_v32_acc64_signed
+name:            VLDA_UPS_4x_acc64_v32_signed
 alignment:       16
 legalized:       true
 regBankSelected: true
 body:             |
   bb.1.entry:
     liveins: $bmll0, $p0, $r0, $r1
-    ; CHECK-LABEL: name: VST_UPS_4x_DM_v32_acc64_signed
+    ; CHECK-LABEL: name: VLDA_UPS_4x_acc64_v32_signed
     ; CHECK: liveins: $bmll0, $p0, $r0, $r1
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
-    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:mdm = COPY $m0
-    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo:%[0-9]+]]:mdm = MOV_PD_imm11_pseudo 16
-    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo1:%[0-9]+]]:mdm = MOV_PD_imm11_pseudo 96
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:edj = COPY $m0
+    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo:%[0-9]+]]:edj = MOV_PD_imm11_pseudo 32
+    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo1:%[0-9]+]]:edj = MOV_PD_imm11_pseudo 512
     ; CHECK-NEXT: [[COPY2:%[0-9]+]]:er = COPY $r1
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 1
     ; CHECK-NEXT: [[COPY3:%[0-9]+]]:es = COPY [[COPY2]]
-    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign1_:%[0-9]+]]:acc2048 = VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign1 [[COPY3]], [[COPY]], [[COPY1]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign1 :: (load (<16 x s32>))
+    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_upsSign1_:%[0-9]+]]:acc2048 = VLDA_UPS_4x_dmx_lda_ups_x2d_idx_upsSign1 [[COPY3]], [[COPY]], [[COPY1]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign1 :: (load (<16 x s32>))
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 1
     ; CHECK-NEXT: [[COPY4:%[0-9]+]]:es = COPY [[COPY2]]
-    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign1_1:%[0-9]+]]:acc2048 = VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign1 [[COPY4]], [[COPY]], 0, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign1 :: (load (<16 x s32>))
+    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign1_:%[0-9]+]]:acc2048 = VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign1 [[COPY4]], [[COPY]], 0, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign1 :: (load (<16 x s32>))
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 1
     ; CHECK-NEXT: [[COPY5:%[0-9]+]]:es = COPY [[COPY2]]
-    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign1_2:%[0-9]+]]:acc2048 = VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign1 [[COPY5]], [[COPY]], [[MOV_PD_imm11_pseudo]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign1 :: (load (<16 x s32>))
+    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_upsSign1_1:%[0-9]+]]:acc2048 = VLDA_UPS_4x_dmx_lda_ups_x2d_idx_upsSign1 [[COPY5]], [[COPY]], [[MOV_PD_imm11_pseudo]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign1 :: (load (<16 x s32>))
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 1
     ; CHECK-NEXT: [[COPY6:%[0-9]+]]:es = COPY [[COPY2]]
-    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign1_3:%[0-9]+]]:acc2048 = VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign1 [[COPY6]], [[COPY]], -128, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign1 :: (load (<16 x s32>))
+    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign1_1:%[0-9]+]]:acc2048 = VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign1 [[COPY6]], [[COPY]], -512, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign1 :: (load (<16 x s32>))
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 1
     ; CHECK-NEXT: [[COPY7:%[0-9]+]]:es = COPY [[COPY2]]
-    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign1_4:%[0-9]+]]:acc2048 = VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign1 [[COPY7]], [[COPY]], [[MOV_PD_imm11_pseudo1]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign1 :: (load (<16 x s32>))
+    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign1_2:%[0-9]+]]:acc2048 = VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign1 [[COPY7]], [[COPY]], 448, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign1 :: (load (<16 x s32>))
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 1
     ; CHECK-NEXT: [[COPY8:%[0-9]+]]:es = COPY [[COPY2]]
-    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign1_5:%[0-9]+]]:acc2048 = VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign1 [[COPY8]], [[COPY]], 128, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign1 :: (load (<16 x s32>))
-    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign1_]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign1_1]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign1_2]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign1_3]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign1_4]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign1_5]]
+    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_upsSign1_2:%[0-9]+]]:acc2048 = VLDA_UPS_4x_dmx_lda_ups_x2d_idx_upsSign1 [[COPY8]], [[COPY]], [[MOV_PD_imm11_pseudo1]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign1 :: (load (<16 x s32>))
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_upsSign1_]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign1_]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_upsSign1_1]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign1_1]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign1_2]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_upsSign1_2]]
     %0:ptrregbank(p0) = COPY $p0
     %7:modregbank(s20) = COPY $m0
     %8:modregbank(s20) = G_CONSTANT i20 0
-    %9:modregbank(s20) = G_CONSTANT i20 16
-    %10:modregbank(s20) = G_CONSTANT i20 -128
-    %11:modregbank(s20) = G_CONSTANT i20 96
-    %12:modregbank(s20) = G_CONSTANT i20 128
+    %9:modregbank(s20) = G_CONSTANT i20 32
+    %10:modregbank(s20) = G_CONSTANT i20 -512
+    %11:modregbank(s20) = G_CONSTANT i20 448
+    %12:modregbank(s20) = G_CONSTANT i20 512
     %101:gprregbank(s32) = COPY $r1
     %102:gprregbank(s32) = G_CONSTANT i32 1
     %25:vregbank(<16 x s32>) = G_AIE_OFFSET_LOAD %0, %7 :: (load (<16 x s32>))
@@ -417,47 +421,47 @@ body:             |
 ...
 
 ---
-name:            VST_UPS_4x_DM_v64_acc32_signed
+name:            VLDA_UPS_4x_acc32_v64_signed
 alignment:       16
 legalized:       true
 regBankSelected: true
 body:             |
   bb.1.entry:
     liveins: $bmll0, $p0, $r0, $r1
-    ; CHECK-LABEL: name: VST_UPS_4x_DM_v64_acc32_signed
+    ; CHECK-LABEL: name: VLDA_UPS_4x_acc32_v64_signed
     ; CHECK: liveins: $bmll0, $p0, $r0, $r1
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
-    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:mdm = COPY $m0
-    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo:%[0-9]+]]:mdm = MOV_PD_imm11_pseudo 16
-    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo1:%[0-9]+]]:mdm = MOV_PD_imm11_pseudo 96
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:edj = COPY $m0
+    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo:%[0-9]+]]:edj = MOV_PD_imm11_pseudo 32
+    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo1:%[0-9]+]]:edj = MOV_PD_imm11_pseudo 512
     ; CHECK-NEXT: [[COPY2:%[0-9]+]]:er = COPY $r1
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: [[COPY3:%[0-9]+]]:es = COPY [[COPY2]]
-    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign1_:%[0-9]+]]:acc2048 = VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign1 [[COPY3]], [[COPY]], [[COPY1]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign1 :: (load (<16 x s32>))
+    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_upsSign1_:%[0-9]+]]:acc2048 = VLDA_UPS_4x_dmx_lda_ups_x2d_idx_upsSign1 [[COPY3]], [[COPY]], [[COPY1]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign1 :: (load (<16 x s32>))
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: [[COPY4:%[0-9]+]]:es = COPY [[COPY2]]
-    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign1_1:%[0-9]+]]:acc2048 = VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign1 [[COPY4]], [[COPY]], 0, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign1 :: (load (<16 x s32>))
+    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign1_:%[0-9]+]]:acc2048 = VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign1 [[COPY4]], [[COPY]], 0, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign1 :: (load (<16 x s32>))
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: [[COPY5:%[0-9]+]]:es = COPY [[COPY2]]
-    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign1_2:%[0-9]+]]:acc2048 = VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign1 [[COPY5]], [[COPY]], [[MOV_PD_imm11_pseudo]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign1 :: (load (<16 x s32>))
+    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_upsSign1_1:%[0-9]+]]:acc2048 = VLDA_UPS_4x_dmx_lda_ups_x2d_idx_upsSign1 [[COPY5]], [[COPY]], [[MOV_PD_imm11_pseudo]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign1 :: (load (<16 x s32>))
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: [[COPY6:%[0-9]+]]:es = COPY [[COPY2]]
-    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign1_3:%[0-9]+]]:acc2048 = VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign1 [[COPY6]], [[COPY]], -128, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign1 :: (load (<16 x s32>))
+    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign1_1:%[0-9]+]]:acc2048 = VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign1 [[COPY6]], [[COPY]], -512, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign1 :: (load (<16 x s32>))
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: [[COPY7:%[0-9]+]]:es = COPY [[COPY2]]
-    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign1_4:%[0-9]+]]:acc2048 = VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign1 [[COPY7]], [[COPY]], [[MOV_PD_imm11_pseudo1]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign1 :: (load (<16 x s32>))
+    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign1_2:%[0-9]+]]:acc2048 = VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign1 [[COPY7]], [[COPY]], 448, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign1 :: (load (<16 x s32>))
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: [[COPY8:%[0-9]+]]:es = COPY [[COPY2]]
-    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign1_5:%[0-9]+]]:acc2048 = VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign1 [[COPY8]], [[COPY]], 128, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign1 :: (load (<16 x s32>))
-    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign1_]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign1_1]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign1_2]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign1_3]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign1_4]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign1_5]]
+    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_upsSign1_2:%[0-9]+]]:acc2048 = VLDA_UPS_4x_dmx_lda_ups_x2d_idx_upsSign1 [[COPY8]], [[COPY]], [[MOV_PD_imm11_pseudo1]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign1 :: (load (<16 x s32>))
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_upsSign1_]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign1_]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_upsSign1_1]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign1_1]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign1_2]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_upsSign1_2]]
     %0:ptrregbank(p0) = COPY $p0
     %7:modregbank(s20) = COPY $m0
     %8:modregbank(s20) = G_CONSTANT i20 0
-    %9:modregbank(s20) = G_CONSTANT i20 16
-    %10:modregbank(s20) = G_CONSTANT i20 -128
-    %11:modregbank(s20) = G_CONSTANT i20 96
-    %12:modregbank(s20) = G_CONSTANT i20 128
+    %9:modregbank(s20) = G_CONSTANT i20 32
+    %10:modregbank(s20) = G_CONSTANT i20 -512
+    %11:modregbank(s20) = G_CONSTANT i20 448
+    %12:modregbank(s20) = G_CONSTANT i20 512
     %101:gprregbank(s32) = COPY $r1
     %102:gprregbank(s32) = G_CONSTANT i32 1
     %25:vregbank(<16 x s32>) = G_AIE_OFFSET_LOAD %0, %7 :: (load (<16 x s32>))
@@ -476,19 +480,20 @@ body:             |
 ...
 
 ---
-name:            VST_UPS_2x_BM_v16_acc32_unsigned
+name:            VLDA_UPS_2x_acc32_v16_unsigned
 alignment:       16
 legalized:       true
 regBankSelected: true
 body:             |
   bb.1.entry:
     liveins: $bmll0, $p0, $r0, $r1
-    ; CHECK-LABEL: name: VST_UPS_2x_BM_v16_acc32_unsigned
+    ; CHECK-LABEL: name: VLDA_UPS_2x_acc32_v16_unsigned
     ; CHECK: liveins: $bmll0, $p0, $r0, $r1
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
     ; CHECK-NEXT: [[COPY1:%[0-9]+]]:edj = COPY $m0
     ; CHECK-NEXT: [[MOV_PD_imm11_pseudo:%[0-9]+]]:edj = MOV_PD_imm11_pseudo 16
+    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo1:%[0-9]+]]:edj = MOV_PD_imm11_pseudo 256
     ; CHECK-NEXT: [[COPY2:%[0-9]+]]:er = COPY $r1
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: [[COPY3:%[0-9]+]]:es = COPY [[COPY2]]
@@ -501,21 +506,21 @@ body:             |
     ; CHECK-NEXT: [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_upsSign0_1:%[0-9]+]]:acc512 = VLDA_UPS_2x_dmw_lda_ups_w2b_idx_upsSign0 [[COPY5]], [[COPY]], [[MOV_PD_imm11_pseudo]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s16>))
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: [[COPY6:%[0-9]+]]:es = COPY [[COPY2]]
-    ; CHECK-NEXT: [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign0_1:%[0-9]+]]:acc512 = VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign0 [[COPY6]], [[COPY]], -128, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s16>))
+    ; CHECK-NEXT: [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign0_1:%[0-9]+]]:acc512 = VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign0 [[COPY6]], [[COPY]], -256, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s16>))
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: [[COPY7:%[0-9]+]]:es = COPY [[COPY2]]
-    ; CHECK-NEXT: [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign0_2:%[0-9]+]]:acc512 = VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign0 [[COPY7]], [[COPY]], 96, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s16>))
+    ; CHECK-NEXT: [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign0_2:%[0-9]+]]:acc512 = VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign0 [[COPY7]], [[COPY]], 224, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s16>))
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: [[COPY8:%[0-9]+]]:es = COPY [[COPY2]]
-    ; CHECK-NEXT: [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign0_3:%[0-9]+]]:acc512 = VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign0 [[COPY8]], [[COPY]], 128, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s16>))
-    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_upsSign0_]], implicit [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign0_]], implicit [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_upsSign0_1]], implicit [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign0_1]], implicit [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign0_2]], implicit [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign0_3]]
+    ; CHECK-NEXT: [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_upsSign0_2:%[0-9]+]]:acc512 = VLDA_UPS_2x_dmw_lda_ups_w2b_idx_upsSign0 [[COPY8]], [[COPY]], [[MOV_PD_imm11_pseudo1]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s16>))
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_upsSign0_]], implicit [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign0_]], implicit [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_upsSign0_1]], implicit [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign0_1]], implicit [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign0_2]], implicit [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_upsSign0_2]]
     %0:ptrregbank(p0) = COPY $p0
     %7:modregbank(s20) = COPY $m0
     %8:modregbank(s20) = G_CONSTANT i20 0
     %9:modregbank(s20) = G_CONSTANT i20 16
-    %10:modregbank(s20) = G_CONSTANT i20 -128
-    %11:modregbank(s20) = G_CONSTANT i20 96
-    %12:modregbank(s20) = G_CONSTANT i20 128
+    %10:modregbank(s20) = G_CONSTANT i20 -256
+    %11:modregbank(s20) = G_CONSTANT i20 224
+    %12:modregbank(s20) = G_CONSTANT i20 256
     %101:gprregbank(s32) = COPY $r1
     %102:gprregbank(s32) = G_CONSTANT i32 0
     %25:vregbank(<16 x s16>) = G_AIE_OFFSET_LOAD %0, %7 :: (load (<16 x s16>))
@@ -534,19 +539,20 @@ body:             |
 ...
 
 ---
-name:            VST_UPS_2x_BM_v8_acc64_unsigned
+name:            VLDA_UPS_2x_acc64_v8_unsigned
 alignment:       16
 legalized:       true
 regBankSelected: true
 body:             |
   bb.1.entry:
     liveins: $bmll0, $p0, $r0, $r1
-    ; CHECK-LABEL: name: VST_UPS_2x_BM_v8_acc64_unsigned
+    ; CHECK-LABEL: name: VLDA_UPS_2x_acc64_v8_unsigned
     ; CHECK: liveins: $bmll0, $p0, $r0, $r1
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
     ; CHECK-NEXT: [[COPY1:%[0-9]+]]:edj = COPY $m0
     ; CHECK-NEXT: [[MOV_PD_imm11_pseudo:%[0-9]+]]:edj = MOV_PD_imm11_pseudo 16
+    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo1:%[0-9]+]]:edj = MOV_PD_imm11_pseudo 256
     ; CHECK-NEXT: [[COPY2:%[0-9]+]]:er = COPY $r1
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 1
     ; CHECK-NEXT: [[COPY3:%[0-9]+]]:es = COPY [[COPY2]]
@@ -559,21 +565,21 @@ body:             |
     ; CHECK-NEXT: [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_upsSign0_1:%[0-9]+]]:acc512 = VLDA_UPS_2x_dmw_lda_ups_w2b_idx_upsSign0 [[COPY5]], [[COPY]], [[MOV_PD_imm11_pseudo]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s16>))
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 1
     ; CHECK-NEXT: [[COPY6:%[0-9]+]]:es = COPY [[COPY2]]
-    ; CHECK-NEXT: [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign0_1:%[0-9]+]]:acc512 = VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign0 [[COPY6]], [[COPY]], -128, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s16>))
+    ; CHECK-NEXT: [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign0_1:%[0-9]+]]:acc512 = VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign0 [[COPY6]], [[COPY]], -256, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s16>))
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 1
     ; CHECK-NEXT: [[COPY7:%[0-9]+]]:es = COPY [[COPY2]]
-    ; CHECK-NEXT: [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign0_2:%[0-9]+]]:acc512 = VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign0 [[COPY7]], [[COPY]], 96, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s16>))
+    ; CHECK-NEXT: [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign0_2:%[0-9]+]]:acc512 = VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign0 [[COPY7]], [[COPY]], 224, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s16>))
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 1
     ; CHECK-NEXT: [[COPY8:%[0-9]+]]:es = COPY [[COPY2]]
-    ; CHECK-NEXT: [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign0_3:%[0-9]+]]:acc512 = VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign0 [[COPY8]], [[COPY]], 128, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s16>))
-    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_upsSign0_]], implicit [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign0_]], implicit [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_upsSign0_1]], implicit [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign0_1]], implicit [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign0_2]], implicit [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign0_3]]
+    ; CHECK-NEXT: [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_upsSign0_2:%[0-9]+]]:acc512 = VLDA_UPS_2x_dmw_lda_ups_w2b_idx_upsSign0 [[COPY8]], [[COPY]], [[MOV_PD_imm11_pseudo1]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s16>))
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_upsSign0_]], implicit [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign0_]], implicit [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_upsSign0_1]], implicit [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign0_1]], implicit [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign0_2]], implicit [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_upsSign0_2]]
     %0:ptrregbank(p0) = COPY $p0
     %7:modregbank(s20) = COPY $m0
     %8:modregbank(s20) = G_CONSTANT i20 0
     %9:modregbank(s20) = G_CONSTANT i20 16
-    %10:modregbank(s20) = G_CONSTANT i20 -128
-    %11:modregbank(s20) = G_CONSTANT i20 96
-    %12:modregbank(s20) = G_CONSTANT i20 128
+    %10:modregbank(s20) = G_CONSTANT i20 -256
+    %11:modregbank(s20) = G_CONSTANT i20 224
+    %12:modregbank(s20) = G_CONSTANT i20 256
     %101:gprregbank(s32) = COPY $r1
     %102:gprregbank(s32) = G_CONSTANT i32 0
     %25:vregbank(<16 x s16>) = G_AIE_OFFSET_LOAD %0, %7 :: (load (<16 x s16>))
@@ -592,19 +598,20 @@ body:             |
 ...
 
 ---
-name:            VST_UPS_4x_CM_v16_acc64_unsigned
+name:            VLDA_UPS_4x_acc64_v16_unsigned
 alignment:       16
 legalized:       true
 regBankSelected: true
 body:             |
   bb.1.entry:
     liveins: $bmll0, $p0, $r0, $r1
-    ; CHECK-LABEL: name: VST_UPS_4x_CM_v16_acc64_unsigned
+    ; CHECK-LABEL: name: VLDA_UPS_4x_acc64_v16_unsigned
     ; CHECK: liveins: $bmll0, $p0, $r0, $r1
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
     ; CHECK-NEXT: [[COPY1:%[0-9]+]]:edj = COPY $m0
     ; CHECK-NEXT: [[MOV_PD_imm11_pseudo:%[0-9]+]]:edj = MOV_PD_imm11_pseudo 16
+    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo1:%[0-9]+]]:edj = MOV_PD_imm11_pseudo 256
     ; CHECK-NEXT: [[COPY2:%[0-9]+]]:er = COPY $r1
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 1
     ; CHECK-NEXT: [[COPY3:%[0-9]+]]:es = COPY [[COPY2]]
@@ -617,21 +624,21 @@ body:             |
     ; CHECK-NEXT: [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_upsSign0_1:%[0-9]+]]:acc1024 = VLDA_UPS_4x_dmw_lda_ups_w2c_idx_upsSign0 [[COPY5]], [[COPY]], [[MOV_PD_imm11_pseudo]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s16>))
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 1
     ; CHECK-NEXT: [[COPY6:%[0-9]+]]:es = COPY [[COPY2]]
-    ; CHECK-NEXT: [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign0_1:%[0-9]+]]:acc1024 = VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign0 [[COPY6]], [[COPY]], -128, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s16>))
+    ; CHECK-NEXT: [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign0_1:%[0-9]+]]:acc1024 = VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign0 [[COPY6]], [[COPY]], -256, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s16>))
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 1
     ; CHECK-NEXT: [[COPY7:%[0-9]+]]:es = COPY [[COPY2]]
-    ; CHECK-NEXT: [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign0_2:%[0-9]+]]:acc1024 = VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign0 [[COPY7]], [[COPY]], 96, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s16>))
+    ; CHECK-NEXT: [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign0_2:%[0-9]+]]:acc1024 = VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign0 [[COPY7]], [[COPY]], 224, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s16>))
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 1
     ; CHECK-NEXT: [[COPY8:%[0-9]+]]:es = COPY [[COPY2]]
-    ; CHECK-NEXT: [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign0_3:%[0-9]+]]:acc1024 = VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign0 [[COPY8]], [[COPY]], 128, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s16>))
-    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_upsSign0_]], implicit [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign0_]], implicit [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_upsSign0_1]], implicit [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign0_1]], implicit [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign0_2]], implicit [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign0_3]]
+    ; CHECK-NEXT: [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_upsSign0_2:%[0-9]+]]:acc1024 = VLDA_UPS_4x_dmw_lda_ups_w2c_idx_upsSign0 [[COPY8]], [[COPY]], [[MOV_PD_imm11_pseudo1]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s16>))
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_upsSign0_]], implicit [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign0_]], implicit [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_upsSign0_1]], implicit [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign0_1]], implicit [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign0_2]], implicit [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_upsSign0_2]]
     %0:ptrregbank(p0) = COPY $p0
     %7:modregbank(s20) = COPY $m0
     %8:modregbank(s20) = G_CONSTANT i20 0
     %9:modregbank(s20) = G_CONSTANT i20 16
-    %10:modregbank(s20) = G_CONSTANT i20 -128
-    %11:modregbank(s20) = G_CONSTANT i20 96
-    %12:modregbank(s20) = G_CONSTANT i20 128
+    %10:modregbank(s20) = G_CONSTANT i20 -256
+    %11:modregbank(s20) = G_CONSTANT i20 224
+    %12:modregbank(s20) = G_CONSTANT i20 256
     %101:gprregbank(s32) = COPY $r1
     %102:gprregbank(s32) = G_CONSTANT i32 0
     %25:vregbank(<16 x s16>) = G_AIE_OFFSET_LOAD %0, %7 :: (load (<16 x s16>))
@@ -650,19 +657,20 @@ body:             |
 ...
 
 ---
-name:            VST_UPS_4x_CM_v32_acc32_unsigned
+name:            VLDA_UPS_4x_acc32_v32_unsigned
 alignment:       16
 legalized:       true
 regBankSelected: true
 body:             |
   bb.1.entry:
     liveins: $bmll0, $p0, $r0, $r1
-    ; CHECK-LABEL: name: VST_UPS_4x_CM_v32_acc32_unsigned
+    ; CHECK-LABEL: name: VLDA_UPS_4x_acc32_v32_unsigned
     ; CHECK: liveins: $bmll0, $p0, $r0, $r1
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
     ; CHECK-NEXT: [[COPY1:%[0-9]+]]:edj = COPY $m0
     ; CHECK-NEXT: [[MOV_PD_imm11_pseudo:%[0-9]+]]:edj = MOV_PD_imm11_pseudo 16
+    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo1:%[0-9]+]]:edj = MOV_PD_imm11_pseudo 256
     ; CHECK-NEXT: [[COPY2:%[0-9]+]]:er = COPY $r1
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: [[COPY3:%[0-9]+]]:es = COPY [[COPY2]]
@@ -675,21 +683,21 @@ body:             |
     ; CHECK-NEXT: [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_upsSign0_1:%[0-9]+]]:acc1024 = VLDA_UPS_4x_dmw_lda_ups_w2c_idx_upsSign0 [[COPY5]], [[COPY]], [[MOV_PD_imm11_pseudo]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s16>))
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: [[COPY6:%[0-9]+]]:es = COPY [[COPY2]]
-    ; CHECK-NEXT: [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign0_1:%[0-9]+]]:acc1024 = VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign0 [[COPY6]], [[COPY]], -128, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s16>))
+    ; CHECK-NEXT: [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign0_1:%[0-9]+]]:acc1024 = VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign0 [[COPY6]], [[COPY]], -256, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s16>))
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: [[COPY7:%[0-9]+]]:es = COPY [[COPY2]]
-    ; CHECK-NEXT: [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign0_2:%[0-9]+]]:acc1024 = VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign0 [[COPY7]], [[COPY]], 96, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s16>))
+    ; CHECK-NEXT: [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign0_2:%[0-9]+]]:acc1024 = VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign0 [[COPY7]], [[COPY]], 224, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s16>))
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: [[COPY8:%[0-9]+]]:es = COPY [[COPY2]]
-    ; CHECK-NEXT: [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign0_3:%[0-9]+]]:acc1024 = VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign0 [[COPY8]], [[COPY]], 128, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s16>))
-    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_upsSign0_]], implicit [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign0_]], implicit [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_upsSign0_1]], implicit [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign0_1]], implicit [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign0_2]], implicit [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign0_3]]
+    ; CHECK-NEXT: [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_upsSign0_2:%[0-9]+]]:acc1024 = VLDA_UPS_4x_dmw_lda_ups_w2c_idx_upsSign0 [[COPY8]], [[COPY]], [[MOV_PD_imm11_pseudo1]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s16>))
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_upsSign0_]], implicit [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign0_]], implicit [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_upsSign0_1]], implicit [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign0_1]], implicit [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign0_2]], implicit [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_upsSign0_2]]
     %0:ptrregbank(p0) = COPY $p0
     %7:modregbank(s20) = COPY $m0
     %8:modregbank(s20) = G_CONSTANT i20 0
     %9:modregbank(s20) = G_CONSTANT i20 16
-    %10:modregbank(s20) = G_CONSTANT i20 -128
-    %11:modregbank(s20) = G_CONSTANT i20 96
-    %12:modregbank(s20) = G_CONSTANT i20 128
+    %10:modregbank(s20) = G_CONSTANT i20 -256
+    %11:modregbank(s20) = G_CONSTANT i20 224
+    %12:modregbank(s20) = G_CONSTANT i20 256
     %101:gprregbank(s32) = COPY $r1
     %102:gprregbank(s32) = G_CONSTANT i32 0
     %25:vregbank(<16 x s16>) = G_AIE_OFFSET_LOAD %0, %7 :: (load (<16 x s16>))
@@ -708,20 +716,20 @@ body:             |
 ...
 
 ---
-name:            VST_UPS_2x_CM_v32_acc32_unsigned
+name:            VLDA_UPS_2x_acc32_v32_unsigned
 alignment:       16
 legalized:       true
 regBankSelected: true
 body:             |
   bb.1.entry:
     liveins: $bmll0, $p0, $r0, $r1
-    ; CHECK-LABEL: name: VST_UPS_2x_CM_v32_acc32_unsigned
+    ; CHECK-LABEL: name: VLDA_UPS_2x_acc32_v32_unsigned
     ; CHECK: liveins: $bmll0, $p0, $r0, $r1
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
     ; CHECK-NEXT: [[COPY1:%[0-9]+]]:edj = COPY $m0
-    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo:%[0-9]+]]:edj = MOV_PD_imm11_pseudo 16
-    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo1:%[0-9]+]]:edj = MOV_PD_imm11_pseudo 96
+    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo:%[0-9]+]]:edj = MOV_PD_imm11_pseudo 32
+    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo1:%[0-9]+]]:edj = MOV_PD_imm11_pseudo 512
     ; CHECK-NEXT: [[COPY2:%[0-9]+]]:er = COPY $r1
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: [[COPY3:%[0-9]+]]:es = COPY [[COPY2]]
@@ -734,21 +742,21 @@ body:             |
     ; CHECK-NEXT: [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_upsSign0_1:%[0-9]+]]:acc1024 = VLDA_UPS_2x_dmx_lda_ups_x2c_idx_upsSign0 [[COPY5]], [[COPY]], [[MOV_PD_imm11_pseudo]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: [[COPY6:%[0-9]+]]:es = COPY [[COPY2]]
-    ; CHECK-NEXT: [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_imm_upsSign0_1:%[0-9]+]]:acc1024 = VLDA_UPS_2x_dmx_lda_ups_x2c_idx_imm_upsSign0 [[COPY6]], [[COPY]], -128, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
+    ; CHECK-NEXT: [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_imm_upsSign0_1:%[0-9]+]]:acc1024 = VLDA_UPS_2x_dmx_lda_ups_x2c_idx_imm_upsSign0 [[COPY6]], [[COPY]], -512, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: [[COPY7:%[0-9]+]]:es = COPY [[COPY2]]
-    ; CHECK-NEXT: [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_upsSign0_2:%[0-9]+]]:acc1024 = VLDA_UPS_2x_dmx_lda_ups_x2c_idx_upsSign0 [[COPY7]], [[COPY]], [[MOV_PD_imm11_pseudo1]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
+    ; CHECK-NEXT: [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_imm_upsSign0_2:%[0-9]+]]:acc1024 = VLDA_UPS_2x_dmx_lda_ups_x2c_idx_imm_upsSign0 [[COPY7]], [[COPY]], 448, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: [[COPY8:%[0-9]+]]:es = COPY [[COPY2]]
-    ; CHECK-NEXT: [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_imm_upsSign0_2:%[0-9]+]]:acc1024 = VLDA_UPS_2x_dmx_lda_ups_x2c_idx_imm_upsSign0 [[COPY8]], [[COPY]], 128, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
-    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_upsSign0_]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_imm_upsSign0_]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_upsSign0_1]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_imm_upsSign0_1]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_upsSign0_2]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_imm_upsSign0_2]]
+    ; CHECK-NEXT: [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_upsSign0_2:%[0-9]+]]:acc1024 = VLDA_UPS_2x_dmx_lda_ups_x2c_idx_upsSign0 [[COPY8]], [[COPY]], [[MOV_PD_imm11_pseudo1]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_upsSign0_]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_imm_upsSign0_]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_upsSign0_1]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_imm_upsSign0_1]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_imm_upsSign0_2]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_upsSign0_2]]
     %0:ptrregbank(p0) = COPY $p0
     %7:modregbank(s20) = COPY $m0
     %8:modregbank(s20) = G_CONSTANT i20 0
-    %9:modregbank(s20) = G_CONSTANT i20 16
-    %10:modregbank(s20) = G_CONSTANT i20 -128
-    %11:modregbank(s20) = G_CONSTANT i20 96
-    %12:modregbank(s20) = G_CONSTANT i20 128
+    %9:modregbank(s20) = G_CONSTANT i20 32
+    %10:modregbank(s20) = G_CONSTANT i20 -512
+    %11:modregbank(s20) = G_CONSTANT i20 448
+    %12:modregbank(s20) = G_CONSTANT i20 512
     %101:gprregbank(s32) = COPY $r1
     %102:gprregbank(s32) = G_CONSTANT i32 0
     %25:vregbank(<16 x s32>) = G_AIE_OFFSET_LOAD %0, %7 :: (load (<16 x s32>))
@@ -767,20 +775,20 @@ body:             |
 ...
 
 ---
-name:            VST_UPS_2x_CM_v16_acc64_unsigned
+name:            VLDA_UPS_2x_acc64_v16_unsigned
 alignment:       16
 legalized:       true
 regBankSelected: true
 body:             |
   bb.1.entry:
     liveins: $bmll0, $p0, $r0, $r1
-    ; CHECK-LABEL: name: VST_UPS_2x_CM_v16_acc64_unsigned
+    ; CHECK-LABEL: name: VLDA_UPS_2x_acc64_v16_unsigned
     ; CHECK: liveins: $bmll0, $p0, $r0, $r1
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
     ; CHECK-NEXT: [[COPY1:%[0-9]+]]:edj = COPY $m0
-    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo:%[0-9]+]]:edj = MOV_PD_imm11_pseudo 16
-    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo1:%[0-9]+]]:edj = MOV_PD_imm11_pseudo 96
+    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo:%[0-9]+]]:edj = MOV_PD_imm11_pseudo 32
+    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo1:%[0-9]+]]:edj = MOV_PD_imm11_pseudo 512
     ; CHECK-NEXT: [[COPY2:%[0-9]+]]:er = COPY $r1
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 1
     ; CHECK-NEXT: [[COPY3:%[0-9]+]]:es = COPY [[COPY2]]
@@ -793,21 +801,21 @@ body:             |
     ; CHECK-NEXT: [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_upsSign0_1:%[0-9]+]]:acc1024 = VLDA_UPS_2x_dmx_lda_ups_x2c_idx_upsSign0 [[COPY5]], [[COPY]], [[MOV_PD_imm11_pseudo]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 1
     ; CHECK-NEXT: [[COPY6:%[0-9]+]]:es = COPY [[COPY2]]
-    ; CHECK-NEXT: [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_imm_upsSign0_1:%[0-9]+]]:acc1024 = VLDA_UPS_2x_dmx_lda_ups_x2c_idx_imm_upsSign0 [[COPY6]], [[COPY]], -128, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
+    ; CHECK-NEXT: [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_imm_upsSign0_1:%[0-9]+]]:acc1024 = VLDA_UPS_2x_dmx_lda_ups_x2c_idx_imm_upsSign0 [[COPY6]], [[COPY]], -512, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 1
     ; CHECK-NEXT: [[COPY7:%[0-9]+]]:es = COPY [[COPY2]]
-    ; CHECK-NEXT: [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_upsSign0_2:%[0-9]+]]:acc1024 = VLDA_UPS_2x_dmx_lda_ups_x2c_idx_upsSign0 [[COPY7]], [[COPY]], [[MOV_PD_imm11_pseudo1]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
+    ; CHECK-NEXT: [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_imm_upsSign0_2:%[0-9]+]]:acc1024 = VLDA_UPS_2x_dmx_lda_ups_x2c_idx_imm_upsSign0 [[COPY7]], [[COPY]], 448, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 1
     ; CHECK-NEXT: [[COPY8:%[0-9]+]]:es = COPY [[COPY2]]
-    ; CHECK-NEXT: [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_imm_upsSign0_2:%[0-9]+]]:acc1024 = VLDA_UPS_2x_dmx_lda_ups_x2c_idx_imm_upsSign0 [[COPY8]], [[COPY]], 128, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
-    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_upsSign0_]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_imm_upsSign0_]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_upsSign0_1]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_imm_upsSign0_1]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_upsSign0_2]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_imm_upsSign0_2]]
+    ; CHECK-NEXT: [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_upsSign0_2:%[0-9]+]]:acc1024 = VLDA_UPS_2x_dmx_lda_ups_x2c_idx_upsSign0 [[COPY8]], [[COPY]], [[MOV_PD_imm11_pseudo1]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_upsSign0_]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_imm_upsSign0_]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_upsSign0_1]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_imm_upsSign0_1]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_imm_upsSign0_2]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_upsSign0_2]]
     %0:ptrregbank(p0) = COPY $p0
     %7:modregbank(s20) = COPY $m0
     %8:modregbank(s20) = G_CONSTANT i20 0
-    %9:modregbank(s20) = G_CONSTANT i20 16
-    %10:modregbank(s20) = G_CONSTANT i20 -128
-    %11:modregbank(s20) = G_CONSTANT i20 96
-    %12:modregbank(s20) = G_CONSTANT i20 128
+    %9:modregbank(s20) = G_CONSTANT i20 32
+    %10:modregbank(s20) = G_CONSTANT i20 -512
+    %11:modregbank(s20) = G_CONSTANT i20 448
+    %12:modregbank(s20) = G_CONSTANT i20 512
     %101:gprregbank(s32) = COPY $r1
     %102:gprregbank(s32) = G_CONSTANT i32 0
     %25:vregbank(<16 x s32>) = G_AIE_OFFSET_LOAD %0, %7 :: (load (<16 x s32>))
@@ -826,47 +834,47 @@ body:             |
 ...
 
 ---
-name:            VST_UPS_4x_DM_v32_acc64_unsigned
+name:            VLDA_UPS_4x_acc64_v32_unsigned
 alignment:       16
 legalized:       true
 regBankSelected: true
 body:             |
   bb.1.entry:
     liveins: $bmll0, $p0, $r0, $r1
-    ; CHECK-LABEL: name: VST_UPS_4x_DM_v32_acc64_unsigned
+    ; CHECK-LABEL: name: VLDA_UPS_4x_acc64_v32_unsigned
     ; CHECK: liveins: $bmll0, $p0, $r0, $r1
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
-    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:mdm = COPY $m0
-    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo:%[0-9]+]]:mdm = MOV_PD_imm11_pseudo 16
-    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo1:%[0-9]+]]:mdm = MOV_PD_imm11_pseudo 96
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:edj = COPY $m0
+    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo:%[0-9]+]]:edj = MOV_PD_imm11_pseudo 32
+    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo1:%[0-9]+]]:edj = MOV_PD_imm11_pseudo 512
     ; CHECK-NEXT: [[COPY2:%[0-9]+]]:er = COPY $r1
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 1
     ; CHECK-NEXT: [[COPY3:%[0-9]+]]:es = COPY [[COPY2]]
-    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0_:%[0-9]+]]:acc2048 = VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0 [[COPY3]], [[COPY]], [[COPY1]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
+    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_upsSign0_:%[0-9]+]]:acc2048 = VLDA_UPS_4x_dmx_lda_ups_x2d_idx_upsSign0 [[COPY3]], [[COPY]], [[COPY1]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 1
     ; CHECK-NEXT: [[COPY4:%[0-9]+]]:es = COPY [[COPY2]]
-    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0_1:%[0-9]+]]:acc2048 = VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0 [[COPY4]], [[COPY]], 0, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
+    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0_:%[0-9]+]]:acc2048 = VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0 [[COPY4]], [[COPY]], 0, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 1
     ; CHECK-NEXT: [[COPY5:%[0-9]+]]:es = COPY [[COPY2]]
-    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0_2:%[0-9]+]]:acc2048 = VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0 [[COPY5]], [[COPY]], [[MOV_PD_imm11_pseudo]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
+    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_upsSign0_1:%[0-9]+]]:acc2048 = VLDA_UPS_4x_dmx_lda_ups_x2d_idx_upsSign0 [[COPY5]], [[COPY]], [[MOV_PD_imm11_pseudo]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 1
     ; CHECK-NEXT: [[COPY6:%[0-9]+]]:es = COPY [[COPY2]]
-    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0_3:%[0-9]+]]:acc2048 = VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0 [[COPY6]], [[COPY]], -128, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
+    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0_1:%[0-9]+]]:acc2048 = VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0 [[COPY6]], [[COPY]], -512, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 1
     ; CHECK-NEXT: [[COPY7:%[0-9]+]]:es = COPY [[COPY2]]
-    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0_4:%[0-9]+]]:acc2048 = VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0 [[COPY7]], [[COPY]], [[MOV_PD_imm11_pseudo1]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
+    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0_2:%[0-9]+]]:acc2048 = VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0 [[COPY7]], [[COPY]], 448, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 1
     ; CHECK-NEXT: [[COPY8:%[0-9]+]]:es = COPY [[COPY2]]
-    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0_5:%[0-9]+]]:acc2048 = VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0 [[COPY8]], [[COPY]], 128, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
-    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0_]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0_1]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0_2]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0_3]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0_4]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0_5]]
+    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_upsSign0_2:%[0-9]+]]:acc2048 = VLDA_UPS_4x_dmx_lda_ups_x2d_idx_upsSign0 [[COPY8]], [[COPY]], [[MOV_PD_imm11_pseudo1]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_upsSign0_]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0_]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_upsSign0_1]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0_1]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0_2]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_upsSign0_2]]
     %0:ptrregbank(p0) = COPY $p0
     %7:modregbank(s20) = COPY $m0
     %8:modregbank(s20) = G_CONSTANT i20 0
-    %9:modregbank(s20) = G_CONSTANT i20 16
-    %10:modregbank(s20) = G_CONSTANT i20 -128
-    %11:modregbank(s20) = G_CONSTANT i20 96
-    %12:modregbank(s20) = G_CONSTANT i20 128
+    %9:modregbank(s20) = G_CONSTANT i20 32
+    %10:modregbank(s20) = G_CONSTANT i20 -512
+    %11:modregbank(s20) = G_CONSTANT i20 448
+    %12:modregbank(s20) = G_CONSTANT i20 512
     %101:gprregbank(s32) = COPY $r1
     %102:gprregbank(s32) = G_CONSTANT i32 0
     %25:vregbank(<16 x s32>) = G_AIE_OFFSET_LOAD %0, %7 :: (load (<16 x s32>))
@@ -885,47 +893,47 @@ body:             |
 ...
 
 ---
-name:            VST_UPS_4x_DM_v64_acc32_unsigned
+name:            VLDA_UPS_4x_acc32_v64_unsigned
 alignment:       16
 legalized:       true
 regBankSelected: true
 body:             |
   bb.1.entry:
     liveins: $bmll0, $p0, $r0, $r1
-    ; CHECK-LABEL: name: VST_UPS_4x_DM_v64_acc32_unsigned
+    ; CHECK-LABEL: name: VLDA_UPS_4x_acc32_v64_unsigned
     ; CHECK: liveins: $bmll0, $p0, $r0, $r1
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
-    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:mdm = COPY $m0
-    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo:%[0-9]+]]:mdm = MOV_PD_imm11_pseudo 16
-    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo1:%[0-9]+]]:mdm = MOV_PD_imm11_pseudo 96
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:edj = COPY $m0
+    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo:%[0-9]+]]:edj = MOV_PD_imm11_pseudo 32
+    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo1:%[0-9]+]]:edj = MOV_PD_imm11_pseudo 512
     ; CHECK-NEXT: [[COPY2:%[0-9]+]]:er = COPY $r1
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: [[COPY3:%[0-9]+]]:es = COPY [[COPY2]]
-    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0_:%[0-9]+]]:acc2048 = VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0 [[COPY3]], [[COPY]], [[COPY1]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
+    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_upsSign0_:%[0-9]+]]:acc2048 = VLDA_UPS_4x_dmx_lda_ups_x2d_idx_upsSign0 [[COPY3]], [[COPY]], [[COPY1]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: [[COPY4:%[0-9]+]]:es = COPY [[COPY2]]
-    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0_1:%[0-9]+]]:acc2048 = VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0 [[COPY4]], [[COPY]], 0, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
+    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0_:%[0-9]+]]:acc2048 = VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0 [[COPY4]], [[COPY]], 0, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: [[COPY5:%[0-9]+]]:es = COPY [[COPY2]]
-    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0_2:%[0-9]+]]:acc2048 = VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0 [[COPY5]], [[COPY]], [[MOV_PD_imm11_pseudo]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
+    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_upsSign0_1:%[0-9]+]]:acc2048 = VLDA_UPS_4x_dmx_lda_ups_x2d_idx_upsSign0 [[COPY5]], [[COPY]], [[MOV_PD_imm11_pseudo]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: [[COPY6:%[0-9]+]]:es = COPY [[COPY2]]
-    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0_3:%[0-9]+]]:acc2048 = VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0 [[COPY6]], [[COPY]], -128, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
+    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0_1:%[0-9]+]]:acc2048 = VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0 [[COPY6]], [[COPY]], -512, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: [[COPY7:%[0-9]+]]:es = COPY [[COPY2]]
-    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0_4:%[0-9]+]]:acc2048 = VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0 [[COPY7]], [[COPY]], [[MOV_PD_imm11_pseudo1]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
+    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0_2:%[0-9]+]]:acc2048 = VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0 [[COPY7]], [[COPY]], 448, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: [[COPY8:%[0-9]+]]:es = COPY [[COPY2]]
-    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0_5:%[0-9]+]]:acc2048 = VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0 [[COPY8]], [[COPY]], 128, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
-    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0_]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0_1]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0_2]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0_3]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0_4]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0_5]]
+    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_upsSign0_2:%[0-9]+]]:acc2048 = VLDA_UPS_4x_dmx_lda_ups_x2d_idx_upsSign0 [[COPY8]], [[COPY]], [[MOV_PD_imm11_pseudo1]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_upsSign0_]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0_]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_upsSign0_1]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0_1]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0_2]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_upsSign0_2]]
     %0:ptrregbank(p0) = COPY $p0
     %7:modregbank(s20) = COPY $m0
     %8:modregbank(s20) = G_CONSTANT i20 0
-    %9:modregbank(s20) = G_CONSTANT i20 16
-    %10:modregbank(s20) = G_CONSTANT i20 -128
-    %11:modregbank(s20) = G_CONSTANT i20 96
-    %12:modregbank(s20) = G_CONSTANT i20 128
+    %9:modregbank(s20) = G_CONSTANT i20 32
+    %10:modregbank(s20) = G_CONSTANT i20 -512
+    %11:modregbank(s20) = G_CONSTANT i20 448
+    %12:modregbank(s20) = G_CONSTANT i20 512
     %101:gprregbank(s32) = COPY $r1
     %102:gprregbank(s32) = G_CONSTANT i32 0
     %25:vregbank(<16 x s32>) = G_AIE_OFFSET_LOAD %0, %7 :: (load (<16 x s32>))
@@ -944,19 +952,20 @@ body:             |
 ...
 
 ---
-name:            VST_UPS_2x_BM_v16_acc32_dynamic
+name:            VLDA_UPS_2x_acc32_v16_dynamic
 alignment:       16
 legalized:       true
 regBankSelected: true
 body:             |
   bb.1.entry:
     liveins: $bmll0, $p0, $r0, $r1, $r2
-    ; CHECK-LABEL: name: VST_UPS_2x_BM_v16_acc32_dynamic
+    ; CHECK-LABEL: name: VLDA_UPS_2x_acc32_v16_dynamic
     ; CHECK: liveins: $bmll0, $p0, $r0, $r1, $r2
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
     ; CHECK-NEXT: [[COPY1:%[0-9]+]]:edj = COPY $m0
     ; CHECK-NEXT: [[MOV_PD_imm11_pseudo:%[0-9]+]]:edj = MOV_PD_imm11_pseudo 16
+    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo1:%[0-9]+]]:edj = MOV_PD_imm11_pseudo 256
     ; CHECK-NEXT: [[COPY2:%[0-9]+]]:er = COPY $r1
     ; CHECK-NEXT: [[COPY3:%[0-9]+]]:er = COPY $r2
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 0
@@ -977,26 +986,26 @@ body:             |
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: $upssign0 = COPY [[COPY3]]
     ; CHECK-NEXT: [[COPY7:%[0-9]+]]:es = COPY [[COPY2]]
-    ; CHECK-NEXT: [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign0_1:%[0-9]+]]:acc512 = VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign0 [[COPY7]], [[COPY]], -128, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s16>))
+    ; CHECK-NEXT: [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign0_1:%[0-9]+]]:acc512 = VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign0 [[COPY7]], [[COPY]], -256, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s16>))
     ; CHECK-NEXT: $upssign0 = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: $upssign0 = COPY [[COPY3]]
     ; CHECK-NEXT: [[COPY8:%[0-9]+]]:es = COPY [[COPY2]]
-    ; CHECK-NEXT: [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign0_2:%[0-9]+]]:acc512 = VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign0 [[COPY8]], [[COPY]], 96, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s16>))
+    ; CHECK-NEXT: [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign0_2:%[0-9]+]]:acc512 = VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign0 [[COPY8]], [[COPY]], 224, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s16>))
     ; CHECK-NEXT: $upssign0 = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: $upssign0 = COPY [[COPY3]]
     ; CHECK-NEXT: [[COPY9:%[0-9]+]]:es = COPY [[COPY2]]
-    ; CHECK-NEXT: [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign0_3:%[0-9]+]]:acc512 = VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign0 [[COPY9]], [[COPY]], 128, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s16>))
+    ; CHECK-NEXT: [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_upsSign0_2:%[0-9]+]]:acc512 = VLDA_UPS_2x_dmw_lda_ups_w2b_idx_upsSign0 [[COPY9]], [[COPY]], [[MOV_PD_imm11_pseudo1]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s16>))
     ; CHECK-NEXT: $upssign0 = MOV_scalar_imm11_pseudo 0
-    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_upsSign0_]], implicit [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign0_]], implicit [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_upsSign0_1]], implicit [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign0_1]], implicit [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign0_2]], implicit [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign0_3]]
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_upsSign0_]], implicit [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign0_]], implicit [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_upsSign0_1]], implicit [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign0_1]], implicit [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign0_2]], implicit [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_upsSign0_2]]
     %0:ptrregbank(p0) = COPY $p0
     %7:modregbank(s20) = COPY $m0
     %8:modregbank(s20) = G_CONSTANT i20 0
     %9:modregbank(s20) = G_CONSTANT i20 16
-    %10:modregbank(s20) = G_CONSTANT i20 -128
-    %11:modregbank(s20) = G_CONSTANT i20 96
-    %12:modregbank(s20) = G_CONSTANT i20 128
+    %10:modregbank(s20) = G_CONSTANT i20 -256
+    %11:modregbank(s20) = G_CONSTANT i20 224
+    %12:modregbank(s20) = G_CONSTANT i20 256
     %101:gprregbank(s32) = COPY $r1
     %102:gprregbank(s32) = COPY $r2
     %25:vregbank(<16 x s16>) = G_AIE_OFFSET_LOAD %0, %7 :: (load (<16 x s16>))
@@ -1015,19 +1024,20 @@ body:             |
 ...
 
 ---
-name:            VST_UPS_2x_BM_v8_acc64_dynamic
+name:            VLDA_UPS_2x_acc64_v8_dynamic
 alignment:       16
 legalized:       true
 regBankSelected: true
 body:             |
   bb.1.entry:
     liveins: $bmll0, $p0, $r0, $r1, $r2
-    ; CHECK-LABEL: name: VST_UPS_2x_BM_v8_acc64_dynamic
+    ; CHECK-LABEL: name: VLDA_UPS_2x_acc64_v8_dynamic
     ; CHECK: liveins: $bmll0, $p0, $r0, $r1, $r2
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
     ; CHECK-NEXT: [[COPY1:%[0-9]+]]:edj = COPY $m0
     ; CHECK-NEXT: [[MOV_PD_imm11_pseudo:%[0-9]+]]:edj = MOV_PD_imm11_pseudo 16
+    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo1:%[0-9]+]]:edj = MOV_PD_imm11_pseudo 256
     ; CHECK-NEXT: [[COPY2:%[0-9]+]]:er = COPY $r1
     ; CHECK-NEXT: [[COPY3:%[0-9]+]]:er = COPY $r2
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 1
@@ -1048,26 +1058,26 @@ body:             |
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 1
     ; CHECK-NEXT: $upssign0 = COPY [[COPY3]]
     ; CHECK-NEXT: [[COPY7:%[0-9]+]]:es = COPY [[COPY2]]
-    ; CHECK-NEXT: [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign0_1:%[0-9]+]]:acc512 = VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign0 [[COPY7]], [[COPY]], -128, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s16>))
+    ; CHECK-NEXT: [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign0_1:%[0-9]+]]:acc512 = VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign0 [[COPY7]], [[COPY]], -256, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s16>))
     ; CHECK-NEXT: $upssign0 = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 1
     ; CHECK-NEXT: $upssign0 = COPY [[COPY3]]
     ; CHECK-NEXT: [[COPY8:%[0-9]+]]:es = COPY [[COPY2]]
-    ; CHECK-NEXT: [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign0_2:%[0-9]+]]:acc512 = VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign0 [[COPY8]], [[COPY]], 96, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s16>))
+    ; CHECK-NEXT: [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign0_2:%[0-9]+]]:acc512 = VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign0 [[COPY8]], [[COPY]], 224, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s16>))
     ; CHECK-NEXT: $upssign0 = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 1
     ; CHECK-NEXT: $upssign0 = COPY [[COPY3]]
     ; CHECK-NEXT: [[COPY9:%[0-9]+]]:es = COPY [[COPY2]]
-    ; CHECK-NEXT: [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign0_3:%[0-9]+]]:acc512 = VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign0 [[COPY9]], [[COPY]], 128, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s16>))
+    ; CHECK-NEXT: [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_upsSign0_2:%[0-9]+]]:acc512 = VLDA_UPS_2x_dmw_lda_ups_w2b_idx_upsSign0 [[COPY9]], [[COPY]], [[MOV_PD_imm11_pseudo1]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s16>))
     ; CHECK-NEXT: $upssign0 = MOV_scalar_imm11_pseudo 0
-    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_upsSign0_]], implicit [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign0_]], implicit [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_upsSign0_1]], implicit [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign0_1]], implicit [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign0_2]], implicit [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign0_3]]
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_upsSign0_]], implicit [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign0_]], implicit [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_upsSign0_1]], implicit [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign0_1]], implicit [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign0_2]], implicit [[VLDA_UPS_2x_dmw_lda_ups_w2b_idx_upsSign0_2]]
     %0:ptrregbank(p0) = COPY $p0
     %7:modregbank(s20) = COPY $m0
     %8:modregbank(s20) = G_CONSTANT i20 0
     %9:modregbank(s20) = G_CONSTANT i20 16
-    %10:modregbank(s20) = G_CONSTANT i20 -128
-    %11:modregbank(s20) = G_CONSTANT i20 96
-    %12:modregbank(s20) = G_CONSTANT i20 128
+    %10:modregbank(s20) = G_CONSTANT i20 -256
+    %11:modregbank(s20) = G_CONSTANT i20 224
+    %12:modregbank(s20) = G_CONSTANT i20 256
     %101:gprregbank(s32) = COPY $r1
     %102:gprregbank(s32) = COPY $r2
     %25:vregbank(<16 x s16>) = G_AIE_OFFSET_LOAD %0, %7 :: (load (<16 x s16>))
@@ -1086,19 +1096,20 @@ body:             |
 ...
 
 ---
-name:            VST_UPS_4x_CM_v16_acc64_dynamic
+name:            VLDA_UPS_4x_acc64_v16_dynamic
 alignment:       16
 legalized:       true
 regBankSelected: true
 body:             |
   bb.1.entry:
     liveins: $bmll0, $p0, $r0, $r1, $r2
-    ; CHECK-LABEL: name: VST_UPS_4x_CM_v16_acc64_dynamic
+    ; CHECK-LABEL: name: VLDA_UPS_4x_acc64_v16_dynamic
     ; CHECK: liveins: $bmll0, $p0, $r0, $r1, $r2
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
     ; CHECK-NEXT: [[COPY1:%[0-9]+]]:edj = COPY $m0
     ; CHECK-NEXT: [[MOV_PD_imm11_pseudo:%[0-9]+]]:edj = MOV_PD_imm11_pseudo 16
+    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo1:%[0-9]+]]:edj = MOV_PD_imm11_pseudo 256
     ; CHECK-NEXT: [[COPY2:%[0-9]+]]:er = COPY $r1
     ; CHECK-NEXT: [[COPY3:%[0-9]+]]:er = COPY $r2
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 1
@@ -1119,26 +1130,26 @@ body:             |
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 1
     ; CHECK-NEXT: $upssign0 = COPY [[COPY3]]
     ; CHECK-NEXT: [[COPY7:%[0-9]+]]:es = COPY [[COPY2]]
-    ; CHECK-NEXT: [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign0_1:%[0-9]+]]:acc1024 = VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign0 [[COPY7]], [[COPY]], -128, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s16>))
+    ; CHECK-NEXT: [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign0_1:%[0-9]+]]:acc1024 = VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign0 [[COPY7]], [[COPY]], -256, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s16>))
     ; CHECK-NEXT: $upssign0 = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 1
     ; CHECK-NEXT: $upssign0 = COPY [[COPY3]]
     ; CHECK-NEXT: [[COPY8:%[0-9]+]]:es = COPY [[COPY2]]
-    ; CHECK-NEXT: [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign0_2:%[0-9]+]]:acc1024 = VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign0 [[COPY8]], [[COPY]], 96, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s16>))
+    ; CHECK-NEXT: [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign0_2:%[0-9]+]]:acc1024 = VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign0 [[COPY8]], [[COPY]], 224, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s16>))
     ; CHECK-NEXT: $upssign0 = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 1
     ; CHECK-NEXT: $upssign0 = COPY [[COPY3]]
     ; CHECK-NEXT: [[COPY9:%[0-9]+]]:es = COPY [[COPY2]]
-    ; CHECK-NEXT: [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign0_3:%[0-9]+]]:acc1024 = VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign0 [[COPY9]], [[COPY]], 128, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s16>))
+    ; CHECK-NEXT: [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_upsSign0_2:%[0-9]+]]:acc1024 = VLDA_UPS_4x_dmw_lda_ups_w2c_idx_upsSign0 [[COPY9]], [[COPY]], [[MOV_PD_imm11_pseudo1]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s16>))
     ; CHECK-NEXT: $upssign0 = MOV_scalar_imm11_pseudo 0
-    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_upsSign0_]], implicit [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign0_]], implicit [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_upsSign0_1]], implicit [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign0_1]], implicit [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign0_2]], implicit [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign0_3]]
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_upsSign0_]], implicit [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign0_]], implicit [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_upsSign0_1]], implicit [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign0_1]], implicit [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign0_2]], implicit [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_upsSign0_2]]
     %0:ptrregbank(p0) = COPY $p0
     %7:modregbank(s20) = COPY $m0
     %8:modregbank(s20) = G_CONSTANT i20 0
     %9:modregbank(s20) = G_CONSTANT i20 16
-    %10:modregbank(s20) = G_CONSTANT i20 -128
-    %11:modregbank(s20) = G_CONSTANT i20 96
-    %12:modregbank(s20) = G_CONSTANT i20 128
+    %10:modregbank(s20) = G_CONSTANT i20 -256
+    %11:modregbank(s20) = G_CONSTANT i20 224
+    %12:modregbank(s20) = G_CONSTANT i20 256
     %101:gprregbank(s32) = COPY $r1
     %102:gprregbank(s32) = COPY $r2
     %25:vregbank(<16 x s16>) = G_AIE_OFFSET_LOAD %0, %7 :: (load (<16 x s16>))
@@ -1157,19 +1168,20 @@ body:             |
 ...
 
 ---
-name:            VST_UPS_4x_CM_v32_acc32_dynamic
+name:            VLDA_UPS_4x_acc32_v32_dynamic
 alignment:       16
 legalized:       true
 regBankSelected: true
 body:             |
   bb.1.entry:
     liveins: $bmll0, $p0, $r0, $r1, $r2
-    ; CHECK-LABEL: name: VST_UPS_4x_CM_v32_acc32_dynamic
+    ; CHECK-LABEL: name: VLDA_UPS_4x_acc32_v32_dynamic
     ; CHECK: liveins: $bmll0, $p0, $r0, $r1, $r2
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
     ; CHECK-NEXT: [[COPY1:%[0-9]+]]:edj = COPY $m0
     ; CHECK-NEXT: [[MOV_PD_imm11_pseudo:%[0-9]+]]:edj = MOV_PD_imm11_pseudo 16
+    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo1:%[0-9]+]]:edj = MOV_PD_imm11_pseudo 256
     ; CHECK-NEXT: [[COPY2:%[0-9]+]]:er = COPY $r1
     ; CHECK-NEXT: [[COPY3:%[0-9]+]]:er = COPY $r2
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 0
@@ -1190,26 +1202,26 @@ body:             |
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: $upssign0 = COPY [[COPY3]]
     ; CHECK-NEXT: [[COPY7:%[0-9]+]]:es = COPY [[COPY2]]
-    ; CHECK-NEXT: [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign0_1:%[0-9]+]]:acc1024 = VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign0 [[COPY7]], [[COPY]], -128, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s16>))
+    ; CHECK-NEXT: [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign0_1:%[0-9]+]]:acc1024 = VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign0 [[COPY7]], [[COPY]], -256, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s16>))
     ; CHECK-NEXT: $upssign0 = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: $upssign0 = COPY [[COPY3]]
     ; CHECK-NEXT: [[COPY8:%[0-9]+]]:es = COPY [[COPY2]]
-    ; CHECK-NEXT: [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign0_2:%[0-9]+]]:acc1024 = VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign0 [[COPY8]], [[COPY]], 96, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s16>))
+    ; CHECK-NEXT: [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign0_2:%[0-9]+]]:acc1024 = VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign0 [[COPY8]], [[COPY]], 224, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s16>))
     ; CHECK-NEXT: $upssign0 = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: $upssign0 = COPY [[COPY3]]
     ; CHECK-NEXT: [[COPY9:%[0-9]+]]:es = COPY [[COPY2]]
-    ; CHECK-NEXT: [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign0_3:%[0-9]+]]:acc1024 = VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign0 [[COPY9]], [[COPY]], 128, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s16>))
+    ; CHECK-NEXT: [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_upsSign0_2:%[0-9]+]]:acc1024 = VLDA_UPS_4x_dmw_lda_ups_w2c_idx_upsSign0 [[COPY9]], [[COPY]], [[MOV_PD_imm11_pseudo1]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s16>))
     ; CHECK-NEXT: $upssign0 = MOV_scalar_imm11_pseudo 0
-    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_upsSign0_]], implicit [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign0_]], implicit [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_upsSign0_1]], implicit [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign0_1]], implicit [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign0_2]], implicit [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign0_3]]
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_upsSign0_]], implicit [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign0_]], implicit [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_upsSign0_1]], implicit [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign0_1]], implicit [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign0_2]], implicit [[VLDA_UPS_4x_dmw_lda_ups_w2c_idx_upsSign0_2]]
     %0:ptrregbank(p0) = COPY $p0
     %7:modregbank(s20) = COPY $m0
     %8:modregbank(s20) = G_CONSTANT i20 0
     %9:modregbank(s20) = G_CONSTANT i20 16
-    %10:modregbank(s20) = G_CONSTANT i20 -128
-    %11:modregbank(s20) = G_CONSTANT i20 96
-    %12:modregbank(s20) = G_CONSTANT i20 128
+    %10:modregbank(s20) = G_CONSTANT i20 -256
+    %11:modregbank(s20) = G_CONSTANT i20 224
+    %12:modregbank(s20) = G_CONSTANT i20 256
     %101:gprregbank(s32) = COPY $r1
     %102:gprregbank(s32) = COPY $r2
     %25:vregbank(<16 x s16>) = G_AIE_OFFSET_LOAD %0, %7 :: (load (<16 x s16>))
@@ -1228,20 +1240,20 @@ body:             |
 ...
 
 ---
-name:            VST_UPS_2x_CM_v32_acc32_dynamic
+name:            VLDA_UPS_2x_acc32_v32_dynamic
 alignment:       16
 legalized:       true
 regBankSelected: true
 body:             |
   bb.1.entry:
     liveins: $bmll0, $p0, $r0, $r1, $r2
-    ; CHECK-LABEL: name: VST_UPS_2x_CM_v32_acc32_dynamic
+    ; CHECK-LABEL: name: VLDA_UPS_2x_acc32_v32_dynamic
     ; CHECK: liveins: $bmll0, $p0, $r0, $r1, $r2
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
     ; CHECK-NEXT: [[COPY1:%[0-9]+]]:edj = COPY $m0
-    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo:%[0-9]+]]:edj = MOV_PD_imm11_pseudo 16
-    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo1:%[0-9]+]]:edj = MOV_PD_imm11_pseudo 96
+    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo:%[0-9]+]]:edj = MOV_PD_imm11_pseudo 32
+    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo1:%[0-9]+]]:edj = MOV_PD_imm11_pseudo 512
     ; CHECK-NEXT: [[COPY2:%[0-9]+]]:er = COPY $r1
     ; CHECK-NEXT: [[COPY3:%[0-9]+]]:er = COPY $r2
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 0
@@ -1262,26 +1274,26 @@ body:             |
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: $upssign0 = COPY [[COPY3]]
     ; CHECK-NEXT: [[COPY7:%[0-9]+]]:es = COPY [[COPY2]]
-    ; CHECK-NEXT: [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_imm_upsSign0_1:%[0-9]+]]:acc1024 = VLDA_UPS_2x_dmx_lda_ups_x2c_idx_imm_upsSign0 [[COPY7]], [[COPY]], -128, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
+    ; CHECK-NEXT: [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_imm_upsSign0_1:%[0-9]+]]:acc1024 = VLDA_UPS_2x_dmx_lda_ups_x2c_idx_imm_upsSign0 [[COPY7]], [[COPY]], -512, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
     ; CHECK-NEXT: $upssign0 = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: $upssign0 = COPY [[COPY3]]
     ; CHECK-NEXT: [[COPY8:%[0-9]+]]:es = COPY [[COPY2]]
-    ; CHECK-NEXT: [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_upsSign0_2:%[0-9]+]]:acc1024 = VLDA_UPS_2x_dmx_lda_ups_x2c_idx_upsSign0 [[COPY8]], [[COPY]], [[MOV_PD_imm11_pseudo1]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
+    ; CHECK-NEXT: [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_imm_upsSign0_2:%[0-9]+]]:acc1024 = VLDA_UPS_2x_dmx_lda_ups_x2c_idx_imm_upsSign0 [[COPY8]], [[COPY]], 448, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
     ; CHECK-NEXT: $upssign0 = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: $upssign0 = COPY [[COPY3]]
     ; CHECK-NEXT: [[COPY9:%[0-9]+]]:es = COPY [[COPY2]]
-    ; CHECK-NEXT: [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_imm_upsSign0_2:%[0-9]+]]:acc1024 = VLDA_UPS_2x_dmx_lda_ups_x2c_idx_imm_upsSign0 [[COPY9]], [[COPY]], 128, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
+    ; CHECK-NEXT: [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_upsSign0_2:%[0-9]+]]:acc1024 = VLDA_UPS_2x_dmx_lda_ups_x2c_idx_upsSign0 [[COPY9]], [[COPY]], [[MOV_PD_imm11_pseudo1]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
     ; CHECK-NEXT: $upssign0 = MOV_scalar_imm11_pseudo 0
-    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_upsSign0_]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_imm_upsSign0_]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_upsSign0_1]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_imm_upsSign0_1]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_upsSign0_2]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_imm_upsSign0_2]]
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_upsSign0_]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_imm_upsSign0_]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_upsSign0_1]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_imm_upsSign0_1]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_imm_upsSign0_2]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_upsSign0_2]]
     %0:ptrregbank(p0) = COPY $p0
     %7:modregbank(s20) = COPY $m0
     %8:modregbank(s20) = G_CONSTANT i20 0
-    %9:modregbank(s20) = G_CONSTANT i20 16
-    %10:modregbank(s20) = G_CONSTANT i20 -128
-    %11:modregbank(s20) = G_CONSTANT i20 96
-    %12:modregbank(s20) = G_CONSTANT i20 128
+    %9:modregbank(s20) = G_CONSTANT i20 32
+    %10:modregbank(s20) = G_CONSTANT i20 -512
+    %11:modregbank(s20) = G_CONSTANT i20 448
+    %12:modregbank(s20) = G_CONSTANT i20 512
     %101:gprregbank(s32) = COPY $r1
     %102:gprregbank(s32) = COPY $r2
     %25:vregbank(<16 x s32>) = G_AIE_OFFSET_LOAD %0, %7 :: (load (<16 x s32>))
@@ -1300,20 +1312,20 @@ body:             |
 ...
 
 ---
-name:            VST_UPS_2x_CM_v16_acc64_dynamic
+name:            VLDA_UPS_2x_acc64_v16_dynamic
 alignment:       16
 legalized:       true
 regBankSelected: true
 body:             |
   bb.1.entry:
     liveins: $bmll0, $p0, $r0, $r1, $r2
-    ; CHECK-LABEL: name: VST_UPS_2x_CM_v16_acc64_dynamic
+    ; CHECK-LABEL: name: VLDA_UPS_2x_acc64_v16_dynamic
     ; CHECK: liveins: $bmll0, $p0, $r0, $r1, $r2
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
     ; CHECK-NEXT: [[COPY1:%[0-9]+]]:edj = COPY $m0
-    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo:%[0-9]+]]:edj = MOV_PD_imm11_pseudo 16
-    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo1:%[0-9]+]]:edj = MOV_PD_imm11_pseudo 96
+    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo:%[0-9]+]]:edj = MOV_PD_imm11_pseudo 32
+    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo1:%[0-9]+]]:edj = MOV_PD_imm11_pseudo 512
     ; CHECK-NEXT: [[COPY2:%[0-9]+]]:er = COPY $r1
     ; CHECK-NEXT: [[COPY3:%[0-9]+]]:er = COPY $r2
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 1
@@ -1334,26 +1346,26 @@ body:             |
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 1
     ; CHECK-NEXT: $upssign0 = COPY [[COPY3]]
     ; CHECK-NEXT: [[COPY7:%[0-9]+]]:es = COPY [[COPY2]]
-    ; CHECK-NEXT: [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_imm_upsSign0_1:%[0-9]+]]:acc1024 = VLDA_UPS_2x_dmx_lda_ups_x2c_idx_imm_upsSign0 [[COPY7]], [[COPY]], -128, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
+    ; CHECK-NEXT: [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_imm_upsSign0_1:%[0-9]+]]:acc1024 = VLDA_UPS_2x_dmx_lda_ups_x2c_idx_imm_upsSign0 [[COPY7]], [[COPY]], -512, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
     ; CHECK-NEXT: $upssign0 = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 1
     ; CHECK-NEXT: $upssign0 = COPY [[COPY3]]
     ; CHECK-NEXT: [[COPY8:%[0-9]+]]:es = COPY [[COPY2]]
-    ; CHECK-NEXT: [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_upsSign0_2:%[0-9]+]]:acc1024 = VLDA_UPS_2x_dmx_lda_ups_x2c_idx_upsSign0 [[COPY8]], [[COPY]], [[MOV_PD_imm11_pseudo1]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
+    ; CHECK-NEXT: [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_imm_upsSign0_2:%[0-9]+]]:acc1024 = VLDA_UPS_2x_dmx_lda_ups_x2c_idx_imm_upsSign0 [[COPY8]], [[COPY]], 448, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
     ; CHECK-NEXT: $upssign0 = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 1
     ; CHECK-NEXT: $upssign0 = COPY [[COPY3]]
     ; CHECK-NEXT: [[COPY9:%[0-9]+]]:es = COPY [[COPY2]]
-    ; CHECK-NEXT: [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_imm_upsSign0_2:%[0-9]+]]:acc1024 = VLDA_UPS_2x_dmx_lda_ups_x2c_idx_imm_upsSign0 [[COPY9]], [[COPY]], 128, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
+    ; CHECK-NEXT: [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_upsSign0_2:%[0-9]+]]:acc1024 = VLDA_UPS_2x_dmx_lda_ups_x2c_idx_upsSign0 [[COPY9]], [[COPY]], [[MOV_PD_imm11_pseudo1]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
     ; CHECK-NEXT: $upssign0 = MOV_scalar_imm11_pseudo 0
-    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_upsSign0_]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_imm_upsSign0_]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_upsSign0_1]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_imm_upsSign0_1]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_upsSign0_2]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_imm_upsSign0_2]]
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_upsSign0_]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_imm_upsSign0_]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_upsSign0_1]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_imm_upsSign0_1]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_imm_upsSign0_2]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_idx_upsSign0_2]]
     %0:ptrregbank(p0) = COPY $p0
     %7:modregbank(s20) = COPY $m0
     %8:modregbank(s20) = G_CONSTANT i20 0
-    %9:modregbank(s20) = G_CONSTANT i20 16
-    %10:modregbank(s20) = G_CONSTANT i20 -128
-    %11:modregbank(s20) = G_CONSTANT i20 96
-    %12:modregbank(s20) = G_CONSTANT i20 128
+    %9:modregbank(s20) = G_CONSTANT i20 32
+    %10:modregbank(s20) = G_CONSTANT i20 -512
+    %11:modregbank(s20) = G_CONSTANT i20 448
+    %12:modregbank(s20) = G_CONSTANT i20 512
     %101:gprregbank(s32) = COPY $r1
     %102:gprregbank(s32) = COPY $r2
     %25:vregbank(<16 x s32>) = G_AIE_OFFSET_LOAD %0, %7 :: (load (<16 x s32>))
@@ -1372,60 +1384,60 @@ body:             |
 ...
 
 ---
-name:            VST_UPS_4x_DM_v32_acc64_dynamic
+name:            VLDA_UPS_4x_acc64_v32_dynamic
 alignment:       16
 legalized:       true
 regBankSelected: true
 body:             |
   bb.1.entry:
     liveins: $bmll0, $p0, $r0, $r1, $r2
-    ; CHECK-LABEL: name: VST_UPS_4x_DM_v32_acc64_dynamic
+    ; CHECK-LABEL: name: VLDA_UPS_4x_acc64_v32_dynamic
     ; CHECK: liveins: $bmll0, $p0, $r0, $r1, $r2
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
-    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:mdm = COPY $m0
-    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo:%[0-9]+]]:mdm = MOV_PD_imm11_pseudo 16
-    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo1:%[0-9]+]]:mdm = MOV_PD_imm11_pseudo 96
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:edj = COPY $m0
+    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo:%[0-9]+]]:edj = MOV_PD_imm11_pseudo 32
+    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo1:%[0-9]+]]:edj = MOV_PD_imm11_pseudo 512
     ; CHECK-NEXT: [[COPY2:%[0-9]+]]:er = COPY $r1
     ; CHECK-NEXT: [[COPY3:%[0-9]+]]:er = COPY $r2
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 1
     ; CHECK-NEXT: $upssign0 = COPY [[COPY3]]
     ; CHECK-NEXT: [[COPY4:%[0-9]+]]:es = COPY [[COPY2]]
-    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0_:%[0-9]+]]:acc2048 = VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0 [[COPY4]], [[COPY]], [[COPY1]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
+    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_upsSign0_:%[0-9]+]]:acc2048 = VLDA_UPS_4x_dmx_lda_ups_x2d_idx_upsSign0 [[COPY4]], [[COPY]], [[COPY1]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
     ; CHECK-NEXT: $upssign0 = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 1
     ; CHECK-NEXT: $upssign0 = COPY [[COPY3]]
     ; CHECK-NEXT: [[COPY5:%[0-9]+]]:es = COPY [[COPY2]]
-    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0_1:%[0-9]+]]:acc2048 = VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0 [[COPY5]], [[COPY]], 0, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
+    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0_:%[0-9]+]]:acc2048 = VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0 [[COPY5]], [[COPY]], 0, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
     ; CHECK-NEXT: $upssign0 = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 1
     ; CHECK-NEXT: $upssign0 = COPY [[COPY3]]
     ; CHECK-NEXT: [[COPY6:%[0-9]+]]:es = COPY [[COPY2]]
-    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0_2:%[0-9]+]]:acc2048 = VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0 [[COPY6]], [[COPY]], [[MOV_PD_imm11_pseudo]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
+    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_upsSign0_1:%[0-9]+]]:acc2048 = VLDA_UPS_4x_dmx_lda_ups_x2d_idx_upsSign0 [[COPY6]], [[COPY]], [[MOV_PD_imm11_pseudo]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
     ; CHECK-NEXT: $upssign0 = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 1
     ; CHECK-NEXT: $upssign0 = COPY [[COPY3]]
     ; CHECK-NEXT: [[COPY7:%[0-9]+]]:es = COPY [[COPY2]]
-    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0_3:%[0-9]+]]:acc2048 = VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0 [[COPY7]], [[COPY]], -128, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
+    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0_1:%[0-9]+]]:acc2048 = VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0 [[COPY7]], [[COPY]], -512, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
     ; CHECK-NEXT: $upssign0 = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 1
     ; CHECK-NEXT: $upssign0 = COPY [[COPY3]]
     ; CHECK-NEXT: [[COPY8:%[0-9]+]]:es = COPY [[COPY2]]
-    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0_4:%[0-9]+]]:acc2048 = VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0 [[COPY8]], [[COPY]], [[MOV_PD_imm11_pseudo1]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
+    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0_2:%[0-9]+]]:acc2048 = VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0 [[COPY8]], [[COPY]], 448, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
     ; CHECK-NEXT: $upssign0 = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 1
     ; CHECK-NEXT: $upssign0 = COPY [[COPY3]]
     ; CHECK-NEXT: [[COPY9:%[0-9]+]]:es = COPY [[COPY2]]
-    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0_5:%[0-9]+]]:acc2048 = VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0 [[COPY9]], [[COPY]], 128, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
+    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_upsSign0_2:%[0-9]+]]:acc2048 = VLDA_UPS_4x_dmx_lda_ups_x2d_idx_upsSign0 [[COPY9]], [[COPY]], [[MOV_PD_imm11_pseudo1]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
     ; CHECK-NEXT: $upssign0 = MOV_scalar_imm11_pseudo 0
-    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0_]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0_1]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0_2]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0_3]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0_4]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0_5]]
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_upsSign0_]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0_]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_upsSign0_1]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0_1]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0_2]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_upsSign0_2]]
     %0:ptrregbank(p0) = COPY $p0
     %7:modregbank(s20) = COPY $m0
     %8:modregbank(s20) = G_CONSTANT i20 0
-    %9:modregbank(s20) = G_CONSTANT i20 16
-    %10:modregbank(s20) = G_CONSTANT i20 -128
-    %11:modregbank(s20) = G_CONSTANT i20 96
-    %12:modregbank(s20) = G_CONSTANT i20 128
+    %9:modregbank(s20) = G_CONSTANT i20 32
+    %10:modregbank(s20) = G_CONSTANT i20 -512
+    %11:modregbank(s20) = G_CONSTANT i20 448
+    %12:modregbank(s20) = G_CONSTANT i20 512
     %101:gprregbank(s32) = COPY $r1
     %102:gprregbank(s32) = COPY $r2
     %25:vregbank(<16 x s32>) = G_AIE_OFFSET_LOAD %0, %7 :: (load (<16 x s32>))
@@ -1444,60 +1456,60 @@ body:             |
 ...
 
 ---
-name:            VST_UPS_4x_DM_v64_acc32_dynamic
+name:            VLDA_UPS_4x_acc32_v64_dynamic
 alignment:       16
 legalized:       true
 regBankSelected: true
 body:             |
   bb.1.entry:
     liveins: $bmll0, $p0, $r0, $r1, $r2
-    ; CHECK-LABEL: name: VST_UPS_4x_DM_v64_acc32_dynamic
+    ; CHECK-LABEL: name: VLDA_UPS_4x_acc32_v64_dynamic
     ; CHECK: liveins: $bmll0, $p0, $r0, $r1, $r2
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
-    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:mdm = COPY $m0
-    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo:%[0-9]+]]:mdm = MOV_PD_imm11_pseudo 16
-    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo1:%[0-9]+]]:mdm = MOV_PD_imm11_pseudo 96
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:edj = COPY $m0
+    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo:%[0-9]+]]:edj = MOV_PD_imm11_pseudo 32
+    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo1:%[0-9]+]]:edj = MOV_PD_imm11_pseudo 512
     ; CHECK-NEXT: [[COPY2:%[0-9]+]]:er = COPY $r1
     ; CHECK-NEXT: [[COPY3:%[0-9]+]]:er = COPY $r2
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: $upssign0 = COPY [[COPY3]]
     ; CHECK-NEXT: [[COPY4:%[0-9]+]]:es = COPY [[COPY2]]
-    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0_:%[0-9]+]]:acc2048 = VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0 [[COPY4]], [[COPY]], [[COPY1]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
+    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_upsSign0_:%[0-9]+]]:acc2048 = VLDA_UPS_4x_dmx_lda_ups_x2d_idx_upsSign0 [[COPY4]], [[COPY]], [[COPY1]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
     ; CHECK-NEXT: $upssign0 = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: $upssign0 = COPY [[COPY3]]
     ; CHECK-NEXT: [[COPY5:%[0-9]+]]:es = COPY [[COPY2]]
-    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0_1:%[0-9]+]]:acc2048 = VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0 [[COPY5]], [[COPY]], 0, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
+    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0_:%[0-9]+]]:acc2048 = VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0 [[COPY5]], [[COPY]], 0, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
     ; CHECK-NEXT: $upssign0 = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: $upssign0 = COPY [[COPY3]]
     ; CHECK-NEXT: [[COPY6:%[0-9]+]]:es = COPY [[COPY2]]
-    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0_2:%[0-9]+]]:acc2048 = VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0 [[COPY6]], [[COPY]], [[MOV_PD_imm11_pseudo]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
+    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_upsSign0_1:%[0-9]+]]:acc2048 = VLDA_UPS_4x_dmx_lda_ups_x2d_idx_upsSign0 [[COPY6]], [[COPY]], [[MOV_PD_imm11_pseudo]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
     ; CHECK-NEXT: $upssign0 = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: $upssign0 = COPY [[COPY3]]
     ; CHECK-NEXT: [[COPY7:%[0-9]+]]:es = COPY [[COPY2]]
-    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0_3:%[0-9]+]]:acc2048 = VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0 [[COPY7]], [[COPY]], -128, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
+    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0_1:%[0-9]+]]:acc2048 = VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0 [[COPY7]], [[COPY]], -512, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
     ; CHECK-NEXT: $upssign0 = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: $upssign0 = COPY [[COPY3]]
     ; CHECK-NEXT: [[COPY8:%[0-9]+]]:es = COPY [[COPY2]]
-    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0_4:%[0-9]+]]:acc2048 = VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0 [[COPY8]], [[COPY]], [[MOV_PD_imm11_pseudo1]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
+    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0_2:%[0-9]+]]:acc2048 = VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0 [[COPY8]], [[COPY]], 448, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
     ; CHECK-NEXT: $upssign0 = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: $upssign0 = COPY [[COPY3]]
     ; CHECK-NEXT: [[COPY9:%[0-9]+]]:es = COPY [[COPY2]]
-    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0_5:%[0-9]+]]:acc2048 = VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0 [[COPY9]], [[COPY]], 128, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
+    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_upsSign0_2:%[0-9]+]]:acc2048 = VLDA_UPS_4x_dmx_lda_ups_x2d_idx_upsSign0 [[COPY9]], [[COPY]], [[MOV_PD_imm11_pseudo1]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
     ; CHECK-NEXT: $upssign0 = MOV_scalar_imm11_pseudo 0
-    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0_]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0_1]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0_2]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0_3]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0_4]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0_5]]
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_upsSign0_]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0_]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_upsSign0_1]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0_1]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0_2]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_idx_upsSign0_2]]
     %0:ptrregbank(p0) = COPY $p0
     %7:modregbank(s20) = COPY $m0
     %8:modregbank(s20) = G_CONSTANT i20 0
-    %9:modregbank(s20) = G_CONSTANT i20 16
-    %10:modregbank(s20) = G_CONSTANT i20 -128
-    %11:modregbank(s20) = G_CONSTANT i20 96
-    %12:modregbank(s20) = G_CONSTANT i20 128
+    %9:modregbank(s20) = G_CONSTANT i20 32
+    %10:modregbank(s20) = G_CONSTANT i20 -512
+    %11:modregbank(s20) = G_CONSTANT i20 448
+    %12:modregbank(s20) = G_CONSTANT i20 512
     %101:gprregbank(s32) = COPY $r1
     %102:gprregbank(s32) = COPY $r2
     %25:vregbank(<16 x s32>) = G_AIE_OFFSET_LOAD %0, %7 :: (load (<16 x s32>))

--- a/llvm/test/CodeGen/AIE/aie2p/GlobalIsel/inst-select-postinc-2d-vlda_ups.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/GlobalIsel/inst-select-postinc-2d-vlda_ups.mir
@@ -4,18 +4,18 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2024-2025 Advanced Micro Devices, Inc. or its affiliates
 # RUN: llc -mtriple aie2p -run-pass=instruction-select %s -verify-machineinstrs -o - | FileCheck %s
 
 ---
-name:            VST_UPS_2x_BM_v16_acc32_signed
+name:            VLDA_UPS_2x_acc32_v16_signed
 legalized:       true
 regBankSelected: true
 tracksRegLiveness: true
 body: |
   bb.0:
     liveins: $p0, $r1, $bmll0
-    ; CHECK-LABEL: name: VST_UPS_2x_BM_v16_acc32_signed
+    ; CHECK-LABEL: name: VLDA_UPS_2x_acc32_v16_signed
     ; CHECK: liveins: $p0, $r1, $bmll0
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
@@ -42,14 +42,14 @@ body: |
 ...
 
 ---
-name:            VST_UPS_2x_BM_v8_acc64_signed
+name:            VLDA_UPS_2x_acc64_v8_signed
 legalized:       true
 regBankSelected: true
 tracksRegLiveness: true
 body: |
   bb.0:
     liveins: $p0, $r1, $bmll0
-    ; CHECK-LABEL: name: VST_UPS_2x_BM_v8_acc64_signed
+    ; CHECK-LABEL: name: VLDA_UPS_2x_acc64_v8_signed
     ; CHECK: liveins: $p0, $r1, $bmll0
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
@@ -76,14 +76,14 @@ body: |
 ...
 
 ---
-name:            VST_UPS_4x_CM_v16_acc64_signed
+name:            VLDA_UPS_4x_acc64_v16_signed
 legalized:       true
 regBankSelected: true
 tracksRegLiveness: true
 body: |
   bb.0:
     liveins: $p0, $r1, $bmll0
-    ; CHECK-LABEL: name: VST_UPS_4x_CM_v16_acc64_signed
+    ; CHECK-LABEL: name: VLDA_UPS_4x_acc64_v16_signed
     ; CHECK: liveins: $p0, $r1, $bmll0
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
@@ -110,14 +110,14 @@ body: |
 ...
 
 ---
-name:            VST_UPS_4x_CM_v32_acc32_signed
+name:            VLDA_UPS_4x_acc32_v32_signed
 legalized:       true
 regBankSelected: true
 tracksRegLiveness: true
 body: |
   bb.0:
     liveins: $p0, $r1, $bmll0
-    ; CHECK-LABEL: name: VST_UPS_4x_CM_v32_acc32_signed
+    ; CHECK-LABEL: name: VLDA_UPS_4x_acc32_v32_signed
     ; CHECK: liveins: $p0, $r1, $bmll0
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
@@ -144,14 +144,14 @@ body: |
 ...
 
 ---
-name:            VST_UPS_2x_CM_v32_acc32_signed
+name:            VLDA_UPS_2x_acc32_v32_signed
 legalized:       true
 regBankSelected: true
 tracksRegLiveness: true
 body: |
   bb.0:
     liveins: $p0, $r1, $bmll0
-    ; CHECK-LABEL: name: VST_UPS_2x_CM_v32_acc32_signed
+    ; CHECK-LABEL: name: VLDA_UPS_2x_acc32_v32_signed
     ; CHECK: liveins: $p0, $r1, $bmll0
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
@@ -178,14 +178,14 @@ body: |
 ...
 
 ---
-name:            VST_UPS_2x_CM_v16_acc64_signed
+name:            VLDA_UPS_2x_acc64_v16_signed
 legalized:       true
 regBankSelected: true
 tracksRegLiveness: true
 body: |
   bb.0:
     liveins: $p0, $r1, $bmll0
-    ; CHECK-LABEL: name: VST_UPS_2x_CM_v16_acc64_signed
+    ; CHECK-LABEL: name: VLDA_UPS_2x_acc64_v16_signed
     ; CHECK: liveins: $p0, $r1, $bmll0
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
@@ -212,14 +212,14 @@ body: |
 ...
 
 ---
-name:            VST_UPS_4x_DM_v32_acc64_signed
+name:            VLDA_UPS_4x_acc64_v32_signed
 legalized:       true
 regBankSelected: true
 tracksRegLiveness: true
 body: |
   bb.0:
     liveins: $p0, $r1, $bmll0
-    ; CHECK-LABEL: name: VST_UPS_4x_DM_v32_acc64_signed
+    ; CHECK-LABEL: name: VLDA_UPS_4x_acc64_v32_signed
     ; CHECK: liveins: $p0, $r1, $bmll0
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
@@ -246,14 +246,14 @@ body: |
 ...
 
 ---
-name:            VST_UPS_4x_DM_v64_acc32_signed
+name:            VLDA_UPS_4x_acc32_v64_signed
 legalized:       true
 regBankSelected: true
 tracksRegLiveness: true
 body: |
   bb.0:
     liveins: $p0, $r1, $bmll0
-    ; CHECK-LABEL: name: VST_UPS_4x_DM_v64_acc32_signed
+    ; CHECK-LABEL: name: VLDA_UPS_4x_acc32_v64_signed
     ; CHECK: liveins: $p0, $r1, $bmll0
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
@@ -280,14 +280,14 @@ body: |
 ...
 
 ---
-name:            VST_UPS_2x_BM_v16_acc32_unsigned
+name:            VLDA_UPS_2x_acc32_v16_unsigned
 legalized:       true
 regBankSelected: true
 tracksRegLiveness: true
 body: |
   bb.0:
     liveins: $p0, $r1, $bmll0
-    ; CHECK-LABEL: name: VST_UPS_2x_BM_v16_acc32_unsigned
+    ; CHECK-LABEL: name: VLDA_UPS_2x_acc32_v16_unsigned
     ; CHECK: liveins: $p0, $r1, $bmll0
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
@@ -314,14 +314,14 @@ body: |
 ...
 
 ---
-name:            VST_UPS_2x_BM_v8_acc64_unsigned
+name:            VLDA_UPS_2x_acc64_v8_unsigned
 legalized:       true
 regBankSelected: true
 tracksRegLiveness: true
 body: |
   bb.0:
     liveins: $p0, $r1, $bmll0
-    ; CHECK-LABEL: name: VST_UPS_2x_BM_v8_acc64_unsigned
+    ; CHECK-LABEL: name: VLDA_UPS_2x_acc64_v8_unsigned
     ; CHECK: liveins: $p0, $r1, $bmll0
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
@@ -348,14 +348,14 @@ body: |
 ...
 
 ---
-name:            VST_UPS_4x_CM_v16_acc64_unsigned
+name:            VLDA_UPS_4x_acc64_v16_unsigned
 legalized:       true
 regBankSelected: true
 tracksRegLiveness: true
 body: |
   bb.0:
     liveins: $p0, $r1, $bmll0
-    ; CHECK-LABEL: name: VST_UPS_4x_CM_v16_acc64_unsigned
+    ; CHECK-LABEL: name: VLDA_UPS_4x_acc64_v16_unsigned
     ; CHECK: liveins: $p0, $r1, $bmll0
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
@@ -382,14 +382,14 @@ body: |
 ...
 
 ---
-name:            VST_UPS_4x_CM_v32_acc32_unsigned
+name:            VLDA_UPS_4x_acc32_v32_unsigned
 legalized:       true
 regBankSelected: true
 tracksRegLiveness: true
 body: |
   bb.0:
     liveins: $p0, $r1, $bmll0
-    ; CHECK-LABEL: name: VST_UPS_4x_CM_v32_acc32_unsigned
+    ; CHECK-LABEL: name: VLDA_UPS_4x_acc32_v32_unsigned
     ; CHECK: liveins: $p0, $r1, $bmll0
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
@@ -416,14 +416,14 @@ body: |
 ...
 
 ---
-name:            VST_UPS_2x_CM_v32_acc32_unsigned
+name:            VLDA_UPS_2x_acc32_v32_unsigned
 legalized:       true
 regBankSelected: true
 tracksRegLiveness: true
 body: |
   bb.0:
     liveins: $p0, $r1, $bmll0
-    ; CHECK-LABEL: name: VST_UPS_2x_CM_v32_acc32_unsigned
+    ; CHECK-LABEL: name: VLDA_UPS_2x_acc32_v32_unsigned
     ; CHECK: liveins: $p0, $r1, $bmll0
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
@@ -450,14 +450,14 @@ body: |
 ...
 
 ---
-name:            VST_UPS_2x_CM_v16_acc64_unsigned
+name:            VLDA_UPS_2x_acc64_v16_unsigned
 legalized:       true
 regBankSelected: true
 tracksRegLiveness: true
 body: |
   bb.0:
     liveins: $p0, $r1, $bmll0
-    ; CHECK-LABEL: name: VST_UPS_2x_CM_v16_acc64_unsigned
+    ; CHECK-LABEL: name: VLDA_UPS_2x_acc64_v16_unsigned
     ; CHECK: liveins: $p0, $r1, $bmll0
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
@@ -484,14 +484,14 @@ body: |
 ...
 
 ---
-name:            VST_UPS_4x_DM_v32_acc64_unsigned
+name:            VLDA_UPS_4x_acc64_v32_unsigned
 legalized:       true
 regBankSelected: true
 tracksRegLiveness: true
 body: |
   bb.0:
     liveins: $p0, $r1, $bmll0
-    ; CHECK-LABEL: name: VST_UPS_4x_DM_v32_acc64_unsigned
+    ; CHECK-LABEL: name: VLDA_UPS_4x_acc64_v32_unsigned
     ; CHECK: liveins: $p0, $r1, $bmll0
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
@@ -518,14 +518,14 @@ body: |
 ...
 
 ---
-name:            VST_UPS_4x_DM_v64_acc32_unsigned
+name:            VLDA_UPS_4x_acc32_v64_unsigned
 legalized:       true
 regBankSelected: true
 tracksRegLiveness: true
 body: |
   bb.0:
     liveins: $p0, $r1, $bmll0
-    ; CHECK-LABEL: name: VST_UPS_4x_DM_v64_acc32_unsigned
+    ; CHECK-LABEL: name: VLDA_UPS_4x_acc32_v64_unsigned
     ; CHECK: liveins: $p0, $r1, $bmll0
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
@@ -552,14 +552,14 @@ body: |
 ...
 
 ---
-name:            VST_UPS_2x_BM_v16_acc32_dynamic
+name:            VLDA_UPS_2x_acc32_v16_dynamic
 legalized:       true
 regBankSelected: true
 tracksRegLiveness: true
 body: |
   bb.0:
     liveins: $p0, $r1, $r2, $bmll0
-    ; CHECK-LABEL: name: VST_UPS_2x_BM_v16_acc32_dynamic
+    ; CHECK-LABEL: name: VLDA_UPS_2x_acc32_v16_dynamic
     ; CHECK: liveins: $p0, $r1, $r2, $bmll0
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
@@ -589,14 +589,14 @@ body: |
 ...
 
 ---
-name:            VST_UPS_2x_BM_v8_acc64_dynamic
+name:            VLDA_UPS_2x_acc64_v8_dynamic
 legalized:       true
 regBankSelected: true
 tracksRegLiveness: true
 body: |
   bb.0:
     liveins: $p0, $r1, $r2, $bmll0
-    ; CHECK-LABEL: name: VST_UPS_2x_BM_v8_acc64_dynamic
+    ; CHECK-LABEL: name: VLDA_UPS_2x_acc64_v8_dynamic
     ; CHECK: liveins: $p0, $r1, $r2, $bmll0
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
@@ -626,14 +626,14 @@ body: |
 ...
 
 ---
-name:            VST_UPS_4x_CM_v16_acc64_dynamic
+name:            VLDA_UPS_4x_acc64_v16_dynamic
 legalized:       true
 regBankSelected: true
 tracksRegLiveness: true
 body: |
   bb.0:
     liveins: $p0, $r1, $r2, $bmll0
-    ; CHECK-LABEL: name: VST_UPS_4x_CM_v16_acc64_dynamic
+    ; CHECK-LABEL: name: VLDA_UPS_4x_acc64_v16_dynamic
     ; CHECK: liveins: $p0, $r1, $r2, $bmll0
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
@@ -663,14 +663,14 @@ body: |
 ...
 
 ---
-name:            VST_UPS_4x_CM_v32_acc32_dynamic
+name:            VLDA_UPS_4x_acc32_v32_dynamic
 legalized:       true
 regBankSelected: true
 tracksRegLiveness: true
 body: |
   bb.0:
     liveins: $p0, $r1, $r2, $bmll0
-    ; CHECK-LABEL: name: VST_UPS_4x_CM_v32_acc32_dynamic
+    ; CHECK-LABEL: name: VLDA_UPS_4x_acc32_v32_dynamic
     ; CHECK: liveins: $p0, $r1, $r2, $bmll0
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
@@ -700,14 +700,14 @@ body: |
 ...
 
 ---
-name:            VST_UPS_2x_CM_v32_acc32_dynamic
+name:            VLDA_UPS_2x_acc32_v32_dynamic
 legalized:       true
 regBankSelected: true
 tracksRegLiveness: true
 body: |
   bb.0:
     liveins: $p0, $r1, $r2, $bmll0
-    ; CHECK-LABEL: name: VST_UPS_2x_CM_v32_acc32_dynamic
+    ; CHECK-LABEL: name: VLDA_UPS_2x_acc32_v32_dynamic
     ; CHECK: liveins: $p0, $r1, $r2, $bmll0
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
@@ -737,14 +737,14 @@ body: |
 ...
 
 ---
-name:            VST_UPS_2x_CM_v16_acc64_dynamic
+name:            VLDA_UPS_2x_acc64_v16_dynamic
 legalized:       true
 regBankSelected: true
 tracksRegLiveness: true
 body: |
   bb.0:
     liveins: $p0, $r1, $r2, $bmll0
-    ; CHECK-LABEL: name: VST_UPS_2x_CM_v16_acc64_dynamic
+    ; CHECK-LABEL: name: VLDA_UPS_2x_acc64_v16_dynamic
     ; CHECK: liveins: $p0, $r1, $r2, $bmll0
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
@@ -774,14 +774,14 @@ body: |
 ...
 
 ---
-name:            VST_UPS_4x_DM_v32_acc64_dynamic
+name:            VLDA_UPS_4x_acc64_v32_dynamic
 legalized:       true
 regBankSelected: true
 tracksRegLiveness: true
 body: |
   bb.0:
     liveins: $p0, $r1, $r2, $bmll0
-    ; CHECK-LABEL: name: VST_UPS_4x_DM_v32_acc64_dynamic
+    ; CHECK-LABEL: name: VLDA_UPS_4x_acc64_v32_dynamic
     ; CHECK: liveins: $p0, $r1, $r2, $bmll0
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
@@ -811,14 +811,14 @@ body: |
 ...
 
 ---
-name:            VST_UPS_4x_DM_v64_acc32_dynamic
+name:            VLDA_UPS_4x_acc32_v64_dynamic
 legalized:       true
 regBankSelected: true
 tracksRegLiveness: true
 body: |
   bb.0:
     liveins: $p0, $r1, $r2, $bmll0
-    ; CHECK-LABEL: name: VST_UPS_4x_DM_v64_acc32_dynamic
+    ; CHECK-LABEL: name: VLDA_UPS_4x_acc32_v64_dynamic
     ; CHECK: liveins: $p0, $r1, $r2, $bmll0
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0

--- a/llvm/test/CodeGen/AIE/aie2p/GlobalIsel/inst-select-postinc-3d-vlda_ups.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/GlobalIsel/inst-select-postinc-3d-vlda_ups.mir
@@ -4,18 +4,18 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2024-2025 Advanced Micro Devices, Inc. or its affiliates
 # RUN: llc -mtriple aie2p -run-pass=instruction-select %s -verify-machineinstrs -o - | FileCheck %s
 
 ---
-name:            VST_UPS_2x_BM_v16_acc32_signed
+name:            VLDA_UPS_2x_acc32_v16_signed
 legalized:       true
 regBankSelected: true
 tracksRegLiveness: true
 body: |
   bb.0:
     liveins: $p0, $r1, $bmll0
-    ; CHECK-LABEL: name: VST_UPS_2x_BM_v16_acc32_signed
+    ; CHECK-LABEL: name: VLDA_UPS_2x_acc32_v16_signed
     ; CHECK: liveins: $p0, $r1, $bmll0
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
@@ -48,14 +48,14 @@ body: |
 ...
 
 ---
-name:            VST_UPS_2x_BM_v8_acc64_signed
+name:            VLDA_UPS_2x_acc64_v8_signed
 legalized:       true
 regBankSelected: true
 tracksRegLiveness: true
 body: |
   bb.0:
     liveins: $p0, $r1, $bmll0
-    ; CHECK-LABEL: name: VST_UPS_2x_BM_v8_acc64_signed
+    ; CHECK-LABEL: name: VLDA_UPS_2x_acc64_v8_signed
     ; CHECK: liveins: $p0, $r1, $bmll0
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
@@ -88,14 +88,14 @@ body: |
 ...
 
 ---
-name:            VST_UPS_4x_CM_v16_acc64_signed
+name:            VLDA_UPS_4x_acc64_v16_signed
 legalized:       true
 regBankSelected: true
 tracksRegLiveness: true
 body: |
   bb.0:
     liveins: $p0, $r1, $bmll0
-    ; CHECK-LABEL: name: VST_UPS_4x_CM_v16_acc64_signed
+    ; CHECK-LABEL: name: VLDA_UPS_4x_acc64_v16_signed
     ; CHECK: liveins: $p0, $r1, $bmll0
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
@@ -128,14 +128,14 @@ body: |
 ...
 
 ---
-name:            VST_UPS_4x_CM_v32_acc32_signed
+name:            VLDA_UPS_4x_acc32_v32_signed
 legalized:       true
 regBankSelected: true
 tracksRegLiveness: true
 body: |
   bb.0:
     liveins: $p0, $r1, $bmll0
-    ; CHECK-LABEL: name: VST_UPS_4x_CM_v32_acc32_signed
+    ; CHECK-LABEL: name: VLDA_UPS_4x_acc32_v32_signed
     ; CHECK: liveins: $p0, $r1, $bmll0
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
@@ -168,14 +168,14 @@ body: |
 ...
 
 ---
-name:            VST_UPS_2x_CM_v32_acc32_signed
+name:            VLDA_UPS_2x_acc32_v32_signed
 legalized:       true
 regBankSelected: true
 tracksRegLiveness: true
 body: |
   bb.0:
     liveins: $p0, $r1, $bmll0
-    ; CHECK-LABEL: name: VST_UPS_2x_CM_v32_acc32_signed
+    ; CHECK-LABEL: name: VLDA_UPS_2x_acc32_v32_signed
     ; CHECK: liveins: $p0, $r1, $bmll0
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
@@ -208,14 +208,14 @@ body: |
 ...
 
 ---
-name:            VST_UPS_2x_CM_v16_acc64_signed
+name:            VLDA_UPS_2x_acc64_v16_signed
 legalized:       true
 regBankSelected: true
 tracksRegLiveness: true
 body: |
   bb.0:
     liveins: $p0, $r1, $bmll0
-    ; CHECK-LABEL: name: VST_UPS_2x_CM_v16_acc64_signed
+    ; CHECK-LABEL: name: VLDA_UPS_2x_acc64_v16_signed
     ; CHECK: liveins: $p0, $r1, $bmll0
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
@@ -248,14 +248,14 @@ body: |
 ...
 
 ---
-name:            VST_UPS_4x_DM_v32_acc64_signed
+name:            VLDA_UPS_4x_acc64_v32_signed
 legalized:       true
 regBankSelected: true
 tracksRegLiveness: true
 body: |
   bb.0:
     liveins: $p0, $r1, $bmll0
-    ; CHECK-LABEL: name: VST_UPS_4x_DM_v32_acc64_signed
+    ; CHECK-LABEL: name: VLDA_UPS_4x_acc64_v32_signed
     ; CHECK: liveins: $p0, $r1, $bmll0
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
@@ -288,14 +288,14 @@ body: |
 ...
 
 ---
-name:            VST_UPS_4x_DM_v64_acc32_signed
+name:            VLDA_UPS_4x_acc32_v64_signed
 legalized:       true
 regBankSelected: true
 tracksRegLiveness: true
 body: |
   bb.0:
     liveins: $p0, $r1, $bmll0
-    ; CHECK-LABEL: name: VST_UPS_4x_DM_v64_acc32_signed
+    ; CHECK-LABEL: name: VLDA_UPS_4x_acc32_v64_signed
     ; CHECK: liveins: $p0, $r1, $bmll0
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
@@ -328,14 +328,14 @@ body: |
 ...
 
 ---
-name:            VST_UPS_2x_BM_v16_acc32_unsigned
+name:            VLDA_UPS_2x_acc32_v16_unsigned
 legalized:       true
 regBankSelected: true
 tracksRegLiveness: true
 body: |
   bb.0:
     liveins: $p0, $r1, $bmll0
-    ; CHECK-LABEL: name: VST_UPS_2x_BM_v16_acc32_unsigned
+    ; CHECK-LABEL: name: VLDA_UPS_2x_acc32_v16_unsigned
     ; CHECK: liveins: $p0, $r1, $bmll0
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
@@ -368,14 +368,14 @@ body: |
 ...
 
 ---
-name:            VST_UPS_2x_BM_v8_acc64_unsigned
+name:            VLDA_UPS_2x_acc64_v8_unsigned
 legalized:       true
 regBankSelected: true
 tracksRegLiveness: true
 body: |
   bb.0:
     liveins: $p0, $r1, $bmll0
-    ; CHECK-LABEL: name: VST_UPS_2x_BM_v8_acc64_unsigned
+    ; CHECK-LABEL: name: VLDA_UPS_2x_acc64_v8_unsigned
     ; CHECK: liveins: $p0, $r1, $bmll0
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
@@ -408,14 +408,14 @@ body: |
 ...
 
 ---
-name:            VST_UPS_4x_CM_v16_acc64_unsigned
+name:            VLDA_UPS_4x_acc64_v16_unsigned
 legalized:       true
 regBankSelected: true
 tracksRegLiveness: true
 body: |
   bb.0:
     liveins: $p0, $r1, $bmll0
-    ; CHECK-LABEL: name: VST_UPS_4x_CM_v16_acc64_unsigned
+    ; CHECK-LABEL: name: VLDA_UPS_4x_acc64_v16_unsigned
     ; CHECK: liveins: $p0, $r1, $bmll0
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
@@ -448,14 +448,14 @@ body: |
 ...
 
 ---
-name:            VST_UPS_4x_CM_v32_acc32_unsigned
+name:            VLDA_UPS_4x_acc32_v32_unsigned
 legalized:       true
 regBankSelected: true
 tracksRegLiveness: true
 body: |
   bb.0:
     liveins: $p0, $r1, $bmll0
-    ; CHECK-LABEL: name: VST_UPS_4x_CM_v32_acc32_unsigned
+    ; CHECK-LABEL: name: VLDA_UPS_4x_acc32_v32_unsigned
     ; CHECK: liveins: $p0, $r1, $bmll0
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
@@ -488,14 +488,14 @@ body: |
 ...
 
 ---
-name:            VST_UPS_2x_CM_v32_acc32_unsigned
+name:            VLDA_UPS_2x_acc32_v32_unsigned
 legalized:       true
 regBankSelected: true
 tracksRegLiveness: true
 body: |
   bb.0:
     liveins: $p0, $r1, $bmll0
-    ; CHECK-LABEL: name: VST_UPS_2x_CM_v32_acc32_unsigned
+    ; CHECK-LABEL: name: VLDA_UPS_2x_acc32_v32_unsigned
     ; CHECK: liveins: $p0, $r1, $bmll0
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
@@ -528,14 +528,14 @@ body: |
 ...
 
 ---
-name:            VST_UPS_2x_CM_v16_acc64_unsigned
+name:            VLDA_UPS_2x_acc64_v16_unsigned
 legalized:       true
 regBankSelected: true
 tracksRegLiveness: true
 body: |
   bb.0:
     liveins: $p0, $r1, $bmll0
-    ; CHECK-LABEL: name: VST_UPS_2x_CM_v16_acc64_unsigned
+    ; CHECK-LABEL: name: VLDA_UPS_2x_acc64_v16_unsigned
     ; CHECK: liveins: $p0, $r1, $bmll0
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
@@ -568,14 +568,14 @@ body: |
 ...
 
 ---
-name:            VST_UPS_4x_DM_v32_acc64_unsigned
+name:            VLDA_UPS_4x_acc64_v32_unsigned
 legalized:       true
 regBankSelected: true
 tracksRegLiveness: true
 body: |
   bb.0:
     liveins: $p0, $r1, $bmll0
-    ; CHECK-LABEL: name: VST_UPS_4x_DM_v32_acc64_unsigned
+    ; CHECK-LABEL: name: VLDA_UPS_4x_acc64_v32_unsigned
     ; CHECK: liveins: $p0, $r1, $bmll0
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
@@ -608,14 +608,14 @@ body: |
 ...
 
 ---
-name:            VST_UPS_4x_DM_v64_acc32_unsigned
+name:            VLDA_UPS_4x_acc32_v64_unsigned
 legalized:       true
 regBankSelected: true
 tracksRegLiveness: true
 body: |
   bb.0:
     liveins: $p0, $r1, $bmll0
-    ; CHECK-LABEL: name: VST_UPS_4x_DM_v64_acc32_unsigned
+    ; CHECK-LABEL: name: VLDA_UPS_4x_acc32_v64_unsigned
     ; CHECK: liveins: $p0, $r1, $bmll0
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
@@ -649,14 +649,14 @@ body: |
 
 
 ---
-name:            VST_UPS_2x_BM_v16_acc32_dynamic
+name:            VLDA_UPS_2x_acc32_v16_dynamic
 legalized:       true
 regBankSelected: true
 tracksRegLiveness: true
 body: |
   bb.0:
     liveins: $p0, $r1, $r2, $bmll0
-    ; CHECK-LABEL: name: VST_UPS_2x_BM_v16_acc32_dynamic
+    ; CHECK-LABEL: name: VLDA_UPS_2x_acc32_v16_dynamic
     ; CHECK: liveins: $p0, $r1, $r2, $bmll0
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
@@ -692,14 +692,14 @@ body: |
 ...
 
 ---
-name:            VST_UPS_2x_BM_v8_acc64_dynamic
+name:            VLDA_UPS_2x_acc64_v8_dynamic
 legalized:       true
 regBankSelected: true
 tracksRegLiveness: true
 body: |
   bb.0:
     liveins: $p0, $r1, $r2, $bmll0
-    ; CHECK-LABEL: name: VST_UPS_2x_BM_v8_acc64_dynamic
+    ; CHECK-LABEL: name: VLDA_UPS_2x_acc64_v8_dynamic
     ; CHECK: liveins: $p0, $r1, $r2, $bmll0
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
@@ -735,14 +735,14 @@ body: |
 ...
 
 ---
-name:            VST_UPS_4x_CM_v16_acc64_dynamic
+name:            VLDA_UPS_4x_acc64_v16_dynamic
 legalized:       true
 regBankSelected: true
 tracksRegLiveness: true
 body: |
   bb.0:
     liveins: $p0, $r1, $r2, $bmll0
-    ; CHECK-LABEL: name: VST_UPS_4x_CM_v16_acc64_dynamic
+    ; CHECK-LABEL: name: VLDA_UPS_4x_acc64_v16_dynamic
     ; CHECK: liveins: $p0, $r1, $r2, $bmll0
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
@@ -778,14 +778,14 @@ body: |
 ...
 
 ---
-name:            VST_UPS_4x_CM_v32_acc32_dynamic
+name:            VLDA_UPS_4x_acc32_v32_dynamic
 legalized:       true
 regBankSelected: true
 tracksRegLiveness: true
 body: |
   bb.0:
     liveins: $p0, $r1, $r2, $bmll0
-    ; CHECK-LABEL: name: VST_UPS_4x_CM_v32_acc32_dynamic
+    ; CHECK-LABEL: name: VLDA_UPS_4x_acc32_v32_dynamic
     ; CHECK: liveins: $p0, $r1, $r2, $bmll0
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
@@ -821,14 +821,14 @@ body: |
 ...
 
 ---
-name:            VST_UPS_2x_CM_v32_acc32_dynamic
+name:            VLDA_UPS_2x_acc32_v32_dynamic
 legalized:       true
 regBankSelected: true
 tracksRegLiveness: true
 body: |
   bb.0:
     liveins: $p0, $r1, $r2, $bmll0
-    ; CHECK-LABEL: name: VST_UPS_2x_CM_v32_acc32_dynamic
+    ; CHECK-LABEL: name: VLDA_UPS_2x_acc32_v32_dynamic
     ; CHECK: liveins: $p0, $r1, $r2, $bmll0
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
@@ -864,14 +864,14 @@ body: |
 ...
 
 ---
-name:            VST_UPS_2x_CM_v16_acc64_dynamic
+name:            VLDA_UPS_2x_acc64_v16_dynamic
 legalized:       true
 regBankSelected: true
 tracksRegLiveness: true
 body: |
   bb.0:
     liveins: $p0, $r1, $r2, $bmll0
-    ; CHECK-LABEL: name: VST_UPS_2x_CM_v16_acc64_dynamic
+    ; CHECK-LABEL: name: VLDA_UPS_2x_acc64_v16_dynamic
     ; CHECK: liveins: $p0, $r1, $r2, $bmll0
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
@@ -907,14 +907,14 @@ body: |
 ...
 
 ---
-name:            VST_UPS_4x_DM_v32_acc64_dynamic
+name:            VLDA_UPS_4x_acc64_v32_dynamic
 legalized:       true
 regBankSelected: true
 tracksRegLiveness: true
 body: |
   bb.0:
     liveins: $p0, $r1, $r2, $bmll0
-    ; CHECK-LABEL: name: VST_UPS_4x_DM_v32_acc64_dynamic
+    ; CHECK-LABEL: name: VLDA_UPS_4x_acc64_v32_dynamic
     ; CHECK: liveins: $p0, $r1, $r2, $bmll0
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
@@ -950,14 +950,14 @@ body: |
 ...
 
 ---
-name:            VST_UPS_4x_DM_v64_acc32_dynamic
+name:            VLDA_UPS_4x_acc32_v64_dynamic
 legalized:       true
 regBankSelected: true
 tracksRegLiveness: true
 body: |
   bb.0:
     liveins: $p0, $r1, $r2, $bmll0
-    ; CHECK-LABEL: name: VST_UPS_4x_DM_v64_acc32_dynamic
+    ; CHECK-LABEL: name: VLDA_UPS_4x_acc32_v64_dynamic
     ; CHECK: liveins: $p0, $r1, $r2, $bmll0
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0

--- a/llvm/test/CodeGen/AIE/aie2p/GlobalIsel/inst-select-postinc-vlda_ups.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/GlobalIsel/inst-select-postinc-vlda_ups.mir
@@ -4,18 +4,18 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2024-2025 Advanced Micro Devices, Inc. or its affiliates
 # RUN: llc -mtriple aie2p -run-pass=instruction-select %s -verify-machineinstrs -o - | FileCheck %s
 
 ---
-name:            VST_UPS_2x_BM_v16_acc32_signed
+name:            VLDA_UPS_2x_acc32_v16_signed
 legalized:       true
 regBankSelected: true
 tracksRegLiveness: true
 body: |
   bb.0:
     liveins: $p0, $r0, $r1, $bmll0
-    ; CHECK-LABEL: name: VST_UPS_2x_BM_v16_acc32_signed
+    ; CHECK-LABEL: name: VLDA_UPS_2x_acc32_v16_signed
     ; CHECK: liveins: $p0, $r0, $r1, $bmll0
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
@@ -69,14 +69,14 @@ body: |
 ...
 
 ---
-name:            VST_UPS_2x_BM_v8_acc64_signed
+name:            VLDA_UPS_2x_acc64_v8_signed
 legalized:       true
 regBankSelected: true
 tracksRegLiveness: true
 body: |
   bb.0:
     liveins: $p0, $r0, $r1, $bmll0
-    ; CHECK-LABEL: name: VST_UPS_2x_BM_v8_acc64_signed
+    ; CHECK-LABEL: name: VLDA_UPS_2x_acc64_v8_signed
     ; CHECK: liveins: $p0, $r0, $r1, $bmll0
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
@@ -130,14 +130,14 @@ body: |
 ...
 
 ---
-name:            VST_UPS_4x_CM_v16_acc64_signed
+name:            VLDA_UPS_4x_acc64_v16_signed
 legalized:       true
 regBankSelected: true
 tracksRegLiveness: true
 body: |
   bb.0:
     liveins: $p0, $r0, $r1, $bmll0
-    ; CHECK-LABEL: name: VST_UPS_4x_CM_v16_acc64_signed
+    ; CHECK-LABEL: name: VLDA_UPS_4x_acc64_v16_signed
     ; CHECK: liveins: $p0, $r0, $r1, $bmll0
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
@@ -191,14 +191,14 @@ body: |
 ...
 
 ---
-name:            VST_UPS_4x_CM_v32_acc32_signed
+name:            VLDA_UPS_4x_acc32_v32_signed
 legalized:       true
 regBankSelected: true
 tracksRegLiveness: true
 body: |
   bb.0:
     liveins: $p0, $r0, $r1, $bmll0
-    ; CHECK-LABEL: name: VST_UPS_4x_CM_v32_acc32_signed
+    ; CHECK-LABEL: name: VLDA_UPS_4x_acc32_v32_signed
     ; CHECK: liveins: $p0, $r0, $r1, $bmll0
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
@@ -252,21 +252,21 @@ body: |
 ...
 
 ---
-name:            VST_UPS_2x_CM_v32_acc32_signed
+name:            VLDA_UPS_2x_acc32_v32_signed
 legalized:       true
 regBankSelected: true
 tracksRegLiveness: true
 body: |
   bb.0:
     liveins: $p0, $r0, $r1, $bmll0
-    ; CHECK-LABEL: name: VST_UPS_2x_CM_v32_acc32_signed
+    ; CHECK-LABEL: name: VLDA_UPS_2x_acc32_v32_signed
     ; CHECK: liveins: $p0, $r0, $r1, $bmll0
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
     ; CHECK-NEXT: [[COPY1:%[0-9]+]]:er = COPY $r0
     ; CHECK-NEXT: [[COPY2:%[0-9]+]]:em = COPY [[COPY1]]
-    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo:%[0-9]+]]:em = MOV_PD_imm11_pseudo 16
-    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo1:%[0-9]+]]:em = MOV_PD_imm11_pseudo 224
+    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo:%[0-9]+]]:em = MOV_PD_imm11_pseudo 32
+    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo1:%[0-9]+]]:em = MOV_PD_imm11_pseudo 512
     ; CHECK-NEXT: [[COPY3:%[0-9]+]]:er = COPY $r1
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: [[COPY4:%[0-9]+]]:es = COPY [[COPY3]]
@@ -279,22 +279,22 @@ body: |
     ; CHECK-NEXT: [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign1_2:%[0-9]+]]:acc1024, [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign1_3:%[0-9]+]]:ep = VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign1 [[COPY6]], [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign1_1]], [[MOV_PD_imm11_pseudo]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign1 :: (load (<16 x s32>))
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: [[COPY7:%[0-9]+]]:es = COPY [[COPY3]]
-    ; CHECK-NEXT: [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign1_2:%[0-9]+]]:acc1024, [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign1_3:%[0-9]+]]:ep = VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign1 [[COPY7]], [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign1_3]], -256, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign1 :: (load (<16 x s32>))
+    ; CHECK-NEXT: [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign1_2:%[0-9]+]]:acc1024, [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign1_3:%[0-9]+]]:ep = VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign1 [[COPY7]], [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign1_3]], -512, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign1 :: (load (<16 x s32>))
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: [[COPY8:%[0-9]+]]:es = COPY [[COPY3]]
-    ; CHECK-NEXT: [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign1_4:%[0-9]+]]:acc1024, [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign1_5:%[0-9]+]]:ep = VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign1 [[COPY8]], [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign1_3]], [[MOV_PD_imm11_pseudo1]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign1 :: (load (<16 x s32>))
+    ; CHECK-NEXT: [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign1_4:%[0-9]+]]:acc1024, [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign1_5:%[0-9]+]]:ep = VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign1 [[COPY8]], [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign1_3]], 448, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign1 :: (load (<16 x s32>))
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: [[COPY9:%[0-9]+]]:es = COPY [[COPY3]]
-    ; CHECK-NEXT: [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign1_4:%[0-9]+]]:acc1024, [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign1_5:%[0-9]+]]:ep = VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign1 [[COPY9]], [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign1_5]], 256, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign1 :: (load (<16 x s32>))
-    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign1_]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign1_]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign1_2]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign1_2]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign1_4]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign1_4]]
+    ; CHECK-NEXT: [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign1_4:%[0-9]+]]:acc1024, [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign1_5:%[0-9]+]]:ep = VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign1 [[COPY9]], [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign1_5]], [[MOV_PD_imm11_pseudo1]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign1 :: (load (<16 x s32>))
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign1_]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign1_]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign1_2]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign1_2]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign1_4]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign1_4]]
     %0:ptrregbank(p0) = COPY $p0
     %1:gprregbank(s32) = COPY $r0
     %7:modregbank(s20) = G_TRUNC %1
     %8:modregbank(s20) = G_CONSTANT i20 0
-    %9:modregbank(s20) = G_CONSTANT i20 16
-    %10:modregbank(s20) = G_CONSTANT i20 -256
-    %11:modregbank(s20) = G_CONSTANT i20 224
-    %12:modregbank(s20) = G_CONSTANT i20 256
+    %9:modregbank(s20) = G_CONSTANT i20 32
+    %10:modregbank(s20) = G_CONSTANT i20 -512
+    %11:modregbank(s20) = G_CONSTANT i20 448
+    %12:modregbank(s20) = G_CONSTANT i20 512
     %101:gprregbank(s32) = COPY $r1
     %102:gprregbank(s32) = G_CONSTANT i32 1
     %25:vregbank(<16 x s32>), %19:ptrregbank(p0) = G_AIE_POSTINC_LOAD %0, %7 :: (load (<16 x s32>))
@@ -313,21 +313,21 @@ body: |
 ...
 
 ---
-name:            VST_UPS_2x_CM_v16_acc64_signed
+name:            VLDA_UPS_2x_acc64_v16_signed
 legalized:       true
 regBankSelected: true
 tracksRegLiveness: true
 body: |
   bb.0:
     liveins: $p0, $r0, $r1, $bmll0
-    ; CHECK-LABEL: name: VST_UPS_2x_CM_v16_acc64_signed
+    ; CHECK-LABEL: name: VLDA_UPS_2x_acc64_v16_signed
     ; CHECK: liveins: $p0, $r0, $r1, $bmll0
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
     ; CHECK-NEXT: [[COPY1:%[0-9]+]]:er = COPY $r0
     ; CHECK-NEXT: [[COPY2:%[0-9]+]]:em = COPY [[COPY1]]
-    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo:%[0-9]+]]:em = MOV_PD_imm11_pseudo 16
-    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo1:%[0-9]+]]:em = MOV_PD_imm11_pseudo 224
+    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo:%[0-9]+]]:em = MOV_PD_imm11_pseudo 32
+    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo1:%[0-9]+]]:em = MOV_PD_imm11_pseudo 512
     ; CHECK-NEXT: [[COPY3:%[0-9]+]]:er = COPY $r1
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 1
     ; CHECK-NEXT: [[COPY4:%[0-9]+]]:es = COPY [[COPY3]]
@@ -340,22 +340,22 @@ body: |
     ; CHECK-NEXT: [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign1_2:%[0-9]+]]:acc1024, [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign1_3:%[0-9]+]]:ep = VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign1 [[COPY6]], [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign1_1]], [[MOV_PD_imm11_pseudo]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign1 :: (load (<16 x s32>))
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 1
     ; CHECK-NEXT: [[COPY7:%[0-9]+]]:es = COPY [[COPY3]]
-    ; CHECK-NEXT: [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign1_2:%[0-9]+]]:acc1024, [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign1_3:%[0-9]+]]:ep = VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign1 [[COPY7]], [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign1_3]], -256, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign1 :: (load (<16 x s32>))
+    ; CHECK-NEXT: [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign1_2:%[0-9]+]]:acc1024, [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign1_3:%[0-9]+]]:ep = VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign1 [[COPY7]], [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign1_3]], -512, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign1 :: (load (<16 x s32>))
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 1
     ; CHECK-NEXT: [[COPY8:%[0-9]+]]:es = COPY [[COPY3]]
-    ; CHECK-NEXT: [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign1_4:%[0-9]+]]:acc1024, [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign1_5:%[0-9]+]]:ep = VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign1 [[COPY8]], [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign1_3]], [[MOV_PD_imm11_pseudo1]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign1 :: (load (<16 x s32>))
+    ; CHECK-NEXT: [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign1_4:%[0-9]+]]:acc1024, [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign1_5:%[0-9]+]]:ep = VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign1 [[COPY8]], [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign1_3]], 448, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign1 :: (load (<16 x s32>))
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 1
     ; CHECK-NEXT: [[COPY9:%[0-9]+]]:es = COPY [[COPY3]]
-    ; CHECK-NEXT: [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign1_4:%[0-9]+]]:acc1024, [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign1_5:%[0-9]+]]:ep = VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign1 [[COPY9]], [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign1_5]], 256, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign1 :: (load (<16 x s32>))
-    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign1_]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign1_]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign1_2]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign1_2]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign1_4]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign1_4]]
+    ; CHECK-NEXT: [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign1_4:%[0-9]+]]:acc1024, [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign1_5:%[0-9]+]]:ep = VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign1 [[COPY9]], [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign1_5]], [[MOV_PD_imm11_pseudo1]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign1 :: (load (<16 x s32>))
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign1_]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign1_]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign1_2]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign1_2]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign1_4]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign1_4]]
     %0:ptrregbank(p0) = COPY $p0
     %1:gprregbank(s32) = COPY $r0
     %7:modregbank(s20) = G_TRUNC %1
     %8:modregbank(s20) = G_CONSTANT i20 0
-    %9:modregbank(s20) = G_CONSTANT i20 16
-    %10:modregbank(s20) = G_CONSTANT i20 -256
-    %11:modregbank(s20) = G_CONSTANT i20 224
-    %12:modregbank(s20) = G_CONSTANT i20 256
+    %9:modregbank(s20) = G_CONSTANT i20 32
+    %10:modregbank(s20) = G_CONSTANT i20 -512
+    %11:modregbank(s20) = G_CONSTANT i20 448
+    %12:modregbank(s20) = G_CONSTANT i20 512
     %101:gprregbank(s32) = COPY $r1
     %102:gprregbank(s32) = G_CONSTANT i32 1
     %25:vregbank(<16 x s32>), %19:ptrregbank(p0) = G_AIE_POSTINC_LOAD %0, %7 :: (load (<16 x s32>))
@@ -374,21 +374,21 @@ body: |
 ...
 
 ---
-name:            VST_UPS_4x_DM_v32_acc64_signed
+name:            VLDA_UPS_4x_acc64_v32_signed
 legalized:       true
 regBankSelected: true
 tracksRegLiveness: true
 body: |
   bb.0:
     liveins: $p0, $r0, $r1, $bmll0
-    ; CHECK-LABEL: name: VST_UPS_4x_DM_v32_acc64_signed
+    ; CHECK-LABEL: name: VLDA_UPS_4x_acc64_v32_signed
     ; CHECK: liveins: $p0, $r0, $r1, $bmll0
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
     ; CHECK-NEXT: [[COPY1:%[0-9]+]]:er = COPY $r0
     ; CHECK-NEXT: [[COPY2:%[0-9]+]]:em = COPY [[COPY1]]
-    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo:%[0-9]+]]:em = MOV_PD_imm11_pseudo 16
-    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo1:%[0-9]+]]:em = MOV_PD_imm11_pseudo 224
+    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo:%[0-9]+]]:em = MOV_PD_imm11_pseudo 32
+    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo1:%[0-9]+]]:em = MOV_PD_imm11_pseudo 512
     ; CHECK-NEXT: [[COPY3:%[0-9]+]]:er = COPY $r1
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 1
     ; CHECK-NEXT: [[COPY4:%[0-9]+]]:es = COPY [[COPY3]]
@@ -401,22 +401,22 @@ body: |
     ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign1_2:%[0-9]+]]:acc2048, [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign1_3:%[0-9]+]]:ep = VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign1 [[COPY6]], [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign1_1]], [[MOV_PD_imm11_pseudo]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign1 :: (load (<16 x s32>))
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 1
     ; CHECK-NEXT: [[COPY7:%[0-9]+]]:es = COPY [[COPY3]]
-    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign1_2:%[0-9]+]]:acc2048, [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign1_3:%[0-9]+]]:ep = VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign1 [[COPY7]], [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign1_3]], -256, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign1 :: (load (<16 x s32>))
+    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign1_2:%[0-9]+]]:acc2048, [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign1_3:%[0-9]+]]:ep = VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign1 [[COPY7]], [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign1_3]], -512, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign1 :: (load (<16 x s32>))
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 1
     ; CHECK-NEXT: [[COPY8:%[0-9]+]]:es = COPY [[COPY3]]
-    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign1_4:%[0-9]+]]:acc2048, [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign1_5:%[0-9]+]]:ep = VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign1 [[COPY8]], [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign1_3]], [[MOV_PD_imm11_pseudo1]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign1 :: (load (<16 x s32>))
+    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign1_4:%[0-9]+]]:acc2048, [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign1_5:%[0-9]+]]:ep = VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign1 [[COPY8]], [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign1_3]], 448, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign1 :: (load (<16 x s32>))
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 1
     ; CHECK-NEXT: [[COPY9:%[0-9]+]]:es = COPY [[COPY3]]
-    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign1_4:%[0-9]+]]:acc2048, [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign1_5:%[0-9]+]]:ep = VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign1 [[COPY9]], [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign1_5]], 256, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign1 :: (load (<16 x s32>))
-    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign1_]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign1_]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign1_2]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign1_2]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign1_4]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign1_4]]
+    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign1_4:%[0-9]+]]:acc2048, [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign1_5:%[0-9]+]]:ep = VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign1 [[COPY9]], [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign1_5]], [[MOV_PD_imm11_pseudo1]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign1 :: (load (<16 x s32>))
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign1_]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign1_]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign1_2]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign1_2]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign1_4]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign1_4]]
     %0:ptrregbank(p0) = COPY $p0
     %1:gprregbank(s32) = COPY $r0
     %7:modregbank(s20) = G_TRUNC %1
     %8:modregbank(s20) = G_CONSTANT i20 0
-    %9:modregbank(s20) = G_CONSTANT i20 16
-    %10:modregbank(s20) = G_CONSTANT i20 -256
-    %11:modregbank(s20) = G_CONSTANT i20 224
-    %12:modregbank(s20) = G_CONSTANT i20 256
+    %9:modregbank(s20) = G_CONSTANT i20 32
+    %10:modregbank(s20) = G_CONSTANT i20 -512
+    %11:modregbank(s20) = G_CONSTANT i20 448
+    %12:modregbank(s20) = G_CONSTANT i20 512
     %101:gprregbank(s32) = COPY $r1
     %102:gprregbank(s32) = G_CONSTANT i32 1
     %25:vregbank(<16 x s32>), %19:ptrregbank(p0) = G_AIE_POSTINC_LOAD %0, %7 :: (load (<16 x s32>))
@@ -435,21 +435,21 @@ body: |
 ...
 
 ---
-name:            VST_UPS_4x_DM_v64_acc32_signed
+name:            VLDA_UPS_4x_acc32_v64_signed
 legalized:       true
 regBankSelected: true
 tracksRegLiveness: true
 body: |
   bb.0:
     liveins: $p0, $r0, $r1, $bmll0
-    ; CHECK-LABEL: name: VST_UPS_4x_DM_v64_acc32_signed
+    ; CHECK-LABEL: name: VLDA_UPS_4x_acc32_v64_signed
     ; CHECK: liveins: $p0, $r0, $r1, $bmll0
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
     ; CHECK-NEXT: [[COPY1:%[0-9]+]]:er = COPY $r0
     ; CHECK-NEXT: [[COPY2:%[0-9]+]]:em = COPY [[COPY1]]
-    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo:%[0-9]+]]:em = MOV_PD_imm11_pseudo 16
-    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo1:%[0-9]+]]:em = MOV_PD_imm11_pseudo 224
+    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo:%[0-9]+]]:em = MOV_PD_imm11_pseudo 32
+    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo1:%[0-9]+]]:em = MOV_PD_imm11_pseudo 512
     ; CHECK-NEXT: [[COPY3:%[0-9]+]]:er = COPY $r1
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: [[COPY4:%[0-9]+]]:es = COPY [[COPY3]]
@@ -462,22 +462,22 @@ body: |
     ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign1_2:%[0-9]+]]:acc2048, [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign1_3:%[0-9]+]]:ep = VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign1 [[COPY6]], [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign1_1]], [[MOV_PD_imm11_pseudo]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign1 :: (load (<16 x s32>))
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: [[COPY7:%[0-9]+]]:es = COPY [[COPY3]]
-    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign1_2:%[0-9]+]]:acc2048, [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign1_3:%[0-9]+]]:ep = VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign1 [[COPY7]], [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign1_3]], -256, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign1 :: (load (<16 x s32>))
+    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign1_2:%[0-9]+]]:acc2048, [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign1_3:%[0-9]+]]:ep = VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign1 [[COPY7]], [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign1_3]], -512, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign1 :: (load (<16 x s32>))
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: [[COPY8:%[0-9]+]]:es = COPY [[COPY3]]
-    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign1_4:%[0-9]+]]:acc2048, [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign1_5:%[0-9]+]]:ep = VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign1 [[COPY8]], [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign1_3]], [[MOV_PD_imm11_pseudo1]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign1 :: (load (<16 x s32>))
+    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign1_4:%[0-9]+]]:acc2048, [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign1_5:%[0-9]+]]:ep = VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign1 [[COPY8]], [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign1_3]], 448, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign1 :: (load (<16 x s32>))
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: [[COPY9:%[0-9]+]]:es = COPY [[COPY3]]
-    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign1_4:%[0-9]+]]:acc2048, [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign1_5:%[0-9]+]]:ep = VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign1 [[COPY9]], [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign1_5]], 256, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign1 :: (load (<16 x s32>))
-    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign1_]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign1_]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign1_2]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign1_2]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign1_4]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign1_4]]
+    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign1_4:%[0-9]+]]:acc2048, [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign1_5:%[0-9]+]]:ep = VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign1 [[COPY9]], [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign1_5]], [[MOV_PD_imm11_pseudo1]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign1 :: (load (<16 x s32>))
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign1_]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign1_]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign1_2]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign1_2]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign1_4]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign1_4]]
     %0:ptrregbank(p0) = COPY $p0
     %1:gprregbank(s32) = COPY $r0
     %7:modregbank(s20) = G_TRUNC %1
     %8:modregbank(s20) = G_CONSTANT i20 0
-    %9:modregbank(s20) = G_CONSTANT i20 16
-    %10:modregbank(s20) = G_CONSTANT i20 -256
-    %11:modregbank(s20) = G_CONSTANT i20 224
-    %12:modregbank(s20) = G_CONSTANT i20 256
+    %9:modregbank(s20) = G_CONSTANT i20 32
+    %10:modregbank(s20) = G_CONSTANT i20 -512
+    %11:modregbank(s20) = G_CONSTANT i20 448
+    %12:modregbank(s20) = G_CONSTANT i20 512
     %101:gprregbank(s32) = COPY $r1
     %102:gprregbank(s32) = G_CONSTANT i32 1
     %25:vregbank(<16 x s32>), %19:ptrregbank(p0) = G_AIE_POSTINC_LOAD %0, %7 :: (load (<16 x s32>))
@@ -496,14 +496,14 @@ body: |
 ...
 
 ---
-name:            VST_UPS_2x_BM_v16_acc32_unsigned
+name:            VLDA_UPS_2x_acc32_v16_unsigned
 legalized:       true
 regBankSelected: true
 tracksRegLiveness: true
 body: |
   bb.0:
     liveins: $p0, $r0, $r1, $bmll0
-    ; CHECK-LABEL: name: VST_UPS_2x_BM_v16_acc32_unsigned
+    ; CHECK-LABEL: name: VLDA_UPS_2x_acc32_v16_unsigned
     ; CHECK: liveins: $p0, $r0, $r1, $bmll0
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
@@ -557,14 +557,14 @@ body: |
 ...
 
 ---
-name:            VST_UPS_2x_BM_v8_acc64_unsigned
+name:            VLDA_UPS_2x_acc64_v8_unsigned
 legalized:       true
 regBankSelected: true
 tracksRegLiveness: true
 body: |
   bb.0:
     liveins: $p0, $r0, $r1, $bmll0
-    ; CHECK-LABEL: name: VST_UPS_2x_BM_v8_acc64_unsigned
+    ; CHECK-LABEL: name: VLDA_UPS_2x_acc64_v8_unsigned
     ; CHECK: liveins: $p0, $r0, $r1, $bmll0
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
@@ -618,14 +618,14 @@ body: |
 ...
 
 ---
-name:            VST_UPS_4x_CM_v16_acc64_unsigned
+name:            VLDA_UPS_4x_acc64_v16_unsigned
 legalized:       true
 regBankSelected: true
 tracksRegLiveness: true
 body: |
   bb.0:
     liveins: $p0, $r0, $r1, $bmll0
-    ; CHECK-LABEL: name: VST_UPS_4x_CM_v16_acc64_unsigned
+    ; CHECK-LABEL: name: VLDA_UPS_4x_acc64_v16_unsigned
     ; CHECK: liveins: $p0, $r0, $r1, $bmll0
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
@@ -679,14 +679,14 @@ body: |
 ...
 
 ---
-name:            VST_UPS_4x_CM_v32_acc32_unsigned
+name:            VLDA_UPS_4x_acc32_v32_unsigned
 legalized:       true
 regBankSelected: true
 tracksRegLiveness: true
 body: |
   bb.0:
     liveins: $p0, $r0, $r1, $bmll0
-    ; CHECK-LABEL: name: VST_UPS_4x_CM_v32_acc32_unsigned
+    ; CHECK-LABEL: name: VLDA_UPS_4x_acc32_v32_unsigned
     ; CHECK: liveins: $p0, $r0, $r1, $bmll0
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
@@ -740,21 +740,21 @@ body: |
 ...
 
 ---
-name:            VST_UPS_2x_CM_v32_acc32_unsigned
+name:            VLDA_UPS_2x_acc32_v32_unsigned
 legalized:       true
 regBankSelected: true
 tracksRegLiveness: true
 body: |
   bb.0:
     liveins: $p0, $r0, $r1, $bmll0
-    ; CHECK-LABEL: name: VST_UPS_2x_CM_v32_acc32_unsigned
+    ; CHECK-LABEL: name: VLDA_UPS_2x_acc32_v32_unsigned
     ; CHECK: liveins: $p0, $r0, $r1, $bmll0
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
     ; CHECK-NEXT: [[COPY1:%[0-9]+]]:er = COPY $r0
     ; CHECK-NEXT: [[COPY2:%[0-9]+]]:em = COPY [[COPY1]]
-    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo:%[0-9]+]]:em = MOV_PD_imm11_pseudo 16
-    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo1:%[0-9]+]]:em = MOV_PD_imm11_pseudo 224
+    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo:%[0-9]+]]:em = MOV_PD_imm11_pseudo 32
+    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo1:%[0-9]+]]:em = MOV_PD_imm11_pseudo 512
     ; CHECK-NEXT: [[COPY3:%[0-9]+]]:er = COPY $r1
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: [[COPY4:%[0-9]+]]:es = COPY [[COPY3]]
@@ -767,22 +767,22 @@ body: |
     ; CHECK-NEXT: [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign0_2:%[0-9]+]]:acc1024, [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign0_3:%[0-9]+]]:ep = VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign0 [[COPY6]], [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign0_1]], [[MOV_PD_imm11_pseudo]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: [[COPY7:%[0-9]+]]:es = COPY [[COPY3]]
-    ; CHECK-NEXT: [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign0_2:%[0-9]+]]:acc1024, [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign0_3:%[0-9]+]]:ep = VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign0 [[COPY7]], [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign0_3]], -256, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
+    ; CHECK-NEXT: [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign0_2:%[0-9]+]]:acc1024, [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign0_3:%[0-9]+]]:ep = VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign0 [[COPY7]], [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign0_3]], -512, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: [[COPY8:%[0-9]+]]:es = COPY [[COPY3]]
-    ; CHECK-NEXT: [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign0_4:%[0-9]+]]:acc1024, [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign0_5:%[0-9]+]]:ep = VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign0 [[COPY8]], [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign0_3]], [[MOV_PD_imm11_pseudo1]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
+    ; CHECK-NEXT: [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign0_4:%[0-9]+]]:acc1024, [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign0_5:%[0-9]+]]:ep = VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign0 [[COPY8]], [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign0_3]], 448, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: [[COPY9:%[0-9]+]]:es = COPY [[COPY3]]
-    ; CHECK-NEXT: [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign0_4:%[0-9]+]]:acc1024, [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign0_5:%[0-9]+]]:ep = VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign0 [[COPY9]], [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign0_5]], 256, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
-    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign0_]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign0_]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign0_2]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign0_2]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign0_4]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign0_4]]
+    ; CHECK-NEXT: [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign0_4:%[0-9]+]]:acc1024, [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign0_5:%[0-9]+]]:ep = VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign0 [[COPY9]], [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign0_5]], [[MOV_PD_imm11_pseudo1]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign0_]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign0_]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign0_2]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign0_2]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign0_4]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign0_4]]
     %0:ptrregbank(p0) = COPY $p0
     %1:gprregbank(s32) = COPY $r0
     %7:modregbank(s20) = G_TRUNC %1
     %8:modregbank(s20) = G_CONSTANT i20 0
-    %9:modregbank(s20) = G_CONSTANT i20 16
-    %10:modregbank(s20) = G_CONSTANT i20 -256
-    %11:modregbank(s20) = G_CONSTANT i20 224
-    %12:modregbank(s20) = G_CONSTANT i20 256
+    %9:modregbank(s20) = G_CONSTANT i20 32
+    %10:modregbank(s20) = G_CONSTANT i20 -512
+    %11:modregbank(s20) = G_CONSTANT i20 448
+    %12:modregbank(s20) = G_CONSTANT i20 512
     %101:gprregbank(s32) = COPY $r1
     %102:gprregbank(s32) = G_CONSTANT i32 0
     %25:vregbank(<16 x s32>), %19:ptrregbank(p0) = G_AIE_POSTINC_LOAD %0, %7 :: (load (<16 x s32>))
@@ -801,21 +801,21 @@ body: |
 ...
 
 ---
-name:            VST_UPS_2x_CM_v16_acc64_unsigned
+name:            VLDA_UPS_2x_acc64_v16_unsigned
 legalized:       true
 regBankSelected: true
 tracksRegLiveness: true
 body: |
   bb.0:
     liveins: $p0, $r0, $r1, $bmll0
-    ; CHECK-LABEL: name: VST_UPS_2x_CM_v16_acc64_unsigned
+    ; CHECK-LABEL: name: VLDA_UPS_2x_acc64_v16_unsigned
     ; CHECK: liveins: $p0, $r0, $r1, $bmll0
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
     ; CHECK-NEXT: [[COPY1:%[0-9]+]]:er = COPY $r0
     ; CHECK-NEXT: [[COPY2:%[0-9]+]]:em = COPY [[COPY1]]
-    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo:%[0-9]+]]:em = MOV_PD_imm11_pseudo 16
-    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo1:%[0-9]+]]:em = MOV_PD_imm11_pseudo 224
+    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo:%[0-9]+]]:em = MOV_PD_imm11_pseudo 32
+    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo1:%[0-9]+]]:em = MOV_PD_imm11_pseudo 512
     ; CHECK-NEXT: [[COPY3:%[0-9]+]]:er = COPY $r1
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 1
     ; CHECK-NEXT: [[COPY4:%[0-9]+]]:es = COPY [[COPY3]]
@@ -828,22 +828,22 @@ body: |
     ; CHECK-NEXT: [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign0_2:%[0-9]+]]:acc1024, [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign0_3:%[0-9]+]]:ep = VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign0 [[COPY6]], [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign0_1]], [[MOV_PD_imm11_pseudo]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 1
     ; CHECK-NEXT: [[COPY7:%[0-9]+]]:es = COPY [[COPY3]]
-    ; CHECK-NEXT: [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign0_2:%[0-9]+]]:acc1024, [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign0_3:%[0-9]+]]:ep = VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign0 [[COPY7]], [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign0_3]], -256, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
+    ; CHECK-NEXT: [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign0_2:%[0-9]+]]:acc1024, [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign0_3:%[0-9]+]]:ep = VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign0 [[COPY7]], [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign0_3]], -512, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 1
     ; CHECK-NEXT: [[COPY8:%[0-9]+]]:es = COPY [[COPY3]]
-    ; CHECK-NEXT: [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign0_4:%[0-9]+]]:acc1024, [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign0_5:%[0-9]+]]:ep = VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign0 [[COPY8]], [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign0_3]], [[MOV_PD_imm11_pseudo1]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
+    ; CHECK-NEXT: [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign0_4:%[0-9]+]]:acc1024, [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign0_5:%[0-9]+]]:ep = VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign0 [[COPY8]], [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign0_3]], 448, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 1
     ; CHECK-NEXT: [[COPY9:%[0-9]+]]:es = COPY [[COPY3]]
-    ; CHECK-NEXT: [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign0_4:%[0-9]+]]:acc1024, [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign0_5:%[0-9]+]]:ep = VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign0 [[COPY9]], [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign0_5]], 256, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
-    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign0_]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign0_]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign0_2]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign0_2]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign0_4]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign0_4]]
+    ; CHECK-NEXT: [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign0_4:%[0-9]+]]:acc1024, [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign0_5:%[0-9]+]]:ep = VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign0 [[COPY9]], [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign0_5]], [[MOV_PD_imm11_pseudo1]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign0_]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign0_]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign0_2]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign0_2]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign0_4]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign0_4]]
     %0:ptrregbank(p0) = COPY $p0
     %1:gprregbank(s32) = COPY $r0
     %7:modregbank(s20) = G_TRUNC %1
     %8:modregbank(s20) = G_CONSTANT i20 0
-    %9:modregbank(s20) = G_CONSTANT i20 16
-    %10:modregbank(s20) = G_CONSTANT i20 -256
-    %11:modregbank(s20) = G_CONSTANT i20 224
-    %12:modregbank(s20) = G_CONSTANT i20 256
+    %9:modregbank(s20) = G_CONSTANT i20 32
+    %10:modregbank(s20) = G_CONSTANT i20 -512
+    %11:modregbank(s20) = G_CONSTANT i20 448
+    %12:modregbank(s20) = G_CONSTANT i20 512
     %101:gprregbank(s32) = COPY $r1
     %102:gprregbank(s32) = G_CONSTANT i32 0
     %25:vregbank(<16 x s32>), %19:ptrregbank(p0) = G_AIE_POSTINC_LOAD %0, %7 :: (load (<16 x s32>))
@@ -862,21 +862,21 @@ body: |
 ...
 
 ---
-name:            VST_UPS_4x_DM_v32_acc64_unsigned
+name:            VLDA_UPS_4x_acc64_v32_unsigned
 legalized:       true
 regBankSelected: true
 tracksRegLiveness: true
 body: |
   bb.0:
     liveins: $p0, $r0, $r1, $bmll0
-    ; CHECK-LABEL: name: VST_UPS_4x_DM_v32_acc64_unsigned
+    ; CHECK-LABEL: name: VLDA_UPS_4x_acc64_v32_unsigned
     ; CHECK: liveins: $p0, $r0, $r1, $bmll0
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
     ; CHECK-NEXT: [[COPY1:%[0-9]+]]:er = COPY $r0
     ; CHECK-NEXT: [[COPY2:%[0-9]+]]:em = COPY [[COPY1]]
-    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo:%[0-9]+]]:em = MOV_PD_imm11_pseudo 16
-    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo1:%[0-9]+]]:em = MOV_PD_imm11_pseudo 224
+    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo:%[0-9]+]]:em = MOV_PD_imm11_pseudo 32
+    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo1:%[0-9]+]]:em = MOV_PD_imm11_pseudo 512
     ; CHECK-NEXT: [[COPY3:%[0-9]+]]:er = COPY $r1
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 1
     ; CHECK-NEXT: [[COPY4:%[0-9]+]]:es = COPY [[COPY3]]
@@ -889,22 +889,22 @@ body: |
     ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign0_2:%[0-9]+]]:acc2048, [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign0_3:%[0-9]+]]:ep = VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign0 [[COPY6]], [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign0_1]], [[MOV_PD_imm11_pseudo]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 1
     ; CHECK-NEXT: [[COPY7:%[0-9]+]]:es = COPY [[COPY3]]
-    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign0_2:%[0-9]+]]:acc2048, [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign0_3:%[0-9]+]]:ep = VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign0 [[COPY7]], [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign0_3]], -256, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
+    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign0_2:%[0-9]+]]:acc2048, [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign0_3:%[0-9]+]]:ep = VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign0 [[COPY7]], [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign0_3]], -512, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 1
     ; CHECK-NEXT: [[COPY8:%[0-9]+]]:es = COPY [[COPY3]]
-    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign0_4:%[0-9]+]]:acc2048, [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign0_5:%[0-9]+]]:ep = VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign0 [[COPY8]], [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign0_3]], [[MOV_PD_imm11_pseudo1]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
+    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign0_4:%[0-9]+]]:acc2048, [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign0_5:%[0-9]+]]:ep = VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign0 [[COPY8]], [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign0_3]], 448, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 1
     ; CHECK-NEXT: [[COPY9:%[0-9]+]]:es = COPY [[COPY3]]
-    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign0_4:%[0-9]+]]:acc2048, [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign0_5:%[0-9]+]]:ep = VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign0 [[COPY9]], [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign0_5]], 256, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
-    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign0_]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign0_]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign0_2]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign0_2]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign0_4]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign0_4]]
+    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign0_4:%[0-9]+]]:acc2048, [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign0_5:%[0-9]+]]:ep = VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign0 [[COPY9]], [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign0_5]], [[MOV_PD_imm11_pseudo1]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign0_]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign0_]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign0_2]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign0_2]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign0_4]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign0_4]]
     %0:ptrregbank(p0) = COPY $p0
     %1:gprregbank(s32) = COPY $r0
     %7:modregbank(s20) = G_TRUNC %1
     %8:modregbank(s20) = G_CONSTANT i20 0
-    %9:modregbank(s20) = G_CONSTANT i20 16
-    %10:modregbank(s20) = G_CONSTANT i20 -256
-    %11:modregbank(s20) = G_CONSTANT i20 224
-    %12:modregbank(s20) = G_CONSTANT i20 256
+    %9:modregbank(s20) = G_CONSTANT i20 32
+    %10:modregbank(s20) = G_CONSTANT i20 -512
+    %11:modregbank(s20) = G_CONSTANT i20 448
+    %12:modregbank(s20) = G_CONSTANT i20 512
     %101:gprregbank(s32) = COPY $r1
     %102:gprregbank(s32) = G_CONSTANT i32 0
     %25:vregbank(<16 x s32>), %19:ptrregbank(p0) = G_AIE_POSTINC_LOAD %0, %7 :: (load (<16 x s32>))
@@ -923,21 +923,21 @@ body: |
 ...
 
 ---
-name:            VST_UPS_4x_DM_v64_acc32_unsigned
+name:            VLDA_UPS_4x_acc32_v64_unsigned
 legalized:       true
 regBankSelected: true
 tracksRegLiveness: true
 body: |
   bb.0:
     liveins: $p0, $r0, $r1, $bmll0
-    ; CHECK-LABEL: name: VST_UPS_4x_DM_v64_acc32_unsigned
+    ; CHECK-LABEL: name: VLDA_UPS_4x_acc32_v64_unsigned
     ; CHECK: liveins: $p0, $r0, $r1, $bmll0
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
     ; CHECK-NEXT: [[COPY1:%[0-9]+]]:er = COPY $r0
     ; CHECK-NEXT: [[COPY2:%[0-9]+]]:em = COPY [[COPY1]]
-    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo:%[0-9]+]]:em = MOV_PD_imm11_pseudo 16
-    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo1:%[0-9]+]]:em = MOV_PD_imm11_pseudo 224
+    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo:%[0-9]+]]:em = MOV_PD_imm11_pseudo 32
+    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo1:%[0-9]+]]:em = MOV_PD_imm11_pseudo 512
     ; CHECK-NEXT: [[COPY3:%[0-9]+]]:er = COPY $r1
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: [[COPY4:%[0-9]+]]:es = COPY [[COPY3]]
@@ -950,22 +950,22 @@ body: |
     ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign0_2:%[0-9]+]]:acc2048, [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign0_3:%[0-9]+]]:ep = VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign0 [[COPY6]], [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign0_1]], [[MOV_PD_imm11_pseudo]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: [[COPY7:%[0-9]+]]:es = COPY [[COPY3]]
-    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign0_2:%[0-9]+]]:acc2048, [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign0_3:%[0-9]+]]:ep = VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign0 [[COPY7]], [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign0_3]], -256, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
+    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign0_2:%[0-9]+]]:acc2048, [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign0_3:%[0-9]+]]:ep = VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign0 [[COPY7]], [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign0_3]], -512, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: [[COPY8:%[0-9]+]]:es = COPY [[COPY3]]
-    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign0_4:%[0-9]+]]:acc2048, [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign0_5:%[0-9]+]]:ep = VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign0 [[COPY8]], [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign0_3]], [[MOV_PD_imm11_pseudo1]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
+    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign0_4:%[0-9]+]]:acc2048, [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign0_5:%[0-9]+]]:ep = VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign0 [[COPY8]], [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign0_3]], 448, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: [[COPY9:%[0-9]+]]:es = COPY [[COPY3]]
-    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign0_4:%[0-9]+]]:acc2048, [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign0_5:%[0-9]+]]:ep = VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign0 [[COPY9]], [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign0_5]], 256, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
-    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign0_]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign0_]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign0_2]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign0_2]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign0_4]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign0_4]]
+    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign0_4:%[0-9]+]]:acc2048, [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign0_5:%[0-9]+]]:ep = VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign0 [[COPY9]], [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign0_5]], [[MOV_PD_imm11_pseudo1]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign0_]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign0_]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign0_2]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign0_2]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign0_4]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign0_4]]
     %0:ptrregbank(p0) = COPY $p0
     %1:gprregbank(s32) = COPY $r0
     %7:modregbank(s20) = G_TRUNC %1
     %8:modregbank(s20) = G_CONSTANT i20 0
-    %9:modregbank(s20) = G_CONSTANT i20 16
-    %10:modregbank(s20) = G_CONSTANT i20 -256
-    %11:modregbank(s20) = G_CONSTANT i20 224
-    %12:modregbank(s20) = G_CONSTANT i20 256
+    %9:modregbank(s20) = G_CONSTANT i20 32
+    %10:modregbank(s20) = G_CONSTANT i20 -512
+    %11:modregbank(s20) = G_CONSTANT i20 448
+    %12:modregbank(s20) = G_CONSTANT i20 512
     %101:gprregbank(s32) = COPY $r1
     %102:gprregbank(s32) = G_CONSTANT i32 0
     %25:vregbank(<16 x s32>), %19:ptrregbank(p0) = G_AIE_POSTINC_LOAD %0, %7 :: (load (<16 x s32>))
@@ -984,14 +984,14 @@ body: |
 ...
 
 ---
-name:            VST_UPS_2x_BM_v16_acc32_dynamic
+name:            VLDA_UPS_2x_acc32_v16_dynamic
 legalized:       true
 regBankSelected: true
 tracksRegLiveness: true
 body: |
   bb.0:
     liveins: $p0, $r0, $r1, $r2, $bmll0
-    ; CHECK-LABEL: name: VST_UPS_2x_BM_v16_acc32_dynamic
+    ; CHECK-LABEL: name: VLDA_UPS_2x_acc32_v16_dynamic
     ; CHECK: liveins: $p0, $r0, $r1, $r2, $bmll0
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
@@ -1058,14 +1058,14 @@ body: |
 ...
 
 ---
-name:            VST_UPS_2x_BM_v8_acc64_dynamic
+name:            VLDA_UPS_2x_acc64_v8_dynamic
 legalized:       true
 regBankSelected: true
 tracksRegLiveness: true
 body: |
   bb.0:
     liveins: $p0, $r0, $r1, $r2, $bmll0
-    ; CHECK-LABEL: name: VST_UPS_2x_BM_v8_acc64_dynamic
+    ; CHECK-LABEL: name: VLDA_UPS_2x_acc64_v8_dynamic
     ; CHECK: liveins: $p0, $r0, $r1, $r2, $bmll0
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
@@ -1132,14 +1132,14 @@ body: |
 ...
 
 ---
-name:            VST_UPS_4x_CM_v16_acc64_dynamic
+name:            VLDA_UPS_4x_acc64_v16_dynamic
 legalized:       true
 regBankSelected: true
 tracksRegLiveness: true
 body: |
   bb.0:
     liveins: $p0, $r0, $r1, $r2, $bmll0
-    ; CHECK-LABEL: name: VST_UPS_4x_CM_v16_acc64_dynamic
+    ; CHECK-LABEL: name: VLDA_UPS_4x_acc64_v16_dynamic
     ; CHECK: liveins: $p0, $r0, $r1, $r2, $bmll0
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
@@ -1206,14 +1206,14 @@ body: |
 ...
 
 ---
-name:            VST_UPS_4x_CM_v32_acc32_dynamic
+name:            VLDA_UPS_4x_acc32_v32_dynamic
 legalized:       true
 regBankSelected: true
 tracksRegLiveness: true
 body: |
   bb.0:
     liveins: $p0, $r0, $r1, $r2, $bmll0
-    ; CHECK-LABEL: name: VST_UPS_4x_CM_v32_acc32_dynamic
+    ; CHECK-LABEL: name: VLDA_UPS_4x_acc32_v32_dynamic
     ; CHECK: liveins: $p0, $r0, $r1, $r2, $bmll0
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
@@ -1280,21 +1280,21 @@ body: |
 ...
 
 ---
-name:            VST_UPS_2x_CM_v32_acc32_dynamic
+name:            VLDA_UPS_2x_acc32_v32_dynamic
 legalized:       true
 regBankSelected: true
 tracksRegLiveness: true
 body: |
   bb.0:
     liveins: $p0, $r0, $r1, $r2, $bmll0
-    ; CHECK-LABEL: name: VST_UPS_2x_CM_v32_acc32_dynamic
+    ; CHECK-LABEL: name: VLDA_UPS_2x_acc32_v32_dynamic
     ; CHECK: liveins: $p0, $r0, $r1, $r2, $bmll0
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
     ; CHECK-NEXT: [[COPY1:%[0-9]+]]:er = COPY $r0
     ; CHECK-NEXT: [[COPY2:%[0-9]+]]:em = COPY [[COPY1]]
-    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo:%[0-9]+]]:em = MOV_PD_imm11_pseudo 16
-    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo1:%[0-9]+]]:em = MOV_PD_imm11_pseudo 224
+    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo:%[0-9]+]]:em = MOV_PD_imm11_pseudo 32
+    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo1:%[0-9]+]]:em = MOV_PD_imm11_pseudo 512
     ; CHECK-NEXT: [[COPY3:%[0-9]+]]:er = COPY $r1
     ; CHECK-NEXT: [[COPY4:%[0-9]+]]:er = COPY $r2
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 0
@@ -1315,27 +1315,27 @@ body: |
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: $upssign0 = COPY [[COPY4]]
     ; CHECK-NEXT: [[COPY8:%[0-9]+]]:es = COPY [[COPY3]]
-    ; CHECK-NEXT: [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign0_2:%[0-9]+]]:acc1024, [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign0_3:%[0-9]+]]:ep = VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign0 [[COPY8]], [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign0_3]], -256, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
+    ; CHECK-NEXT: [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign0_2:%[0-9]+]]:acc1024, [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign0_3:%[0-9]+]]:ep = VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign0 [[COPY8]], [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign0_3]], -512, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
     ; CHECK-NEXT: $upssign0 = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: $upssign0 = COPY [[COPY4]]
     ; CHECK-NEXT: [[COPY9:%[0-9]+]]:es = COPY [[COPY3]]
-    ; CHECK-NEXT: [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign0_4:%[0-9]+]]:acc1024, [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign0_5:%[0-9]+]]:ep = VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign0 [[COPY9]], [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign0_3]], [[MOV_PD_imm11_pseudo1]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
+    ; CHECK-NEXT: [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign0_4:%[0-9]+]]:acc1024, [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign0_5:%[0-9]+]]:ep = VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign0 [[COPY9]], [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign0_3]], 448, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
     ; CHECK-NEXT: $upssign0 = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: $upssign0 = COPY [[COPY4]]
     ; CHECK-NEXT: [[COPY10:%[0-9]+]]:es = COPY [[COPY3]]
-    ; CHECK-NEXT: [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign0_4:%[0-9]+]]:acc1024, [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign0_5:%[0-9]+]]:ep = VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign0 [[COPY10]], [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign0_5]], 256, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
+    ; CHECK-NEXT: [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign0_4:%[0-9]+]]:acc1024, [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign0_5:%[0-9]+]]:ep = VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign0 [[COPY10]], [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign0_5]], [[MOV_PD_imm11_pseudo1]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
     ; CHECK-NEXT: $upssign0 = MOV_scalar_imm11_pseudo 0
-    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign0_]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign0_]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign0_2]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign0_2]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign0_4]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign0_4]]
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign0_]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign0_]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign0_2]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign0_2]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign0_4]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign0_4]]
     %0:ptrregbank(p0) = COPY $p0
     %1:gprregbank(s32) = COPY $r0
     %7:modregbank(s20) = G_TRUNC %1
     %8:modregbank(s20) = G_CONSTANT i20 0
-    %9:modregbank(s20) = G_CONSTANT i20 16
-    %10:modregbank(s20) = G_CONSTANT i20 -256
-    %11:modregbank(s20) = G_CONSTANT i20 224
-    %12:modregbank(s20) = G_CONSTANT i20 256
+    %9:modregbank(s20) = G_CONSTANT i20 32
+    %10:modregbank(s20) = G_CONSTANT i20 -512
+    %11:modregbank(s20) = G_CONSTANT i20 448
+    %12:modregbank(s20) = G_CONSTANT i20 512
     %101:gprregbank(s32) = COPY $r1
     %102:gprregbank(s32) = COPY $r2
     %25:vregbank(<16 x s32>), %19:ptrregbank(p0) = G_AIE_POSTINC_LOAD %0, %7 :: (load (<16 x s32>))
@@ -1354,21 +1354,21 @@ body: |
 ...
 
 ---
-name:            VST_UPS_2x_CM_v16_acc64_dynamic
+name:            VLDA_UPS_2x_acc64_v16_dynamic
 legalized:       true
 regBankSelected: true
 tracksRegLiveness: true
 body: |
   bb.0:
     liveins: $p0, $r0, $r1, $r2, $bmll0
-    ; CHECK-LABEL: name: VST_UPS_2x_CM_v16_acc64_dynamic
+    ; CHECK-LABEL: name: VLDA_UPS_2x_acc64_v16_dynamic
     ; CHECK: liveins: $p0, $r0, $r1, $r2, $bmll0
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
     ; CHECK-NEXT: [[COPY1:%[0-9]+]]:er = COPY $r0
     ; CHECK-NEXT: [[COPY2:%[0-9]+]]:em = COPY [[COPY1]]
-    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo:%[0-9]+]]:em = MOV_PD_imm11_pseudo 16
-    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo1:%[0-9]+]]:em = MOV_PD_imm11_pseudo 224
+    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo:%[0-9]+]]:em = MOV_PD_imm11_pseudo 32
+    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo1:%[0-9]+]]:em = MOV_PD_imm11_pseudo 512
     ; CHECK-NEXT: [[COPY3:%[0-9]+]]:er = COPY $r1
     ; CHECK-NEXT: [[COPY4:%[0-9]+]]:er = COPY $r2
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 1
@@ -1389,27 +1389,27 @@ body: |
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 1
     ; CHECK-NEXT: $upssign0 = COPY [[COPY4]]
     ; CHECK-NEXT: [[COPY8:%[0-9]+]]:es = COPY [[COPY3]]
-    ; CHECK-NEXT: [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign0_2:%[0-9]+]]:acc1024, [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign0_3:%[0-9]+]]:ep = VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign0 [[COPY8]], [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign0_3]], -256, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
+    ; CHECK-NEXT: [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign0_2:%[0-9]+]]:acc1024, [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign0_3:%[0-9]+]]:ep = VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign0 [[COPY8]], [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign0_3]], -512, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
     ; CHECK-NEXT: $upssign0 = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 1
     ; CHECK-NEXT: $upssign0 = COPY [[COPY4]]
     ; CHECK-NEXT: [[COPY9:%[0-9]+]]:es = COPY [[COPY3]]
-    ; CHECK-NEXT: [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign0_4:%[0-9]+]]:acc1024, [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign0_5:%[0-9]+]]:ep = VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign0 [[COPY9]], [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign0_3]], [[MOV_PD_imm11_pseudo1]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
+    ; CHECK-NEXT: [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign0_4:%[0-9]+]]:acc1024, [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign0_5:%[0-9]+]]:ep = VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign0 [[COPY9]], [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign0_3]], 448, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
     ; CHECK-NEXT: $upssign0 = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 1
     ; CHECK-NEXT: $upssign0 = COPY [[COPY4]]
     ; CHECK-NEXT: [[COPY10:%[0-9]+]]:es = COPY [[COPY3]]
-    ; CHECK-NEXT: [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign0_4:%[0-9]+]]:acc1024, [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign0_5:%[0-9]+]]:ep = VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign0 [[COPY10]], [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign0_5]], 256, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
+    ; CHECK-NEXT: [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign0_4:%[0-9]+]]:acc1024, [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign0_5:%[0-9]+]]:ep = VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign0 [[COPY10]], [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign0_5]], [[MOV_PD_imm11_pseudo1]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
     ; CHECK-NEXT: $upssign0 = MOV_scalar_imm11_pseudo 0
-    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign0_]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign0_]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign0_2]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign0_2]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign0_4]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign0_4]]
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign0_]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign0_]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign0_2]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign0_2]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign0_4]], implicit [[VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_upsSign0_4]]
     %0:ptrregbank(p0) = COPY $p0
     %1:gprregbank(s32) = COPY $r0
     %7:modregbank(s20) = G_TRUNC %1
     %8:modregbank(s20) = G_CONSTANT i20 0
-    %9:modregbank(s20) = G_CONSTANT i20 16
-    %10:modregbank(s20) = G_CONSTANT i20 -256
-    %11:modregbank(s20) = G_CONSTANT i20 224
-    %12:modregbank(s20) = G_CONSTANT i20 256
+    %9:modregbank(s20) = G_CONSTANT i20 32
+    %10:modregbank(s20) = G_CONSTANT i20 -512
+    %11:modregbank(s20) = G_CONSTANT i20 448
+    %12:modregbank(s20) = G_CONSTANT i20 512
     %101:gprregbank(s32) = COPY $r1
     %102:gprregbank(s32) = COPY $r2
     %25:vregbank(<16 x s32>), %19:ptrregbank(p0) = G_AIE_POSTINC_LOAD %0, %7 :: (load (<16 x s32>))
@@ -1428,21 +1428,21 @@ body: |
 ...
 
 ---
-name:            VST_UPS_4x_DM_v32_acc64_dynamic
+name:            VLDA_UPS_4x_acc64_v32_dynamic
 legalized:       true
 regBankSelected: true
 tracksRegLiveness: true
 body: |
   bb.0:
     liveins: $p0, $r0, $r1, $r2, $bmll0
-    ; CHECK-LABEL: name: VST_UPS_4x_DM_v32_acc64_dynamic
+    ; CHECK-LABEL: name: VLDA_UPS_4x_acc64_v32_dynamic
     ; CHECK: liveins: $p0, $r0, $r1, $r2, $bmll0
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
     ; CHECK-NEXT: [[COPY1:%[0-9]+]]:er = COPY $r0
     ; CHECK-NEXT: [[COPY2:%[0-9]+]]:em = COPY [[COPY1]]
-    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo:%[0-9]+]]:em = MOV_PD_imm11_pseudo 16
-    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo1:%[0-9]+]]:em = MOV_PD_imm11_pseudo 224
+    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo:%[0-9]+]]:em = MOV_PD_imm11_pseudo 32
+    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo1:%[0-9]+]]:em = MOV_PD_imm11_pseudo 512
     ; CHECK-NEXT: [[COPY3:%[0-9]+]]:er = COPY $r1
     ; CHECK-NEXT: [[COPY4:%[0-9]+]]:er = COPY $r2
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 1
@@ -1463,27 +1463,27 @@ body: |
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 1
     ; CHECK-NEXT: $upssign0 = COPY [[COPY4]]
     ; CHECK-NEXT: [[COPY8:%[0-9]+]]:es = COPY [[COPY3]]
-    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign0_2:%[0-9]+]]:acc2048, [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign0_3:%[0-9]+]]:ep = VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign0 [[COPY8]], [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign0_3]], -256, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
+    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign0_2:%[0-9]+]]:acc2048, [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign0_3:%[0-9]+]]:ep = VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign0 [[COPY8]], [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign0_3]], -512, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
     ; CHECK-NEXT: $upssign0 = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 1
     ; CHECK-NEXT: $upssign0 = COPY [[COPY4]]
     ; CHECK-NEXT: [[COPY9:%[0-9]+]]:es = COPY [[COPY3]]
-    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign0_4:%[0-9]+]]:acc2048, [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign0_5:%[0-9]+]]:ep = VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign0 [[COPY9]], [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign0_3]], [[MOV_PD_imm11_pseudo1]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
+    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign0_4:%[0-9]+]]:acc2048, [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign0_5:%[0-9]+]]:ep = VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign0 [[COPY9]], [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign0_3]], 448, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
     ; CHECK-NEXT: $upssign0 = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 1
     ; CHECK-NEXT: $upssign0 = COPY [[COPY4]]
     ; CHECK-NEXT: [[COPY10:%[0-9]+]]:es = COPY [[COPY3]]
-    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign0_4:%[0-9]+]]:acc2048, [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign0_5:%[0-9]+]]:ep = VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign0 [[COPY10]], [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign0_5]], 256, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
+    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign0_4:%[0-9]+]]:acc2048, [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign0_5:%[0-9]+]]:ep = VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign0 [[COPY10]], [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign0_5]], [[MOV_PD_imm11_pseudo1]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
     ; CHECK-NEXT: $upssign0 = MOV_scalar_imm11_pseudo 0
-    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign0_]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign0_]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign0_2]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign0_2]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign0_4]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign0_4]]
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign0_]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign0_]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign0_2]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign0_2]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign0_4]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign0_4]]
     %0:ptrregbank(p0) = COPY $p0
     %1:gprregbank(s32) = COPY $r0
     %7:modregbank(s20) = G_TRUNC %1
     %8:modregbank(s20) = G_CONSTANT i20 0
-    %9:modregbank(s20) = G_CONSTANT i20 16
-    %10:modregbank(s20) = G_CONSTANT i20 -256
-    %11:modregbank(s20) = G_CONSTANT i20 224
-    %12:modregbank(s20) = G_CONSTANT i20 256
+    %9:modregbank(s20) = G_CONSTANT i20 32
+    %10:modregbank(s20) = G_CONSTANT i20 -512
+    %11:modregbank(s20) = G_CONSTANT i20 448
+    %12:modregbank(s20) = G_CONSTANT i20 512
     %101:gprregbank(s32) = COPY $r1
     %102:gprregbank(s32) = COPY $r2
     %25:vregbank(<16 x s32>), %19:ptrregbank(p0) = G_AIE_POSTINC_LOAD %0, %7 :: (load (<16 x s32>))
@@ -1502,21 +1502,21 @@ body: |
 ...
 
 ---
-name:            VST_UPS_4x_DM_v64_acc32_dynamic
+name:            VLDA_UPS_4x_acc32_v64_dynamic
 legalized:       true
 regBankSelected: true
 tracksRegLiveness: true
 body: |
   bb.0:
     liveins: $p0, $r0, $r1, $r2, $bmll0
-    ; CHECK-LABEL: name: VST_UPS_4x_DM_v64_acc32_dynamic
+    ; CHECK-LABEL: name: VLDA_UPS_4x_acc32_v64_dynamic
     ; CHECK: liveins: $p0, $r0, $r1, $r2, $bmll0
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
     ; CHECK-NEXT: [[COPY1:%[0-9]+]]:er = COPY $r0
     ; CHECK-NEXT: [[COPY2:%[0-9]+]]:em = COPY [[COPY1]]
-    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo:%[0-9]+]]:em = MOV_PD_imm11_pseudo 16
-    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo1:%[0-9]+]]:em = MOV_PD_imm11_pseudo 224
+    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo:%[0-9]+]]:em = MOV_PD_imm11_pseudo 32
+    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo1:%[0-9]+]]:em = MOV_PD_imm11_pseudo 512
     ; CHECK-NEXT: [[COPY3:%[0-9]+]]:er = COPY $r1
     ; CHECK-NEXT: [[COPY4:%[0-9]+]]:er = COPY $r2
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 0
@@ -1537,27 +1537,27 @@ body: |
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: $upssign0 = COPY [[COPY4]]
     ; CHECK-NEXT: [[COPY8:%[0-9]+]]:es = COPY [[COPY3]]
-    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign0_2:%[0-9]+]]:acc2048, [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign0_3:%[0-9]+]]:ep = VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign0 [[COPY8]], [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign0_3]], -256, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
+    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign0_2:%[0-9]+]]:acc2048, [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign0_3:%[0-9]+]]:ep = VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign0 [[COPY8]], [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign0_3]], -512, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
     ; CHECK-NEXT: $upssign0 = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: $upssign0 = COPY [[COPY4]]
     ; CHECK-NEXT: [[COPY9:%[0-9]+]]:es = COPY [[COPY3]]
-    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign0_4:%[0-9]+]]:acc2048, [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign0_5:%[0-9]+]]:ep = VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign0 [[COPY9]], [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign0_3]], [[MOV_PD_imm11_pseudo1]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
+    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign0_4:%[0-9]+]]:acc2048, [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign0_5:%[0-9]+]]:ep = VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign0 [[COPY9]], [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign0_3]], 448, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
     ; CHECK-NEXT: $upssign0 = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: $crupsmode = MOV_scalar_imm11_pseudo 0
     ; CHECK-NEXT: $upssign0 = COPY [[COPY4]]
     ; CHECK-NEXT: [[COPY10:%[0-9]+]]:es = COPY [[COPY3]]
-    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign0_4:%[0-9]+]]:acc2048, [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign0_5:%[0-9]+]]:ep = VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign0 [[COPY10]], [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign0_5]], 256, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
+    ; CHECK-NEXT: [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign0_4:%[0-9]+]]:acc2048, [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign0_5:%[0-9]+]]:ep = VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign0 [[COPY10]], [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign0_5]], [[MOV_PD_imm11_pseudo1]], implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0 :: (load (<16 x s32>))
     ; CHECK-NEXT: $upssign0 = MOV_scalar_imm11_pseudo 0
-    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign0_]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign0_]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign0_2]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign0_2]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign0_4]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign0_4]]
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign0_]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign0_]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign0_2]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign0_2]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign0_4]], implicit [[VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_upsSign0_4]]
     %0:ptrregbank(p0) = COPY $p0
     %1:gprregbank(s32) = COPY $r0
     %7:modregbank(s20) = G_TRUNC %1
     %8:modregbank(s20) = G_CONSTANT i20 0
-    %9:modregbank(s20) = G_CONSTANT i20 16
-    %10:modregbank(s20) = G_CONSTANT i20 -256
-    %11:modregbank(s20) = G_CONSTANT i20 224
-    %12:modregbank(s20) = G_CONSTANT i20 256
+    %9:modregbank(s20) = G_CONSTANT i20 32
+    %10:modregbank(s20) = G_CONSTANT i20 -512
+    %11:modregbank(s20) = G_CONSTANT i20 448
+    %12:modregbank(s20) = G_CONSTANT i20 512
     %101:gprregbank(s32) = COPY $r1
     %102:gprregbank(s32) = COPY $r2
     %25:vregbank(<16 x s32>), %19:ptrregbank(p0) = G_AIE_POSTINC_LOAD %0, %7 :: (load (<16 x s32>))

--- a/llvm/test/CodeGen/AIE/aie2p/GlobalIsel/inst-select-vlda_ups.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/GlobalIsel/inst-select-vlda_ups.mir
@@ -4,18 +4,18 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2024-2025 Advanced Micro Devices, Inc. or its affiliates
 # RUN: llc -mtriple aie2p -run-pass=instruction-select %s -verify-machineinstrs -o - | FileCheck %s
 
 ---
-name:            VST_UPS_2x_BM_v16_acc32_signed
+name:            VLDA_UPS_2x_acc32_v16_signed
 alignment:       16
 legalized:       true
 regBankSelected: true
 body:             |
   bb.1.entry:
     liveins: $bmll0, $p0, $r0, $r1
-    ; CHECK-LABEL: name: VST_UPS_2x_BM_v16_acc32_signed
+    ; CHECK-LABEL: name: VLDA_UPS_2x_acc32_v16_signed
     ; CHECK: liveins: $bmll0, $p0, $r0, $r1
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
@@ -33,14 +33,14 @@ body:             |
 ...
 
 ---
-name:            VST_UPS_2x_BM_v8_acc64_signed
+name:            VLDA_UPS_2x_acc64_v8_signed
 alignment:       16
 legalized:       true
 regBankSelected: true
 body:             |
   bb.1.entry:
     liveins: $bmll0, $p0, $r0, $r1
-    ; CHECK-LABEL: name: VST_UPS_2x_BM_v8_acc64_signed
+    ; CHECK-LABEL: name: VLDA_UPS_2x_acc64_v8_signed
     ; CHECK: liveins: $bmll0, $p0, $r0, $r1
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
@@ -58,14 +58,14 @@ body:             |
 ...
 
 ---
-name:            VST_UPS_4x_CM_v16_acc64_signed
+name:            VLDA_UPS_4x_acc64_v16_signed
 alignment:       16
 legalized:       true
 regBankSelected: true
 body:             |
   bb.1.entry:
     liveins: $bmll0, $p0, $r0, $r1
-    ; CHECK-LABEL: name: VST_UPS_4x_CM_v16_acc64_signed
+    ; CHECK-LABEL: name: VLDA_UPS_4x_acc64_v16_signed
     ; CHECK: liveins: $bmll0, $p0, $r0, $r1
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
@@ -83,14 +83,14 @@ body:             |
 ...
 
 ---
-name:            VST_UPS_4x_CM_v32_acc32_signed
+name:            VLDA_UPS_4x_acc32_v32_signed
 alignment:       16
 legalized:       true
 regBankSelected: true
 body:             |
   bb.1.entry:
     liveins: $bmll0, $p0, $r0, $r1
-    ; CHECK-LABEL: name: VST_UPS_4x_CM_v32_acc32_signed
+    ; CHECK-LABEL: name: VLDA_UPS_4x_acc32_v32_signed
     ; CHECK: liveins: $bmll0, $p0, $r0, $r1
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
@@ -108,14 +108,14 @@ body:             |
 ...
 
 ---
-name:            VST_UPS_2x_CM_v32_acc32_signed
+name:            VLDA_UPS_2x_acc32_v32_signed
 alignment:       16
 legalized:       true
 regBankSelected: true
 body:             |
   bb.1.entry:
     liveins: $bmll0, $p0, $r0, $r1
-    ; CHECK-LABEL: name: VST_UPS_2x_CM_v32_acc32_signed
+    ; CHECK-LABEL: name: VLDA_UPS_2x_acc32_v32_signed
     ; CHECK: liveins: $bmll0, $p0, $r0, $r1
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
@@ -133,14 +133,14 @@ body:             |
 ...
 
 ---
-name:            VST_UPS_2x_CM_v16_acc64_signed
+name:            VLDA_UPS_2x_acc64_v16_signed
 alignment:       16
 legalized:       true
 regBankSelected: true
 body:             |
   bb.1.entry:
     liveins: $bmll0, $p0, $r0, $r1
-    ; CHECK-LABEL: name: VST_UPS_2x_CM_v16_acc64_signed
+    ; CHECK-LABEL: name: VLDA_UPS_2x_acc64_v16_signed
     ; CHECK: liveins: $bmll0, $p0, $r0, $r1
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
@@ -158,14 +158,14 @@ body:             |
 ...
 
 ---
-name:            VST_UPS_4x_DM_v32_acc64_signed
+name:            VLDA_UPS_4x_acc64_v32_signed
 alignment:       16
 legalized:       true
 regBankSelected: true
 body:             |
   bb.1.entry:
     liveins: $bmll0, $p0, $r0, $r1
-    ; CHECK-LABEL: name: VST_UPS_4x_DM_v32_acc64_signed
+    ; CHECK-LABEL: name: VLDA_UPS_4x_acc64_v32_signed
     ; CHECK: liveins: $bmll0, $p0, $r0, $r1
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
@@ -183,14 +183,14 @@ body:             |
 ...
 
 ---
-name:            VST_UPS_4x_DM_v64_acc32_signed
+name:            VLDA_UPS_4x_acc32_v64_signed
 alignment:       16
 legalized:       true
 regBankSelected: true
 body:             |
   bb.1.entry:
     liveins: $bmll0, $p0, $r0, $r1
-    ; CHECK-LABEL: name: VST_UPS_4x_DM_v64_acc32_signed
+    ; CHECK-LABEL: name: VLDA_UPS_4x_acc32_v64_signed
     ; CHECK: liveins: $bmll0, $p0, $r0, $r1
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
@@ -208,14 +208,14 @@ body:             |
 ...
 
 ---
-name:            VST_UPS_2x_BM_v16_acc32_unsigned
+name:            VLDA_UPS_2x_acc32_v16_unsigned
 alignment:       16
 legalized:       true
 regBankSelected: true
 body:             |
   bb.1.entry:
     liveins: $bmll0, $p0, $r0, $r1
-    ; CHECK-LABEL: name: VST_UPS_2x_BM_v16_acc32_unsigned
+    ; CHECK-LABEL: name: VLDA_UPS_2x_acc32_v16_unsigned
     ; CHECK: liveins: $bmll0, $p0, $r0, $r1
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
@@ -233,14 +233,14 @@ body:             |
 ...
 
 ---
-name:            VST_UPS_2x_BM_v8_acc64_unsigned
+name:            VLDA_UPS_2x_acc64_v8_unsigned
 alignment:       16
 legalized:       true
 regBankSelected: true
 body:             |
   bb.1.entry:
     liveins: $bmll0, $p0, $r0, $r1
-    ; CHECK-LABEL: name: VST_UPS_2x_BM_v8_acc64_unsigned
+    ; CHECK-LABEL: name: VLDA_UPS_2x_acc64_v8_unsigned
     ; CHECK: liveins: $bmll0, $p0, $r0, $r1
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
@@ -258,14 +258,14 @@ body:             |
 ...
 
 ---
-name:            VST_UPS_4x_CM_v16_acc64_unsigned
+name:            VLDA_UPS_4x_acc64_v16_unsigned
 alignment:       16
 legalized:       true
 regBankSelected: true
 body:             |
   bb.1.entry:
     liveins: $bmll0, $p0, $r0, $r1
-    ; CHECK-LABEL: name: VST_UPS_4x_CM_v16_acc64_unsigned
+    ; CHECK-LABEL: name: VLDA_UPS_4x_acc64_v16_unsigned
     ; CHECK: liveins: $bmll0, $p0, $r0, $r1
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
@@ -283,14 +283,14 @@ body:             |
 ...
 
 ---
-name:            VST_UPS_4x_CM_v32_acc32_unsigned
+name:            VLDA_UPS_4x_acc32_v32_unsigned
 alignment:       16
 legalized:       true
 regBankSelected: true
 body:             |
   bb.1.entry:
     liveins: $bmll0, $p0, $r0, $r1
-    ; CHECK-LABEL: name: VST_UPS_4x_CM_v32_acc32_unsigned
+    ; CHECK-LABEL: name: VLDA_UPS_4x_acc32_v32_unsigned
     ; CHECK: liveins: $bmll0, $p0, $r0, $r1
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
@@ -308,14 +308,14 @@ body:             |
 ...
 
 ---
-name:            VST_UPS_2x_CM_v32_acc32_unsigned
+name:            VLDA_UPS_2x_acc32_v32_unsigned
 alignment:       16
 legalized:       true
 regBankSelected: true
 body:             |
   bb.1.entry:
     liveins: $bmll0, $p0, $r0, $r1
-    ; CHECK-LABEL: name: VST_UPS_2x_CM_v32_acc32_unsigned
+    ; CHECK-LABEL: name: VLDA_UPS_2x_acc32_v32_unsigned
     ; CHECK: liveins: $bmll0, $p0, $r0, $r1
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
@@ -333,14 +333,14 @@ body:             |
 ...
 
 ---
-name:            VST_UPS_2x_CM_v16_acc64_unsigned
+name:            VLDA_UPS_2x_acc64_v16_unsigned
 alignment:       16
 legalized:       true
 regBankSelected: true
 body:             |
   bb.1.entry:
     liveins: $bmll0, $p0, $r0, $r1
-    ; CHECK-LABEL: name: VST_UPS_2x_CM_v16_acc64_unsigned
+    ; CHECK-LABEL: name: VLDA_UPS_2x_acc64_v16_unsigned
     ; CHECK: liveins: $bmll0, $p0, $r0, $r1
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
@@ -358,14 +358,14 @@ body:             |
 ...
 
 ---
-name:            VST_UPS_4x_DM_v32_acc64_unsigned
+name:            VLDA_UPS_4x_acc64_v32_unsigned
 alignment:       16
 legalized:       true
 regBankSelected: true
 body:             |
   bb.1.entry:
     liveins: $bmll0, $p0, $r0, $r1
-    ; CHECK-LABEL: name: VST_UPS_4x_DM_v32_acc64_unsigned
+    ; CHECK-LABEL: name: VLDA_UPS_4x_acc64_v32_unsigned
     ; CHECK: liveins: $bmll0, $p0, $r0, $r1
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
@@ -383,14 +383,14 @@ body:             |
 ...
 
 ---
-name:            VST_UPS_4x_DM_v64_acc32_unsigned
+name:            VLDA_UPS_4x_acc32_v64_unsigned
 alignment:       16
 legalized:       true
 regBankSelected: true
 body:             |
   bb.1.entry:
     liveins: $bmll0, $p0, $r0, $r1
-    ; CHECK-LABEL: name: VST_UPS_4x_DM_v64_acc32_unsigned
+    ; CHECK-LABEL: name: VLDA_UPS_4x_acc32_v64_unsigned
     ; CHECK: liveins: $bmll0, $p0, $r0, $r1
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
@@ -408,14 +408,14 @@ body:             |
 ...
 
 ---
-name:            VST_UPS_2x_BM_v16_acc32_dynamic
+name:            VLDA_UPS_2x_acc32_v16_dynamic
 alignment:       16
 legalized:       true
 regBankSelected: true
 body:             |
   bb.1.entry:
     liveins: $bmll0, $p0, $r0, $r1
-    ; CHECK-LABEL: name: VST_UPS_2x_BM_v16_acc32_dynamic
+    ; CHECK-LABEL: name: VLDA_UPS_2x_acc32_v16_dynamic
     ; CHECK: liveins: $bmll0, $p0, $r0, $r1
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
@@ -436,14 +436,14 @@ body:             |
 ...
 
 ---
-name:            VST_UPS_2x_BM_v8_acc64_dynamic
+name:            VLDA_UPS_2x_acc64_v8_dynamic
 alignment:       16
 legalized:       true
 regBankSelected: true
 body:             |
   bb.1.entry:
     liveins: $bmll0, $p0, $r0, $r1
-    ; CHECK-LABEL: name: VST_UPS_2x_BM_v8_acc64_dynamic
+    ; CHECK-LABEL: name: VLDA_UPS_2x_acc64_v8_dynamic
     ; CHECK: liveins: $bmll0, $p0, $r0, $r1
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
@@ -464,14 +464,14 @@ body:             |
 ...
 
 ---
-name:            VST_UPS_4x_CM_v16_acc64_dynamic
+name:            VLDA_UPS_4x_acc64_v16_dynamic
 alignment:       16
 legalized:       true
 regBankSelected: true
 body:             |
   bb.1.entry:
     liveins: $bmll0, $p0, $r0, $r1
-    ; CHECK-LABEL: name: VST_UPS_4x_CM_v16_acc64_dynamic
+    ; CHECK-LABEL: name: VLDA_UPS_4x_acc64_v16_dynamic
     ; CHECK: liveins: $bmll0, $p0, $r0, $r1
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
@@ -492,14 +492,14 @@ body:             |
 ...
 
 ---
-name:            VST_UPS_4x_CM_v32_acc32_dynamic
+name:            VLDA_UPS_4x_acc32_v32_dynamic
 alignment:       16
 legalized:       true
 regBankSelected: true
 body:             |
   bb.1.entry:
     liveins: $bmll0, $p0, $r0, $r1
-    ; CHECK-LABEL: name: VST_UPS_4x_CM_v32_acc32_dynamic
+    ; CHECK-LABEL: name: VLDA_UPS_4x_acc32_v32_dynamic
     ; CHECK: liveins: $bmll0, $p0, $r0, $r1
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
@@ -520,14 +520,14 @@ body:             |
 ...
 
 ---
-name:            VST_UPS_2x_CM_v32_acc32_dynamic
+name:            VLDA_UPS_2x_acc32_v32_dynamic
 alignment:       16
 legalized:       true
 regBankSelected: true
 body:             |
   bb.1.entry:
     liveins: $bmll0, $p0, $r0, $r1
-    ; CHECK-LABEL: name: VST_UPS_2x_CM_v32_acc32_dynamic
+    ; CHECK-LABEL: name: VLDA_UPS_2x_acc32_v32_dynamic
     ; CHECK: liveins: $bmll0, $p0, $r0, $r1
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
@@ -548,14 +548,14 @@ body:             |
 ...
 
 ---
-name:            VST_UPS_2x_CM_v16_acc64_dynamic
+name:            VLDA_UPS_2x_acc64_v16_dynamic
 alignment:       16
 legalized:       true
 regBankSelected: true
 body:             |
   bb.1.entry:
     liveins: $bmll0, $p0, $r0, $r1
-    ; CHECK-LABEL: name: VST_UPS_2x_CM_v16_acc64_dynamic
+    ; CHECK-LABEL: name: VLDA_UPS_2x_acc64_v16_dynamic
     ; CHECK: liveins: $bmll0, $p0, $r0, $r1
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
@@ -576,14 +576,14 @@ body:             |
 ...
 
 ---
-name:            VST_UPS_4x_DM_v32_acc64_dynamic
+name:            VLDA_UPS_4x_acc64_v32_dynamic
 alignment:       16
 legalized:       true
 regBankSelected: true
 body:             |
   bb.1.entry:
     liveins: $bmll0, $p0, $r0, $r1
-    ; CHECK-LABEL: name: VST_UPS_4x_DM_v32_acc64_dynamic
+    ; CHECK-LABEL: name: VLDA_UPS_4x_acc64_v32_dynamic
     ; CHECK: liveins: $bmll0, $p0, $r0, $r1
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
@@ -604,14 +604,14 @@ body:             |
 ...
 
 ---
-name:            VST_UPS_4x_DM_v64_acc32_dynamic
+name:            VLDA_UPS_4x_acc32_v64_dynamic
 alignment:       16
 legalized:       true
 regBankSelected: true
 body:             |
   bb.1.entry:
     liveins: $bmll0, $p0, $r0, $r1
-    ; CHECK-LABEL: name: VST_UPS_4x_DM_v64_acc32_dynamic
+    ; CHECK-LABEL: name: VLDA_UPS_4x_acc32_v64_dynamic
     ; CHECK: liveins: $bmll0, $p0, $r0, $r1
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0


### PR DESCRIPTION
This PR fixes the incorrect instruction selection that currently occurs in some cases when combining VLDA and UPS instructions, due to incorrectly selecting instructions with or without an immediate operands.