### PR TITLE
[AIE] Add llvm-as to wheel

### DIFF
--- a/clang/cmake/caches/Peano-AIE.cmake
+++ b/clang/cmake/caches/Peano-AIE.cmake
@@ -35,6 +35,7 @@ set(LLVM_INSTALL_TOOLCHAIN_ONLY ON CACHE BOOL "")
 set(LLVM_TOOLCHAIN_TOOLS
   llc
   llvm-ar
+  llvm-as
   llvm-cxxfilt
   llvm-dwarfdump
   llvm-nm


### PR DESCRIPTION
I'd like to create both .s and .o files, but don't want to call llc twice (on a representative workload it takes 4 seconds, opt only takes 1 seconds, so invoking llc twice will ~double compile time). So I'd like to use llc to create .s, and then llvm-as to create .o from .s. 
