### PR TITLE
[AIE2P] Support more instructions for 2D/3D operand splitting

### DIFF
--- a/llvm/lib/Target/AIE/AIE2InstrInfo.cpp
+++ b/llvm/lib/Target/AIE/AIE2InstrInfo.cpp
@@ -1403,6 +1403,12 @@ AIE2InstrInfo::getTiedRegInfo(unsigned Opcode) const {
   }
 }
 
+TiedRegOperands
+AIE2InstrInfo::getTiedRegInfoForSplitting(unsigned Opcode) const {
+  assert(getTiedRegInfo(Opcode).size() == 1);
+  return getTiedRegInfo(Opcode).front();
+}
+
 bool AIE2InstrInfo::isHardwareLoopDec(unsigned Opcode) const {
   return Opcode == AIE2::LoopDec;
 }

--- a/llvm/lib/Target/AIE/AIE2InstrInfo.h
+++ b/llvm/lib/Target/AIE/AIE2InstrInfo.h
@@ -134,6 +134,8 @@ public:
   std::optional<unsigned>
   getOpcodeWithAtomicOperands(unsigned Opcode) const override;
 
+  TiedRegOperands getTiedRegInfoForSplitting(unsigned Opcode) const override;
+
   std::optional<unsigned>
   getOpcodeWithTupleOperands(unsigned Opcode) const override;
 

--- a/llvm/lib/Target/AIE/AIEBaseInstrInfo.h
+++ b/llvm/lib/Target/AIE/AIEBaseInstrInfo.h
@@ -366,6 +366,11 @@ struct AIEBaseInstrInfo : public TargetInstrInfo {
     return getTiedRegInfo(MI.getOpcode());
   }
 
+  /// Information about tied operands which can be splitted.
+  virtual TiedRegOperands getTiedRegInfoForSplitting(unsigned Opcode) const {
+    return {};
+  }
+
   /// Finds the opcode that is equivalent to \p Opcode except some operands
   /// are expanded into multiple sub-registers operands to facilitate register
   /// allocation.

--- a/llvm/lib/Target/AIE/AIESplitInstructionRewriter.cpp
+++ b/llvm/lib/Target/AIE/AIESplitInstructionRewriter.cpp
@@ -68,8 +68,8 @@ bool AIESplitInstrBuilder::runOnMachineFunction(MachineFunction &MF) {
     for (MachineInstr &MI : make_early_inc_range(MBB)) {
       if (std::optional<unsigned> SplitOpcode =
               TII.getOpcodeWithAtomicOperands(MI.getOpcode())) {
-        assert(TII.getTiedRegInfo(MI).size() == 1);
-        rewriteInstruction(TII.getTiedRegInfo(MI).front(), MI, *SplitOpcode);
+        rewriteInstruction(TII.getTiedRegInfoForSplitting(MI.getOpcode()), MI,
+                           *SplitOpcode);
       }
     }
   }
@@ -178,8 +178,7 @@ bool AIESplitInstrReplacer::runOnMachineFunction(MachineFunction &MF) {
     for (MachineInstr &MI : make_early_inc_range(MBB)) {
       if (std::optional<unsigned> OpcodeWithTuple =
               TII.getOpcodeWithTupleOperands(MI.getOpcode())) {
-        assert(TII.getTiedRegInfo(*OpcodeWithTuple).size() == 1);
-        rewriteInstruction(TII.getTiedRegInfo(*OpcodeWithTuple).front(), MI,
+        rewriteInstruction(TII.getTiedRegInfoForSplitting(*OpcodeWithTuple), MI,
                            *OpcodeWithTuple);
       }
     }

--- a/llvm/lib/Target/AIE/AIETiedRegOperands.cpp
+++ b/llvm/lib/Target/AIE/AIETiedRegOperands.cpp
@@ -25,3 +25,10 @@ TiedRegOperands::findOperandInfo(unsigned OpIdx) const {
   }
   return nullptr;
 }
+
+bool TiedRegOperands::canSplitSrcOps() const {
+  assert(SrcOps.size() == 1 && "Expected only one SrcOp (NoSubRegister) ");
+
+  const auto &SrcSubRegsSplit = SrcOps.front().SubRegsSplit;
+  return SrcSubRegsSplit.size() > 0;
+}

--- a/llvm/lib/Target/AIE/AIETiedRegOperands.h
+++ b/llvm/lib/Target/AIE/AIETiedRegOperands.h
@@ -59,6 +59,9 @@ struct TiedRegOperands {
 
   /// Find the OperandSubRegMapping for the operand at index \p OpIdx, if any.
   const OperandSubRegMapping *findOperandInfo(unsigned OpIdx) const;
+
+  ///
+  bool canSplitSrcOps() const;
 };
 
 } // end namespace llvm

--- a/llvm/lib/Target/AIE/aie2p/AIE2PInstrInfo.cpp
+++ b/llvm/lib/Target/AIE/aie2p/AIE2PInstrInfo.cpp
@@ -1635,6 +1635,21 @@ AIE2PInstrInfo::getTiedRegInfo(unsigned Opcode) const {
   }
 }
 
