### PR TITLE
ci: remove volume mount in container

### DIFF
--- a/.github/workflows/llvm-project-tests.yml
+++ b/.github/workflows/llvm-project-tests.yml
@@ -73,8 +73,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     container:
       image: ${{(startsWith(matrix.os, 'ubuntu') && 'ghcr.io/llvm/ci-ubuntu-22.04:latest') || null}}
-      volumes:
-        - /mnt/:/mnt/
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
In order to enable self-hosted runners, I propose this PR which removes the directive to mount `/mnt/` from the host to the build container inside the `llvm-project-tests.yml` workflow file. The purpose of this mount is unclear as a build directory, which has been left behind from other, differently configured builds, breaks other workflows and can't be reused properly.

Please see [this PR](https://github.com/Xilinx/llvm-aie/pull/329) to confirm, that the workflows are working as expected on the self-hosted runner.