### PR TITLE
[AIE2P] Fix VADD.f and VSUB.f configuration to silence the simulator

### DIFF
--- a/llvm/lib/Target/AIE/aie2p/AIE2PInstrPatterns.td
+++ b/llvm/lib/Target/AIE/aie2p/AIE2PInstrPatterns.td
@@ -63,7 +63,10 @@ class VecConf {
   dag ConfBits = (MOV_RLC_imm11_pseudo (i32 all));
 }
 
-def accfp32_vecconf : VecConf { let amode = AMODE_FP32; let bmode = BMODE_16x16; }
+// The multiplication mode (cmode) should be irrelevant for an addition/substraction but it is part of 
+// the amode, bmode, cmode combination to perform an element wise multiplication according to ISA, we set it 
+// to the value of that combination (1) to silence our tools (e.g. simulator)
+def accfp32_vecconf : VecConf { let amode = AMODE_FP32; let bmode = BMODE_16x16; let cmode = 1;}
 def mulbf16_vecconf : VecConf { let amode = AMODE_FP32; let bmode = BMODE_16x16; let cmode = CMODE_BF16xBF16_1_elem_1; }
 
 /// Generic pattern classes

--- a/llvm/test/CodeGen/AIE/aie2p/GlobalIsel/inst-select-fadd.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/GlobalIsel/inst-select-fadd.mir
@@ -22,7 +22,7 @@ body:             |
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:acc2048 = COPY $dm0
     ; CHECK-NEXT: [[COPY1:%[0-9]+]]:acc2048 = COPY $dm1
-    ; CHECK-NEXT: [[MOV_RLC_imm11_pseudo:%[0-9]+]]:er = MOV_RLC_imm11_pseudo 28
+    ; CHECK-NEXT: [[MOV_RLC_imm11_pseudo:%[0-9]+]]:er = MOV_RLC_imm11_pseudo 60
     ; CHECK-NEXT: [[VADD_f_vmac_cm2_add_reg:%[0-9]+]]:acc2048 = VADD_f_vmac_cm2_add_reg [[COPY]], [[COPY1]], [[MOV_RLC_imm11_pseudo]], implicit-def dead $srfpflags, implicit $crfpmask
     ; CHECK-NEXT: $dm0 = COPY [[VADD_f_vmac_cm2_add_reg]]
     ; CHECK-NEXT: PseudoRET implicit $lr, implicit $dm0

--- a/llvm/test/CodeGen/AIE/aie2p/GlobalIsel/inst-select-fsub.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/GlobalIsel/inst-select-fsub.mir
@@ -22,7 +22,7 @@ body:             |
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:acc2048 = COPY $dm0
     ; CHECK-NEXT: [[COPY1:%[0-9]+]]:acc2048 = COPY $dm1
-    ; CHECK-NEXT: [[MOV_RLC_imm11_pseudo:%[0-9]+]]:er = MOV_RLC_imm11_pseudo 28
+    ; CHECK-NEXT: [[MOV_RLC_imm11_pseudo:%[0-9]+]]:er = MOV_RLC_imm11_pseudo 60
     ; CHECK-NEXT: [[VSUB_f_vmac_cm2_add_reg:%[0-9]+]]:acc2048 = VSUB_f_vmac_cm2_add_reg [[COPY]], [[COPY1]], [[MOV_RLC_imm11_pseudo]], implicit-def dead $srfpflags, implicit $crfpmask
     ; CHECK-NEXT: $dm0 = COPY [[VSUB_f_vmac_cm2_add_reg]]
     ; CHECK-NEXT: PseudoRET implicit $lr, implicit $dm0


### PR DESCRIPTION
The multiplication mode (cmode) should be irrelevant for an addition/substraction but it is part of the amode, bmode, cmode combination to perform an element wise multiplication according to ISA, we set it to the value of that combination (1) to silence our tools (e.g. simulator complaining about an `Invalid multiplication mode`)