+TiedRegOperands
+AIE2PInstrInfo::getTiedRegInfoForSplitting(unsigned Opcode) const {
+  const auto &TiedRegInfoVector = getTiedRegInfo(Opcode);
+  unsigned Size = TiedRegInfoVector.size();
+  assert(Size >= 1 && "Expected to have tied register info");
+
+  for (auto &TiedRegInfo : TiedRegInfoVector) {
+    if (TiedRegInfo.SrcOps.size() > 1)
+      continue;
+    if (TiedRegInfo.canSplitSrcOps())
+      return TiedRegInfo;
+  }
+  return {};
+}
+
 unsigned AIE2PInstrInfo::getNumBypassedCycles(
     const InstrItineraryData *ItinData, const MachineInstr &DefMI,
     unsigned DefIdx, const MachineInstr &UseMI, unsigned UseIdx) const {

--- a/llvm/lib/Target/AIE/aie2p/AIE2PInstrInfo.h
+++ b/llvm/lib/Target/AIE/aie2p/AIE2PInstrInfo.h
@@ -135,6 +135,8 @@ public:
   std::optional<unsigned>
   getOpcodeWithAtomicOperands(unsigned Opcode) const override;
 
+  TiedRegOperands getTiedRegInfoForSplitting(unsigned Opcode) const override;
+
   std::optional<unsigned>
   getOpcodeWithTupleOperands(unsigned Opcode) const override;
 

--- a/llvm/lib/Target/AIE/aie2p/AIE2PInstrInfo.td
+++ b/llvm/lib/Target/AIE/aie2p/AIE2PInstrInfo.td
@@ -133,7 +133,7 @@ let hasDelaySlot = true, isBranch = true, isTerminator = true,
 include "aie2p/AIE2PMultiSlotPseudoInstrInfo.td"
 // Define _split variants for instructions using 2D registers
 class Split2DInstr<Instruction RealInst, int opidx> : SplitPseudo<RealInst,
-    opidx, (ins eM:$mod, eDN:$dim_size, eDJ:$dim_stride, eDC:$dim_count)> {}
+    opidx, (ins eM:$mod_2d, eDN:$dim_size, eDJ:$dim_stride, eDC:$dim_count)> {}
 
 foreach instr = [PADDA_2D, PADDB_2D, PADDS_2D, PADD_2D_pseudo] in
     def instr # _split : Split2DInstr<instr, /*opidx=*/3>;
@@ -192,6 +192,18 @@ foreach instr = [
   VST_2D_SRS_4x_dmx_sts_srs_dm_srsSign0,
   VST_2D_SRS_4x_dmx_sts_srs_dm_srsSign1] in
     def instr # _split : Split2DInstr<instr, /*opidx=*/5>;
+
+foreach instr = [
+     VST_FLUSH_512_2D, VST_FLUSH_512_CONV_2D] in
+    def instr # _split : Split2DInstr<instr, /*opidx=*/7>;
+
+foreach instr = [
+    VLDA_POP_512_2D, VLDA_POP_544_2D, VLDA_POP_576_2D, VLDA_POP_640_2D,
+    VLDA_POP_704_2D, VLDB_POP_512_2D, VLDB_POP_544_2D, VLDB_POP_576_2D,
+    VLDB_POP_640_2D, VLDB_POP_704_2D,
+    VLD_POP_512_2D_pseudo, VLD_POP_544_2D_pseudo, VLD_POP_576_2D_pseudo, 
+    VLD_POP_640_2D_pseudo, VLD_POP_704_2D_pseudo] in
+    def instr # _split : Split2DInstr<instr, /*opidx=*/8>;
 
 // Define _split variants for instructions using 3D registers
 class Split3DInstr<Instruction RealInst, int opidx> : SplitPseudo<RealInst,
@@ -262,6 +274,17 @@ foreach instr = [ VLDA_3D_UPS_2x_dmw_lda_ups_w2b_upsSign0,
   VST_3D_SRS_4x_dmx_sts_srs_dm_srsSign1] in   
     def instr # _split : Split3DInstr<instr, /*opidx=*/6>;
 
+foreach instr = [
+    VST_FLUSH_512_3D, VST_FLUSH_512_CONV_3D] in
+    def instr # _split : Split3DInstr<instr, /*opidx=*/8>;
+
+foreach instr = [
+    VLDA_POP_512_3D, VLDA_POP_544_3D, VLDA_POP_576_3D, VLDA_POP_640_3D,
+    VLDA_POP_704_3D, VLDB_POP_512_3D, VLDB_POP_544_3D, VLDB_POP_576_3D,
+    VLDB_POP_640_3D, VLDB_POP_704_3D,
+    VLD_POP_512_3D_pseudo, VLD_POP_544_3D_pseudo, VLD_POP_576_3D_pseudo,
+    VLD_POP_640_3D_pseudo, VLD_POP_704_3D_pseudo] in
+    def instr # _split : Split3DInstr<instr, /*opidx=*/9>;
 
 let hasSideEffects = 0, Uses = [sp] in {
 let mayLoad = false, mayStore = true in {

--- a/llvm/lib/Target/AIE/aie2p/AIE2PInstrInfo.td
+++ b/llvm/lib/Target/AIE/aie2p/AIE2PInstrInfo.td
@@ -130,18 +130,138 @@ let hasDelaySlot = true, isBranch = true, isTerminator = true,
   }
 }
 
+include "aie2p/AIE2PMultiSlotPseudoInstrInfo.td"
 // Define _split variants for instructions using 2D registers
 class Split2DInstr<Instruction RealInst, int opidx> : SplitPseudo<RealInst,
     opidx, (ins eM:$mod, eDN:$dim_size, eDJ:$dim_stride, eDC:$dim_count)> {}
-foreach instr = [PADDA_2D, PADDB_2D, PADDS_2D] in
+
+foreach instr = [PADDA_2D, PADDB_2D, PADDS_2D, PADD_2D_pseudo] in
     def instr # _split : Split2DInstr<instr, /*opidx=*/3>;
+
+foreach instr = [
+  LDA_2D_dms_lda,
+  LDA_2D_s8,
+  LDA_2D_u16,
+  LDA_2D_u8,
+  LDA_TM_2D,
+  ST_2D_dms_sts,
+  ST_2D_dmv_sts_q,
+  ST_2D_s16,
+  ST_2D_s8,
+  ST_TM_2D,
+  VLDA_2D_128,
+  VLDA_2D_CONV_fp32_bf16_dmw_lda_ups_bf,
+  VLDA_2D_CONV_fp32_bf16_dmx_lda_ups_bf,
+  VLDA_2D_dmw_lda_w,
+  VLDA_2D_dmx_lda_bm,
+  VLDA_2D_dmx_lda_fifohl,
+  VLDA_2D_dmx_lda_x,
+  VLDB_2D_128,
+  VLDB_2D_UNPACK_dmw_ldb_unpack_unpackSign0,
+  VLDB_2D_UNPACK_dmw_ldb_unpack_unpackSign1,
+  VLDB_2D_UNPACK_dmx_ldb_unpack_unpackSign0,
+  VLDB_2D_UNPACK_dmx_ldb_unpack_unpackSign1,
+  VLDB_2D_dmw_ldb,
+  VLDB_2D_dmx_ldb_x,
+  VST_2D_128,
+  VST_2D_CONV_bf16_fp32_dmw_sts_srs_bf,
+  VST_2D_CONV_bf16_fp32_dmx_sts_srs_bf,
+  VST_2D_PACK_dmw_sts_pack_packSign0,
+  VST_2D_PACK_dmw_sts_pack_packSign1,
+  VST_2D_PACK_dmx_sts_pack_packSign0,
+  VST_2D_PACK_dmx_sts_pack_packSign1,
+  VST_2D_dmw_sts_w,
+  VST_2D_dmx_sts_bm,
+  VST_2D_dmx_sts_fifohl,
+  VST_2D_dmx_sts_x, VLD_2D_128_pseudo, VLD_2D_w_pseudo, VLD_2D_x_pseudo] in
+    def instr # _split : Split2DInstr<instr, /*opidx=*/4>;
+
+foreach instr = [
+  VLDA_2D_UPS_2x_dmw_lda_ups_w2b_upsSign0,
+  VLDA_2D_UPS_2x_dmw_lda_ups_w2b_upsSign1,
+  VLDA_2D_UPS_2x_dmx_lda_ups_x2c_upsSign0,
+  VLDA_2D_UPS_2x_dmx_lda_ups_x2c_upsSign1,
+  VLDA_2D_UPS_4x_dmw_lda_ups_w2c_upsSign0,
+  VLDA_2D_UPS_4x_dmw_lda_ups_w2c_upsSign1, 
+  VST_2D_SRS_2x_dm_sts_srs_cm_srsSign0,
+  VST_2D_SRS_2x_dm_sts_srs_cm_srsSign1, 
+  VST_2D_SRS_2x_dmw_sts_srs_bm_srsSign0,
+  VST_2D_SRS_2x_dmw_sts_srs_bm_srsSign1, 
+  VST_2D_SRS_4x_dm_sts_srs_cm_srsSign0,
+  VST_2D_SRS_4x_dm_sts_srs_cm_srsSign1, 
+  VST_2D_SRS_4x_dmx_sts_srs_dm_srsSign0,
+  VST_2D_SRS_4x_dmx_sts_srs_dm_srsSign1] in
+    def instr # _split : Split2DInstr<instr, /*opidx=*/5>;
 
 // Define _split variants for instructions using 3D registers
 class Split3DInstr<Instruction RealInst, int opidx> : SplitPseudo<RealInst,
     opidx, (ins eM:$mod1, eDN:$dim_size1, eDJ:$dim_stride1, eDC:$dim_count1,
                 eM:$mod2, eDN:$dim_size2, eDJ:$dim_stride2, eDC:$dim_count2)> {}
-foreach instr = [PADDA_3D, PADDB_3D, PADDS_3D] in
+
+foreach instr = [PADDA_3D, PADDB_3D, PADDS_3D, PADD_3D_pseudo] in
     def instr # _split : Split3DInstr<instr, /*opidx=*/4>;
+
+foreach instr = [
+  LDA_3D_dms_lda,
+  LDA_3D_dmv_lda_q,
+  LDA_3D_s16,
+  LDA_3D_s8,
+  LDA_3D_u16,
+  LDA_3D_u8,
+  LDA_TM_3D,
+  ST_3D_dms_sts,
+  ST_3D_dmv_sts_q,
+  ST_3D_s16,
+  ST_3D_s8,
+  ST_TM_3D,
+  VLDA_3D_128,
+  VLDA_3D_CONV_fp32_bf16_dmw_lda_ups_bf,
+  VLDA_3D_CONV_fp32_bf16_dmx_lda_ups_bf,
+  VLDA_3D_dmw_lda_w,
+  VLDA_3D_dmx_lda_bm,
+  VLDA_3D_dmx_lda_fifohl,
+  VLDA_3D_dmx_lda_x,
+  VLDB_3D_128,
+  VLDB_3D_UNPACK_dmw_ldb_unpack_unpackSign0,
+  VLDB_3D_UNPACK_dmw_ldb_unpack_unpackSign1,
+  VLDB_3D_UNPACK_dmx_ldb_unpack_unpackSign0,
+  VLDB_3D_UNPACK_dmx_ldb_unpack_unpackSign1,
+  VLDB_3D_dmw_ldb,
+  VLDB_3D_dmx_ldb_x,
+  VST_3D_128,
+  VST_3D_CONV_bf16_fp32_dmw_sts_srs_bf,
+  VST_3D_CONV_bf16_fp32_dmx_sts_srs_bf,
+  VST_3D_PACK_dmw_sts_pack_packSign0,
+  VST_3D_PACK_dmw_sts_pack_packSign1,
+  VST_3D_PACK_dmx_sts_pack_packSign0,
+  VST_3D_PACK_dmx_sts_pack_packSign1,
+  VST_3D_dmw_sts_w,
+  VST_3D_dmx_sts_bm,
+  VST_3D_dmx_sts_fifohl,
+  VST_3D_dmx_sts_x,
+  VLD_3D_w_pseudo,
+  VLD_3D_x_pseudo,
+  VLD_3D_128_pseudo] in       
+    def instr # _split : Split3DInstr<instr, /*opidx=*/5>;
+
+foreach instr = [ VLDA_3D_UPS_2x_dmw_lda_ups_w2b_upsSign0,
+  VLDA_3D_UPS_2x_dmw_lda_ups_w2b_upsSign1, 
+  VLDA_3D_UPS_2x_dmx_lda_ups_x2c_upsSign0, 
+  VLDA_3D_UPS_2x_dmx_lda_ups_x2c_upsSign1, 
+  VLDA_3D_UPS_4x_dmw_lda_ups_w2c_upsSign0, 
+  VLDA_3D_UPS_4x_dmw_lda_ups_w2c_upsSign1, 
+  VLDA_3D_UPS_4x_dmx_lda_ups_x2d_upsSign0, 
+  VLDA_3D_UPS_4x_dmx_lda_ups_x2d_upsSign1, 
+  VST_3D_SRS_2x_dm_sts_srs_cm_srsSign0, 
+  VST_3D_SRS_2x_dm_sts_srs_cm_srsSign1, 
+  VST_3D_SRS_2x_dmw_sts_srs_bm_srsSign0, 
+  VST_3D_SRS_2x_dmw_sts_srs_bm_srsSign1, 
+  VST_3D_SRS_4x_dm_sts_srs_cm_srsSign0, 
+  VST_3D_SRS_4x_dm_sts_srs_cm_srsSign1, 
+  VST_3D_SRS_4x_dmx_sts_srs_dm_srsSign0, 
+  VST_3D_SRS_4x_dmx_sts_srs_dm_srsSign1] in   
+    def instr # _split : Split3DInstr<instr, /*opidx=*/6>;
+
 
 let hasSideEffects = 0, Uses = [sp] in {
 let mayLoad = false, mayStore = true in {
@@ -178,5 +298,5 @@ def VLDA_E_SPILL : Pseudo<(outs EXPVEC64:$dst), (ins c12n_step4:$imm), "vlda_e_s
 }
 }
 
-include "aie2p/AIE2PMultiSlotPseudoInstrInfo.td"
+
 include "aie2p/AIE2PInstrPatterns.td"

--- a/llvm/test/CodeGen/AIE/aie2p/ra/split-instrs-create.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/ra/split-instrs-create.mir
@@ -4,14 +4,14 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2024-2025 Advanced Micro Devices, Inc. or its affiliates
 # RUN: llc -O2 -mtriple=aie2p -verify-machineinstrs -run-pass=aie-split-instrs-create %s -o - | FileCheck %s
 
 # Verify that instructions are successfully rewritten into _split instructions
 # that expose sub-registers.
 
 ---
-name:            test_split_2D
+name:            test_split_2D_opIdx3
 alignment:       16
 legalized:       true
 regBankSelected: true
@@ -20,24 +20,71 @@ tracksRegLiveness: true
 body:             |
   bb.1.entry:
     liveins: $p0, $d1
-    ; CHECK-LABEL: name: test_split_2D
+    ; CHECK-LABEL: name: test_split_2D_opIdx3
     ; CHECK: liveins: $p0, $d1
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
     ; CHECK-NEXT: [[COPY1:%[0-9]+]]:ed = COPY $d1
-    ; CHECK-NEXT: [[COPY]]:ep, [[COPY1]].sub_dim_count:ed = PADDA_2D_split killed [[COPY]], killed [[COPY1]].sub_mod, killed [[COPY1]].sub_dim_size, killed [[COPY1]].sub_dim_stride, killed [[COPY1]].sub_dim_count
-    ; CHECK-NEXT: [[COPY]]:ep, [[COPY1]].sub_dim_count:ed = PADDB_2D_split killed [[COPY]], killed [[COPY1]].sub_mod, killed [[COPY1]].sub_dim_size, killed [[COPY1]].sub_dim_stride, killed [[COPY1]].sub_dim_count
-    ; CHECK-NEXT: dead [[COPY]]:ep, dead [[COPY1]].sub_dim_count:ed = PADDS_2D_split killed [[COPY]], killed [[COPY1]].sub_mod, killed [[COPY1]].sub_dim_size, killed [[COPY1]].sub_dim_stride, killed [[COPY1]].sub_dim_count
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep, [[COPY1:%[0-9]+]].sub_dim_count:ed = PADDA_2D_split killed [[COPY]], killed [[COPY1]].sub_mod, killed [[COPY1]].sub_dim_size, killed [[COPY1]].sub_dim_stride, killed [[COPY1]].sub_dim_count
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep, [[COPY1:%[0-9]+]].sub_dim_count:ed = PADDB_2D_split killed [[COPY]], killed [[COPY1]].sub_mod, killed [[COPY1]].sub_dim_size, killed [[COPY1]].sub_dim_stride, killed [[COPY1]].sub_dim_count
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep, [[COPY1:%[0-9]+]].sub_dim_count:ed = PADDS_2D_split killed [[COPY]], killed [[COPY1]].sub_mod, killed [[COPY1]].sub_dim_size, killed [[COPY1]].sub_dim_stride, killed [[COPY1]].sub_dim_count
+    ; CHECK-NEXT: dead [[COPY:%[0-9]+]]:ep, dead [[COPY1:%[0-9]+]].sub_dim_count:ed = PADD_2D_pseudo_split killed [[COPY]], killed [[COPY1]].sub_mod, killed [[COPY1]].sub_dim_size, killed [[COPY1]].sub_dim_stride, killed [[COPY1]].sub_dim_count
     %20:ep = COPY $p0
     %100:ed = COPY $d1
     %20:ep, %100.sub_dim_count:ed = PADDA_2D killed %20, killed %100
     %20:ep, %100.sub_dim_count:ed = PADDB_2D killed %20, killed %100
-    dead %20:ep, dead %100.sub_dim_count:ed = PADDS_2D killed %20, killed %100
+    %20:ep, %100.sub_dim_count:ed = PADDS_2D killed %20, killed %100
+    dead %20:ep, dead %100.sub_dim_count:ed = PADD_2D_pseudo killed %20, killed %100
 ...
+
+---
+name:            test_split_2D_opIdx4
+alignment:       16
+legalized:       true
+regBankSelected: true
+selected:        true
+tracksRegLiveness: true
+body:             |
+  bb.1.entry:
+    liveins: $p0, $d1, $sfh
+    ; CHECK-LABEL: name: test_split_2D_opIdx4
+    ; CHECK: liveins: $p0, $d1, $sfh
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:ed = COPY $d1
+    ; CHECK-NEXT: $r4, [[COPY]]:ep, [[COPY1]].sub_dim_count:ed = LDA_2D_dms_lda_split killed [[COPY]], killed [[COPY1]].sub_mod, killed [[COPY1]].sub_dim_size, killed [[COPY1]].sub_dim_stride, killed [[COPY1]].sub_dim_count
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep, [[COPY1:%[0-9]+]].sub_dim_count:ed = VST_2D_dmx_sts_fifohl_split $sfh, killed [[COPY]], killed [[COPY1]].sub_mod, killed [[COPY1]].sub_dim_size, killed [[COPY1]].sub_dim_stride, killed [[COPY1]].sub_dim_count
+    %20:ep = COPY $p0
+    %100:ed = COPY $d1
+    $r4, %20:ep, %100.sub_dim_count:ed = LDA_2D_dms_lda killed %20, killed %100
+    %20:ep, %100.sub_dim_count:ed = VST_2D_dmx_sts_fifohl $sfh, killed %20, killed %100
+...
+
+---
+name:            test_split_2D_opIdx5
+alignment:       16
+legalized:       true
+regBankSelected: true
+selected:        true
+tracksRegLiveness: true
+body:             |
+  bb.1.entry:
+    liveins: $p0, $d1, $s0
+    ; CHECK-LABEL: name: test_split_2D_opIdx5
+    ; CHECK: liveins: $p0, $d1, $s0
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:ed = COPY $d1
+    ; CHECK-NEXT: $bmhh0, [[COPY]]:ep, [[COPY1]].sub_dim_count:ed = VLDA_2D_UPS_2x_dmw_lda_ups_w2b_upsSign0_split $s0, killed [[COPY]], killed [[COPY1]].sub_mod, killed [[COPY1]].sub_dim_size, killed [[COPY1]].sub_dim_stride, killed [[COPY1]].sub_dim_count, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0
+    %20:ep = COPY $p0
+    %100:ed = COPY $d1
+    $bmhh0, %20:ep, %100.sub_dim_count:ed = VLDA_2D_UPS_2x_dmw_lda_ups_w2b_upsSign0 $s0, killed %20, killed %100, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0
+...
+
 
 # In particular, pay attention to undef for sub_hi_dim_then_sub_mod.
 ---
-name:            test_split_3D
+name:            test_split_3D_opIdx4
 alignment:       16
 legalized:       true
 regBankSelected: true
@@ -46,17 +93,57 @@ tracksRegLiveness: true
 body:             |
   bb.1.entry:
     liveins: $p0, $d1_3d
-    ; CHECK-LABEL: name: test_split_3D
+    ; CHECK-LABEL: name: test_split_3D_opIdx4
     ; CHECK: liveins: $p0, $d1_3d
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
     ; CHECK-NEXT: [[COPY1:%[0-9]+]]:eds = COPY $d1_3d
-    ; CHECK-NEXT: [[COPY]]:ep, [[COPY1]].sub_dim_count:eds, [[COPY1]].sub_hi_dim_then_sub_dim_count:eds = PADDA_3D_split killed [[COPY]], killed [[COPY1]].sub_mod, killed [[COPY1]].sub_dim_size, killed [[COPY1]].sub_dim_stride, killed [[COPY1]].sub_dim_count, killed undef [[COPY1]].sub_hi_dim_then_sub_mod, killed [[COPY1]].sub_hi_dim_then_sub_dim_size, killed [[COPY1]].sub_hi_dim_then_sub_dim_stride, killed [[COPY1]].sub_hi_dim_then_sub_dim_count
-    ; CHECK-NEXT: [[COPY]]:ep, [[COPY1]].sub_dim_count:eds, [[COPY1]].sub_hi_dim_then_sub_dim_count:eds = PADDB_3D_split killed [[COPY]], killed [[COPY1]].sub_mod, killed [[COPY1]].sub_dim_size, killed [[COPY1]].sub_dim_stride, killed [[COPY1]].sub_dim_count, killed undef [[COPY1]].sub_hi_dim_then_sub_mod, killed [[COPY1]].sub_hi_dim_then_sub_dim_size, killed [[COPY1]].sub_hi_dim_then_sub_dim_stride, killed [[COPY1]].sub_hi_dim_then_sub_dim_count
-    ; CHECK-NEXT: dead [[COPY]]:ep, dead [[COPY1]].sub_dim_count:eds, dead [[COPY1]].sub_hi_dim_then_sub_dim_count:eds = PADDS_3D_split killed [[COPY]], killed [[COPY1]].sub_mod, killed [[COPY1]].sub_dim_size, killed [[COPY1]].sub_dim_stride, killed [[COPY1]].sub_dim_count, killed undef [[COPY1]].sub_hi_dim_then_sub_mod, killed [[COPY1]].sub_hi_dim_then_sub_dim_size, killed [[COPY1]].sub_hi_dim_then_sub_dim_stride, killed [[COPY1]].sub_hi_dim_then_sub_dim_count
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep, [[COPY1:%[0-9]+]].sub_dim_count:eds, [[COPY1:%[0-9]+]].sub_hi_dim_then_sub_dim_count:eds = PADDA_3D_split killed [[COPY]], killed [[COPY1]].sub_mod, killed [[COPY1]].sub_dim_size, killed [[COPY1]].sub_dim_stride, killed [[COPY1]].sub_dim_count, killed undef [[COPY1]].sub_hi_dim_then_sub_mod, killed [[COPY1]].sub_hi_dim_then_sub_dim_size, killed [[COPY1]].sub_hi_dim_then_sub_dim_stride, killed [[COPY1]].sub_hi_dim_then_sub_dim_count
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep, [[COPY1:%[0-9]+]].sub_dim_count:eds, [[COPY1:%[0-9]+]].sub_hi_dim_then_sub_dim_count:eds = PADDB_3D_split killed [[COPY]], killed [[COPY1]].sub_mod, killed [[COPY1]].sub_dim_size, killed [[COPY1]].sub_dim_stride, killed [[COPY1]].sub_dim_count, killed undef [[COPY1]].sub_hi_dim_then_sub_mod, killed [[COPY1]].sub_hi_dim_then_sub_dim_size, killed [[COPY1]].sub_hi_dim_then_sub_dim_stride, killed [[COPY1]].sub_hi_dim_then_sub_dim_count
+    ; CHECK-NEXT: dead [[COPY:%[0-9]+]]:ep, dead [[COPY1:%[0-9]+]].sub_dim_count:eds, dead [[COPY1:%[0-9]+]].sub_hi_dim_then_sub_dim_count:eds = PADDS_3D_split killed [[COPY]], killed [[COPY1]].sub_mod, killed [[COPY1]].sub_dim_size, killed [[COPY1]].sub_dim_stride, killed [[COPY1]].sub_dim_count, killed undef [[COPY1]].sub_hi_dim_then_sub_mod, killed [[COPY1]].sub_hi_dim_then_sub_dim_size, killed [[COPY1]].sub_hi_dim_then_sub_dim_stride, killed [[COPY1]].sub_hi_dim_then_sub_dim_count
     %20:ep = COPY $p0
     %100:eds = COPY $d1_3d
     %20:ep, %100.sub_dim_count:eds, %100.sub_hi_dim_then_sub_dim_count:eds = PADDA_3D killed %20, killed %100
     %20:ep, %100.sub_dim_count:eds, %100.sub_hi_dim_then_sub_dim_count:eds = PADDB_3D killed %20, killed %100
     dead %20:ep, dead %100.sub_dim_count:eds, dead %100.sub_hi_dim_then_sub_dim_count:eds = PADDS_3D killed %20, killed %100
+...
+---
+name:            test_split_3D_opIdx5
+alignment:       16
+legalized:       true
+regBankSelected: true
+selected:        true
+tracksRegLiveness: true
+body:             |
+  bb.1.entry:
+    liveins: $p0, $d1_3d
+    ; CHECK-LABEL: name: test_split_3D_opIdx5
+    ; CHECK: liveins: $p0, $d1_3d
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:eds = COPY $d1_3d
+    ; CHECK-NEXT: $r4, [[COPY]]:ep, [[COPY1]].sub_dim_count:eds, [[COPY1]].sub_hi_dim_then_sub_dim_count:eds = LDA_3D_dms_lda_split killed [[COPY]], killed [[COPY1]].sub_mod, killed [[COPY1]].sub_dim_size, killed [[COPY1]].sub_dim_stride, killed [[COPY1]].sub_dim_count, killed undef [[COPY1]].sub_hi_dim_then_sub_mod, killed [[COPY1]].sub_hi_dim_then_sub_dim_size, killed [[COPY1]].sub_hi_dim_then_sub_dim_stride, killed [[COPY1]].sub_hi_dim_then_sub_dim_count
+    %20:ep = COPY $p0
+    %100:eds = COPY $d1_3d
+    $r4, %20:ep, %100.sub_dim_count:eds, %100.sub_hi_dim_then_sub_dim_count:eds = LDA_3D_dms_lda killed %20, killed %100
+...
+---
+name:            test_split_3D_opIdx6
+alignment:       16
+legalized:       true
+regBankSelected: true
+selected:        true
+tracksRegLiveness: true
+body:             |
+  bb.1.entry:
+    liveins: $p0, $d1_3d, $s0
+    ; CHECK-LABEL: name: test_split_3D_opIdx6
+    ; CHECK: liveins: $p0, $d1_3d, $s0
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p0
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:eds = COPY $d1_3d
+    ; CHECK-NEXT: [[VLDA_3D_UPS_4x_dmx_lda_ups_x2d_upsSign0_split:%[0-9]+]]:edm, [[COPY:%[0-9]+]]:ep, [[COPY1:%[0-9]+]].sub_dim_count:eds, [[COPY1:%[0-9]+]].sub_hi_dim_then_sub_dim_count:eds = VLDA_3D_UPS_4x_dmx_lda_ups_x2d_upsSign0_split $s0, [[COPY]], [[COPY1]].sub_mod, [[COPY1]].sub_dim_size, [[COPY1]].sub_dim_stride, [[COPY1]].sub_dim_count, undef [[COPY1]].sub_hi_dim_then_sub_mod, [[COPY1]].sub_hi_dim_then_sub_dim_size, [[COPY1]].sub_hi_dim_then_sub_dim_stride, [[COPY1]].sub_hi_dim_then_sub_dim_count, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0
+    %20:ep = COPY $p0
+    %100:eds = COPY $d1_3d
+    %0:edm, %20:ep, %100.sub_dim_count:eds, %100.sub_hi_dim_then_sub_dim_count:eds = VLDA_3D_UPS_4x_dmx_lda_ups_x2d_upsSign0 $s0, %20, %100, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0
 ...

--- a/llvm/test/CodeGen/AIE/aie2p/ra/split-instrs-create.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/ra/split-instrs-create.mir
@@ -81,6 +81,74 @@ body:             |
     $bmhh0, %20:ep, %100.sub_dim_count:ed = VLDA_2D_UPS_2x_dmw_lda_ups_w2b_upsSign0 $s0, killed %20, killed %100, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0
 ...
 
+---
+name:            test_split_2D_opIdx8
+alignment:       16
+legalized:       true
+regBankSelected: true
+selected:        true
+tracksRegLiveness: true
+body:             |
+  bb.1.entry:
+    liveins: $p0, $p1
+
+    ; CHECK-LABEL: name: test_split_2D_opIdx8
+    ; CHECK: liveins: $p0, $p1
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p1
+    ; CHECK-NEXT: undef [[MOV_PD_imm11_pseudo:%[0-9]+]].sub_mod:ed = MOV_PD_imm11_pseudo 0
+    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo:%[0-9]+]].sub_dim_size:ed = LDA_dms_lda_idx_imm [[COPY]], 0 :: (load (s20), align 4)
+    ; CHECK-NEXT: undef [[COPY1:%[0-9]+]].sub_ptr:epsrfldf = COPY $p0
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]].sub_avail:epsrfldf = MOV_RLC_imm11_pseudo 0
+    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo:%[0-9]+]].sub_dim_stride:ed = COPY [[MOV_PD_imm11_pseudo]].sub_mod
+    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo:%[0-9]+]].sub_dim_count:ed = COPY [[MOV_PD_imm11_pseudo]].sub_dim_size
+    ; CHECK-NEXT: [[VLD_POP_512_2D_pseudo_split:%[0-9]+]]:vec512, dead [[COPY1:%[0-9]+]].sub_ptr:epsrfldf, dead [[COPY1:%[0-9]+]].sub_fifo:epsrfldf, dead [[COPY1:%[0-9]+]].sub_avail:epsrfldf, dead [[MOV_PD_imm11_pseudo:%[0-9]+]].sub_dim_count:ed = VLD_POP_512_2D_pseudo_split [[COPY1]].sub_ptr, undef [[COPY1]].sub_fifo, [[COPY1]].sub_avail, [[MOV_PD_imm11_pseudo]].sub_mod, [[MOV_PD_imm11_pseudo]].sub_dim_size, [[MOV_PD_imm11_pseudo]].sub_dim_stride, [[MOV_PD_imm11_pseudo]].sub_dim_count, implicit-def $srfifo_uf
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[VLD_POP_512_2D_pseudo_split]]
+    %2:ep = COPY $p1
+    undef %13.sub_mod:ed = MOV_PD_imm11_pseudo 0
+    %13.sub_dim_size:ed = LDA_dms_lda_idx_imm %2, 0 :: (load (s20), align 4)
+    undef %16.sub_ptr:epsrfldf = COPY $p0
+    %16.sub_avail:epsrfldf = MOV_RLC_imm11_pseudo 0
+    %13.sub_dim_stride:ed = COPY %13.sub_mod
+    %13.sub_dim_count:ed = COPY %13.sub_dim_size
+    %7:vec512, dead %16.sub_ptr:epsrfldf, dead %16.sub_fifo:epsrfldf, dead %16.sub_avail:epsrfldf, dead %13.sub_dim_count:ed = VLD_POP_512_2D_pseudo %16.sub_ptr, undef %16.sub_fifo, %16.sub_avail, %13, implicit-def $srfifo_uf
+    PseudoRET implicit $lr, implicit %7
+...
+
+
+
+---
+name:            test_split_2D_opIdx7
+alignment:       16
+legalized:       true
+regBankSelected: true
+selected:        true
+tracksRegLiveness: true
+body:             |
+  bb.1.entry:
+    liveins: $p0, $p1, $sf, $r26
+
+    ; CHECK-LABEL: name: test_split_2D_opIdx7
+    ; CHECK: liveins: $p0, $p1, $sf, $r26
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:ep = COPY $p1
+    ; CHECK-NEXT: undef [[MOV_PD_imm11_pseudo:%[0-9]+]].sub_mod:ed = MOV_PD_imm11_pseudo 0
+    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo:%[0-9]+]].sub_dim_size:ed = LDA_dms_lda_idx_imm [[COPY]], 0 :: (load (s20), align 4)
+    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo:%[0-9]+]].sub_dim_stride:ed = COPY [[MOV_PD_imm11_pseudo]].sub_mod
+    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo:%[0-9]+]].sub_dim_count:ed = COPY [[MOV_PD_imm11_pseudo]].sub_dim_size
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:mpfs = COPY $p0
+    ; CHECK-NEXT: $sf, [[COPY1]]:mpfs, $r26, dead [[MOV_PD_imm11_pseudo]].sub_dim_count:ed = VST_FLUSH_512_2D_split $sf, [[COPY1]], $r26, [[MOV_PD_imm11_pseudo]].sub_mod, [[MOV_PD_imm11_pseudo]].sub_dim_size, [[MOV_PD_imm11_pseudo]].sub_dim_stride, [[MOV_PD_imm11_pseudo]].sub_dim_count, implicit-def $srfifo_of
+    ; CHECK-NEXT: PseudoRET implicit $lr
+    %2:ep = COPY $p1
+    undef %13.sub_mod:ed = MOV_PD_imm11_pseudo 0
+    %13.sub_dim_size:ed = LDA_dms_lda_idx_imm %2, 0 :: (load (s20), align 4)
+    %13.sub_dim_stride:ed = COPY %13.sub_mod
+    %13.sub_dim_count:ed = COPY %13.sub_dim_size
+    %4:mpfs = COPY $p0
+    $sf, %4:mpfs, $r26, dead %13.sub_dim_count:ed = VST_FLUSH_512_2D $sf, %4:mpfs, $r26, %13, implicit-def $srfifo_of
+    PseudoRET implicit $lr
+...
+
 
 # In particular, pay attention to undef for sub_hi_dim_then_sub_mod.
 ---
