### PR TITLE
[AIEX] Handle lock delays during SWP prologue merge with pre-header 

### DIFF
--- a/llvm/lib/Target/AIE/AIEBaseInstrInfo.cpp
+++ b/llvm/lib/Target/AIE/AIEBaseInstrInfo.cpp
@@ -771,6 +771,10 @@ SmallVector<int, 2>
 AIEBaseInstrInfo::getMemoryCycles(unsigned SchedClass) const {
   return {};
 }
+/// FIXME: Delays for locks to reach the core aren't completely described in
+/// the ISA. The numbers are therefore conservative.
+int AIEBaseInstrInfo::getCoreStallCycleAfterLock() const { return 2; }
+int AIEBaseInstrInfo::getCoreResumeCycleAfterLock() const { return 8; }
 
 unsigned
 AIEBaseInstrInfo::getSchedClass(const MCInstrDesc &Desc,

--- a/llvm/lib/Target/AIE/AIEBaseInstrInfo.h
+++ b/llvm/lib/Target/AIE/AIEBaseInstrInfo.h
@@ -491,6 +491,10 @@ struct AIEBaseInstrInfo : public TargetInstrInfo {
   virtual int getMaxLastMemoryCycle() const;
   /// Return cycles for memory operations of an instruction.
   virtual SmallVector<int, 2> getMemoryCycles(unsigned SchedClass) const;
+  /// Return cycles for core to stall after lock instruction.
+  virtual int getCoreStallCycleAfterLock() const;
+  /// Return cycles for core to resume after lock instruction.
+  virtual int getCoreResumeCycleAfterLock() const;
 
   /// Return the schedclass for the given instruction descriptor based on
   /// operand regclass.

--- a/llvm/lib/Target/AIE/AIEBaseSubtarget.cpp
+++ b/llvm/lib/Target/AIE/AIEBaseSubtarget.cpp
@@ -194,11 +194,9 @@ bool updateSuccLatency(SDep &SuccEdge, SUnit &PredSU, int Latency) {
 // locks/DONE.
 class LockDelays : public ScheduleDAGMutation {
   void apply(ScheduleDAGInstrs *DAG) override {
-    // FIXME: Delays for locks to reach the core aren't completely described in
-    // the ISA. The numbers are therefore conservative.
-    const int CoreStallCycle = 2;
-    const int CoreResumeCycle = 8;
     const auto *TII = static_cast<const AIEBaseInstrInfo *>(DAG->TII);
+    const int CoreStallCycle = TII->getCoreStallCycleAfterLock();
+    const int CoreResumeCycle = TII->getCoreResumeCycleAfterLock();
 
     // Iterate over all the predecessors and successors of Lock instructions
     // to increase the edge latency.

--- a/llvm/lib/Target/AIE/AIEBaseSubtarget.cpp
+++ b/llvm/lib/Target/AIE/AIEBaseSubtarget.cpp
@@ -396,8 +396,21 @@ public:
           DAG->getSUnit(&*getBundleStart(FixedDepMI->getIterator()));
       assert(FixedDepSU && "Fixed Bundle has no corresponding SU.");
       SDep Dep(&FreeSU, SDep::Artificial);
-      Dep.setLatency(
-          AIE::maxLatency(&MI, *TII, *ItinData, /*IncludeStages=*/true));
+      auto Latency =
+          AIE::maxLatency(&MI, *TII, *ItinData, /*IncludeStages=*/true);
+      if (TII->isLock(MI.getOpcode())) {
+        Dep.setLatency(std::max(
+            TII->getCoreResumeCycleAfterLock() -
+                *TII->getFirstMemoryCycle(FixedDepMI->getDesc().SchedClass) + 1,
+            Latency));
+      } else if (TII->isLock(FixedDepMI->getOpcode())) {
+        Dep.setLatency(
+            std::max(*TII->getLastMemoryCycle(MI.getDesc().SchedClass) -
+                         TII->getCoreStallCycleAfterLock() + 1,
+                     Latency));
+      } else {
+        Dep.setLatency(Latency);
+      }
       FixedDepSU->addPred(Dep, /*Required=*/true);
     }
 

--- a/llvm/lib/Target/AIE/AIEMaxLatencyFinder.cpp
+++ b/llvm/lib/Target/AIE/AIEMaxLatencyFinder.cpp
@@ -90,6 +90,14 @@ static bool overlap(const MachineOperand &SrcOp, const MachineOperand &DstOp,
 /// Check whether Dst depends on Src
 static bool depends(const MachineInstr &Src, const MachineInstr &Dst,
                     const TargetRegisterInfo *TRI) {
+
+  const AIEBaseInstrInfo *const TII = static_cast<const AIEBaseInstrInfo *>(
+      Src.getMF()->getSubtarget().getInstrInfo());
+  // Detect dependency between lock and ld/st intructions.
+  if ((TII->isLock(Src.getOpcode()) && (Dst.mayLoadOrStore())) ||
+      (TII->isLock(Dst.getOpcode()) && (Src.mayLoadOrStore()))) {
+    return true;
+  }
   // We don't try anything clever in terms of alias analysis
   // The memory latency is accounted for by maxLatency() and any
   // possible dependence will be corrected for by its scheduled cycle.
@@ -126,7 +134,6 @@ InstrAndCycle findEarliestRef(const MachineInstr &SrcMI,
                               ArrayRef<MachineBundle> Bundles, int Prune) {
   const TargetRegisterInfo *TRI =
       SrcMI.getMF()->getSubtarget().getRegisterInfo();
-
   int Cycle = 0;
   for (const auto &Bundle : Bundles) {
     if (Cycle >= Prune) {
@@ -134,7 +141,7 @@ InstrAndCycle findEarliestRef(const MachineInstr &SrcMI,
       return {/*MI=*/nullptr, Cycle};
     }
     for (MachineInstr *DstMI : Bundle.getInstrs()) {
-      LLVM_DEBUG(dbgs() << "  " << *DstMI);
+      LLVM_DEBUG(dbgs() << " " << *DstMI);
       if (depends(SrcMI, *DstMI, TRI)) {
         LLVM_DEBUG(dbgs() << "    depends in cycle=" << Cycle << "\n");
         return {DstMI, Cycle};

--- a/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/interleave-prologue.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/interleave-prologue.mir
@@ -448,16 +448,15 @@ body:             |
   ; CHECK-NEXT:   successors: %bb.1(0x80000000)
   ; CHECK-NEXT:   liveins: $p0, $p1, $r0, $r18
   ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT:   ACQ_mLockId_imm 49, killed renamable $r18
+  ; CHECK-NEXT:   NOP
   ; CHECK-NEXT:   $lc = ADD_NC $r0, -7
   ; CHECK-NEXT:   $ls = MOVXM_lng_cg %bb.2
   ; CHECK-NEXT:   $le = MOVXM_lng_cg <mcsymbol .L_LEnd0>
   ; CHECK-NEXT:   $x6, $p0 = VLDB_UNPACK_S16_S8_ag_pstm_nrm killed $p0, $m0
   ; CHECK-NEXT:   $x6, $p0 = VLDB_UNPACK_S16_S8_ag_pstm_nrm killed $p0, $m0
   ; CHECK-NEXT:   $x6, $p0 = VLDB_UNPACK_S16_S8_ag_pstm_nrm killed $p0, $m0
-  ; CHECK-NEXT:   BUNDLE implicit-def $x6, implicit-def $wl6, implicit-def $wh6, implicit-def $p0, implicit killed $p0, implicit $m0, implicit killed $r18 {
-  ; CHECK-NEXT:     $x6, $p0 = VLDB_UNPACK_S16_S8_ag_pstm_nrm killed $p0, $m0
-  ; CHECK-NEXT:     ACQ_mLockId_imm 49, killed renamable $r18
-  ; CHECK-NEXT:   }
+  ; CHECK-NEXT:   $x6, $p0 = VLDB_UNPACK_S16_S8_ag_pstm_nrm killed $p0, $m0
   ; CHECK-NEXT:   BUNDLE implicit-def $r1, implicit-def $x6, implicit-def $wl6, implicit-def $wh6, implicit-def $p0, implicit killed $p0, implicit $m0 {
   ; CHECK-NEXT:     $r1 = MOVA_lda_cg 0
   ; CHECK-NEXT:     $x6, $p0 = VLDB_UNPACK_S16_S8_ag_pstm_nrm killed $p0, $m0

--- a/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/interleave-prologue.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/interleave-prologue.mir
@@ -437,3 +437,88 @@ body:             |
     RET implicit $lr
     DelayedSchedBarrier
 ...
+# A Ld/St instruction should wait for core resume cycles after lock instruction.
+---
+name:            load_lock
+alignment:       16
+tracksRegLiveness: true
+body:             |
+  ; CHECK-LABEL: name: load_lock
+  ; CHECK: bb.0:
+  ; CHECK-NEXT:   successors: %bb.1(0x80000000)
+  ; CHECK-NEXT:   liveins: $p0, $p1, $r0, $r18
+  ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT:   $lc = ADD_NC $r0, -7
+  ; CHECK-NEXT:   $ls = MOVXM_lng_cg %bb.2
+  ; CHECK-NEXT:   $le = MOVXM_lng_cg <mcsymbol .L_LEnd0>
+  ; CHECK-NEXT:   $x6, $p0 = VLDB_UNPACK_S16_S8_ag_pstm_nrm killed $p0, $m0
+  ; CHECK-NEXT:   $x6, $p0 = VLDB_UNPACK_S16_S8_ag_pstm_nrm killed $p0, $m0
+  ; CHECK-NEXT:   $x6, $p0 = VLDB_UNPACK_S16_S8_ag_pstm_nrm killed $p0, $m0
+  ; CHECK-NEXT:   BUNDLE implicit-def $x6, implicit-def $wl6, implicit-def $wh6, implicit-def $p0, implicit killed $p0, implicit $m0, implicit killed $r18 {
+  ; CHECK-NEXT:     $x6, $p0 = VLDB_UNPACK_S16_S8_ag_pstm_nrm killed $p0, $m0
+  ; CHECK-NEXT:     ACQ_mLockId_imm 49, killed renamable $r18
+  ; CHECK-NEXT:   }
+  ; CHECK-NEXT:   BUNDLE implicit-def $r1, implicit-def $x6, implicit-def $wl6, implicit-def $wh6, implicit-def $p0, implicit killed $p0, implicit $m0 {
+  ; CHECK-NEXT:     $r1 = MOVA_lda_cg 0
+  ; CHECK-NEXT:     $x6, $p0 = VLDB_UNPACK_S16_S8_ag_pstm_nrm killed $p0, $m0
+  ; CHECK-NEXT:   }
+  ; CHECK-NEXT:   BUNDLE implicit-def $x6, implicit-def $wl6, implicit-def $wh6, implicit-def $p0, implicit-def $x0, implicit-def $wl0, implicit-def $wh0, implicit killed $p0, implicit $m0, implicit killed $r1 {
+  ; CHECK-NEXT:     $x6, $p0 = VLDB_UNPACK_S16_S8_ag_pstm_nrm killed $p0, $m0
+  ; CHECK-NEXT:     $x0 = VBCST_16 killed $r1
+  ; CHECK-NEXT:   }
+  ; CHECK-NEXT:   $x6, $p0 = VLDB_UNPACK_S16_S8_ag_pstm_nrm killed $p0, $m0
+  ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT: bb.1:
+  ; CHECK-NEXT:   successors: %bb.1(0x7c000000), %bb.2(0x04000000)
+  ; CHECK-NEXT:   liveins: $p0, $p1, $r0, $m0, $x0, $x2, $x4
+  ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT:   BUNDLE implicit-def $x6, implicit-def $wl6, implicit-def $wh6, implicit-def $p0, implicit-def $x0, implicit-def $wl0, implicit-def $wh0, implicit killed $p0, implicit $m0, implicit killed $x0 {
+  ; CHECK-NEXT:     $x6, $p0 = VLDB_UNPACK_S16_S8_ag_pstm_nrm killed $p0, $m0
+  ; CHECK-NEXT:     $x0 = VADD_16 killed $x0, internal $x6
+  ; CHECK-NEXT:   }
+  ; CHECK-NEXT:   PseudoLoopEnd <mcsymbol .L_LEnd0>, %bb.1
+  ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT: bb.2:
+  ; CHECK-NEXT:   liveins: $p0, $p1, $x0
+  ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT:   $x0 = VADD_16 killed $x0, $x6
+  ; CHECK-NEXT:   $x0 = VADD_16 killed $x0, $x6
+  ; CHECK-NEXT:   $x0 = VADD_16 killed $x0, $x6
+  ; CHECK-NEXT:   $x0 = VADD_16 killed $x0, $x6
+  ; CHECK-NEXT:   $x0 = VADD_16 killed $x0, $x6
+  ; CHECK-NEXT:   $x0 = VADD_16 killed $x0, $x6
+  ; CHECK-NEXT:   $x0 = VADD_16 killed $x0, killed $x6
+  ; CHECK-NEXT:   NOP
+  ; CHECK-NEXT:   VST_PACK_S8_S16_ag_idx_imm killed $p1, 0, killed $x0, implicit $crsat
+  ; CHECK-NEXT:   RET implicit $lr
+  ; CHECK-NEXT:   NOP
+  ; CHECK-NEXT:   NOP
+  ; CHECK-NEXT:   NOP
+  ; CHECK-NEXT:   NOP
+  ; CHECK-NEXT:   NOP
+  ; CHECK-NEXT:   DelayedSchedBarrier
+  bb.0:
+    successors: %bb.1(0x80000000)
+    liveins: $p0, $p1, $r0, $r18
+
+    $lc = ADD_NC $r0, 0
+    $ls = MOVXM_lng_cg %bb.2
+    $le = MOVXM_lng_cg <mcsymbol .L_LEnd0>
+    $r1 = MOV_RLC_imm10_pseudo 0
+    $x0 = VBCST_16 $r1
+    ACQ_mLockId_imm 49, renamable $r18
+
+  bb.1:
+    successors: %bb.1(0x7c000000), %bb.2(0x04000000)
+    liveins: $p0, $p1, $r0, $m0, $x0, $x2, $x4
+
+    $x6, $p0 = VLDB_UNPACK_S16_S8_ag_pstm_nrm $p0, $m0
+    $x0 = VADD_16 $x0, $x6
+    PseudoLoopEnd <mcsymbol .L_LEnd0>, %bb.1
+
+  bb.2:
+    liveins: $p0, $p1, $x0
+    VST_PACK_S8_S16_ag_idx_imm $p1, 0, $x0, implicit $crsat
+    RET implicit $lr
+    DelayedSchedBarrier
+...


### PR DESCRIPTION
The merging of the postpipeliner prologue with the preheader block's instruction doesn't respect lock delays. This allows lock instructions to be moved across loads.