### PR TITLE
[AIE2p] Register re-allocation for BFP16 regs

### DIFF
--- a/llvm/lib/Target/AIE/aie2p/AIE2PRegisterInfo.cpp
+++ b/llvm/lib/Target/AIE/aie2p/AIE2PRegisterInfo.cpp
@@ -591,6 +591,11 @@ bool AIE2PRegisterInfo::isVecOrAccRegClass(
   if (AIE2P::ACC2048RegClass.hasSubClassEq(&RC))
     return true;
 
+  // BFP16 registers
+  if (AIE2P::VEC576RegClass.hasSubClassEq(&RC) ||
+      AIE2P::eEYRegClass.hasSubClassEq(&RC))
+    return true;
+
   return false;
 }
 

--- a/llvm/test/CodeGen/AIE/aie2p/ra/waw_reg_renaming.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/ra/waw_reg_renaming.mir
@@ -54,3 +54,89 @@ body:             |
   bb.2:
     PseudoRET implicit $lr
 ...
+
+# Make sure the VSHUFFLE get two new EX registers.
+# This is based on the innermost loop of Conv2D_bfp16
+---
+name:            vec576_reg
+alignment:       16
+legalized:       true
+tracksRegLiveness: true
+body:             |
+  ; CHECK-LABEL: name: vec576_reg
+  ; CHECK: bb.0:
+  ; CHECK-NEXT:   successors: %bb.1(0x80000000)
+  ; CHECK-NEXT:   liveins: $dm0, $m1, $p0, $p1, $p2, $p3, $p4, $p5, $r0, $r1, $r2, $r3, $r4, $r5, $r6, $d0_3d
+  ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT:   renamable $r1 = MOV_RLC_imm11_pseudo 780
+  ; CHECK-NEXT:   LoopStart $r0, 0
+  ; CHECK-NEXT:   renamable $r24 = MOV_RLC_imm11_pseudo 0
+  ; CHECK-NEXT:   renamable $r25 = MOV_RLC_imm11_pseudo 0
+  ; CHECK-NEXT:   renamable $dm3 = COPY $dm0
+  ; CHECK-NEXT:   renamable $dm2 = COPY $dm0
+  ; CHECK-NEXT:   renamable $dm1 = COPY $dm0
+  ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT: bb.1:
+  ; CHECK-NEXT:   successors: %bb.1(0x7c000000), %bb.2(0x04000000)
+  ; CHECK-NEXT:   liveins: $dm0, $dm1, $dm2, $dm3, $m1, $plfr0:0x0000000000484040, $plfr1:0x0000000000484040, $r1, $r4, $d0_3d:0x0003C00000200E00
+  ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT:   $p1, $lf1, $r25 = VLD_FILL_512_pseudo $p1, $lf1, $r25
+  ; CHECK-NEXT:   $p1, $lf1, $r25 = VLD_FILL_512_pseudo $p1, $lf1, $r25
+  ; CHECK-NEXT:   $p0, $lf0, $r24 = VLD_FILL_512_pseudo $p0, $lf0, $r24
+  ; CHECK-NEXT:   $ex0, $p1, $lf1, $r25 = VLD_POP_576_normal_pop_pseudo $p1, $lf1, $r25, implicit-def $srfifo_uf
+  ; CHECK-NEXT:   $ex2, $p1, $lf1, $r25, $dc0, $dc4 = VLD_POP_576_3D_pseudo $p1, $lf1, $r25, $d0_3d, implicit-def $srfifo_uf
+  ; CHECK-NEXT:   $ex4, $p0, $lf0, $r24 = VLD_POP_576_normal_pop_pseudo $p0, $lf0, $r24, implicit-def $srfifo_uf
+  ; CHECK-NEXT:   $ex6, $p0, $lf0, $r24 = VLD_POP_576_fifo_1d_pop_pseudo $p0, $lf0, $r24, $m1, implicit-def $srfifo_uf
+  ; CHECK-NEXT:   renamable $ex8 = VSHUFFLE_vec_shuffle_ex renamable $ex0, renamable $ex2, renamable $r4
+  ; CHECK-NEXT:   renamable $ex10 = VSHUFFLE_vec_shuffle_ex killed renamable $ex0, killed renamable $ex2, renamable $r4
+  ; CHECK-NEXT:   renamable $dm0 = VMAC_f_vmac_bfp_vmul_bfp_core_EX_EX killed renamable $dm0, renamable $ex8, renamable $ex4, renamable $r1, implicit-def dead $srfpflags, implicit $crfpmask
+  ; CHECK-NEXT:   renamable $dm1 = VMAC_f_vmac_bfp_vmul_bfp_core_EX_EX killed renamable $dm1, renamable $ex10, killed renamable $ex4, renamable $r1, implicit-def dead $srfpflags, implicit $crfpmask
+  ; CHECK-NEXT:   renamable $dm2 = VMAC_f_vmac_bfp_vmul_bfp_core_EX_EX killed renamable $dm2, killed renamable $ex8, renamable $ex6, renamable $r1, implicit-def dead $srfpflags, implicit $crfpmask
+  ; CHECK-NEXT:   renamable $dm3 = VMAC_f_vmac_bfp_vmul_bfp_core_EX_EX killed renamable $dm3, killed renamable $ex10, killed renamable $ex6, renamable $r1, implicit-def dead $srfpflags, implicit $crfpmask
+  ; CHECK-NEXT:   PseudoLoopEnd <mcsymbol .L_LEnd0>, %bb.1
+  ; CHECK-NEXT:   PseudoJ_jump_imm %bb.2
+  ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT: bb.2:
+  ; CHECK-NEXT:   liveins: $dm0, $dm1, $dm2, $dm3
+  ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT:   PseudoRET implicit $lr, implicit killed renamable $dm3, implicit killed renamable $dm2, implicit killed renamable $dm1, implicit killed renamable $dm0
+  bb.0:
+    successors: %bb.1(0x80000000)
+    liveins: $p0, $p1, $p2, $p3, $p4, $p5, $r0, $r1, $r2, $r3, $r4, $r5, $r6, $dm0, $d0_3d, $m1
+
+    undef %193.sub_ptr:epsrfldf = COPY $p0
+    undef %190.sub_ptr:epsrfldf = COPY $p1
+    %17:em = COPY $m1
+    %18:er = COPY $r4
+    %156:eds = COPY $d0_3d
+    %105:er = MOV_RLC_imm11_pseudo 780
+    LoopStart $r0, 0
+    %193.sub_avail:epsrfldf = MOV_RLC_imm11_pseudo 0
+    %190.sub_avail:epsrfldf = MOV_RLC_imm11_pseudo 0
+    %6:acc2048 = COPY $dm0
+    %7:acc2048 = COPY $dm0
+    %8:acc2048 = COPY $dm0
+    %9:acc2048 = COPY $dm0
+
+  bb.1:
+    successors: %bb.1(0x7c000000), %bb.2(0x04000000)
+
+    %190.sub_ptr:epsrfldf, %190.sub_fifo:epsrfldf, %190.sub_avail:epsrfldf = VLD_FILL_512_pseudo %190.sub_ptr, %190.sub_fifo, %190.sub_avail
+    %190.sub_ptr:epsrfldf, %190.sub_fifo:epsrfldf, %190.sub_avail:epsrfldf = VLD_FILL_512_pseudo %190.sub_ptr, %190.sub_fifo, %190.sub_avail
+    %193.sub_ptr:epsrfldf, %193.sub_fifo:epsrfldf, %193.sub_avail:epsrfldf = VLD_FILL_512_pseudo %193.sub_ptr, %193.sub_fifo, %193.sub_avail
+    %150:vec576, %190.sub_ptr:epsrfldf, %190.sub_fifo:epsrfldf, %190.sub_avail:epsrfldf = VLD_POP_576_normal_pop_pseudo %190.sub_ptr, %190.sub_fifo, %190.sub_avail, implicit-def $srfifo_uf
+    %151:vec576, %190.sub_ptr:epsrfldf, %190.sub_fifo:epsrfldf, %190.sub_avail:epsrfldf, %156.sub_dim_count:eds, %156.sub_hi_dim_then_sub_dim_count:eds = VLD_POP_576_3D_pseudo %190.sub_ptr, %190.sub_fifo, %190.sub_avail, %156, implicit-def $srfifo_uf
+    %146:vec576, %193.sub_ptr:epsrfldf, %193.sub_fifo:epsrfldf, %193.sub_avail:epsrfldf = VLD_POP_576_normal_pop_pseudo %193.sub_ptr, %193.sub_fifo, %193.sub_avail, implicit-def $srfifo_uf
+    %142:vec576, %193.sub_ptr:epsrfldf, %193.sub_fifo:epsrfldf, %193.sub_avail:epsrfldf = VLD_POP_576_fifo_1d_pop_pseudo %193.sub_ptr, %193.sub_fifo, %193.sub_avail, %17, implicit-def $srfifo_uf
+    %145:vec576 = VSHUFFLE_vec_shuffle_ex %150, %151, %18
+    %143:vec576 = VSHUFFLE_vec_shuffle_ex %150, %151, %18
+    %9:acc2048 = VMAC_f_vmac_bfp_vmul_bfp_core_EX_EX %9, %145, %146, %105, implicit-def dead $srfpflags, implicit $crfpmask
+    %8:acc2048 = VMAC_f_vmac_bfp_vmul_bfp_core_EX_EX %8, %143, %146, %105, implicit-def dead $srfpflags, implicit $crfpmask
+    %7:acc2048 = VMAC_f_vmac_bfp_vmul_bfp_core_EX_EX %7, %145, %142, %105, implicit-def dead $srfpflags, implicit $crfpmask
+    %6:acc2048 = VMAC_f_vmac_bfp_vmul_bfp_core_EX_EX %6, %143, %142, %105, implicit-def dead $srfpflags, implicit $crfpmask
+    PseudoLoopEnd <mcsymbol .L_LEnd0>, %bb.1
+    PseudoJ_jump_imm %bb.2
+
+  bb.2:
+    PseudoRET implicit $lr, implicit %6, implicit %7, implicit %8, implicit %9
+...


### PR DESCRIPTION
Enable register re-allocation for EX/EY registers. Needed for Conv2D_bfp16