@@ -146,4 +214,78 @@ body:             |
     %20:ep = COPY $p0
     %100:eds = COPY $d1_3d
     %0:edm, %20:ep, %100.sub_dim_count:eds, %100.sub_hi_dim_then_sub_dim_count:eds = VLDA_3D_UPS_4x_dmx_lda_ups_x2d_upsSign0 $s0, %20, %100, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0
+...
+
+---
+name:            test_split_3D_opIdx8
+alignment:       16
+legalized:       true
+regBankSelected: true
+selected:        true
+tracksRegLiveness: true
+body:             |
+  bb.1.entry:
+    liveins: $p0, $sf, $r26
+
+    ; CHECK-LABEL: name: test_split_3D_opIdx8
+    ; CHECK: liveins: $p0, $sf, $r26
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: undef [[MOV_PD_imm11_pseudo:%[0-9]+]].sub_mod:eds = MOV_PD_imm11_pseudo 0
+    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo:%[0-9]+]].sub_hi_dim_then_sub_dim_stride:eds = MOV_PD_imm11_pseudo 128
+    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo:%[0-9]+]].sub_dim_stride:eds = COPY [[MOV_PD_imm11_pseudo]].sub_mod
+    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo:%[0-9]+]].sub_dim_size:eds = COPY [[MOV_PD_imm11_pseudo]].sub_hi_dim_then_sub_dim_stride
+    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo:%[0-9]+]].sub_dim_count:eds = COPY [[MOV_PD_imm11_pseudo]].sub_mod
+    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo:%[0-9]+]].sub_hi_dim_then_sub_dim_count:eds = COPY [[MOV_PD_imm11_pseudo]].sub_mod
+    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo:%[0-9]+]].sub_hi_dim_then_sub_dim_size:eds = COPY [[MOV_PD_imm11_pseudo]].sub_dim_size
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:mpfs = COPY $p0
+    ; CHECK-NEXT: $sf, %2:mpfs, $r26, dead [[MOV_PD_imm11_pseudo]].sub_dim_count:eds, dead [[MOV_PD_imm11_pseudo]].sub_hi_dim_then_sub_dim_count:eds = VST_FLUSH_512_3D_split $sf, %2, $r26, [[MOV_PD_imm11_pseudo]].sub_mod, [[MOV_PD_imm11_pseudo]].sub_dim_size, [[MOV_PD_imm11_pseudo]].sub_dim_stride, [[MOV_PD_imm11_pseudo]].sub_dim_count, undef [[MOV_PD_imm11_pseudo]].sub_hi_dim_then_sub_mod, [[MOV_PD_imm11_pseudo]].sub_hi_dim_then_sub_dim_size, [[MOV_PD_imm11_pseudo]].sub_hi_dim_then_sub_dim_stride, [[MOV_PD_imm11_pseudo]].sub_hi_dim_then_sub_dim_count, implicit-def $srfifo_of
+    ; CHECK-NEXT: PseudoRET implicit $lr
+    undef %12.sub_mod:eds = MOV_PD_imm11_pseudo 0
+    %12.sub_hi_dim_then_sub_dim_stride:eds = MOV_PD_imm11_pseudo 128
+    %12.sub_dim_stride:eds = COPY %12.sub_mod
+    %12.sub_dim_size:eds = COPY %12.sub_hi_dim_then_sub_dim_stride
+    %12.sub_dim_count:eds = COPY %12.sub_mod
+    %12.sub_hi_dim_then_sub_dim_count:eds = COPY %12.sub_mod
+    %12.sub_hi_dim_then_sub_dim_size:eds = COPY %12.sub_dim_size
+    %0:mpfs = COPY $p0
+    $sf, %30:mpfs, $r26, dead %12.sub_dim_count:eds, dead %12.sub_hi_dim_then_sub_dim_count:eds = VST_FLUSH_512_3D $sf, %30:mpfs, $r26, %12, implicit-def $srfifo_of
+    PseudoRET implicit $lr
+...
+
+---
+name:            test_split_3D_opIdx9
+alignment:       16
+legalized:       true
+regBankSelected: true
+selected:        true
+tracksRegLiveness: true
+body:             |
+  bb.1.entry:
+    liveins: $p0
+
+    ; CHECK-LABEL: name: test_split_3D_opIdx9
+    ; CHECK: liveins: $p0
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: undef [[MOV_PD_imm11_pseudo:%[0-9]+]].sub_mod:eds = MOV_PD_imm11_pseudo 0
+    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo:%[0-9]+]].sub_hi_dim_then_sub_dim_stride:eds = MOV_PD_imm11_pseudo 128
+    ; CHECK-NEXT: undef [[COPY:%[0-9]+]].sub_ptr:epsrfldf = COPY $p0
+    ; CHECK-NEXT: [[COPY:%[0-9]+]].sub_avail:epsrfldf = MOV_RLC_imm11_pseudo 0
+    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo:%[0-9]+]].sub_dim_stride:eds = COPY [[MOV_PD_imm11_pseudo]].sub_mod
+    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo:%[0-9]+]].sub_dim_size:eds = COPY [[MOV_PD_imm11_pseudo]].sub_hi_dim_then_sub_dim_stride
+    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo:%[0-9]+]].sub_dim_count:eds = COPY [[MOV_PD_imm11_pseudo]].sub_mod
+    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo:%[0-9]+]].sub_hi_dim_then_sub_dim_count:eds = COPY [[MOV_PD_imm11_pseudo]].sub_mod
+    ; CHECK-NEXT: [[MOV_PD_imm11_pseudo:%[0-9]+]].sub_hi_dim_then_sub_dim_size:eds = COPY [[MOV_PD_imm11_pseudo]].sub_dim_size
+    ; CHECK-NEXT: [[VLD_POP_512_3D_pseudo_split:%[0-9]+]]:vec512, dead [[COPY:%[0-9]+]].sub_ptr:epsrfldf, dead [[COPY:%[0-9]+]].sub_fifo:epsrfldf, dead [[COPY:%[0-9]+]].sub_avail:epsrfldf, dead [[MOV_PD_imm11_pseudo:%[0-9]+]].sub_dim_count:eds, dead [[MOV_PD_imm11_pseudo:%[0-9]+]].sub_hi_dim_then_sub_dim_count:eds = VLD_POP_512_3D_pseudo_split [[COPY]].sub_ptr, undef [[COPY]].sub_fifo, [[COPY]].sub_avail, [[MOV_PD_imm11_pseudo]].sub_mod, [[MOV_PD_imm11_pseudo]].sub_dim_size, [[MOV_PD_imm11_pseudo]].sub_dim_stride, [[MOV_PD_imm11_pseudo]].sub_dim_count, undef [[MOV_PD_imm11_pseudo]].sub_hi_dim_then_sub_mod, [[MOV_PD_imm11_pseudo]].sub_hi_dim_then_sub_dim_size, [[MOV_PD_imm11_pseudo]].sub_hi_dim_then_sub_dim_stride, [[MOV_PD_imm11_pseudo]].sub_hi_dim_then_sub_dim_count, implicit-def $srfifo_uf
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[VLD_POP_512_3D_pseudo_split]]
+    undef %12.sub_mod:eds = MOV_PD_imm11_pseudo 0
+    %12.sub_hi_dim_then_sub_dim_stride:eds = MOV_PD_imm11_pseudo 128
+    undef %18.sub_ptr:epsrfldf = COPY $p0
+    %18.sub_avail:epsrfldf = MOV_RLC_imm11_pseudo 0
+    %12.sub_dim_stride:eds = COPY %12.sub_mod
+    %12.sub_dim_size:eds = COPY %12.sub_hi_dim_then_sub_dim_stride
+    %12.sub_dim_count:eds = COPY %12.sub_mod
+    %12.sub_hi_dim_then_sub_dim_count:eds = COPY %12.sub_mod
+    %12.sub_hi_dim_then_sub_dim_size:eds = COPY %12.sub_dim_size
+    %5:vec512, dead %18.sub_ptr:epsrfldf, dead %18.sub_fifo:epsrfldf, dead %18.sub_avail:epsrfldf, dead %12.sub_dim_count:eds, dead %12.sub_hi_dim_then_sub_dim_count:eds = VLD_POP_512_3D_pseudo %18.sub_ptr, undef %18.sub_fifo, %18.sub_avail, %12, implicit-def $srfifo_uf
+    PseudoRET implicit $lr, implicit %5
 ...

