### PR TITLE
[AIE2P] VSHIFT pattern for bf16

### DIFF
--- a/llvm/lib/Target/AIE/aie2p/AIE2PInstrPatterns.td
+++ b/llvm/lib/Target/AIE/aie2p/AIE2PInstrPatterns.td
@@ -826,9 +826,11 @@ foreach intr = [VSHUFFLE_vec_shuffle_x, VSHUFFLE_vec_shuffle_bm] in {
 // VSHIFT Intrinsic (shift/shiftx/shift_bytes)
 def : Pat<(int_aie2p_vshift_I512_I512 VEC512:$s1, VEC512:$s2, 0x0, eR:$shift),
            (VSHIFT VEC512:$s1, VEC512:$s2, eR:$shift)>;
-def : Pat<(int_aie2p_vshift_I512_I512 VEC512:$s1, VEC512:$s2, mSs:$pre ,eR:$shift),
+def : Pat<(int_aie2p_vshift_bf512_bf512 VEC512:$s1, VEC512:$s2, 0x0, eR:$shift),
+           (VSHIFT VEC512:$s1, VEC512:$s2, eR:$shift)>;
+def : Pat<(int_aie2p_vshift_I512_I512 VEC512:$s1, VEC512:$s2, mSs:$pre, eR:$shift),
            (VSHIFT_ALIGN VEC512:$s1, mSs:$pre, VEC512:$s2, eR:$shift)>;
-def : Pat<(int_aie2p_vshift_bf512_bf512 VEC512:$s1, VEC512:$s2, mSs:$pre ,eR:$shift),
+def : Pat<(int_aie2p_vshift_bf512_bf512 VEC512:$s1, VEC512:$s2, mSs:$pre, eR:$shift),
            (VSHIFT_ALIGN VEC512:$s1, mSs:$pre, VEC512:$s2, eR:$shift)>;
 
 // VINSERT

--- a/llvm/test/CodeGen/AIE/aie2p/GlobalIsel/inst-select-shift.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/GlobalIsel/inst-select-shift.mir
@@ -125,3 +125,30 @@ body:             |
     $x0 = COPY %0:vregbank(<32 x s16>)
     PseudoRET implicit $lr, implicit $x0
 ...
+
+---
+name:            select_vshift_bf16
+alignment:       16
+legalized:       true
+regBankSelected: true
+body:             |
+  bb.1.entry:
+    liveins: $r0, $x2, $x4
+    ; CHECK-LABEL: name: select_vshift_bf16
+    ; CHECK: liveins: $r0, $x2, $x4
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:vec512 = COPY $x2
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:vec512 = COPY $x4
+    ; CHECK-NEXT: [[COPY2:%[0-9]+]]:er = COPY $r0
+    ; CHECK-NEXT: [[VSHIFT:%[0-9]+]]:vec512 = VSHIFT [[COPY]], [[COPY1]], [[COPY2]]
+    ; CHECK-NEXT: $x0 = COPY [[VSHIFT]]
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit $x0
+    %1:vregbank(<32 x s16>) = COPY $x2
+    %2:vregbank(<32 x s16>) = COPY $x4
+    %3:gprregbank(s32) = G_CONSTANT i32 0
+    %4:gprregbank(s32) = COPY $r0
+    %0:vregbank(<32 x s16>) = G_INTRINSIC intrinsic(@llvm.aie2p.vshift.bf512.bf512), %1:vregbank(<32 x s16>), %2:vregbank(<32 x s16>), %3:gprregbank(s32), %4:gprregbank(s32)
+    $x0 = COPY %0:vregbank(<32 x s16>)
+    PseudoRET implicit $lr, implicit $x0
+...
+


### PR DESCRIPTION
zero preshift can use VSHIFT in stead of VSHIFT.ALIGN. That allows to use an arbitrary GPR rather than the fixed r30, which eliminates many moves to r30 in MaxPool / AvgPool.