### PR TITLE
[AIE] lower the limit of ZOL reject.

### DIFF
--- a/llvm/lib/Target/AIE/AIEBaseTargetTransformInfo.cpp
+++ b/llvm/lib/Target/AIE/AIEBaseTargetTransformInfo.cpp
@@ -29,7 +29,7 @@ static cl::opt<bool>
                 cl::init(true), cl::Hidden);
 
 static cl::opt<int> MinIterCountHLReject(
-    "aie-hardware-loops-minitercount", cl::Hidden, cl::init(3),
+    "aie-hardware-loops-minitercount", cl::Hidden, cl::init(2),
     cl::desc("Minimum trip count threshold for HL rejection"));
 
 static cl::opt<bool>

--- a/llvm/test/CodeGen/AIE/aie2/schedule/swp/min_iter_loopinfo.ll
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/swp/min_iter_loopinfo.ll
@@ -3,11 +3,14 @@
 ; See https://llvm.org/LICENSE.txt for license information.
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 ;
-; (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+; (c) Copyright 2024-2025 Advanced Micro Devices, Inc. or its affiliates
 ;
-; RUN: llc --mtriple=aie2 -O2 --stop-after=pipeliner %s -o - | FileCheck %s
+; RUN: llc --mtriple=aie2 -O2 \
+; RUN:   --aie-hardware-loops-minitercount=3 --stop-after=pipeliner %s \
+; RUN:   -o - | FileCheck %s
 
-; We check that we have a three stage pipeline with unconditional controlflow in the prologue
+; We check that we have a three stage pipeline with unconditional
+; controlflow in the prologue
 
 ; CHECK:  bb.4
 ; CHECK:   LDA


### PR DESCRIPTION
This reflects offloading more to the postpipeliner, which doesn't handle JNZ loops.

With this, AvgPool2D_bfloat16_0's main loop is post-pipelined into two stages. Without it, the pre-pipeliner doesn't produce a schedule and we lose ~25% in that loop. 