--- a/llvm/test/CodeGen/AIE/aie2p/ra/split-instrs-replace.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/ra/split-instrs-replace.mir
@@ -148,13 +148,13 @@ body:             |
 ...
 
 ---
-name:            PADD_2D
+name:            test_split_2D_opIdx3
 tracksRegLiveness: true
 body:             |
   bb.0.entry:
     liveins: $dc4, $dj4, $dn4, $m4, $p0, $r0
 
-    ; CHECK-LABEL: name: PADD_2D
+    ; CHECK-LABEL: name: test_split_2D_opIdx3
     ; CHECK: liveins: $d4:0x0000000000200E00, $dc4, $dj4, $dn4, $m4, $p0, $r0
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: $p0, $dc4 = PADDA_2D killed $p0, $d4
@@ -199,12 +199,64 @@ body:             |
 ...
 
 ---
-name:            PADD_3D
+name:            test_split_2D_opIdx7
+tracksRegLiveness: true
+body:             |
+  bb.0.entry:
+    liveins: $sf, $p0, $p1, $r26
+
+    ; CHECK-LABEL: name: test_split_2D_opIdx7
+    ; CHECK: liveins: $sf, $p0, $p1, $r26
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: renamable $m0 = MOV_PD_imm11_pseudo 0
+    ; CHECK-NEXT: renamable $dn0 = LDA_dms_lda_idx_imm killed renamable $p1, 0 :: (load (s20), align 4)
+    ; CHECK-NEXT: renamable $dj0 = COPY renamable $m0
+    ; CHECK-NEXT: renamable $dc0 = COPY renamable $dn0
+    ; CHECK-NEXT: renamable $p2 = COPY $p0
+    ; CHECK-NEXT: $sf, dead $p2, $r26, dead $dc0 = VST_FLUSH_512_2D $sf, killed $p2, $r26, $d0, implicit-def $srfifo_of
+    ; CHECK-NEXT: PseudoRET implicit $lr
+    renamable $m0 = MOV_PD_imm11_pseudo 0
+    renamable $dn0 = LDA_dms_lda_idx_imm killed renamable $p1, 0 :: (load (s20), align 4)
+    renamable $dj0 = COPY renamable $m0
+    renamable $dc0 = COPY renamable $dn0
+    renamable $p2 = COPY $p0
+    $sf, dead $p2, $r26, dead $dc0 = VST_FLUSH_512_2D_split $sf, killed $p2, $r26, killed $m0, killed $dn0, killed $dj0, killed $dc0, implicit-def $srfifo_of
+    PseudoRET implicit $lr
+...
+
+---
+name:            test_split_2D_opIdx8
+tracksRegLiveness: true
+body:             |
+  bb.0.entry:
+    liveins: $p0, $p1
+
+    ; CHECK-LABEL: name: test_split_2D_opIdx8
+    ; CHECK: liveins: $p0, $p1
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: renamable $m0 = MOV_PD_imm11_pseudo 0
+    ; CHECK-NEXT: renamable $dn0 = LDA_dms_lda_idx_imm killed renamable $p1, 0 :: (load (s20), align 4)
+    ; CHECK-NEXT: renamable $r24 = MOV_RLC_imm11_pseudo 0
+    ; CHECK-NEXT: renamable $dj0 = COPY renamable $m0
+    ; CHECK-NEXT: renamable $dc0 = COPY renamable $dn0
+    ; CHECK-NEXT: $x0, dead $p0, dead $lf0, dead $r24, dead $dc0 = VLD_POP_512_2D_pseudo killed $p0, undef $lf0, $r24, $d0, implicit-def $srfifo_uf
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit killed renamable $x0
+    renamable $m0 = MOV_PD_imm11_pseudo 0
+    renamable $dn0 = LDA_dms_lda_idx_imm killed renamable $p1, 0 :: (load (s20), align 4)
+    renamable $r24 = MOV_RLC_imm11_pseudo 0
+    renamable $dj0 = COPY renamable $m0
+    renamable $dc0 = COPY renamable $dn0
+    $x0, dead $p0, dead $lf0, dead $r24, dead $dc0 = VLD_POP_512_2D_pseudo_split killed $p0, undef $lf0, $r24, killed $m0, killed $dn0, killed $dj0, killed $dc0, implicit-def $srfifo_uf
+    PseudoRET implicit $lr, implicit killed renamable $x0
+...
+
+---
+name:            test_split_3D_opIdx4
 tracksRegLiveness: true
 body:             |
   bb.0.entry:
     liveins: $dc4, $dj4, $dn4, $p0, $m0, $dn0, $dj0, $dc0
