### PR TITLE
[AIE] Constrain get.ctrl.reg destination to GPR regclass

### DIFF
--- a/llvm/lib/Target/AIE/AIE2InstructionSelector.cpp
+++ b/llvm/lib/Target/AIE/AIE2InstructionSelector.cpp
@@ -2306,7 +2306,7 @@ bool AIE2InstructionSelector::selectGetControlRegister(
   else
     llvm_unreachable("Expected const value for control register map index.");
 
-  if (!RBI.constrainGenericRegister(DstReg, AIE2::eRCRRegClass, MRI))
+  if (!RBI.constrainGenericRegister(DstReg, AIE2::eRRegClass, MRI))
     return false;
 
   auto CopyInstr =

--- a/llvm/lib/Target/AIE/aie2p/AIE2PInstructionSelector.cpp
+++ b/llvm/lib/Target/AIE/aie2p/AIE2PInstructionSelector.cpp
@@ -728,7 +728,7 @@ bool AIE2PInstructionSelector::selectGetControlRegister(
   else
     llvm_unreachable("Expected const value for control register map index.");
 
-  if (!RBI.constrainGenericRegister(DstReg, AIE2P::eRCRRegClass, MRI))
+  if (!RBI.constrainGenericRegister(DstReg, AIE2P::eRRegClass, MRI))
     return false;
 
   auto CopyInstr =

--- a/llvm/test/CodeGen/AIE/aie2/GlobalISel/inst-select-set-mode.mir
+++ b/llvm/test/CodeGen/AIE/aie2/GlobalISel/inst-select-set-mode.mir
@@ -164,7 +164,7 @@ regBankSelected: true
 body:             |
   bb.1.entry:
     ; CHECK-LABEL: name: get_satmode
-    ; CHECK: [[COPY:%[0-9]+]]:ercr = COPY $crsat
+    ; CHECK: [[COPY:%[0-9]+]]:er = COPY $crsat
     ; CHECK-NEXT: $r0 = COPY [[COPY]]
     ; CHECK-NEXT: PseudoRET implicit $lr, implicit $r0
     %1:gprregbank(s32) = G_CONSTANT i32 9
@@ -182,7 +182,7 @@ regBankSelected: true
 body:             |
   bb.1.entry:
     ; CHECK-LABEL: name: get_sat
-    ; CHECK: [[COPY:%[0-9]+]]:ercr = COPY $crsat
+    ; CHECK: [[COPY:%[0-9]+]]:er = COPY $crsat
     ; CHECK-NEXT: $r0 = COPY [[COPY]]
     ; CHECK-NEXT: PseudoRET implicit $lr, implicit $r0
     %1:gprregbank(s32) = G_CONSTANT i32 9
@@ -200,7 +200,7 @@ regBankSelected: true
 body:             |
   bb.1.entry:
     ; CHECK-LABEL: name: get_rnd
-    ; CHECK: [[COPY:%[0-9]+]]:ercr = COPY $crrnd
+    ; CHECK: [[COPY:%[0-9]+]]:er = COPY $crrnd
     ; CHECK-NEXT: $r0 = COPY [[COPY]]
     ; CHECK-NEXT: PseudoRET implicit $lr, implicit $r0
     %1:gprregbank(s32) = G_CONSTANT i32 6
@@ -218,7 +218,7 @@ regBankSelected: true
 body:             |
   bb.1.entry:
     ; CHECK-LABEL: name: get_fpmulmac_mask
-    ; CHECK: [[COPY:%[0-9]+]]:ercr = COPY $crfpmask
+    ; CHECK: [[COPY:%[0-9]+]]:er = COPY $crfpmask
     ; CHECK-NEXT: $r0 = COPY [[COPY]]
     ; CHECK-NEXT: PseudoRET implicit $lr, implicit $r0
     %1:gprregbank(s32) = G_CONSTANT i32 3
@@ -236,7 +236,7 @@ regBankSelected: true
 body:             |
   bb.1.entry:
     ; CHECK-LABEL: name: get_fp2int_mask
-    ; CHECK: [[COPY:%[0-9]+]]:ercr = COPY $crf2imask
+    ; CHECK: [[COPY:%[0-9]+]]:er = COPY $crf2imask
     ; CHECK-NEXT: $r0 = COPY [[COPY]]
     ; CHECK-NEXT: PseudoRET implicit $lr, implicit $r0
     %1:gprregbank(s32) = G_CONSTANT i32 2
@@ -254,7 +254,7 @@ regBankSelected: true
 body:             |
   bb.1.entry:
     ; CHECK-LABEL: name: get_fp2bfmask
-    ; CHECK: [[COPY:%[0-9]+]]:ercr = COPY $crf2fmask
+    ; CHECK: [[COPY:%[0-9]+]]:er = COPY $crf2fmask
     ; CHECK-NEXT: $r0 = COPY [[COPY]]
     ; CHECK-NEXT: PseudoRET implicit $lr, implicit $r0
     %1:gprregbank(s32) = G_CONSTANT i32 1

--- a/llvm/test/CodeGen/AIE/aie2p/GlobalIsel/inst-select-set-mode.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/GlobalIsel/inst-select-set-mode.mir
@@ -164,7 +164,7 @@ regBankSelected: true
 body:             |
   bb.1.entry:
     ; CHECK-LABEL: name: get_satmode
-    ; CHECK: [[COPY:%[0-9]+]]:ercr = COPY $crsat
+    ; CHECK: [[COPY:%[0-9]+]]:er = COPY $crsat
     ; CHECK-NEXT: $r0 = COPY [[COPY]]
     ; CHECK-NEXT: PseudoRET implicit $lr, implicit $r0
     %1:gprregbank(s32) = G_CONSTANT i32 0
@@ -182,7 +182,7 @@ regBankSelected: true
 body:             |
   bb.1.entry:
     ; CHECK-LABEL: name: get_sat
-    ; CHECK: [[COPY:%[0-9]+]]:ercr = COPY $crsat
+    ; CHECK: [[COPY:%[0-9]+]]:er = COPY $crsat
     ; CHECK-NEXT: $r0 = COPY [[COPY]]
     ; CHECK-NEXT: PseudoRET implicit $lr, implicit $r0
     %1:gprregbank(s32) = G_CONSTANT i32 0
@@ -200,7 +200,7 @@ regBankSelected: true
 body:             |
   bb.1.entry:
     ; CHECK-LABEL: name: get_rnd
-    ; CHECK: [[COPY:%[0-9]+]]:ercr = COPY $crrnd
+    ; CHECK: [[COPY:%[0-9]+]]:er = COPY $crrnd
     ; CHECK-NEXT: $r0 = COPY [[COPY]]
     ; CHECK-NEXT: PseudoRET implicit $lr, implicit $r0
     %1:gprregbank(s32) = G_CONSTANT i32 1
@@ -218,7 +218,7 @@ regBankSelected: true
 body:             |
   bb.1.entry:
     ; CHECK-LABEL: name: get_fpmulmac_mask
-    ; CHECK: [[COPY:%[0-9]+]]:ercr = COPY $crfpmask
+    ; CHECK: [[COPY:%[0-9]+]]:er = COPY $crfpmask
     ; CHECK-NEXT: $r0 = COPY [[COPY]]
     ; CHECK-NEXT: PseudoRET implicit $lr, implicit $r0
     %1:gprregbank(s32) = G_CONSTANT i32 2
@@ -236,7 +236,7 @@ regBankSelected: true
 body:             |
   bb.1.entry:
     ; CHECK-LABEL: name: get_fp2int_mask
-    ; CHECK: [[COPY:%[0-9]+]]:ercr = COPY $crf2imask
+    ; CHECK: [[COPY:%[0-9]+]]:er = COPY $crf2imask
     ; CHECK-NEXT: $r0 = COPY [[COPY]]
     ; CHECK-NEXT: PseudoRET implicit $lr, implicit $r0
     %1:gprregbank(s32) = G_CONSTANT i32 3
@@ -253,7 +253,7 @@ regBankSelected: true
 body:             |
   bb.1.entry:
     ; CHECK-LABEL: name: get_fp2bfmask
-    ; CHECK: [[COPY:%[0-9]+]]:ercr = COPY $crf2fmask
+    ; CHECK: [[COPY:%[0-9]+]]:er = COPY $crf2fmask
     ; CHECK-NEXT: $r0 = COPY [[COPY]]
     ; CHECK-NEXT: PseudoRET implicit $lr, implicit $r0
     %1:gprregbank(s32) = G_CONSTANT i32 4
@@ -270,7 +270,7 @@ regBankSelected: true
 body:             |
   bb.1.entry:
     ; CHECK-LABEL: name: get_fp2bmask
-    ; CHECK: [[COPY:%[0-9]+]]:ercr = COPY $crf2bmask
+    ; CHECK: [[COPY:%[0-9]+]]:er = COPY $crf2bmask
     ; CHECK-NEXT: $r0 = COPY [[COPY]]
     ; CHECK-NEXT: PseudoRET implicit $lr, implicit $r0
     %1:gprregbank(s32) = G_CONSTANT i32 5
@@ -287,7 +287,7 @@ regBankSelected: true
 body:             |
   bb.1.entry:
     ; CHECK-LABEL: name: get_crfpnlfMask
-    ; CHECK: [[COPY:%[0-9]+]]:ercr = COPY $crfpnlfmask
+    ; CHECK: [[COPY:%[0-9]+]]:er = COPY $crfpnlfmask
     ; CHECK-NEXT: $r0 = COPY [[COPY]]
     ; CHECK-NEXT: PseudoRET implicit $lr, implicit $r0
     %1:gprregbank(s32) = G_CONSTANT i32 22
@@ -304,7 +304,7 @@ regBankSelected: true
 body:             |
   bb.1.entry:
     ; CHECK-LABEL: name: get_crFPCnvFx2FlMask
-    ; CHECK: [[COPY:%[0-9]+]]:ercr = COPY $crfpcnvfx2flmask
+    ; CHECK: [[COPY:%[0-9]+]]:er = COPY $crfpcnvfx2flmask
     ; CHECK-NEXT: $r0 = COPY [[COPY]]
     ; CHECK-NEXT: PseudoRET implicit $lr, implicit $r0
     %1:gprregbank(s32) = G_CONSTANT i32 23
@@ -321,7 +321,7 @@ regBankSelected: true
 body:             |
   bb.1.entry:
     ; CHECK-LABEL: name: get_crfpcnvfl2fxmask
-    ; CHECK: [[COPY:%[0-9]+]]:ercr = COPY $crfpcnvfl2fxmask
+    ; CHECK: [[COPY:%[0-9]+]]:er = COPY $crfpcnvfl2fxmask
     ; CHECK-NEXT: $r0 = COPY [[COPY]]
     ; CHECK-NEXT: PseudoRET implicit $lr, implicit $r0
     %1:gprregbank(s32) = G_CONSTANT i32 24


### PR DESCRIPTION
Previously we allowed COPYing to the larger eRCR regclass. However this class cannot be spilled easily, because control registers cannot be stored to memory directly, but need to bounce through a GPR. There is very little benefit in constraining the class to eRCR, namely allowing direct COPY from one control register to another. That case can be handled as a peephole optimization of needed.