### PR TITLE
[AIE2][AIE2P] Make i64 a legal register type

### DIFF
--- a/clang/test/CodeGen/aie/aie-vadd-intrinsics.cpp
+++ b/clang/test/CodeGen/aie/aie-vadd-intrinsics.cpp
@@ -4847,17 +4847,23 @@ unsigned int test_ne_v32bfloat16(v32bfloat16 a, v32bfloat16 b) {
 //
 // AIE2P-LABEL: @_Z7test_ltDv16_fS_(
 // AIE2P-NEXT:  entry:
-// AIE2P-NEXT:    [[TMP0:%.*]] = shufflevector <16 x float> [[V1:%.*]], <16 x float> poison, <64 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
-// AIE2P-NEXT:    [[TMP1:%.*]] = shufflevector <16 x float> [[V2:%.*]], <16 x float> poison, <64 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
-// AIE2P-NEXT:    [[TMP2:%.*]] = tail call noundef <64 x float> @llvm.aie2p.ACC2048.accfloat.sub.conf(<64 x float> [[TMP0]], <64 x float> [[TMP1]], i32 60)
-// AIE2P-NEXT:    [[TMP3:%.*]] = shufflevector <64 x float> [[TMP2]], <64 x float> poison, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
-// AIE2P-NEXT:    [[TMP4:%.*]] = tail call noundef <16 x bfloat> @llvm.aie2p.v16accfloat.to.v16bf16(<16 x float> [[TMP3]])
-// AIE2P-NEXT:    [[TMP5:%.*]] = bitcast <16 x bfloat> [[TMP4]] to <8 x i32>
-// AIE2P-NEXT:    [[SHUFFLE_I_I_I:%.*]] = shufflevector <8 x i32> [[TMP5]], <8 x i32> poison, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
+// AIE2P-NEXT:    [[TMP0:%.*]] = bitcast <16 x float> [[V1:%.*]] to <8 x i64>
+// AIE2P-NEXT:    [[SHUFFLE1_I_I_I_I:%.*]] = shufflevector <8 x i64> [[TMP0]], <8 x i64> poison, <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
+// AIE2P-NEXT:    [[TMP1:%.*]] = bitcast <32 x i64> [[SHUFFLE1_I_I_I_I]] to <64 x float>
+// AIE2P-NEXT:    [[TMP2:%.*]] = bitcast <16 x float> [[V2:%.*]] to <8 x i64>
+// AIE2P-NEXT:    [[SHUFFLE1_I_I4_I_I:%.*]] = shufflevector <8 x i64> [[TMP2]], <8 x i64> poison, <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
+// AIE2P-NEXT:    [[TMP3:%.*]] = bitcast <32 x i64> [[SHUFFLE1_I_I4_I_I]] to <64 x float>
+// AIE2P-NEXT:    [[TMP4:%.*]] = tail call noundef <64 x float> @llvm.aie2p.ACC2048.accfloat.sub.conf(<64 x float> [[TMP1]], <64 x float> [[TMP3]], i32 60)
+// AIE2P-NEXT:    [[TMP5:%.*]] = bitcast <64 x float> [[TMP4]] to <32 x i64>
+// AIE2P-NEXT:    [[SHUFFLE_I_I_I_I:%.*]] = shufflevector <32 x i64> [[TMP5]], <32 x i64> poison, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+// AIE2P-NEXT:    [[TMP6:%.*]] = bitcast <8 x i64> [[SHUFFLE_I_I_I_I]] to <16 x float>
+// AIE2P-NEXT:    [[TMP7:%.*]] = tail call noundef <16 x bfloat> @llvm.aie2p.v16accfloat.to.v16bf16(<16 x float> [[TMP6]])
+// AIE2P-NEXT:    [[TMP8:%.*]] = bitcast <16 x bfloat> [[TMP7]] to <8 x i32>
+// AIE2P-NEXT:    [[SHUFFLE_I_I_I:%.*]] = shufflevector <8 x i32> [[TMP8]], <8 x i32> poison, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
 // AIE2P-NEXT:    [[SHUFFLE1_I_I_I:%.*]] = shufflevector <16 x i32> [[SHUFFLE_I_I_I]], <16 x i32> <i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0>, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
-// AIE2P-NEXT:    [[TMP6:%.*]] = bitcast <16 x i32> [[SHUFFLE1_I_I_I]] to <32 x bfloat>
-// AIE2P-NEXT:    [[TMP7:%.*]] = tail call noundef i32 @llvm.aie2p.vltbf16(<32 x bfloat> [[TMP6]], <32 x bfloat> zeroinitializer)
-// AIE2P-NEXT:    ret i32 [[TMP7]]
+// AIE2P-NEXT:    [[TMP9:%.*]] = bitcast <16 x i32> [[SHUFFLE1_I_I_I]] to <32 x bfloat>
+// AIE2P-NEXT:    [[TMP10:%.*]] = tail call noundef i32 @llvm.aie2p.vltbf16(<32 x bfloat> [[TMP9]], <32 x bfloat> zeroinitializer)
+// AIE2P-NEXT:    ret i32 [[TMP10]]
 //
 unsigned int test_lt(v16float v1, v16float v2) {
   return lt(v1, v2);
@@ -4881,22 +4887,28 @@ unsigned int test_lt(v16float v1, v16float v2) {
 //
 // AIE2P-LABEL: @_Z11test_max_ltDv16_fS_Rj(
 // AIE2P-NEXT:  entry:
-// AIE2P-NEXT:    [[TMP0:%.*]] = shufflevector <16 x float> [[V1:%.*]], <16 x float> poison, <64 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
-// AIE2P-NEXT:    [[TMP1:%.*]] = shufflevector <16 x float> [[V2:%.*]], <16 x float> poison, <64 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
-// AIE2P-NEXT:    [[TMP2:%.*]] = tail call noundef <64 x float> @llvm.aie2p.ACC2048.accfloat.sub.conf(<64 x float> [[TMP0]], <64 x float> [[TMP1]], i32 60)
-// AIE2P-NEXT:    [[TMP3:%.*]] = shufflevector <64 x float> [[TMP2]], <64 x float> poison, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
-// AIE2P-NEXT:    [[TMP4:%.*]] = tail call noundef <16 x bfloat> @llvm.aie2p.v16accfloat.to.v16bf16(<16 x float> [[TMP3]])
-// AIE2P-NEXT:    [[TMP5:%.*]] = bitcast <16 x bfloat> [[TMP4]] to <8 x i32>
-// AIE2P-NEXT:    [[SHUFFLE_I_I_I_I:%.*]] = shufflevector <8 x i32> [[TMP5]], <8 x i32> poison, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
+// AIE2P-NEXT:    [[TMP0:%.*]] = bitcast <16 x float> [[V1:%.*]] to <8 x i64>
+// AIE2P-NEXT:    [[SHUFFLE1_I_I_I_I_I:%.*]] = shufflevector <8 x i64> [[TMP0]], <8 x i64> poison, <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
+// AIE2P-NEXT:    [[TMP1:%.*]] = bitcast <32 x i64> [[SHUFFLE1_I_I_I_I_I]] to <64 x float>
+// AIE2P-NEXT:    [[TMP2:%.*]] = bitcast <16 x float> [[V2:%.*]] to <8 x i64>
+// AIE2P-NEXT:    [[SHUFFLE1_I_I4_I_I_I:%.*]] = shufflevector <8 x i64> [[TMP2]], <8 x i64> poison, <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
+// AIE2P-NEXT:    [[TMP3:%.*]] = bitcast <32 x i64> [[SHUFFLE1_I_I4_I_I_I]] to <64 x float>
+// AIE2P-NEXT:    [[TMP4:%.*]] = tail call noundef <64 x float> @llvm.aie2p.ACC2048.accfloat.sub.conf(<64 x float> [[TMP1]], <64 x float> [[TMP3]], i32 60)
+// AIE2P-NEXT:    [[TMP5:%.*]] = bitcast <64 x float> [[TMP4]] to <32 x i64>
+// AIE2P-NEXT:    [[SHUFFLE_I_I_I_I_I:%.*]] = shufflevector <32 x i64> [[TMP5]], <32 x i64> poison, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+// AIE2P-NEXT:    [[TMP6:%.*]] = bitcast <8 x i64> [[SHUFFLE_I_I_I_I_I]] to <16 x float>
+// AIE2P-NEXT:    [[TMP7:%.*]] = tail call noundef <16 x bfloat> @llvm.aie2p.v16accfloat.to.v16bf16(<16 x float> [[TMP6]])
+// AIE2P-NEXT:    [[TMP8:%.*]] = bitcast <16 x bfloat> [[TMP7]] to <8 x i32>
+// AIE2P-NEXT:    [[SHUFFLE_I_I_I_I:%.*]] = shufflevector <8 x i32> [[TMP8]], <8 x i32> poison, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
 // AIE2P-NEXT:    [[SHUFFLE1_I_I_I_I:%.*]] = shufflevector <16 x i32> [[SHUFFLE_I_I_I_I]], <16 x i32> <i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0>, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
-// AIE2P-NEXT:    [[TMP6:%.*]] = bitcast <16 x i32> [[SHUFFLE1_I_I_I_I]] to <32 x bfloat>
-// AIE2P-NEXT:    [[TMP7:%.*]] = tail call noundef i32 @llvm.aie2p.vltbf16(<32 x bfloat> [[TMP6]], <32 x bfloat> zeroinitializer)
-// AIE2P-NEXT:    store i32 [[TMP7]], ptr [[CMP:%.*]], align 4, !tbaa [[TBAA6]]
-// AIE2P-NEXT:    [[TMP8:%.*]] = bitcast <16 x float> [[V1]] to <16 x i32>
-// AIE2P-NEXT:    [[TMP9:%.*]] = bitcast <16 x float> [[V2]] to <16 x i32>
-// AIE2P-NEXT:    [[TMP10:%.*]] = tail call noundef <16 x i32> @llvm.aie2p.vsel32(<16 x i32> [[TMP8]], <16 x i32> [[TMP9]], i32 [[TMP7]])
-// AIE2P-NEXT:    [[TMP11:%.*]] = bitcast <16 x i32> [[TMP10]] to <16 x float>
-// AIE2P-NEXT:    ret <16 x float> [[TMP11]]
+// AIE2P-NEXT:    [[TMP9:%.*]] = bitcast <16 x i32> [[SHUFFLE1_I_I_I_I]] to <32 x bfloat>
+// AIE2P-NEXT:    [[TMP10:%.*]] = tail call noundef i32 @llvm.aie2p.vltbf16(<32 x bfloat> [[TMP9]], <32 x bfloat> zeroinitializer)
+// AIE2P-NEXT:    store i32 [[TMP10]], ptr [[CMP:%.*]], align 4, !tbaa [[TBAA6]]
+// AIE2P-NEXT:    [[TMP11:%.*]] = bitcast <16 x float> [[V1]] to <16 x i32>
+// AIE2P-NEXT:    [[TMP12:%.*]] = bitcast <16 x float> [[V2]] to <16 x i32>
+// AIE2P-NEXT:    [[TMP13:%.*]] = tail call noundef <16 x i32> @llvm.aie2p.vsel32(<16 x i32> [[TMP11]], <16 x i32> [[TMP12]], i32 [[TMP10]])
+// AIE2P-NEXT:    [[TMP14:%.*]] = bitcast <16 x i32> [[TMP13]] to <16 x float>
+// AIE2P-NEXT:    ret <16 x float> [[TMP14]]
 //
 v16float test_max_lt(v16float v1, v16float v2, unsigned int &cmp) {
   return max_lt(v1, v2, cmp);
@@ -4919,21 +4931,27 @@ v16float test_max_lt(v16float v1, v16float v2, unsigned int &cmp) {
 //
 // AIE2P-LABEL: @_Z8test_maxDv16_fS_(
 // AIE2P-NEXT:  entry:
-// AIE2P-NEXT:    [[TMP0:%.*]] = shufflevector <16 x float> [[V1:%.*]], <16 x float> poison, <64 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
-// AIE2P-NEXT:    [[TMP1:%.*]] = shufflevector <16 x float> [[V2:%.*]], <16 x float> poison, <64 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
-// AIE2P-NEXT:    [[TMP2:%.*]] = tail call noundef <64 x float> @llvm.aie2p.ACC2048.accfloat.sub.conf(<64 x float> [[TMP0]], <64 x float> [[TMP1]], i32 60)
-// AIE2P-NEXT:    [[TMP3:%.*]] = shufflevector <64 x float> [[TMP2]], <64 x float> poison, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
-// AIE2P-NEXT:    [[TMP4:%.*]] = tail call noundef <16 x bfloat> @llvm.aie2p.v16accfloat.to.v16bf16(<16 x float> [[TMP3]])
-// AIE2P-NEXT:    [[TMP5:%.*]] = bitcast <16 x bfloat> [[TMP4]] to <8 x i32>
-// AIE2P-NEXT:    [[SHUFFLE_I_I_I_I:%.*]] = shufflevector <8 x i32> [[TMP5]], <8 x i32> poison, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
+// AIE2P-NEXT:    [[TMP0:%.*]] = bitcast <16 x float> [[V1:%.*]] to <8 x i64>
+// AIE2P-NEXT:    [[SHUFFLE1_I_I_I_I_I:%.*]] = shufflevector <8 x i64> [[TMP0]], <8 x i64> poison, <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
+// AIE2P-NEXT:    [[TMP1:%.*]] = bitcast <32 x i64> [[SHUFFLE1_I_I_I_I_I]] to <64 x float>
+// AIE2P-NEXT:    [[TMP2:%.*]] = bitcast <16 x float> [[V2:%.*]] to <8 x i64>
+// AIE2P-NEXT:    [[SHUFFLE1_I_I4_I_I_I:%.*]] = shufflevector <8 x i64> [[TMP2]], <8 x i64> poison, <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
+// AIE2P-NEXT:    [[TMP3:%.*]] = bitcast <32 x i64> [[SHUFFLE1_I_I4_I_I_I]] to <64 x float>
+// AIE2P-NEXT:    [[TMP4:%.*]] = tail call noundef <64 x float> @llvm.aie2p.ACC2048.accfloat.sub.conf(<64 x float> [[TMP1]], <64 x float> [[TMP3]], i32 60)
+// AIE2P-NEXT:    [[TMP5:%.*]] = bitcast <64 x float> [[TMP4]] to <32 x i64>
+// AIE2P-NEXT:    [[SHUFFLE_I_I_I_I_I:%.*]] = shufflevector <32 x i64> [[TMP5]], <32 x i64> poison, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+// AIE2P-NEXT:    [[TMP6:%.*]] = bitcast <8 x i64> [[SHUFFLE_I_I_I_I_I]] to <16 x float>
+// AIE2P-NEXT:    [[TMP7:%.*]] = tail call noundef <16 x bfloat> @llvm.aie2p.v16accfloat.to.v16bf16(<16 x float> [[TMP6]])
+// AIE2P-NEXT:    [[TMP8:%.*]] = bitcast <16 x bfloat> [[TMP7]] to <8 x i32>
+// AIE2P-NEXT:    [[SHUFFLE_I_I_I_I:%.*]] = shufflevector <8 x i32> [[TMP8]], <8 x i32> poison, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
 // AIE2P-NEXT:    [[SHUFFLE1_I_I_I_I:%.*]] = shufflevector <16 x i32> [[SHUFFLE_I_I_I_I]], <16 x i32> <i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0>, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
-// AIE2P-NEXT:    [[TMP6:%.*]] = bitcast <16 x i32> [[SHUFFLE1_I_I_I_I]] to <32 x bfloat>
-// AIE2P-NEXT:    [[TMP7:%.*]] = tail call noundef i32 @llvm.aie2p.vltbf16(<32 x bfloat> [[TMP6]], <32 x bfloat> zeroinitializer)
-// AIE2P-NEXT:    [[TMP8:%.*]] = bitcast <16 x float> [[V1]] to <16 x i32>
-// AIE2P-NEXT:    [[TMP9:%.*]] = bitcast <16 x float> [[V2]] to <16 x i32>
-// AIE2P-NEXT:    [[TMP10:%.*]] = tail call noundef <16 x i32> @llvm.aie2p.vsel32(<16 x i32> [[TMP8]], <16 x i32> [[TMP9]], i32 [[TMP7]])
-// AIE2P-NEXT:    [[TMP11:%.*]] = bitcast <16 x i32> [[TMP10]] to <16 x float>
-// AIE2P-NEXT:    ret <16 x float> [[TMP11]]
+// AIE2P-NEXT:    [[TMP9:%.*]] = bitcast <16 x i32> [[SHUFFLE1_I_I_I_I]] to <32 x bfloat>
+// AIE2P-NEXT:    [[TMP10:%.*]] = tail call noundef i32 @llvm.aie2p.vltbf16(<32 x bfloat> [[TMP9]], <32 x bfloat> zeroinitializer)
+// AIE2P-NEXT:    [[TMP11:%.*]] = bitcast <16 x float> [[V1]] to <16 x i32>
+// AIE2P-NEXT:    [[TMP12:%.*]] = bitcast <16 x float> [[V2]] to <16 x i32>
+// AIE2P-NEXT:    [[TMP13:%.*]] = tail call noundef <16 x i32> @llvm.aie2p.vsel32(<16 x i32> [[TMP11]], <16 x i32> [[TMP12]], i32 [[TMP10]])
+// AIE2P-NEXT:    [[TMP14:%.*]] = bitcast <16 x i32> [[TMP13]] to <16 x float>
+// AIE2P-NEXT:    ret <16 x float> [[TMP14]]
 //
 v16float test_max(v16float v1, v16float v2) {
   return max(v1, v2);
@@ -4953,17 +4971,23 @@ v16float test_max(v16float v1, v16float v2) {
 //
 // AIE2P-LABEL: @_Z7test_geDv16_fS_(
 // AIE2P-NEXT:  entry:
-// AIE2P-NEXT:    [[TMP0:%.*]] = shufflevector <16 x float> [[V1:%.*]], <16 x float> poison, <64 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
-// AIE2P-NEXT:    [[TMP1:%.*]] = shufflevector <16 x float> [[V2:%.*]], <16 x float> poison, <64 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
-// AIE2P-NEXT:    [[TMP2:%.*]] = tail call noundef <64 x float> @llvm.aie2p.ACC2048.accfloat.sub.conf(<64 x float> [[TMP0]], <64 x float> [[TMP1]], i32 60)
-// AIE2P-NEXT:    [[TMP3:%.*]] = shufflevector <64 x float> [[TMP2]], <64 x float> poison, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
-// AIE2P-NEXT:    [[TMP4:%.*]] = tail call noundef <16 x bfloat> @llvm.aie2p.v16accfloat.to.v16bf16(<16 x float> [[TMP3]])
-// AIE2P-NEXT:    [[TMP5:%.*]] = bitcast <16 x bfloat> [[TMP4]] to <8 x i32>
-// AIE2P-NEXT:    [[SHUFFLE_I_I_I:%.*]] = shufflevector <8 x i32> [[TMP5]], <8 x i32> poison, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
+// AIE2P-NEXT:    [[TMP0:%.*]] = bitcast <16 x float> [[V1:%.*]] to <8 x i64>
+// AIE2P-NEXT:    [[SHUFFLE1_I_I_I_I:%.*]] = shufflevector <8 x i64> [[TMP0]], <8 x i64> poison, <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
+// AIE2P-NEXT:    [[TMP1:%.*]] = bitcast <32 x i64> [[SHUFFLE1_I_I_I_I]] to <64 x float>
+// AIE2P-NEXT:    [[TMP2:%.*]] = bitcast <16 x float> [[V2:%.*]] to <8 x i64>
+// AIE2P-NEXT:    [[SHUFFLE1_I_I4_I_I:%.*]] = shufflevector <8 x i64> [[TMP2]], <8 x i64> poison, <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
+// AIE2P-NEXT:    [[TMP3:%.*]] = bitcast <32 x i64> [[SHUFFLE1_I_I4_I_I]] to <64 x float>
+// AIE2P-NEXT:    [[TMP4:%.*]] = tail call noundef <64 x float> @llvm.aie2p.ACC2048.accfloat.sub.conf(<64 x float> [[TMP1]], <64 x float> [[TMP3]], i32 60)
+// AIE2P-NEXT:    [[TMP5:%.*]] = bitcast <64 x float> [[TMP4]] to <32 x i64>
+// AIE2P-NEXT:    [[SHUFFLE_I_I_I_I:%.*]] = shufflevector <32 x i64> [[TMP5]], <32 x i64> poison, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+// AIE2P-NEXT:    [[TMP6:%.*]] = bitcast <8 x i64> [[SHUFFLE_I_I_I_I]] to <16 x float>
+// AIE2P-NEXT:    [[TMP7:%.*]] = tail call noundef <16 x bfloat> @llvm.aie2p.v16accfloat.to.v16bf16(<16 x float> [[TMP6]])
+// AIE2P-NEXT:    [[TMP8:%.*]] = bitcast <16 x bfloat> [[TMP7]] to <8 x i32>
+// AIE2P-NEXT:    [[SHUFFLE_I_I_I:%.*]] = shufflevector <8 x i32> [[TMP8]], <8 x i32> poison, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
 // AIE2P-NEXT:    [[SHUFFLE1_I_I_I:%.*]] = shufflevector <16 x i32> [[SHUFFLE_I_I_I]], <16 x i32> <i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0>, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
-// AIE2P-NEXT:    [[TMP6:%.*]] = bitcast <16 x i32> [[SHUFFLE1_I_I_I]] to <32 x bfloat>
-// AIE2P-NEXT:    [[TMP7:%.*]] = tail call noundef i32 @llvm.aie2p.vgebf16(<32 x bfloat> [[TMP6]], <32 x bfloat> zeroinitializer)
-// AIE2P-NEXT:    [[AND_I:%.*]] = and i32 [[TMP7]], 65535
+// AIE2P-NEXT:    [[TMP9:%.*]] = bitcast <16 x i32> [[SHUFFLE1_I_I_I]] to <32 x bfloat>
+// AIE2P-NEXT:    [[TMP10:%.*]] = tail call noundef i32 @llvm.aie2p.vgebf16(<32 x bfloat> [[TMP9]], <32 x bfloat> zeroinitializer)
+// AIE2P-NEXT:    [[AND_I:%.*]] = and i32 [[TMP10]], 65535
 // AIE2P-NEXT:    ret i32 [[AND_I]]
 //
 unsigned int test_ge(v16float v1, v16float v2) {
@@ -4989,23 +5013,29 @@ unsigned int test_ge(v16float v1, v16float v2) {
 //
 // AIE2P-LABEL: @_Z11test_min_geDv16_fS_Rj(
 // AIE2P-NEXT:  entry:
-// AIE2P-NEXT:    [[TMP0:%.*]] = shufflevector <16 x float> [[V1:%.*]], <16 x float> poison, <64 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
-// AIE2P-NEXT:    [[TMP1:%.*]] = shufflevector <16 x float> [[V2:%.*]], <16 x float> poison, <64 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
-// AIE2P-NEXT:    [[TMP2:%.*]] = tail call noundef <64 x float> @llvm.aie2p.ACC2048.accfloat.sub.conf(<64 x float> [[TMP0]], <64 x float> [[TMP1]], i32 60)
-// AIE2P-NEXT:    [[TMP3:%.*]] = shufflevector <64 x float> [[TMP2]], <64 x float> poison, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
-// AIE2P-NEXT:    [[TMP4:%.*]] = tail call noundef <16 x bfloat> @llvm.aie2p.v16accfloat.to.v16bf16(<16 x float> [[TMP3]])
-// AIE2P-NEXT:    [[TMP5:%.*]] = bitcast <16 x bfloat> [[TMP4]] to <8 x i32>
-// AIE2P-NEXT:    [[SHUFFLE_I_I_I_I:%.*]] = shufflevector <8 x i32> [[TMP5]], <8 x i32> poison, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
+// AIE2P-NEXT:    [[TMP0:%.*]] = bitcast <16 x float> [[V1:%.*]] to <8 x i64>
+// AIE2P-NEXT:    [[SHUFFLE1_I_I_I_I_I:%.*]] = shufflevector <8 x i64> [[TMP0]], <8 x i64> poison, <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
+// AIE2P-NEXT:    [[TMP1:%.*]] = bitcast <32 x i64> [[SHUFFLE1_I_I_I_I_I]] to <64 x float>
+// AIE2P-NEXT:    [[TMP2:%.*]] = bitcast <16 x float> [[V2:%.*]] to <8 x i64>
+// AIE2P-NEXT:    [[SHUFFLE1_I_I4_I_I_I:%.*]] = shufflevector <8 x i64> [[TMP2]], <8 x i64> poison, <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
+// AIE2P-NEXT:    [[TMP3:%.*]] = bitcast <32 x i64> [[SHUFFLE1_I_I4_I_I_I]] to <64 x float>
+// AIE2P-NEXT:    [[TMP4:%.*]] = tail call noundef <64 x float> @llvm.aie2p.ACC2048.accfloat.sub.conf(<64 x float> [[TMP1]], <64 x float> [[TMP3]], i32 60)
+// AIE2P-NEXT:    [[TMP5:%.*]] = bitcast <64 x float> [[TMP4]] to <32 x i64>
+// AIE2P-NEXT:    [[SHUFFLE_I_I_I_I_I:%.*]] = shufflevector <32 x i64> [[TMP5]], <32 x i64> poison, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+// AIE2P-NEXT:    [[TMP6:%.*]] = bitcast <8 x i64> [[SHUFFLE_I_I_I_I_I]] to <16 x float>
+// AIE2P-NEXT:    [[TMP7:%.*]] = tail call noundef <16 x bfloat> @llvm.aie2p.v16accfloat.to.v16bf16(<16 x float> [[TMP6]])
+// AIE2P-NEXT:    [[TMP8:%.*]] = bitcast <16 x bfloat> [[TMP7]] to <8 x i32>
+// AIE2P-NEXT:    [[SHUFFLE_I_I_I_I:%.*]] = shufflevector <8 x i32> [[TMP8]], <8 x i32> poison, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
 // AIE2P-NEXT:    [[SHUFFLE1_I_I_I_I:%.*]] = shufflevector <16 x i32> [[SHUFFLE_I_I_I_I]], <16 x i32> <i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0>, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
-// AIE2P-NEXT:    [[TMP6:%.*]] = bitcast <16 x i32> [[SHUFFLE1_I_I_I_I]] to <32 x bfloat>
-// AIE2P-NEXT:    [[TMP7:%.*]] = tail call noundef i32 @llvm.aie2p.vgebf16(<32 x bfloat> [[TMP6]], <32 x bfloat> zeroinitializer)
-// AIE2P-NEXT:    [[AND_I_I:%.*]] = and i32 [[TMP7]], 65535
+// AIE2P-NEXT:    [[TMP9:%.*]] = bitcast <16 x i32> [[SHUFFLE1_I_I_I_I]] to <32 x bfloat>
+// AIE2P-NEXT:    [[TMP10:%.*]] = tail call noundef i32 @llvm.aie2p.vgebf16(<32 x bfloat> [[TMP9]], <32 x bfloat> zeroinitializer)
+// AIE2P-NEXT:    [[AND_I_I:%.*]] = and i32 [[TMP10]], 65535
 // AIE2P-NEXT:    store i32 [[AND_I_I]], ptr [[CMP:%.*]], align 4, !tbaa [[TBAA6]]
-// AIE2P-NEXT:    [[TMP8:%.*]] = bitcast <16 x float> [[V1]] to <16 x i32>
-// AIE2P-NEXT:    [[TMP9:%.*]] = bitcast <16 x float> [[V2]] to <16 x i32>
-// AIE2P-NEXT:    [[TMP10:%.*]] = tail call noundef <16 x i32> @llvm.aie2p.vsel32(<16 x i32> [[TMP8]], <16 x i32> [[TMP9]], i32 [[AND_I_I]])
-// AIE2P-NEXT:    [[TMP11:%.*]] = bitcast <16 x i32> [[TMP10]] to <16 x float>
-// AIE2P-NEXT:    ret <16 x float> [[TMP11]]
+// AIE2P-NEXT:    [[TMP11:%.*]] = bitcast <16 x float> [[V1]] to <16 x i32>
+// AIE2P-NEXT:    [[TMP12:%.*]] = bitcast <16 x float> [[V2]] to <16 x i32>
+// AIE2P-NEXT:    [[TMP13:%.*]] = tail call noundef <16 x i32> @llvm.aie2p.vsel32(<16 x i32> [[TMP11]], <16 x i32> [[TMP12]], i32 [[AND_I_I]])
+// AIE2P-NEXT:    [[TMP14:%.*]] = bitcast <16 x i32> [[TMP13]] to <16 x float>
+// AIE2P-NEXT:    ret <16 x float> [[TMP14]]
 //
 v16float test_min_ge(v16float v1, v16float v2, unsigned int &cmp) {
   return min_ge(v1, v2, cmp);
@@ -5029,22 +5059,28 @@ v16float test_min_ge(v16float v1, v16float v2, unsigned int &cmp) {
 //
 // AIE2P-LABEL: @_Z8test_minDv16_fS_(
 // AIE2P-NEXT:  entry:
-// AIE2P-NEXT:    [[TMP0:%.*]] = shufflevector <16 x float> [[V1:%.*]], <16 x float> poison, <64 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
-// AIE2P-NEXT:    [[TMP1:%.*]] = shufflevector <16 x float> [[V2:%.*]], <16 x float> poison, <64 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
-// AIE2P-NEXT:    [[TMP2:%.*]] = tail call noundef <64 x float> @llvm.aie2p.ACC2048.accfloat.sub.conf(<64 x float> [[TMP0]], <64 x float> [[TMP1]], i32 60)
-// AIE2P-NEXT:    [[TMP3:%.*]] = shufflevector <64 x float> [[TMP2]], <64 x float> poison, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
-// AIE2P-NEXT:    [[TMP4:%.*]] = tail call noundef <16 x bfloat> @llvm.aie2p.v16accfloat.to.v16bf16(<16 x float> [[TMP3]])
-// AIE2P-NEXT:    [[TMP5:%.*]] = bitcast <16 x bfloat> [[TMP4]] to <8 x i32>
-// AIE2P-NEXT:    [[SHUFFLE_I_I_I_I:%.*]] = shufflevector <8 x i32> [[TMP5]], <8 x i32> poison, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
+// AIE2P-NEXT:    [[TMP0:%.*]] = bitcast <16 x float> [[V1:%.*]] to <8 x i64>
+// AIE2P-NEXT:    [[SHUFFLE1_I_I_I_I_I:%.*]] = shufflevector <8 x i64> [[TMP0]], <8 x i64> poison, <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
+// AIE2P-NEXT:    [[TMP1:%.*]] = bitcast <32 x i64> [[SHUFFLE1_I_I_I_I_I]] to <64 x float>
+// AIE2P-NEXT:    [[TMP2:%.*]] = bitcast <16 x float> [[V2:%.*]] to <8 x i64>
+// AIE2P-NEXT:    [[SHUFFLE1_I_I4_I_I_I:%.*]] = shufflevector <8 x i64> [[TMP2]], <8 x i64> poison, <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
+// AIE2P-NEXT:    [[TMP3:%.*]] = bitcast <32 x i64> [[SHUFFLE1_I_I4_I_I_I]] to <64 x float>
+// AIE2P-NEXT:    [[TMP4:%.*]] = tail call noundef <64 x float> @llvm.aie2p.ACC2048.accfloat.sub.conf(<64 x float> [[TMP1]], <64 x float> [[TMP3]], i32 60)
+// AIE2P-NEXT:    [[TMP5:%.*]] = bitcast <64 x float> [[TMP4]] to <32 x i64>
+// AIE2P-NEXT:    [[SHUFFLE_I_I_I_I_I:%.*]] = shufflevector <32 x i64> [[TMP5]], <32 x i64> poison, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+// AIE2P-NEXT:    [[TMP6:%.*]] = bitcast <8 x i64> [[SHUFFLE_I_I_I_I_I]] to <16 x float>
+// AIE2P-NEXT:    [[TMP7:%.*]] = tail call noundef <16 x bfloat> @llvm.aie2p.v16accfloat.to.v16bf16(<16 x float> [[TMP6]])
+// AIE2P-NEXT:    [[TMP8:%.*]] = bitcast <16 x bfloat> [[TMP7]] to <8 x i32>
+// AIE2P-NEXT:    [[SHUFFLE_I_I_I_I:%.*]] = shufflevector <8 x i32> [[TMP8]], <8 x i32> poison, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
 // AIE2P-NEXT:    [[SHUFFLE1_I_I_I_I:%.*]] = shufflevector <16 x i32> [[SHUFFLE_I_I_I_I]], <16 x i32> <i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0>, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
-// AIE2P-NEXT:    [[TMP6:%.*]] = bitcast <16 x i32> [[SHUFFLE1_I_I_I_I]] to <32 x bfloat>
-// AIE2P-NEXT:    [[TMP7:%.*]] = tail call noundef i32 @llvm.aie2p.vgebf16(<32 x bfloat> [[TMP6]], <32 x bfloat> zeroinitializer)
-// AIE2P-NEXT:    [[AND_I_I:%.*]] = and i32 [[TMP7]], 65535
-// AIE2P-NEXT:    [[TMP8:%.*]] = bitcast <16 x float> [[V1]] to <16 x i32>
-// AIE2P-NEXT:    [[TMP9:%.*]] = bitcast <16 x float> [[V2]] to <16 x i32>
-// AIE2P-NEXT:    [[TMP10:%.*]] = tail call noundef <16 x i32> @llvm.aie2p.vsel32(<16 x i32> [[TMP8]], <16 x i32> [[TMP9]], i32 [[AND_I_I]])
-// AIE2P-NEXT:    [[TMP11:%.*]] = bitcast <16 x i32> [[TMP10]] to <16 x float>
-// AIE2P-NEXT:    ret <16 x float> [[TMP11]]
+// AIE2P-NEXT:    [[TMP9:%.*]] = bitcast <16 x i32> [[SHUFFLE1_I_I_I_I]] to <32 x bfloat>
+// AIE2P-NEXT:    [[TMP10:%.*]] = tail call noundef i32 @llvm.aie2p.vgebf16(<32 x bfloat> [[TMP9]], <32 x bfloat> zeroinitializer)
+// AIE2P-NEXT:    [[AND_I_I:%.*]] = and i32 [[TMP10]], 65535
+// AIE2P-NEXT:    [[TMP11:%.*]] = bitcast <16 x float> [[V1]] to <16 x i32>
+// AIE2P-NEXT:    [[TMP12:%.*]] = bitcast <16 x float> [[V2]] to <16 x i32>
+// AIE2P-NEXT:    [[TMP13:%.*]] = tail call noundef <16 x i32> @llvm.aie2p.vsel32(<16 x i32> [[TMP11]], <16 x i32> [[TMP12]], i32 [[AND_I_I]])
+// AIE2P-NEXT:    [[TMP14:%.*]] = bitcast <16 x i32> [[TMP13]] to <16 x float>
+// AIE2P-NEXT:    ret <16 x float> [[TMP14]]
 //
 v16float test_min(v16float v1, v16float v2) {
   return min(v1,v2);
@@ -5063,17 +5099,23 @@ v16float test_min(v16float v1, v16float v2) {
 //
 // AIE2P-LABEL: @_Z7test_gtDv16_fS_(
 // AIE2P-NEXT:  entry:
-// AIE2P-NEXT:    [[TMP0:%.*]] = shufflevector <16 x float> [[V1:%.*]], <16 x float> poison, <64 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
-// AIE2P-NEXT:    [[TMP1:%.*]] = shufflevector <16 x float> [[V2:%.*]], <16 x float> poison, <64 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
-// AIE2P-NEXT:    [[TMP2:%.*]] = tail call noundef <64 x float> @llvm.aie2p.ACC2048.accfloat.sub.conf(<64 x float> [[TMP0]], <64 x float> [[TMP1]], i32 60)
-// AIE2P-NEXT:    [[TMP3:%.*]] = shufflevector <64 x float> [[TMP2]], <64 x float> poison, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
-// AIE2P-NEXT:    [[TMP4:%.*]] = tail call noundef <16 x bfloat> @llvm.aie2p.v16accfloat.to.v16bf16(<16 x float> [[TMP3]])
-// AIE2P-NEXT:    [[TMP5:%.*]] = bitcast <16 x bfloat> [[TMP4]] to <8 x i32>
-// AIE2P-NEXT:    [[SHUFFLE_I_I_I:%.*]] = shufflevector <8 x i32> [[TMP5]], <8 x i32> poison, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
+// AIE2P-NEXT:    [[TMP0:%.*]] = bitcast <16 x float> [[V1:%.*]] to <8 x i64>
+// AIE2P-NEXT:    [[SHUFFLE1_I_I_I_I:%.*]] = shufflevector <8 x i64> [[TMP0]], <8 x i64> poison, <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
+// AIE2P-NEXT:    [[TMP1:%.*]] = bitcast <32 x i64> [[SHUFFLE1_I_I_I_I]] to <64 x float>
+// AIE2P-NEXT:    [[TMP2:%.*]] = bitcast <16 x float> [[V2:%.*]] to <8 x i64>
+// AIE2P-NEXT:    [[SHUFFLE1_I_I4_I_I:%.*]] = shufflevector <8 x i64> [[TMP2]], <8 x i64> poison, <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
+// AIE2P-NEXT:    [[TMP3:%.*]] = bitcast <32 x i64> [[SHUFFLE1_I_I4_I_I]] to <64 x float>
+// AIE2P-NEXT:    [[TMP4:%.*]] = tail call noundef <64 x float> @llvm.aie2p.ACC2048.accfloat.sub.conf(<64 x float> [[TMP1]], <64 x float> [[TMP3]], i32 60)
+// AIE2P-NEXT:    [[TMP5:%.*]] = bitcast <64 x float> [[TMP4]] to <32 x i64>
+// AIE2P-NEXT:    [[SHUFFLE_I_I_I_I:%.*]] = shufflevector <32 x i64> [[TMP5]], <32 x i64> poison, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+// AIE2P-NEXT:    [[TMP6:%.*]] = bitcast <8 x i64> [[SHUFFLE_I_I_I_I]] to <16 x float>
+// AIE2P-NEXT:    [[TMP7:%.*]] = tail call noundef <16 x bfloat> @llvm.aie2p.v16accfloat.to.v16bf16(<16 x float> [[TMP6]])
+// AIE2P-NEXT:    [[TMP8:%.*]] = bitcast <16 x bfloat> [[TMP7]] to <8 x i32>
+// AIE2P-NEXT:    [[SHUFFLE_I_I_I:%.*]] = shufflevector <8 x i32> [[TMP8]], <8 x i32> poison, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
 // AIE2P-NEXT:    [[SHUFFLE1_I_I_I:%.*]] = shufflevector <16 x i32> [[SHUFFLE_I_I_I]], <16 x i32> <i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0>, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
-// AIE2P-NEXT:    [[TMP6:%.*]] = bitcast <16 x i32> [[SHUFFLE1_I_I_I]] to <32 x bfloat>
-// AIE2P-NEXT:    [[TMP7:%.*]] = tail call noundef i32 @llvm.aie2p.vltbf16(<32 x bfloat> zeroinitializer, <32 x bfloat> [[TMP6]])
-// AIE2P-NEXT:    ret i32 [[TMP7]]
+// AIE2P-NEXT:    [[TMP9:%.*]] = bitcast <16 x i32> [[SHUFFLE1_I_I_I]] to <32 x bfloat>
+// AIE2P-NEXT:    [[TMP10:%.*]] = tail call noundef i32 @llvm.aie2p.vltbf16(<32 x bfloat> zeroinitializer, <32 x bfloat> [[TMP9]])
+// AIE2P-NEXT:    ret i32 [[TMP10]]
 //
 unsigned int test_gt(v16float v1, v16float v2) {
   return gt(v1, v2);
@@ -5117,22 +5159,27 @@ v16float test_abs(v16float v1) { return abs(v1); }
 // AIE2P-NEXT:    [[TMP0:%.*]] = bitcast <16 x float> [[V2:%.*]] to <16 x i32>
 // AIE2P-NEXT:    [[TMP1:%.*]] = tail call { <16 x i32>, i32 } @llvm.aie2p.vabs.gtz32(<16 x i32> [[TMP0]], i32 1)
 // AIE2P-NEXT:    [[TMP2:%.*]] = extractvalue { <16 x i32>, i32 } [[TMP1]], 0
-// AIE2P-NEXT:    [[TMP3:%.*]] = shufflevector <16 x float> [[V1:%.*]], <16 x float> poison, <64 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
-// AIE2P-NEXT:    [[TMP4:%.*]] = bitcast <16 x i32> [[TMP2]] to <16 x float>
-// AIE2P-NEXT:    [[TMP5:%.*]] = shufflevector <16 x float> [[TMP4]], <16 x float> poison, <64 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
-// AIE2P-NEXT:    [[TMP6:%.*]] = tail call noundef <64 x float> @llvm.aie2p.ACC2048.accfloat.sub.conf(<64 x float> [[TMP3]], <64 x float> [[TMP5]], i32 60)
-// AIE2P-NEXT:    [[TMP7:%.*]] = shufflevector <64 x float> [[TMP6]], <64 x float> poison, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
-// AIE2P-NEXT:    [[TMP8:%.*]] = tail call noundef <16 x bfloat> @llvm.aie2p.v16accfloat.to.v16bf16(<16 x float> [[TMP7]])
-// AIE2P-NEXT:    [[TMP9:%.*]] = bitcast <16 x bfloat> [[TMP8]] to <8 x i32>
-// AIE2P-NEXT:    [[SHUFFLE_I_I_I_I:%.*]] = shufflevector <8 x i32> [[TMP9]], <8 x i32> poison, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
+// AIE2P-NEXT:    [[TMP3:%.*]] = bitcast <16 x float> [[V1:%.*]] to <8 x i64>
+// AIE2P-NEXT:    [[SHUFFLE1_I_I_I_I_I:%.*]] = shufflevector <8 x i64> [[TMP3]], <8 x i64> poison, <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
+// AIE2P-NEXT:    [[TMP4:%.*]] = bitcast <32 x i64> [[SHUFFLE1_I_I_I_I_I]] to <64 x float>
+// AIE2P-NEXT:    [[TMP5:%.*]] = bitcast <16 x i32> [[TMP2]] to <8 x i64>
+// AIE2P-NEXT:    [[SHUFFLE1_I_I4_I_I_I:%.*]] = shufflevector <8 x i64> [[TMP5]], <8 x i64> poison, <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
+// AIE2P-NEXT:    [[TMP6:%.*]] = bitcast <32 x i64> [[SHUFFLE1_I_I4_I_I_I]] to <64 x float>
+// AIE2P-NEXT:    [[TMP7:%.*]] = tail call noundef <64 x float> @llvm.aie2p.ACC2048.accfloat.sub.conf(<64 x float> [[TMP4]], <64 x float> [[TMP6]], i32 60)
+// AIE2P-NEXT:    [[TMP8:%.*]] = bitcast <64 x float> [[TMP7]] to <32 x i64>
+// AIE2P-NEXT:    [[SHUFFLE_I_I_I_I_I:%.*]] = shufflevector <32 x i64> [[TMP8]], <32 x i64> poison, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+// AIE2P-NEXT:    [[TMP9:%.*]] = bitcast <8 x i64> [[SHUFFLE_I_I_I_I_I]] to <16 x float>
+// AIE2P-NEXT:    [[TMP10:%.*]] = tail call noundef <16 x bfloat> @llvm.aie2p.v16accfloat.to.v16bf16(<16 x float> [[TMP9]])
+// AIE2P-NEXT:    [[TMP11:%.*]] = bitcast <16 x bfloat> [[TMP10]] to <8 x i32>
+// AIE2P-NEXT:    [[SHUFFLE_I_I_I_I:%.*]] = shufflevector <8 x i32> [[TMP11]], <8 x i32> poison, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
 // AIE2P-NEXT:    [[SHUFFLE1_I_I_I_I:%.*]] = shufflevector <16 x i32> [[SHUFFLE_I_I_I_I]], <16 x i32> <i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0>, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
-// AIE2P-NEXT:    [[TMP10:%.*]] = bitcast <16 x i32> [[SHUFFLE1_I_I_I_I]] to <32 x bfloat>
-// AIE2P-NEXT:    [[TMP11:%.*]] = tail call noundef i32 @llvm.aie2p.vgebf16(<32 x bfloat> [[TMP10]], <32 x bfloat> zeroinitializer)
-// AIE2P-NEXT:    [[AND_I_I:%.*]] = and i32 [[TMP11]], 65535
-// AIE2P-NEXT:    [[TMP12:%.*]] = bitcast <16 x float> [[V1]] to <16 x i32>
-// AIE2P-NEXT:    [[TMP13:%.*]] = tail call noundef <16 x i32> @llvm.aie2p.vsel32(<16 x i32> [[TMP12]], <16 x i32> [[TMP0]], i32 [[AND_I_I]])
-// AIE2P-NEXT:    [[TMP14:%.*]] = bitcast <16 x i32> [[TMP13]] to <16 x float>
-// AIE2P-NEXT:    ret <16 x float> [[TMP14]]
+// AIE2P-NEXT:    [[TMP12:%.*]] = bitcast <16 x i32> [[SHUFFLE1_I_I_I_I]] to <32 x bfloat>
+// AIE2P-NEXT:    [[TMP13:%.*]] = tail call noundef i32 @llvm.aie2p.vgebf16(<32 x bfloat> [[TMP12]], <32 x bfloat> zeroinitializer)
+// AIE2P-NEXT:    [[AND_I_I:%.*]] = and i32 [[TMP13]], 65535
+// AIE2P-NEXT:    [[TMP14:%.*]] = bitcast <16 x float> [[V1]] to <16 x i32>
+// AIE2P-NEXT:    [[TMP15:%.*]] = tail call noundef <16 x i32> @llvm.aie2p.vsel32(<16 x i32> [[TMP14]], <16 x i32> [[TMP0]], i32 [[AND_I_I]])
+// AIE2P-NEXT:    [[TMP16:%.*]] = bitcast <16 x i32> [[TMP15]] to <16 x float>
+// AIE2P-NEXT:    ret <16 x float> [[TMP16]]
 //
 v16float test_min_abs(v16float v1, v16float v2) {
   return min_abs(v1, v2);
@@ -5160,21 +5207,26 @@ v16float test_min_abs(v16float v1, v16float v2) {
 // AIE2P-NEXT:    [[TMP0:%.*]] = bitcast <16 x float> [[V2:%.*]] to <16 x i32>
 // AIE2P-NEXT:    [[TMP1:%.*]] = tail call { <16 x i32>, i32 } @llvm.aie2p.vabs.gtz32(<16 x i32> [[TMP0]], i32 1)
 // AIE2P-NEXT:    [[TMP2:%.*]] = extractvalue { <16 x i32>, i32 } [[TMP1]], 0
-// AIE2P-NEXT:    [[TMP3:%.*]] = shufflevector <16 x float> [[V1:%.*]], <16 x float> poison, <64 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
-// AIE2P-NEXT:    [[TMP4:%.*]] = bitcast <16 x i32> [[TMP2]] to <16 x float>
-// AIE2P-NEXT:    [[TMP5:%.*]] = shufflevector <16 x float> [[TMP4]], <16 x float> poison, <64 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
-// AIE2P-NEXT:    [[TMP6:%.*]] = tail call noundef <64 x float> @llvm.aie2p.ACC2048.accfloat.sub.conf(<64 x float> [[TMP3]], <64 x float> [[TMP5]], i32 60)
-// AIE2P-NEXT:    [[TMP7:%.*]] = shufflevector <64 x float> [[TMP6]], <64 x float> poison, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
-// AIE2P-NEXT:    [[TMP8:%.*]] = tail call noundef <16 x bfloat> @llvm.aie2p.v16accfloat.to.v16bf16(<16 x float> [[TMP7]])
-// AIE2P-NEXT:    [[TMP9:%.*]] = bitcast <16 x bfloat> [[TMP8]] to <8 x i32>
-// AIE2P-NEXT:    [[SHUFFLE_I_I_I_I:%.*]] = shufflevector <8 x i32> [[TMP9]], <8 x i32> poison, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
+// AIE2P-NEXT:    [[TMP3:%.*]] = bitcast <16 x float> [[V1:%.*]] to <8 x i64>
+// AIE2P-NEXT:    [[SHUFFLE1_I_I_I_I_I:%.*]] = shufflevector <8 x i64> [[TMP3]], <8 x i64> poison, <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
+// AIE2P-NEXT:    [[TMP4:%.*]] = bitcast <32 x i64> [[SHUFFLE1_I_I_I_I_I]] to <64 x float>
+// AIE2P-NEXT:    [[TMP5:%.*]] = bitcast <16 x i32> [[TMP2]] to <8 x i64>
+// AIE2P-NEXT:    [[SHUFFLE1_I_I4_I_I_I:%.*]] = shufflevector <8 x i64> [[TMP5]], <8 x i64> poison, <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
+// AIE2P-NEXT:    [[TMP6:%.*]] = bitcast <32 x i64> [[SHUFFLE1_I_I4_I_I_I]] to <64 x float>
+// AIE2P-NEXT:    [[TMP7:%.*]] = tail call noundef <64 x float> @llvm.aie2p.ACC2048.accfloat.sub.conf(<64 x float> [[TMP4]], <64 x float> [[TMP6]], i32 60)
+// AIE2P-NEXT:    [[TMP8:%.*]] = bitcast <64 x float> [[TMP7]] to <32 x i64>
+// AIE2P-NEXT:    [[SHUFFLE_I_I_I_I_I:%.*]] = shufflevector <32 x i64> [[TMP8]], <32 x i64> poison, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+// AIE2P-NEXT:    [[TMP9:%.*]] = bitcast <8 x i64> [[SHUFFLE_I_I_I_I_I]] to <16 x float>
+// AIE2P-NEXT:    [[TMP10:%.*]] = tail call noundef <16 x bfloat> @llvm.aie2p.v16accfloat.to.v16bf16(<16 x float> [[TMP9]])
+// AIE2P-NEXT:    [[TMP11:%.*]] = bitcast <16 x bfloat> [[TMP10]] to <8 x i32>
+// AIE2P-NEXT:    [[SHUFFLE_I_I_I_I:%.*]] = shufflevector <8 x i32> [[TMP11]], <8 x i32> poison, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
 // AIE2P-NEXT:    [[SHUFFLE1_I_I_I_I:%.*]] = shufflevector <16 x i32> [[SHUFFLE_I_I_I_I]], <16 x i32> <i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0>, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
-// AIE2P-NEXT:    [[TMP10:%.*]] = bitcast <16 x i32> [[SHUFFLE1_I_I_I_I]] to <32 x bfloat>
-// AIE2P-NEXT:    [[TMP11:%.*]] = tail call noundef i32 @llvm.aie2p.vltbf16(<32 x bfloat> [[TMP10]], <32 x bfloat> zeroinitializer)
-// AIE2P-NEXT:    [[TMP12:%.*]] = bitcast <16 x float> [[V1]] to <16 x i32>
-// AIE2P-NEXT:    [[TMP13:%.*]] = tail call noundef <16 x i32> @llvm.aie2p.vsel32(<16 x i32> [[TMP12]], <16 x i32> [[TMP0]], i32 [[TMP11]])
-// AIE2P-NEXT:    [[TMP14:%.*]] = bitcast <16 x i32> [[TMP13]] to <16 x float>
-// AIE2P-NEXT:    ret <16 x float> [[TMP14]]
+// AIE2P-NEXT:    [[TMP12:%.*]] = bitcast <16 x i32> [[SHUFFLE1_I_I_I_I]] to <32 x bfloat>
+// AIE2P-NEXT:    [[TMP13:%.*]] = tail call noundef i32 @llvm.aie2p.vltbf16(<32 x bfloat> [[TMP12]], <32 x bfloat> zeroinitializer)
+// AIE2P-NEXT:    [[TMP14:%.*]] = bitcast <16 x float> [[V1]] to <16 x i32>
+// AIE2P-NEXT:    [[TMP15:%.*]] = tail call noundef <16 x i32> @llvm.aie2p.vsel32(<16 x i32> [[TMP14]], <16 x i32> [[TMP0]], i32 [[TMP13]])
+// AIE2P-NEXT:    [[TMP16:%.*]] = bitcast <16 x i32> [[TMP15]] to <16 x float>
+// AIE2P-NEXT:    ret <16 x float> [[TMP16]]
 //
 v16float test_max_abs(v16float v1, v16float v2) {
   return max_abs(v1, v2);
@@ -5200,18 +5252,23 @@ v16float test_max_abs(v16float v1, v16float v2) {
 // AIE2P-NEXT:    [[TMP0:%.*]] = bitcast <16 x float> [[V2:%.*]] to <16 x i32>
 // AIE2P-NEXT:    [[TMP1:%.*]] = tail call { <16 x i32>, i32 } @llvm.aie2p.vabs.gtz32(<16 x i32> [[TMP0]], i32 1)
 // AIE2P-NEXT:    [[TMP2:%.*]] = extractvalue { <16 x i32>, i32 } [[TMP1]], 0
-// AIE2P-NEXT:    [[TMP3:%.*]] = shufflevector <16 x float> [[V1:%.*]], <16 x float> poison, <64 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
-// AIE2P-NEXT:    [[TMP4:%.*]] = bitcast <16 x i32> [[TMP2]] to <16 x float>
-// AIE2P-NEXT:    [[TMP5:%.*]] = shufflevector <16 x float> [[TMP4]], <16 x float> poison, <64 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
-// AIE2P-NEXT:    [[TMP6:%.*]] = tail call noundef <64 x float> @llvm.aie2p.ACC2048.accfloat.sub.conf(<64 x float> [[TMP3]], <64 x float> [[TMP5]], i32 60)
-// AIE2P-NEXT:    [[TMP7:%.*]] = shufflevector <64 x float> [[TMP6]], <64 x float> poison, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
-// AIE2P-NEXT:    [[TMP8:%.*]] = tail call noundef <16 x bfloat> @llvm.aie2p.v16accfloat.to.v16bf16(<16 x float> [[TMP7]])
-// AIE2P-NEXT:    [[TMP9:%.*]] = bitcast <16 x bfloat> [[TMP8]] to <8 x i32>
-// AIE2P-NEXT:    [[SHUFFLE_I_I_I:%.*]] = shufflevector <8 x i32> [[TMP9]], <8 x i32> poison, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
+// AIE2P-NEXT:    [[TMP3:%.*]] = bitcast <16 x float> [[V1:%.*]] to <8 x i64>
+// AIE2P-NEXT:    [[SHUFFLE1_I_I_I_I:%.*]] = shufflevector <8 x i64> [[TMP3]], <8 x i64> poison, <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
+// AIE2P-NEXT:    [[TMP4:%.*]] = bitcast <32 x i64> [[SHUFFLE1_I_I_I_I]] to <64 x float>
+// AIE2P-NEXT:    [[TMP5:%.*]] = bitcast <16 x i32> [[TMP2]] to <8 x i64>
+// AIE2P-NEXT:    [[SHUFFLE1_I_I4_I_I:%.*]] = shufflevector <8 x i64> [[TMP5]], <8 x i64> poison, <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
+// AIE2P-NEXT:    [[TMP6:%.*]] = bitcast <32 x i64> [[SHUFFLE1_I_I4_I_I]] to <64 x float>
+// AIE2P-NEXT:    [[TMP7:%.*]] = tail call noundef <64 x float> @llvm.aie2p.ACC2048.accfloat.sub.conf(<64 x float> [[TMP4]], <64 x float> [[TMP6]], i32 60)
+// AIE2P-NEXT:    [[TMP8:%.*]] = bitcast <64 x float> [[TMP7]] to <32 x i64>
+// AIE2P-NEXT:    [[SHUFFLE_I_I_I_I:%.*]] = shufflevector <32 x i64> [[TMP8]], <32 x i64> poison, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+// AIE2P-NEXT:    [[TMP9:%.*]] = bitcast <8 x i64> [[SHUFFLE_I_I_I_I]] to <16 x float>
+// AIE2P-NEXT:    [[TMP10:%.*]] = tail call noundef <16 x bfloat> @llvm.aie2p.v16accfloat.to.v16bf16(<16 x float> [[TMP9]])
+// AIE2P-NEXT:    [[TMP11:%.*]] = bitcast <16 x bfloat> [[TMP10]] to <8 x i32>
+// AIE2P-NEXT:    [[SHUFFLE_I_I_I:%.*]] = shufflevector <8 x i32> [[TMP11]], <8 x i32> poison, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
 // AIE2P-NEXT:    [[SHUFFLE1_I_I_I:%.*]] = shufflevector <16 x i32> [[SHUFFLE_I_I_I]], <16 x i32> <i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0>, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
-// AIE2P-NEXT:    [[TMP10:%.*]] = bitcast <16 x i32> [[SHUFFLE1_I_I_I]] to <32 x bfloat>
-// AIE2P-NEXT:    [[TMP11:%.*]] = tail call noundef i32 @llvm.aie2p.vgebf16(<32 x bfloat> [[TMP10]], <32 x bfloat> zeroinitializer)
-// AIE2P-NEXT:    [[AND_I:%.*]] = and i32 [[TMP11]], 65535
+// AIE2P-NEXT:    [[TMP12:%.*]] = bitcast <16 x i32> [[SHUFFLE1_I_I_I]] to <32 x bfloat>
+// AIE2P-NEXT:    [[TMP13:%.*]] = tail call noundef i32 @llvm.aie2p.vgebf16(<32 x bfloat> [[TMP12]], <32 x bfloat> zeroinitializer)
+// AIE2P-NEXT:    [[AND_I:%.*]] = and i32 [[TMP13]], 65535
 // AIE2P-NEXT:    ret i32 [[AND_I]]
 //
 unsigned int test_ge_abs(v16float v1, v16float v2) {
@@ -5237,18 +5294,23 @@ unsigned int test_ge_abs(v16float v1, v16float v2) {
 // AIE2P-NEXT:    [[TMP0:%.*]] = bitcast <16 x float> [[V2:%.*]] to <16 x i32>
 // AIE2P-NEXT:    [[TMP1:%.*]] = tail call { <16 x i32>, i32 } @llvm.aie2p.vabs.gtz32(<16 x i32> [[TMP0]], i32 1)
 // AIE2P-NEXT:    [[TMP2:%.*]] = extractvalue { <16 x i32>, i32 } [[TMP1]], 0
-// AIE2P-NEXT:    [[TMP3:%.*]] = shufflevector <16 x float> [[V1:%.*]], <16 x float> poison, <64 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
-// AIE2P-NEXT:    [[TMP4:%.*]] = bitcast <16 x i32> [[TMP2]] to <16 x float>
-// AIE2P-NEXT:    [[TMP5:%.*]] = shufflevector <16 x float> [[TMP4]], <16 x float> poison, <64 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
-// AIE2P-NEXT:    [[TMP6:%.*]] = tail call noundef <64 x float> @llvm.aie2p.ACC2048.accfloat.sub.conf(<64 x float> [[TMP3]], <64 x float> [[TMP5]], i32 60)
-// AIE2P-NEXT:    [[TMP7:%.*]] = shufflevector <64 x float> [[TMP6]], <64 x float> poison, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
-// AIE2P-NEXT:    [[TMP8:%.*]] = tail call noundef <16 x bfloat> @llvm.aie2p.v16accfloat.to.v16bf16(<16 x float> [[TMP7]])
-// AIE2P-NEXT:    [[TMP9:%.*]] = bitcast <16 x bfloat> [[TMP8]] to <8 x i32>
-// AIE2P-NEXT:    [[SHUFFLE_I_I_I:%.*]] = shufflevector <8 x i32> [[TMP9]], <8 x i32> poison, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
+// AIE2P-NEXT:    [[TMP3:%.*]] = bitcast <16 x float> [[V1:%.*]] to <8 x i64>
+// AIE2P-NEXT:    [[SHUFFLE1_I_I_I_I:%.*]] = shufflevector <8 x i64> [[TMP3]], <8 x i64> poison, <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
+// AIE2P-NEXT:    [[TMP4:%.*]] = bitcast <32 x i64> [[SHUFFLE1_I_I_I_I]] to <64 x float>
+// AIE2P-NEXT:    [[TMP5:%.*]] = bitcast <16 x i32> [[TMP2]] to <8 x i64>
+// AIE2P-NEXT:    [[SHUFFLE1_I_I4_I_I:%.*]] = shufflevector <8 x i64> [[TMP5]], <8 x i64> poison, <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
+// AIE2P-NEXT:    [[TMP6:%.*]] = bitcast <32 x i64> [[SHUFFLE1_I_I4_I_I]] to <64 x float>
+// AIE2P-NEXT:    [[TMP7:%.*]] = tail call noundef <64 x float> @llvm.aie2p.ACC2048.accfloat.sub.conf(<64 x float> [[TMP4]], <64 x float> [[TMP6]], i32 60)
+// AIE2P-NEXT:    [[TMP8:%.*]] = bitcast <64 x float> [[TMP7]] to <32 x i64>
+// AIE2P-NEXT:    [[SHUFFLE_I_I_I_I:%.*]] = shufflevector <32 x i64> [[TMP8]], <32 x i64> poison, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+// AIE2P-NEXT:    [[TMP9:%.*]] = bitcast <8 x i64> [[SHUFFLE_I_I_I_I]] to <16 x float>
+// AIE2P-NEXT:    [[TMP10:%.*]] = tail call noundef <16 x bfloat> @llvm.aie2p.v16accfloat.to.v16bf16(<16 x float> [[TMP9]])
+// AIE2P-NEXT:    [[TMP11:%.*]] = bitcast <16 x bfloat> [[TMP10]] to <8 x i32>
+// AIE2P-NEXT:    [[SHUFFLE_I_I_I:%.*]] = shufflevector <8 x i32> [[TMP11]], <8 x i32> poison, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
 // AIE2P-NEXT:    [[SHUFFLE1_I_I_I:%.*]] = shufflevector <16 x i32> [[SHUFFLE_I_I_I]], <16 x i32> <i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0, i32 0>, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
-// AIE2P-NEXT:    [[TMP10:%.*]] = bitcast <16 x i32> [[SHUFFLE1_I_I_I]] to <32 x bfloat>
-// AIE2P-NEXT:    [[TMP11:%.*]] = tail call noundef i32 @llvm.aie2p.vltbf16(<32 x bfloat> [[TMP10]], <32 x bfloat> zeroinitializer)
-// AIE2P-NEXT:    ret i32 [[TMP11]]
+// AIE2P-NEXT:    [[TMP12:%.*]] = bitcast <16 x i32> [[SHUFFLE1_I_I_I]] to <32 x bfloat>
+// AIE2P-NEXT:    [[TMP13:%.*]] = tail call noundef i32 @llvm.aie2p.vltbf16(<32 x bfloat> [[TMP12]], <32 x bfloat> zeroinitializer)
+// AIE2P-NEXT:    ret i32 [[TMP13]]
 //
 unsigned int test_lt_abs(v16float v1, v16float v2) {
   return lt_abs(v1, v2);

--- a/clang/test/CodeGen/aie/aie2p/aie2p-upd-ext-intrinsic.cpp
+++ b/clang/test/CodeGen/aie/aie2p/aie2p-upd-ext-intrinsic.cpp
@@ -5122,10 +5122,15 @@ v64accfloat test_set_v64accfloat (int idx, v16accfloat b)
 // CHECK-LABEL: define dso_local inreg noundef <64 x float> @_Z11test_concatDv16_u10__accfloatS_S_S_(
 // CHECK-SAME: <16 x float> inreg noundef [[A0:%.*]], <16 x float> inreg noundef [[A1:%.*]], <16 x float> inreg noundef [[A2:%.*]], <16 x float> inreg noundef [[A3:%.*]]) local_unnamed_addr #[[ATTR0]] {
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[TMP0:%.*]] = shufflevector <16 x float> [[A0]], <16 x float> [[A1]], <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
-// CHECK-NEXT:    [[TMP1:%.*]] = shufflevector <16 x float> [[A2]], <16 x float> [[A3]], <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
-// CHECK-NEXT:    [[TMP2:%.*]] = shufflevector <32 x float> [[TMP0]], <32 x float> [[TMP1]], <64 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31, i32 32, i32 33, i32 34, i32 35, i32 36, i32 37, i32 38, i32 39, i32 40, i32 41, i32 42, i32 43, i32 44, i32 45, i32 46, i32 47, i32 48, i32 49, i32 50, i32 51, i32 52, i32 53, i32 54, i32 55, i32 56, i32 57, i32 58, i32 59, i32 60, i32 61, i32 62, i32 63>
-// CHECK-NEXT:    ret <64 x float> [[TMP2]]
+// CHECK-NEXT:    [[TMP0:%.*]] = bitcast <16 x float> [[A0]] to <8 x i64>
+// CHECK-NEXT:    [[TMP1:%.*]] = bitcast <16 x float> [[A1]] to <8 x i64>
+// CHECK-NEXT:    [[TMP2:%.*]] = bitcast <16 x float> [[A2]] to <8 x i64>
+// CHECK-NEXT:    [[TMP3:%.*]] = bitcast <16 x float> [[A3]] to <8 x i64>
+// CHECK-NEXT:    [[SHUFFLE_I_I:%.*]] = shufflevector <8 x i64> [[TMP0]], <8 x i64> [[TMP1]], <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
+// CHECK-NEXT:    [[SHUFFLE1_I_I:%.*]] = shufflevector <8 x i64> [[TMP2]], <8 x i64> [[TMP3]], <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
+// CHECK-NEXT:    [[SHUFFLE2_I_I:%.*]] = shufflevector <16 x i64> [[SHUFFLE_I_I]], <16 x i64> [[SHUFFLE1_I_I]], <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+// CHECK-NEXT:    [[TMP4:%.*]] = bitcast <32 x i64> [[SHUFFLE2_I_I]] to <64 x float>
+// CHECK-NEXT:    ret <64 x float> [[TMP4]]
 //
 v64accfloat test_concat (v16accfloat a0, v16accfloat a1, v16accfloat a2, v16accfloat a3)
 {
@@ -5208,8 +5213,11 @@ v64accfloat test_set_v64accfloat (int idx, v32accfloat b)
 // CHECK-LABEL: define dso_local inreg noundef <64 x float> @_Z11test_concatDv32_u10__accfloatS_(
 // CHECK-SAME: <32 x float> inreg noundef [[A0:%.*]], <32 x float> inreg noundef [[A1:%.*]]) local_unnamed_addr #[[ATTR0]] {
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[TMP0:%.*]] = shufflevector <32 x float> [[A0]], <32 x float> [[A1]], <64 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31, i32 32, i32 33, i32 34, i32 35, i32 36, i32 37, i32 38, i32 39, i32 40, i32 41, i32 42, i32 43, i32 44, i32 45, i32 46, i32 47, i32 48, i32 49, i32 50, i32 51, i32 52, i32 53, i32 54, i32 55, i32 56, i32 57, i32 58, i32 59, i32 60, i32 61, i32 62, i32 63>
-// CHECK-NEXT:    ret <64 x float> [[TMP0]]
+// CHECK-NEXT:    [[TMP0:%.*]] = bitcast <32 x float> [[A0]] to <16 x i64>
+// CHECK-NEXT:    [[TMP1:%.*]] = bitcast <32 x float> [[A1]] to <16 x i64>
+// CHECK-NEXT:    [[SHUFFLE_I_I:%.*]] = shufflevector <16 x i64> [[TMP0]], <16 x i64> [[TMP1]], <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+// CHECK-NEXT:    [[TMP2:%.*]] = bitcast <32 x i64> [[SHUFFLE_I_I]] to <64 x float>
+// CHECK-NEXT:    ret <64 x float> [[TMP2]]
 //
 v64accfloat test_concat (v32accfloat a0, v32accfloat a1)
 {
@@ -5319,10 +5327,15 @@ v64acc32 test_set_v64acc32 (int idx, v16acc32 b)
 // CHECK-LABEL: define dso_local inreg noundef <64 x i32> @_Z11test_concatDv16_u7__acc32S_S_S_(
 // CHECK-SAME: <16 x i32> inreg noundef [[A0:%.*]], <16 x i32> inreg noundef [[A1:%.*]], <16 x i32> inreg noundef [[A2:%.*]], <16 x i32> inreg noundef [[A3:%.*]]) local_unnamed_addr #[[ATTR0]] {
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[TMP0:%.*]] = shufflevector <16 x i32> [[A0]], <16 x i32> [[A1]], <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
-// CHECK-NEXT:    [[TMP1:%.*]] = shufflevector <16 x i32> [[A2]], <16 x i32> [[A3]], <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
-// CHECK-NEXT:    [[TMP2:%.*]] = shufflevector <32 x i32> [[TMP0]], <32 x i32> [[TMP1]], <64 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31, i32 32, i32 33, i32 34, i32 35, i32 36, i32 37, i32 38, i32 39, i32 40, i32 41, i32 42, i32 43, i32 44, i32 45, i32 46, i32 47, i32 48, i32 49, i32 50, i32 51, i32 52, i32 53, i32 54, i32 55, i32 56, i32 57, i32 58, i32 59, i32 60, i32 61, i32 62, i32 63>
-// CHECK-NEXT:    ret <64 x i32> [[TMP2]]
+// CHECK-NEXT:    [[TMP0:%.*]] = bitcast <16 x i32> [[A0]] to <8 x i64>
+// CHECK-NEXT:    [[TMP1:%.*]] = bitcast <16 x i32> [[A1]] to <8 x i64>
+// CHECK-NEXT:    [[TMP2:%.*]] = bitcast <16 x i32> [[A2]] to <8 x i64>
+// CHECK-NEXT:    [[TMP3:%.*]] = bitcast <16 x i32> [[A3]] to <8 x i64>
+// CHECK-NEXT:    [[SHUFFLE_I_I:%.*]] = shufflevector <8 x i64> [[TMP0]], <8 x i64> [[TMP1]], <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
+// CHECK-NEXT:    [[SHUFFLE1_I_I:%.*]] = shufflevector <8 x i64> [[TMP2]], <8 x i64> [[TMP3]], <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
+// CHECK-NEXT:    [[SHUFFLE2_I_I:%.*]] = shufflevector <16 x i64> [[SHUFFLE_I_I]], <16 x i64> [[SHUFFLE1_I_I]], <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+// CHECK-NEXT:    [[TMP4:%.*]] = bitcast <32 x i64> [[SHUFFLE2_I_I]] to <64 x i32>
+// CHECK-NEXT:    ret <64 x i32> [[TMP4]]
 //
 v64acc32 test_concat (v16acc32 a0, v16acc32 a1, v16acc32 a2, v16acc32 a3)
 {
@@ -5405,8 +5418,11 @@ v64acc32 test_set_v64acc32 (int idx, v32acc32 b)
 // CHECK-LABEL: define dso_local inreg noundef <64 x i32> @_Z11test_concatDv32_u7__acc32S_(
 // CHECK-SAME: <32 x i32> inreg noundef [[A0:%.*]], <32 x i32> inreg noundef [[A1:%.*]]) local_unnamed_addr #[[ATTR0]] {
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[TMP0:%.*]] = shufflevector <32 x i32> [[A0]], <32 x i32> [[A1]], <64 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31, i32 32, i32 33, i32 34, i32 35, i32 36, i32 37, i32 38, i32 39, i32 40, i32 41, i32 42, i32 43, i32 44, i32 45, i32 46, i32 47, i32 48, i32 49, i32 50, i32 51, i32 52, i32 53, i32 54, i32 55, i32 56, i32 57, i32 58, i32 59, i32 60, i32 61, i32 62, i32 63>
-// CHECK-NEXT:    ret <64 x i32> [[TMP0]]
+// CHECK-NEXT:    [[TMP0:%.*]] = bitcast <32 x i32> [[A0]] to <16 x i64>
+// CHECK-NEXT:    [[TMP1:%.*]] = bitcast <32 x i32> [[A1]] to <16 x i64>
+// CHECK-NEXT:    [[SHUFFLE_I_I:%.*]] = shufflevector <16 x i64> [[TMP0]], <16 x i64> [[TMP1]], <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
+// CHECK-NEXT:    [[TMP2:%.*]] = bitcast <32 x i64> [[SHUFFLE_I_I]] to <64 x i32>
+// CHECK-NEXT:    ret <64 x i32> [[TMP2]]
 //
 v64acc32 test_concat (v32acc32 a0, v32acc32 a1)
 {

--- a/clang/test/CodeGen/aie/aie2p/aie2p-vmult-intrinsic.cpp
+++ b/clang/test/CodeGen/aie/aie2p/aie2p-vmult-intrinsic.cpp
@@ -110107,11 +110107,17 @@ v64accfloat test_neg(v64accfloat acc) { return neg(acc); }
 // CHECK-LABEL: define dso_local inreg noundef <32 x float> @_Z8test_addDv32_u10__accfloatS_(
 // CHECK-SAME: <32 x float> inreg noundef [[ACC1:%.*]], <32 x float> inreg noundef [[ACC2:%.*]]) local_unnamed_addr #[[ATTR1]] {
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[TMP0:%.*]] = shufflevector <32 x float> [[ACC1]], <32 x float> poison, <64 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
-// CHECK-NEXT:    [[TMP1:%.*]] = shufflevector <32 x float> [[ACC2]], <32 x float> poison, <64 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <64 x float> @llvm.aie2p.ACC2048.accfloat.add.conf(<64 x float> [[TMP0]], <64 x float> [[TMP1]], i32 60)
-// CHECK-NEXT:    [[TMP3:%.*]] = shufflevector <64 x float> [[TMP2]], <64 x float> poison, <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
-// CHECK-NEXT:    ret <32 x float> [[TMP3]]
+// CHECK-NEXT:    [[TMP0:%.*]] = bitcast <32 x float> [[ACC1]] to <16 x i64>
+// CHECK-NEXT:    [[SHUFFLE_I_I_I:%.*]] = shufflevector <16 x i64> [[TMP0]], <16 x i64> poison, <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
+// CHECK-NEXT:    [[TMP1:%.*]] = bitcast <32 x i64> [[SHUFFLE_I_I_I]] to <64 x float>
+// CHECK-NEXT:    [[TMP2:%.*]] = bitcast <32 x float> [[ACC2]] to <16 x i64>
+// CHECK-NEXT:    [[SHUFFLE_I_I4_I:%.*]] = shufflevector <16 x i64> [[TMP2]], <16 x i64> poison, <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
+// CHECK-NEXT:    [[TMP3:%.*]] = bitcast <32 x i64> [[SHUFFLE_I_I4_I]] to <64 x float>
+// CHECK-NEXT:    [[TMP4:%.*]] = tail call noundef <64 x float> @llvm.aie2p.ACC2048.accfloat.add.conf(<64 x float> [[TMP1]], <64 x float> [[TMP3]], i32 60)
+// CHECK-NEXT:    [[TMP5:%.*]] = bitcast <64 x float> [[TMP4]] to <32 x i64>
+// CHECK-NEXT:    [[SHUFFLE_I_I5_I:%.*]] = shufflevector <32 x i64> [[TMP5]], <32 x i64> poison, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
+// CHECK-NEXT:    [[TMP6:%.*]] = bitcast <16 x i64> [[SHUFFLE_I_I5_I]] to <32 x float>
+// CHECK-NEXT:    ret <32 x float> [[TMP6]]
 //
 v32accfloat test_add(v32accfloat acc1, v32accfloat acc2) {
   return add(acc1, acc2);
@@ -110119,11 +110125,17 @@ v32accfloat test_add(v32accfloat acc1, v32accfloat acc2) {
 // CHECK-LABEL: define dso_local inreg noundef <32 x float> @_Z8test_subDv32_u10__accfloatS_(
 // CHECK-SAME: <32 x float> inreg noundef [[ACC1:%.*]], <32 x float> inreg noundef [[ACC2:%.*]]) local_unnamed_addr #[[ATTR1]] {
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[TMP0:%.*]] = shufflevector <32 x float> [[ACC1]], <32 x float> poison, <64 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
-// CHECK-NEXT:    [[TMP1:%.*]] = shufflevector <32 x float> [[ACC2]], <32 x float> poison, <64 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <64 x float> @llvm.aie2p.ACC2048.accfloat.sub.conf(<64 x float> [[TMP0]], <64 x float> [[TMP1]], i32 60)
-// CHECK-NEXT:    [[TMP3:%.*]] = shufflevector <64 x float> [[TMP2]], <64 x float> poison, <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
-// CHECK-NEXT:    ret <32 x float> [[TMP3]]
+// CHECK-NEXT:    [[TMP0:%.*]] = bitcast <32 x float> [[ACC1]] to <16 x i64>
+// CHECK-NEXT:    [[SHUFFLE_I_I_I:%.*]] = shufflevector <16 x i64> [[TMP0]], <16 x i64> poison, <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
+// CHECK-NEXT:    [[TMP1:%.*]] = bitcast <32 x i64> [[SHUFFLE_I_I_I]] to <64 x float>
+// CHECK-NEXT:    [[TMP2:%.*]] = bitcast <32 x float> [[ACC2]] to <16 x i64>
+// CHECK-NEXT:    [[SHUFFLE_I_I4_I:%.*]] = shufflevector <16 x i64> [[TMP2]], <16 x i64> poison, <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
+// CHECK-NEXT:    [[TMP3:%.*]] = bitcast <32 x i64> [[SHUFFLE_I_I4_I]] to <64 x float>
+// CHECK-NEXT:    [[TMP4:%.*]] = tail call noundef <64 x float> @llvm.aie2p.ACC2048.accfloat.sub.conf(<64 x float> [[TMP1]], <64 x float> [[TMP3]], i32 60)
+// CHECK-NEXT:    [[TMP5:%.*]] = bitcast <64 x float> [[TMP4]] to <32 x i64>
+// CHECK-NEXT:    [[SHUFFLE_I_I5_I:%.*]] = shufflevector <32 x i64> [[TMP5]], <32 x i64> poison, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
+// CHECK-NEXT:    [[TMP6:%.*]] = bitcast <16 x i64> [[SHUFFLE_I_I5_I]] to <32 x float>
+// CHECK-NEXT:    ret <32 x float> [[TMP6]]
 //
 v32accfloat test_sub(v32accfloat acc1, v32accfloat acc2) {
   return sub(acc1, acc2);
@@ -110131,21 +110143,31 @@ v32accfloat test_sub(v32accfloat acc1, v32accfloat acc2) {
 // CHECK-LABEL: define dso_local inreg noundef <32 x float> @_Z8test_negDv32_u10__accfloat(
 // CHECK-SAME: <32 x float> inreg noundef [[ACC:%.*]]) local_unnamed_addr #[[ATTR1]] {
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[TMP0:%.*]] = shufflevector <32 x float> [[ACC]], <32 x float> poison, <64 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
-// CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef <64 x float> @llvm.aie2p.ACC2048.accfloat.neg.conf(<64 x float> [[TMP0]], i32 60)
-// CHECK-NEXT:    [[TMP2:%.*]] = shufflevector <64 x float> [[TMP1]], <64 x float> poison, <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 16, i32 17, i32 18, i32 19, i32 20, i32 21, i32 22, i32 23, i32 24, i32 25, i32 26, i32 27, i32 28, i32 29, i32 30, i32 31>
-// CHECK-NEXT:    ret <32 x float> [[TMP2]]
+// CHECK-NEXT:    [[TMP0:%.*]] = bitcast <32 x float> [[ACC]] to <16 x i64>
+// CHECK-NEXT:    [[SHUFFLE_I_I_I:%.*]] = shufflevector <16 x i64> [[TMP0]], <16 x i64> poison, <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
+// CHECK-NEXT:    [[TMP1:%.*]] = bitcast <32 x i64> [[SHUFFLE_I_I_I]] to <64 x float>
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <64 x float> @llvm.aie2p.ACC2048.accfloat.neg.conf(<64 x float> [[TMP1]], i32 60)
+// CHECK-NEXT:    [[TMP3:%.*]] = bitcast <64 x float> [[TMP2]] to <32 x i64>
+// CHECK-NEXT:    [[SHUFFLE_I_I3_I:%.*]] = shufflevector <32 x i64> [[TMP3]], <32 x i64> poison, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
+// CHECK-NEXT:    [[TMP4:%.*]] = bitcast <16 x i64> [[SHUFFLE_I_I3_I]] to <32 x float>
+// CHECK-NEXT:    ret <32 x float> [[TMP4]]
 //
 v32accfloat test_neg(v32accfloat acc) { return neg(acc); }
 
 // CHECK-LABEL: define dso_local inreg noundef <16 x float> @_Z8test_addDv16_u10__accfloatS_(
 // CHECK-SAME: <16 x float> inreg noundef [[ACC1:%.*]], <16 x float> inreg noundef [[ACC2:%.*]]) local_unnamed_addr #[[ATTR1]] {
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[TMP0:%.*]] = shufflevector <16 x float> [[ACC1]], <16 x float> poison, <64 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
-// CHECK-NEXT:    [[TMP1:%.*]] = shufflevector <16 x float> [[ACC2]], <16 x float> poison, <64 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <64 x float> @llvm.aie2p.ACC2048.accfloat.add.conf(<64 x float> [[TMP0]], <64 x float> [[TMP1]], i32 60)
-// CHECK-NEXT:    [[TMP3:%.*]] = shufflevector <64 x float> [[TMP2]], <64 x float> poison, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
-// CHECK-NEXT:    ret <16 x float> [[TMP3]]
+// CHECK-NEXT:    [[TMP0:%.*]] = bitcast <16 x float> [[ACC1]] to <8 x i64>
+// CHECK-NEXT:    [[SHUFFLE1_I_I_I:%.*]] = shufflevector <8 x i64> [[TMP0]], <8 x i64> poison, <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
+// CHECK-NEXT:    [[TMP1:%.*]] = bitcast <32 x i64> [[SHUFFLE1_I_I_I]] to <64 x float>
+// CHECK-NEXT:    [[TMP2:%.*]] = bitcast <16 x float> [[ACC2]] to <8 x i64>
+// CHECK-NEXT:    [[SHUFFLE1_I_I4_I:%.*]] = shufflevector <8 x i64> [[TMP2]], <8 x i64> poison, <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
+// CHECK-NEXT:    [[TMP3:%.*]] = bitcast <32 x i64> [[SHUFFLE1_I_I4_I]] to <64 x float>
+// CHECK-NEXT:    [[TMP4:%.*]] = tail call noundef <64 x float> @llvm.aie2p.ACC2048.accfloat.add.conf(<64 x float> [[TMP1]], <64 x float> [[TMP3]], i32 60)
+// CHECK-NEXT:    [[TMP5:%.*]] = bitcast <64 x float> [[TMP4]] to <32 x i64>
+// CHECK-NEXT:    [[SHUFFLE_I_I_I:%.*]] = shufflevector <32 x i64> [[TMP5]], <32 x i64> poison, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+// CHECK-NEXT:    [[TMP6:%.*]] = bitcast <8 x i64> [[SHUFFLE_I_I_I]] to <16 x float>
+// CHECK-NEXT:    ret <16 x float> [[TMP6]]
 //
 v16accfloat test_add(v16accfloat acc1, v16accfloat acc2) {
   return add(acc1, acc2);
@@ -110153,11 +110175,17 @@ v16accfloat test_add(v16accfloat acc1, v16accfloat acc2) {
 // CHECK-LABEL: define dso_local inreg noundef <16 x float> @_Z8test_subDv16_u10__accfloatS_(
 // CHECK-SAME: <16 x float> inreg noundef [[ACC1:%.*]], <16 x float> inreg noundef [[ACC2:%.*]]) local_unnamed_addr #[[ATTR1]] {
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[TMP0:%.*]] = shufflevector <16 x float> [[ACC1]], <16 x float> poison, <64 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
-// CHECK-NEXT:    [[TMP1:%.*]] = shufflevector <16 x float> [[ACC2]], <16 x float> poison, <64 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <64 x float> @llvm.aie2p.ACC2048.accfloat.sub.conf(<64 x float> [[TMP0]], <64 x float> [[TMP1]], i32 60)
-// CHECK-NEXT:    [[TMP3:%.*]] = shufflevector <64 x float> [[TMP2]], <64 x float> poison, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
-// CHECK-NEXT:    ret <16 x float> [[TMP3]]
+// CHECK-NEXT:    [[TMP0:%.*]] = bitcast <16 x float> [[ACC1]] to <8 x i64>
+// CHECK-NEXT:    [[SHUFFLE1_I_I_I:%.*]] = shufflevector <8 x i64> [[TMP0]], <8 x i64> poison, <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
+// CHECK-NEXT:    [[TMP1:%.*]] = bitcast <32 x i64> [[SHUFFLE1_I_I_I]] to <64 x float>
+// CHECK-NEXT:    [[TMP2:%.*]] = bitcast <16 x float> [[ACC2]] to <8 x i64>
+// CHECK-NEXT:    [[SHUFFLE1_I_I4_I:%.*]] = shufflevector <8 x i64> [[TMP2]], <8 x i64> poison, <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
+// CHECK-NEXT:    [[TMP3:%.*]] = bitcast <32 x i64> [[SHUFFLE1_I_I4_I]] to <64 x float>
+// CHECK-NEXT:    [[TMP4:%.*]] = tail call noundef <64 x float> @llvm.aie2p.ACC2048.accfloat.sub.conf(<64 x float> [[TMP1]], <64 x float> [[TMP3]], i32 60)
+// CHECK-NEXT:    [[TMP5:%.*]] = bitcast <64 x float> [[TMP4]] to <32 x i64>
+// CHECK-NEXT:    [[SHUFFLE_I_I_I:%.*]] = shufflevector <32 x i64> [[TMP5]], <32 x i64> poison, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+// CHECK-NEXT:    [[TMP6:%.*]] = bitcast <8 x i64> [[SHUFFLE_I_I_I]] to <16 x float>
+// CHECK-NEXT:    ret <16 x float> [[TMP6]]
 //
 v16accfloat test_sub(v16accfloat acc1, v16accfloat acc2) {
   return sub(acc1, acc2);
@@ -110165,9 +110193,13 @@ v16accfloat test_sub(v16accfloat acc1, v16accfloat acc2) {
 // CHECK-LABEL: define dso_local inreg noundef <16 x float> @_Z8test_negDv16_u10__accfloat(
 // CHECK-SAME: <16 x float> inreg noundef [[ACC:%.*]]) local_unnamed_addr #[[ATTR1]] {
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[TMP0:%.*]] = shufflevector <16 x float> [[ACC]], <16 x float> poison, <64 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
-// CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef <64 x float> @llvm.aie2p.ACC2048.accfloat.neg.conf(<64 x float> [[TMP0]], i32 60)
-// CHECK-NEXT:    [[TMP2:%.*]] = shufflevector <64 x float> [[TMP1]], <64 x float> poison, <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
-// CHECK-NEXT:    ret <16 x float> [[TMP2]]
+// CHECK-NEXT:    [[TMP0:%.*]] = bitcast <16 x float> [[ACC]] to <8 x i64>
+// CHECK-NEXT:    [[SHUFFLE1_I_I_I:%.*]] = shufflevector <8 x i64> [[TMP0]], <8 x i64> poison, <32 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
+// CHECK-NEXT:    [[TMP1:%.*]] = bitcast <32 x i64> [[SHUFFLE1_I_I_I]] to <64 x float>
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <64 x float> @llvm.aie2p.ACC2048.accfloat.neg.conf(<64 x float> [[TMP1]], i32 60)
+// CHECK-NEXT:    [[TMP3:%.*]] = bitcast <64 x float> [[TMP2]] to <32 x i64>
+// CHECK-NEXT:    [[SHUFFLE_I_I_I:%.*]] = shufflevector <32 x i64> [[TMP3]], <32 x i64> poison, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+// CHECK-NEXT:    [[TMP4:%.*]] = bitcast <8 x i64> [[SHUFFLE_I_I_I]] to <16 x float>
+// CHECK-NEXT:    ret <16 x float> [[TMP4]]
 //
 v16accfloat test_neg(v16accfloat acc) { return neg(acc); }

--- a/llvm/lib/Target/AIE/AIE2GenRegisterInfo.td
+++ b/llvm/lib/Target/AIE/AIE2GenRegisterInfo.td
@@ -481,7 +481,7 @@ class AIE2Dim3DRegisterClass <dag reglist, RegAltNameIndex idx = NoRegAltName> :
                   DwarfRegNum<[!add(!mul(i, 2), 167)]>;
   }
 
-  def eL : AIE2RegisterClass<64, 32, [v8i8, v4i16, v4bf16, v2i32],
+  def eL : AIE2RegisterClass<64, 32, [i64, v8i8, v4i16, v4bf16, v2i32],
                              (add l0, l1, l2, l3, l4, l5, l6, l7)>;
 
   class AIE2ShiftReg<bits<2> Enc, string n> : Register<n> {

--- a/llvm/lib/Target/AIE/AIE2ISelLowering.cpp
+++ b/llvm/lib/Target/AIE/AIE2ISelLowering.cpp
@@ -80,7 +80,7 @@ MVT AIE2TargetLowering::getRegisterTypeForCallingConv(LLVMContext &Context,
   if (VT.isScalarInteger() && VT.getScalarSizeInBits() == 128)
     return VT.getSimpleVT();
 
-  return TargetLowering::getRegisterTypeForCallingConv(Context, CC, VT);
+  return AIEBaseTargetLowering::getRegisterTypeForCallingConv(Context, CC, VT);
 }
 
 unsigned AIE2TargetLowering::getNumRegistersForCallingConv(LLVMContext &Context,
@@ -89,7 +89,7 @@ unsigned AIE2TargetLowering::getNumRegistersForCallingConv(LLVMContext &Context,
   // See getRegisterTypeForCallingConv(): i128 is passed in a single register
   if (VT.isScalarInteger() && VT.getScalarSizeInBits() == 128)
     return 1;
-  return TargetLowering::getNumRegistersForCallingConv(Context, CC, VT);
+  return AIEBaseTargetLowering::getNumRegistersForCallingConv(Context, CC, VT);
 }
 
 // Returns true if type name matches with a sparse type name

--- a/llvm/lib/Target/AIE/AIEBaseISelLowering.cpp
+++ b/llvm/lib/Target/AIE/AIEBaseISelLowering.cpp
@@ -534,3 +534,28 @@ void AIEBaseTargetLowering::alignFirstVASlot(CCState &CCInfo) {
 MVT AIEBaseTargetLowering::getVectorIdxTy(const DataLayout &DL) const {
   return MVT::i32;
 }
+
+unsigned AIEBaseTargetLowering::getNumRegistersForCallingConv(
+    LLVMContext &Context, CallingConv::ID CC, EVT VT) const {
+  if (VT == MVT::i64 || VT == MVT::f64) {
+    return 2;
+  }
+  return TargetLowering::getNumRegistersForCallingConv(Context, CC, VT);
+}
+
+MVT AIEBaseTargetLowering::getRegisterTypeForCallingConvAssignment(
+    LLVMContext &Context, CallingConv::ID CC, EVT VT) const {
+  if (VT == MVT::i64 || VT == MVT::f64)
+    return MVT::i32;
+
+  return TargetLowering::getRegisterTypeForCallingConv(Context, CC, VT);
+}
+
+MVT AIEBaseTargetLowering::getRegisterTypeForCallingConv(LLVMContext &Context,
+                                                         CallingConv::ID CC,
+                                                         EVT VT) const {
+  if (VT == MVT::i64 || VT == MVT::f64)
+    return MVT::i32;
+
+  return TargetLowering::getRegisterTypeForCallingConv(Context, CC, VT);
+}

--- a/llvm/lib/Target/AIE/AIEBaseISelLowering.h
+++ b/llvm/lib/Target/AIE/AIEBaseISelLowering.h
@@ -64,6 +64,10 @@ public:
   /// Returns the alignment for arguments on the stack.
   static Align getStackArgumentAlignment() { return Align(4); }
 
+  virtual unsigned getNumRegistersForCallingConv(LLVMContext &Context,
+                                                 CallingConv::ID CC,
+                                                 EVT VT) const override;
+
   /// Return the type to be used for assigning \p VT to a CC register decided by
   /// the convention. This might be different from
   /// getRegisterTypeForCallingConv() when the type of the vreg to assign is
@@ -71,9 +75,11 @@ public:
   /// the former returns v4i32, while this returns v8i32.
   virtual MVT getRegisterTypeForCallingConvAssignment(LLVMContext &Context,
                                                       CallingConv::ID CC,
-                                                      EVT VT) const {
-    return TargetLowering::getRegisterTypeForCallingConv(Context, CC, VT);
-  }
+                                                      EVT VT) const;
+
+  virtual MVT getRegisterTypeForCallingConv(LLVMContext &Context,
+                                            CallingConv::ID CC,
+                                            EVT VT) const override;
 
 protected:
   bool isEligibleForTailCallOptimization(

--- a/llvm/lib/Target/AIE/aie2p/AIE2PRegisterInfo.td
+++ b/llvm/lib/Target/AIE/aie2p/AIE2PRegisterInfo.td
@@ -180,7 +180,7 @@ class AIE2PRegisterClass <int size, int align, list<ValueType> regTypes, dag reg
   }
 
   class AIE2PScalar64RegisterClass<dag reglist, RegAltNameIndex idx = NoRegAltName>
-      : AIE2PRegisterClass<64, 32, [v8i8, v4i16, v4bf16, v2i32, v2f32], reglist,
+      : AIE2PRegisterClass<64, 32, [i64, v8i8, v4i16, v4bf16, v2i32, v2f32], reglist,
                           idx>;
 
   def eL : AIE2PScalar64RegisterClass<(add l0, l1, l2, l3, l4, l5, l6, l7,

--- a/llvm/test/CodeGen/AIE/aie2p/fifo-loads.ll
+++ b/llvm/test/CodeGen/AIE/aie2p/fifo-loads.ll
@@ -20,7 +20,7 @@ define dso_local void @_Z17test_fifo_ld_fillRPDv64_DB8_R12fifo_state_t(ptr nocap
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
-; CHECK-NEXT:    mov p3, p0
+; CHECK-NEXT:    mov p2, p0
 ; CHECK-NEXT:    vlda lfl0, [p1, #0]
 ; CHECK-NEXT:    vlda lfh0, [p1, #64]
 ; CHECK-NEXT:    vldb.fill.512 [p0, lf0, r24]
@@ -32,7 +32,7 @@ define dso_local void @_Z17test_fifo_ld_fillRPDv64_DB8_R12fifo_state_t(ptr nocap
 ; CHECK-NEXT:    st r24, [p1, dj0] // Delay Slot 5
 ; CHECK-NEXT:    vst lfl0, [p1, #0] // Delay Slot 4
 ; CHECK-NEXT:    vst lfh0, [p1, #64] // Delay Slot 3
-; CHECK-NEXT:    st p0, [p3, #0] // Delay Slot 2
+; CHECK-NEXT:    st p0, [p2, #0] // Delay Slot 2
 ; CHECK-NEXT:    nop // Delay Slot 1
 entry:
   %pos1.i = getelementptr inbounds i8, ptr %s, i20 128
@@ -58,7 +58,7 @@ define dso_local noundef <64 x i8> @_Z16test_fifo_ld_popRPDv64_DB8_R12fifo_state
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
-; CHECK-NEXT:    mov p3, p0
+; CHECK-NEXT:    mov p2, p0
 ; CHECK-NEXT:    vlda lfl0, [p1, #0]
 ; CHECK-NEXT:    vlda lfh0, [p1, #64]
 ; CHECK-NEXT:    vldb.pop.512 x0, [p0, lf0, r24]
@@ -70,7 +70,7 @@ define dso_local noundef <64 x i8> @_Z16test_fifo_ld_popRPDv64_DB8_R12fifo_state
 ; CHECK-NEXT:    st r24, [p1, dj0] // Delay Slot 5
 ; CHECK-NEXT:    vst lfl0, [p1, #0] // Delay Slot 4
 ; CHECK-NEXT:    vst lfh0, [p1, #64] // Delay Slot 3
-; CHECK-NEXT:    st p0, [p3, #0] // Delay Slot 2
+; CHECK-NEXT:    st p0, [p2, #0] // Delay Slot 2
 ; CHECK-NEXT:    nop // Delay Slot 1
 entry:
   %pos1.i = getelementptr inbounds i8, ptr %s, i20 128
@@ -97,7 +97,7 @@ define dso_local noundef <64 x i8> @_Z24test_fifo_ld_pop_1d_byteRPDv64_DB8_R12fi
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
-; CHECK-NEXT:    mov p3, p0
+; CHECK-NEXT:    mov p2, p0
 ; CHECK-NEXT:    vlda lfl0, [p1, #0]
 ; CHECK-NEXT:    vlda lfh0, [p1, #64]; mov m0, r0
 ; CHECK-NEXT:    vldb.pop.512 x0, [p0, lf0, r24, m0]
@@ -109,7 +109,7 @@ define dso_local noundef <64 x i8> @_Z24test_fifo_ld_pop_1d_byteRPDv64_DB8_R12fi
 ; CHECK-NEXT:    st r24, [p1, dj0] // Delay Slot 5
 ; CHECK-NEXT:    vst lfl0, [p1, #0] // Delay Slot 4
 ; CHECK-NEXT:    vst lfh0, [p1, #64] // Delay Slot 3
-; CHECK-NEXT:    st p0, [p3, #0] // Delay Slot 2
+; CHECK-NEXT:    st p0, [p2, #0] // Delay Slot 2
 ; CHECK-NEXT:    nop // Delay Slot 1
 entry:
   %pos1.i = getelementptr inbounds i8, ptr %s, i20 128
@@ -138,7 +138,7 @@ define dso_local noundef <64 x i8> @_Z24test_fifo_ld_pop_2d_byteRPDv64_DB8_R12fi
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    mov m0, r0
-; CHECK-NEXT:    mov p4, p0
+; CHECK-NEXT:    mov p3, p0
 ; CHECK-NEXT:    vlda lfl0, [p1, #0]; mov dn0, r1
 ; CHECK-NEXT:    vlda lfh0, [p1, #64]; mov dj0, r2
 ; CHECK-NEXT:    vldb.pop.512.2d x0, [p0, lf0, r24, d0]
@@ -150,7 +150,7 @@ define dso_local noundef <64 x i8> @_Z24test_fifo_ld_pop_2d_byteRPDv64_DB8_R12fi
 ; CHECK-NEXT:    st r24, [p1, dj1] // Delay Slot 5
 ; CHECK-NEXT:    vst lfl0, [p1, #0] // Delay Slot 4
 ; CHECK-NEXT:    vst lfh0, [p1, #64] // Delay Slot 3
-; CHECK-NEXT:    st p0, [p4, #0] // Delay Slot 2
+; CHECK-NEXT:    st p0, [p3, #0] // Delay Slot 2
 ; CHECK-NEXT:    nop // Delay Slot 1
 entry:
   %pos1.i = getelementptr inbounds i8, ptr %s, i20 128
@@ -242,7 +242,7 @@ define dso_local %struct.v64bfp16ebs8 @_Z16test_fifo_ld_popRP22v64bfp16ebs8_unal
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
-; CHECK-NEXT:    mov p3, p0
+; CHECK-NEXT:    mov p2, p0
 ; CHECK-NEXT:    vlda lfl0, [p1, #0]
 ; CHECK-NEXT:    vlda lfh0, [p1, #64]
 ; CHECK-NEXT:    vldb.pop.576 ex0, [p0, lf0, r24]
@@ -254,7 +254,7 @@ define dso_local %struct.v64bfp16ebs8 @_Z16test_fifo_ld_popRP22v64bfp16ebs8_unal
 ; CHECK-NEXT:    st r24, [p1, dj0] // Delay Slot 5
 ; CHECK-NEXT:    vst lfl0, [p1, #0] // Delay Slot 4
 ; CHECK-NEXT:    vst lfh0, [p1, #64] // Delay Slot 3
-; CHECK-NEXT:    st p0, [p3, #0] // Delay Slot 2
+; CHECK-NEXT:    st p0, [p2, #0] // Delay Slot 2
 ; CHECK-NEXT:    nop // Delay Slot 1
 entry:
   %pos1.i = getelementptr inbounds i8, ptr %s, i20 128
@@ -284,7 +284,7 @@ define dso_local %struct.v64bfp16ebs8 @_Z24test_fifo_ld_pop_1d_byteRP22v64bfp16e
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
-; CHECK-NEXT:    mov p3, p0
+; CHECK-NEXT:    mov p2, p0
 ; CHECK-NEXT:    vlda lfl0, [p1, #0]
 ; CHECK-NEXT:    vlda lfh0, [p1, #64]; mov m0, r0
 ; CHECK-NEXT:    vldb.pop.576 ex0, [p0, lf0, r24, m0]
@@ -296,7 +296,7 @@ define dso_local %struct.v64bfp16ebs8 @_Z24test_fifo_ld_pop_1d_byteRP22v64bfp16e
 ; CHECK-NEXT:    st r24, [p1, dj0] // Delay Slot 5
 ; CHECK-NEXT:    vst lfl0, [p1, #0] // Delay Slot 4
 ; CHECK-NEXT:    vst lfh0, [p1, #64] // Delay Slot 3
-; CHECK-NEXT:    st p0, [p3, #0] // Delay Slot 2
+; CHECK-NEXT:    st p0, [p2, #0] // Delay Slot 2
 ; CHECK-NEXT:    nop // Delay Slot 1
 entry:
   %pos1.i = getelementptr inbounds i8, ptr %s, i20 128
@@ -328,7 +328,7 @@ define dso_local %struct.v64bfp16ebs8 @_Z24test_fifo_ld_pop_2d_byteRP22v64bfp16e
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    mov m0, r0
-; CHECK-NEXT:    mov p4, p0
+; CHECK-NEXT:    mov p3, p0
 ; CHECK-NEXT:    vlda lfl0, [p1, #0]; mov dn0, r1
 ; CHECK-NEXT:    vlda lfh0, [p1, #64]; mov dj0, r2
 ; CHECK-NEXT:    vldb.pop.576.2d ex0, [p0, lf0, r24, d0]
@@ -340,7 +340,7 @@ define dso_local %struct.v64bfp16ebs8 @_Z24test_fifo_ld_pop_2d_byteRP22v64bfp16e
 ; CHECK-NEXT:    st r24, [p1, dj1] // Delay Slot 5
 ; CHECK-NEXT:    vst lfl0, [p1, #0] // Delay Slot 4
 ; CHECK-NEXT:    vst lfh0, [p1, #64] // Delay Slot 3
-; CHECK-NEXT:    st p0, [p4, #0] // Delay Slot 2
+; CHECK-NEXT:    st p0, [p3, #0] // Delay Slot 2
 ; CHECK-NEXT:    nop // Delay Slot 1
 entry:
   %pos1.i = getelementptr inbounds i8, ptr %s, i20 128
@@ -438,7 +438,7 @@ define dso_local %struct.v64bfp16ebs16 @_Z16test_fifo_ld_popRP23v64bfp16ebs16_un
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
-; CHECK-NEXT:    mov p3, p0
+; CHECK-NEXT:    mov p2, p0
 ; CHECK-NEXT:    vlda lfl0, [p1, #0]
 ; CHECK-NEXT:    vlda lfh0, [p1, #64]
 ; CHECK-NEXT:    vldb.pop.544 ex0, [p0, lf0, r24]
@@ -450,7 +450,7 @@ define dso_local %struct.v64bfp16ebs16 @_Z16test_fifo_ld_popRP23v64bfp16ebs16_un
 ; CHECK-NEXT:    st r24, [p1, dj0] // Delay Slot 5
 ; CHECK-NEXT:    vst lfl0, [p1, #0] // Delay Slot 4
 ; CHECK-NEXT:    vst lfh0, [p1, #64] // Delay Slot 3
-; CHECK-NEXT:    st p0, [p3, #0] // Delay Slot 2
+; CHECK-NEXT:    st p0, [p2, #0] // Delay Slot 2
 ; CHECK-NEXT:    nop // Delay Slot 1
 entry:
   %pos1.i = getelementptr inbounds i8, ptr %s, i20 128
@@ -480,7 +480,7 @@ define dso_local %struct.v64bfp16ebs16 @_Z24test_fifo_ld_pop_1d_byteRP23v64bfp16
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
-; CHECK-NEXT:    mov p3, p0
+; CHECK-NEXT:    mov p2, p0
 ; CHECK-NEXT:    vlda lfl0, [p1, #0]
 ; CHECK-NEXT:    vlda lfh0, [p1, #64]; mov m0, r0
 ; CHECK-NEXT:    vldb.pop.544 ex0, [p0, lf0, r24, m0]
@@ -492,7 +492,7 @@ define dso_local %struct.v64bfp16ebs16 @_Z24test_fifo_ld_pop_1d_byteRP23v64bfp16
 ; CHECK-NEXT:    st r24, [p1, dj0] // Delay Slot 5
 ; CHECK-NEXT:    vst lfl0, [p1, #0] // Delay Slot 4
 ; CHECK-NEXT:    vst lfh0, [p1, #64] // Delay Slot 3
-; CHECK-NEXT:    st p0, [p3, #0] // Delay Slot 2
+; CHECK-NEXT:    st p0, [p2, #0] // Delay Slot 2
 ; CHECK-NEXT:    nop // Delay Slot 1
 entry:
   %pos1.i = getelementptr inbounds i8, ptr %s, i20 128
@@ -524,7 +524,7 @@ define dso_local %struct.v64bfp16ebs16 @_Z24test_fifo_ld_pop_2d_byteRP23v64bfp16
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    mov m0, r0
-; CHECK-NEXT:    mov p4, p0
+; CHECK-NEXT:    mov p3, p0
 ; CHECK-NEXT:    vlda lfl0, [p1, #0]; mov dn0, r1
 ; CHECK-NEXT:    vlda lfh0, [p1, #64]; mov dj0, r2
 ; CHECK-NEXT:    vldb.pop.544.2d ex0, [p0, lf0, r24, d0]
@@ -536,7 +536,7 @@ define dso_local %struct.v64bfp16ebs16 @_Z24test_fifo_ld_pop_2d_byteRP23v64bfp16
 ; CHECK-NEXT:    st r24, [p1, dj1] // Delay Slot 5
 ; CHECK-NEXT:    vst lfl0, [p1, #0] // Delay Slot 4
 ; CHECK-NEXT:    vst lfh0, [p1, #64] // Delay Slot 3
-; CHECK-NEXT:    st p0, [p4, #0] // Delay Slot 2
+; CHECK-NEXT:    st p0, [p3, #0] // Delay Slot 2
 ; CHECK-NEXT:    nop // Delay Slot 1
 entry:
   %pos1.i = getelementptr inbounds i8, ptr %s, i20 128


### PR DESCRIPTION
This is needed to be able to write TableGen selection patterns using this type.
We still want to pass 64-bit values as 2 x 32-bit GPRs in CallLowering.
This should be NFC, apart from making i64 available in TableGen patterns.