-    ; CHECK-LABEL: name: PADD_3D
+    ; CHECK-LABEL: name: test_split_3D_opIdx4
     ; CHECK: liveins: $dc0, $dc4, $dj0, $dj4, $dn0, $dn4, $m0, $p0, $d0_3d:0x0001C00000200E00
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: $p0, $dc0, $dc4 = PADDA_3D killed $p0, $d0_3d
@@ -244,4 +296,68 @@ body:             |
     ; CHECK-NEXT: dead $dm0, dead $p0, dead $dc1, dead $dc5 = VLDA_3D_UPS_4x_dmx_lda_ups_x2d_upsSign0 $s0, killed $p0, $d1_3d, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0
     dead $dm0, dead $p0, dead $dc1, dead $dc5 = VLDA_3D_UPS_4x_dmx_lda_ups_x2d_upsSign0_split $s0, killed $p0, $m1, $dn1, $dj1, $dc1, undef $m5, $dn5, $dj5, $dc5, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0
 
+...
+
+---
+name:            test_split_3D_opIdx8
+tracksRegLiveness: true
+body:             |
+  bb.0.entry:
+    liveins: $sf, $p0, $r26
+
+    ; CHECK-LABEL: name: test_split_3D_opIdx8
+    ; CHECK: liveins: $sf, $p0, $r26
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: renamable $m0 = MOV_PD_imm11_pseudo 0
+    ; CHECK-NEXT: renamable $dj4 = MOV_PD_imm11_pseudo 128
+    ; CHECK-NEXT: renamable $dj0 = COPY renamable $m0
+    ; CHECK-NEXT: renamable $dn0 = COPY renamable $dj4
+    ; CHECK-NEXT: renamable $dc0 = COPY renamable $m0
+    ; CHECK-NEXT: renamable $dc4 = COPY renamable $m0
+    ; CHECK-NEXT: renamable $dn4 = COPY renamable $dn0
+    ; CHECK-NEXT: renamable $p2 = COPY $p0
+    ; CHECK-NEXT: $sf, dead $p2, $r26, dead $dc0, dead $dc4 = VST_FLUSH_512_3D $sf, killed $p2, $r26, $d0_3d, implicit-def $srfifo_of
+    ; CHECK-NEXT: PseudoRET implicit $lr
+    renamable $m0 = MOV_PD_imm11_pseudo 0
+    renamable $dj4 = MOV_PD_imm11_pseudo 128
+    renamable $dj0 = COPY renamable $m0
+    renamable $dn0 = COPY renamable $dj4
+    renamable $dc0 = COPY renamable $m0
+    renamable $dc4 = COPY renamable $m0
+    renamable $dn4 = COPY renamable $dn0
+    renamable $p2 = COPY $p0
+    $sf, dead $p2, $r26, dead $dc0, dead $dc4 = VST_FLUSH_512_3D_split $sf, killed $p2, $r26, killed $m0, killed $dn0, killed $dj0, killed $dc0, undef $m4, killed $dn4, killed $dj4, killed $dc4, implicit-def $srfifo_of
+    PseudoRET implicit $lr
+...
+
+---
+name:            test_split_3D_opIdx9
+tracksRegLiveness: true
+body:             |
+  bb.0.entry:
+    liveins: $p0
+
+    ; CHECK-LABEL: name: test_split_3D_opIdx9
+    ; CHECK: liveins: $p0
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: renamable $m0 = MOV_PD_imm11_pseudo 0
+    ; CHECK-NEXT: renamable $dj4 = MOV_PD_imm11_pseudo 128
+    ; CHECK-NEXT: renamable $r24 = MOV_RLC_imm11_pseudo 0
+    ; CHECK-NEXT: renamable $dj0 = COPY renamable $m0
+    ; CHECK-NEXT: renamable $dn0 = COPY renamable $dj4
+    ; CHECK-NEXT: renamable $dc0 = COPY renamable $m0
+    ; CHECK-NEXT: renamable $dc4 = COPY renamable $m0
+    ; CHECK-NEXT: renamable $dn4 = COPY renamable $dn0
+    ; CHECK-NEXT: $x0, dead $p0, dead $lf0, dead $r24, dead $dc0, dead $dc4 = VLD_POP_512_3D_pseudo killed $p0, undef $lf0, $r24, $d0_3d, implicit-def $srfifo_uf
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit killed renamable $x0
+    renamable $m0 = MOV_PD_imm11_pseudo 0
+    renamable $dj4 = MOV_PD_imm11_pseudo 128
+    renamable $r24 = MOV_RLC_imm11_pseudo 0
+    renamable $dj0 = COPY renamable $m0
+    renamable $dn0 = COPY renamable $dj4
+    renamable $dc0 = COPY renamable $m0
+    renamable $dc4 = COPY renamable $m0
+    renamable $dn4 = COPY renamable $dn0
+    $x0, dead $p0, dead $lf0, dead $r24, dead $dc0, dead $dc4 = VLD_POP_512_3D_pseudo_split killed $p0, undef $lf0, $r24, killed $m0, killed $dn0, killed $dj0, killed $dc0, undef $m4, killed $dn4, killed $dj4, killed $dc4, implicit-def $srfifo_uf
+    PseudoRET implicit $lr, implicit killed renamable $x0
 ...

