### PR TITLE
[AIE2P] Handle large stack offset for PLFR

### DIFF
--- a/llvm/lib/Target/AIE/AIEBaseInstrInfo.cpp
+++ b/llvm/lib/Target/AIE/AIEBaseInstrInfo.cpp
@@ -457,7 +457,10 @@ void AIEBaseInstrInfo::expandSpillPseudo(
         EI.SubRegIndex ? Register(TRI.getSubReg(Reg, EI.SubRegIndex)) : Reg;
     if (MI.hasOrderedMemoryRef() || SEH.isLiveReg(SubReg)) {
       MachineInstrBuilder MIB;
-      if (SPReg) {
+      // If the SPReg is set, we need to spill using register offset. However,
+      // for pseudo instructions, we skip this step since we will come back to
+      // it once we expand the pseudo instruction into multiple instructions.
+      if (SPReg && !get(EI.ExpandedOpCode).isPseudo()) {
         auto OffsetRegInfo =
             getRegOffsetSpillInstrInfoFromImmOffset(EI.ExpandedOpCode);
         MachineFunction &MF = *MI.getMF();
@@ -502,7 +505,7 @@ void AIEBaseInstrInfo::expandSpillPseudo(
   // E.g. In AIE2 eDS spills are expanded into 2 eD spills, which are themselves
   // expanded into 4 other spills.
   for (MachineInstr *ExpandedMI : ExpandedInsts)
-    expandSpillPseudo(*ExpandedMI, TRI, SubRegOffsetAlign);
+    expandSpillPseudo(*ExpandedMI, TRI, SubRegOffsetAlign, SPReg);
 }
 
 /// Collect all the "atomic" sub-registers that make up \ref Reg.

--- a/llvm/lib/Target/AIE/aie2p/AIE2PInstrInfo.cpp
+++ b/llvm/lib/Target/AIE/aie2p/AIE2PInstrInfo.cpp
@@ -1065,6 +1065,10 @@ AIE2PInstrInfo::getRegOffsetSpillInstrInfoFromImmOffset(
     return {AIE2P::ST_dms_sts_idx, AIE2P::MOVXM, &AIE2P::eDJRegClass};
   case AIE2P::LDA_dms_lda_spill:
     return {AIE2P::LDA_dms_lda_idx, AIE2P::MOVXM, &AIE2P::eDJRegClass};
+  case AIE2P::VST_dmx_sts_fifohl_spill:
+    return {AIE2P::VST_dmx_sts_fifohl_idx, AIE2P::MOVXM, &AIE2P::eDJRegClass};
+  case AIE2P::VLDA_dmx_lda_fifohl_spill:
+    return {AIE2P::VLDA_dmx_lda_fifohl_idx, AIE2P::MOVXM, &AIE2P::eDJRegClass};
   default:
     llvm_unreachable("Offset register spill instruction info un-implemented");
   }

--- a/llvm/lib/Target/AIE/aie2p/AIE2PRegisterInfo.cpp
+++ b/llvm/lib/Target/AIE/aie2p/AIE2PRegisterInfo.cpp
@@ -182,7 +182,11 @@ bool AIE2PRegisterInfo::eliminateFrameIndex(MachineBasicBlock::iterator II,
   case AIE2P::LDA_D_SPILL:
   case AIE2P::ST_D_SPILL:
   case AIE2P::LDA_DS_SPILL:
-  case AIE2P::ST_DS_SPILL: {
+  case AIE2P::ST_DS_SPILL:
+  case AIE2P::VLDA_PLFR_SPILL:
+  case AIE2P::VST_PLFR_SPILL: {
+    // When a pseudo instruction expands to multiple instructions, this case
+    // looks for the smallest encodable offset that can be used.
     // The stack grows upward so if Offset is in range, the offsets of its
     // sub-register spills should also be fine.
     if (isEncodableAsNegativeInt<9, 4>(Offset)) {
@@ -201,12 +205,10 @@ bool AIE2PRegisterInfo::eliminateFrameIndex(MachineBasicBlock::iterator II,
   case AIE2P::VST_DM_SPILL:
   case AIE2P::VST_CM_SPILL:
   case AIE2P::VST_FIFO_SPILL:
-  case AIE2P::VST_PLFR_SPILL:
   case AIE2P::VST_Y_SPILL:
   case AIE2P::VLDA_DM_SPILL:
   case AIE2P::VLDA_CM_SPILL:
   case AIE2P::VLDA_FIFO_SPILL:
-  case AIE2P::VLDA_PLFR_SPILL:
   case AIE2P::VLDA_Y_SPILL:
     MI.getOperand(FIOperandNum).ChangeToImmediate(Offset);
     TII->expandSpillPseudo(MI, TRI, /*SubRegOffsetAlign=*/Align(4));

--- a/llvm/test/CodeGen/AIE/aie2p/eliminate-frame-index.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/eliminate-frame-index.mir
@@ -413,3 +413,42 @@ body:             |
     ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
     PseudoRET implicit $lr
 ...
+---
+name:            test_fifo_plfr_bigstack
+alignment:       16
+frameInfo:
+  adjustsStack:    true
+stack:
+  - { id: 0, name: '', type: default, offset: 0, size: 2200, alignment: 16 }
+  - { id: 1, name: '', type: spill-slot, offset: 0, size: 8, alignment: 8 }
+body:             |
+  bb.0 (align 16):
+    ; CHECK-LABEL: name: test_fifo_plfr_bigstack
+    ; CHECK: frame-setup PADDXM_pstm_sp_imm 2240, implicit-def $sp, implicit $sp
+    ; CHECK-NEXT: $p0 = MOV_alu_mv_mv_mv_scl $sp
+    ; CHECK-NEXT: $m0 = MOVXM -2240
+    ; CHECK-NEXT: $p0 = PADD_mod_pseudo $p0, killed $m0
+    ; CHECK-NEXT: $p0 = MOV_alu_mv_mv_mv_scl $sp
+    ; CHECK-NEXT: $dj0 = MOVXM -2240
+    ; CHECK-NEXT: $lfl0 = VLDA_dmx_lda_fifohl_idx $p0, killed $dj0
+    ; CHECK-NEXT: $dj0 = MOVXM -2176
+    ; CHECK-NEXT: $lfh0 = VLDA_dmx_lda_fifohl_idx $p0, killed $dj0
+    ; CHECK-NEXT: $dj0 = MOVXM -2112
+    ; CHECK-NEXT: $r24 = LDA_dms_lda_idx $p0, killed $dj0
+    ; CHECK-NEXT: $dj0 = MOVXM -2108
+    ; CHECK-NEXT: $p0 = LDA_dms_lda_idx killed $p0, killed $dj0
+    ; CHECK-NEXT: $p1 = MOV_alu_mv_mv_mv_scl $sp
+    ; CHECK-NEXT: $dj0 = MOVXM -2240
+    ; CHECK-NEXT: VST_dmx_sts_fifohl_idx $lfl0, $p1, killed $dj0
+    ; CHECK-NEXT: $dj0 = MOVXM -2176
+    ; CHECK-NEXT: VST_dmx_sts_fifohl_idx $lfh0, $p1, killed $dj0
+    ; CHECK-NEXT: $dj0 = MOVXM -2112
+    ; CHECK-NEXT: ST_dms_sts_idx $p0, $p1, killed $dj0
+    ; CHECK-NEXT: $dj0 = MOVXM -2108
+    ; CHECK-NEXT: ST_dms_sts_idx $r24, killed $p1, killed $dj0
+    renamable $p0 = PseudoFI %stack.0, implicit $sp
+    ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
+    $plfr0 = VLDA_PLFR_SPILL %stack.0, implicit $sp
+    VST_PLFR_SPILL $plfr0, %stack.0, implicit $sp
+    ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
+...


### PR DESCRIPTION
This change handles large stack offset for PLFR, which split the pseudo instruction again to pseudo which needs special handling.