--- a/llvm/test/CodeGen/AIE/aie2p/ra/split-instrs-replace.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/ra/split-instrs-replace.mir
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2024-2025 Advanced Micro Devices, Inc. or its affiliates
 # RUN: llc -O2 -mtriple=aie2p -verify-machineinstrs -run-pass=aie-split-instrs-replace %s -o - | FileCheck %s
 
 
@@ -168,6 +168,37 @@ body:             |
 ...
 
 ---
+name:            test_split_2D_opIdx4
+tracksRegLiveness: true
+body:             |
+  bb.0.entry:
+    liveins: $sfh, $d1, $p0
+
+    ; CHECK-LABEL: name: test_split_2D_opIdx4
+    ; CHECK: liveins: $sfh, $d1, $p0
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: $r4, $p0, $dc1 = LDA_2D_dms_lda killed $p0, $d1
+    ; CHECK-NEXT: dead $p0, dead $dc1 = VST_2D_dmx_sts_fifohl $sfh, killed $p0, $d1
+    $r4, $p0, $dc1 = LDA_2D_dms_lda_split killed $p0, $m1, $dn1, $dj1, $dc1
+    dead $p0, dead $dc1 = VST_2D_dmx_sts_fifohl_split $sfh, killed $p0, $m1, $dn1, $dj1, $dc1
+...
+
+---
+name:            test_split_2D_opIdx5
+tracksRegLiveness: true
+body:             |
+  bb.0.entry:
+    liveins: $d1, $p0, $s0
+
+    ; CHECK-LABEL: name: test_split_2D_opIdx5
+    ; CHECK: liveins: $d1, $p0, $s0
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: $bmhh0, dead $p0, dead $dc1 = VLDA_2D_UPS_2x_dmw_lda_ups_w2b_upsSign0 $s0, killed $p0, $d1, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0
+    $bmhh0, dead $p0, dead $dc1 = VLDA_2D_UPS_2x_dmw_lda_ups_w2b_upsSign0_split $s0, killed $p0, $m1, $dn1, $dj1, $dc1, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0
+
+...
+
+---
 name:            PADD_3D
 tracksRegLiveness: true
 body:             |
@@ -184,4 +215,33 @@ body:             |
     $p0, $dc0, $dc4 = PADDB_3D_split killed $p0, $m0, $dn0, $dj0, $dc0, undef $m4, $dn4, $dj4, $dc4
     $p0, $dc0, $dc4 = PADDS_3D_split killed $p0, killed $m0, killed $dn0, killed $dj0, killed $dc0, killed undef $m4, killed $dn4, killed $dj4, killed $dc4
     PseudoRET implicit $lr, implicit killed renamable $p0, implicit killed renamable $dc0, implicit killed renamable $dc4
+...
+
+---
+name:            test_split_3D_opIdx5
+tracksRegLiveness: true
+body:             |
+  bb.0.entry:
+    liveins: $p0, $d1_3d
+
+    ; CHECK-LABEL: name: test_split_3D_opIdx5
+    ; CHECK: liveins: $p0, $d1_3d
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: $r4, dead $p0, dead $dc1, dead $dc5 = LDA_3D_dms_lda killed $p0, $d1_3d
+    $r4, dead $p0, dead $dc1, dead $dc5 = LDA_3D_dms_lda_split killed $p0, $m1, $dn1, $dj1, $dc1, undef $m5, $dn5, $dj5, $dc5
+...
+
+---
+name:            test_split_3D_opIdx6
+tracksRegLiveness: true
+body:             |
+  bb.0.entry:
+    liveins: $p0, $s0, $d1_3d
+
+    ; CHECK-LABEL: name: test_split_3D_opIdx6
+    ; CHECK: liveins: $p0, $s0, $d1_3d
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: dead $dm0, dead $p0, dead $dc1, dead $dc5 = VLDA_3D_UPS_4x_dmx_lda_ups_x2d_upsSign0 $s0, killed $p0, $d1_3d, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0
+    dead $dm0, dead $p0, dead $dc1, dead $dc5 = VLDA_3D_UPS_4x_dmx_lda_ups_x2d_upsSign0_split $s0, killed $p0, $m1, $dn1, $dj1, $dc1, undef $m5, $dn5, $dj5, $dc5, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0
+
 ...


### PR DESCRIPTION
This PR add support for more instructions for 2d/3d splitting.
Extend the AIESplitInstructionRewriter for supporting multiple tied register sets.