### PR TITLE
[AIE2P] Allow G_IMPLICIT_DEF as valid operand in broadcast

### DIFF
--- a/llvm/lib/Target/AIE/AIECombine.td
+++ b/llvm/lib/Target/AIE/AIECombine.td
@@ -114,6 +114,12 @@ def combine_vector_shuffle_to_extract_insert_elt : GICombineRule<
          [{ return matchShuffleToExtractInsertElt(*${root}, MRI, ${matchinfo}); }]),
   (apply [{ Helper.applyBuildFn(*${root}, ${matchinfo}); }])>;
 
+def combine_vector_shuffle_bcst_to_copy : GICombineRule<
+  (defs root:$root, build_fn_matchinfo:$matchinfo),
+  (match (wip_match_opcode G_SHUFFLE_VECTOR): $root,
+         [{ return matchShuffleBcstToCopy(*${root}, MRI, (const AIEBaseInstrInfo &)B.getTII(), ${matchinfo}); }]),
+  (apply [{ Helper.applyBuildFn(*${root}, ${matchinfo}); }])>;
+
 def AIE2PreLegalizerCombiner
     : GICombiner<"AIE2PreLegalizerCombinerImpl", [ combine_unpad_vector, combine_pad_vector,
                                                                  all_combines, combine_S20NarrowingOpt,
@@ -131,7 +137,9 @@ def AIE2PPreLegalizerCombiner
                                                                  all_combines, combine_S20NarrowingOpt,
                                                                  combine_globalval_offset,
                                                                  combine_extract_vector_elt_and_zsa_ext,
-                                                                 combine_splat_vector, combine_vector_broadcast,
+                                                                 combine_splat_vector, 
+                                                                 combine_vector_shuffle_bcst_to_copy,
+                                                                 combine_vector_broadcast,
                                                                  combine_concat_to_pad_vector, 
                                                                  combine_vector_shuffle_vsel,
                                                                  combine_vector_shuffle_broadcast,

--- a/llvm/lib/Target/AIE/AIECombinerHelper.cpp
+++ b/llvm/lib/Target/AIE/AIECombinerHelper.cpp
@@ -1178,18 +1178,38 @@ bool llvm::matchSplatVector(MachineInstr &MI, MachineRegisterInfo &MRI,
   case 2048:
     break;
   default:
-    // unimplemented
+    // unimplemented.
     return false;
   }
 
+  auto IsUndef = [&](const MachineOperand &Op) {
+    const MachineInstr *Undef = MRI.getVRegDef(Op.getReg());
+    return Undef && Undef->getOpcode() == TargetOpcode::G_IMPLICIT_DEF;
+  };
   const unsigned NumOps = MI.getNumOperands();
-  const MachineOperand FirstOp = MI.getOperand(1);
-  for (unsigned i = 2; i < NumOps; i++) {
-    if (!MI.getOperand(i).isIdenticalTo(FirstOp)) {
-      return false;
+  // First non-undef operand.
+  unsigned SrcReg = 0;
+  bool FoundSrc = false;
+  bool AllUndef = true;
+
+  // Find the first non-undef operand as the reference.
+  for (unsigned I = 1; I < NumOps; I++) {
+    const MachineOperand &Op = MI.getOperand(I);
+    if (!IsUndef(Op)) {
+      if (!FoundSrc) {
+        SrcReg = Op.getReg();
+        FoundSrc = true;
+      } else if (Op.getReg() != SrcReg) {
+        return false;
+      }
+      AllUndef = false;
     }
   }
-  MatchInfo = std::make_pair(DstVecReg, FirstOp.getReg());
+
+  if (AllUndef)
+    SrcReg = MI.getOperand(1).getReg();
+
+  MatchInfo = {DstVecReg, SrcReg};
   return true;
 }
 
@@ -1205,7 +1225,7 @@ static void buildBroadcastVector(MachineIRBuilder &B, MachineRegisterInfo &MRI,
     return Cst && Cst->Value.isZero();
   };
   // Check if the source is constant zero and build a 2048-bit
-  // vector destination
+  // vector destination.
   auto isConstantZero = IsConstantZeroReg(SrcReg) && DstVecSize == 2048;
   if (SrcTy == LLT::scalar(8) || SrcTy == LLT::scalar(16)) {
     const LLT S32 = LLT::scalar(32);
@@ -2828,6 +2848,41 @@ bool llvm::matchShuffleToConcatExtractedSubvectors(MachineInstr &MI,
     }
     B.buildConcatVectors({DstReg}, ExtractedSubvectors);
   };
+
+  return true;
+}
+
+///  %1:_(s32) = COPY $r0
+///  %2:_(<16 x s32>) = G_IMPLICIT_DEF
+///  %3:_(<16 x s32>) = G_AIE_BROADCAST_VECTOR %1:_(s32)
+///  %0:_(<16 x s32>) = G_SHUFFLE_VECTOR %3(<16 x s32>), %2(<16 x s32>),
+///  shufflemask(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+/// To convert to:
+///  %0:_(<16 x s32>) = G_AIE_BROADCAST_VECTOR %1(s32)
+bool llvm::matchShuffleBcstToCopy(MachineInstr &MI, MachineRegisterInfo &MRI,
+                                  const TargetInstrInfo &TII,
+                                  BuildFnTy &MatchInfo) {
+  assert(MI.getOpcode() == TargetOpcode::G_SHUFFLE_VECTOR);
+
+  const auto [DstReg, DstTy, Src1Reg, Src1Ty] = MI.getFirst2RegLLTs();
+  if (DstTy != Src1Ty)
+    return false;
+
+  ArrayRef<int> Mask = MI.getOperand(3).getShuffleMask();
+  const AIEBaseInstrInfo &AIETII = (const AIEBaseInstrInfo &)TII;
+  MachineInstr *SrcVec = MRI.getVRegDef(Src1Reg);
+  // Check if the first source is defined by a Broadcast.
+  if (SrcVec->getOpcode() != AIETII.getGenericBroadcastVectorOpcode())
+    return false;
+
+  const unsigned NumSrcElems = Src1Ty.isVector() ? Src1Ty.getNumElements() : 1;
+  if (Mask.size() != NumSrcElems)
+    return false;
+
+  if (MaskMatch::isMaskWithAllUndefs(Mask))
+    return false;
+
+  MatchInfo = [=](MachineIRBuilder &B) { B.buildCopy(DstReg, Src1Reg); };
 
   return true;
 }

--- a/llvm/lib/Target/AIE/AIECombinerHelper.cpp
+++ b/llvm/lib/Target/AIE/AIECombinerHelper.cpp
@@ -2864,7 +2864,11 @@ bool llvm::matchShuffleBcstToCopy(MachineInstr &MI, MachineRegisterInfo &MRI,
                                   BuildFnTy &MatchInfo) {
   assert(MI.getOpcode() == TargetOpcode::G_SHUFFLE_VECTOR);
 
-  const auto [DstReg, DstTy, Src1Reg, Src1Ty] = MI.getFirst2RegLLTs();
+  const Register DstReg = MI.getOperand(0).getReg();
+  const Register Src1Reg = MI.getOperand(1).getReg();
+  const LLT DstTy = MRI.getType(DstReg);
+  const LLT Src1Ty = MRI.getType(Src1Reg);
+
   if (DstTy != Src1Ty)
     return false;
 

--- a/llvm/lib/Target/AIE/AIECombinerHelper.h
+++ b/llvm/lib/Target/AIE/AIECombinerHelper.h
@@ -271,6 +271,8 @@ bool matchShuffleToConcatExtractedSubvectors(MachineInstr &MI,
 
 bool matchShuffleToCopy(MachineInstr &MI, MachineRegisterInfo &MRI,
                         BuildFnTy &MatchInfo);
+bool matchShuffleBcstToCopy(MachineInstr &MI, MachineRegisterInfo &MRI,
+                            const TargetInstrInfo &TII, BuildFnTy &MatchInfo);
 
 bool matchShuffleToExtractInsertElt(MachineInstr &MI, MachineRegisterInfo &MRI,
                                     BuildFnTy &MatchInfo);

--- a/llvm/test/CodeGen/AIE/aie2p/GlobalIsel/prelegalizercombiner-vector-broadcast.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/GlobalIsel/prelegalizercombiner-vector-broadcast.mir
@@ -267,3 +267,202 @@ body:             |
     $dm0 = COPY %0(<32 x s64>)
 
 ...
+---
+name:       test_broadcast_constant_0_and_undef_to_v16s32
+alignment:       16
+body:             |
+  bb.1.entry:
+    ; CHECK-LABEL: name: test_broadcast_constant_0_and_undef_to_v16s32
+    ; CHECK: [[C:%[0-9]+]]:_(s32) = G_CONSTANT i32 0
+    ; CHECK-NEXT: [[AIE_BROADCAST_VECTOR:%[0-9]+]]:_(<16 x s32>) = G_AIE_BROADCAST_VECTOR [[C]](s32)
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[AIE_BROADCAST_VECTOR]](<16 x s32>)
+    %1:_(s32) = G_CONSTANT i32 0
+    %2:_(s32) = G_IMPLICIT_DEF
+    %0:_(<16 x s32>) = G_BUILD_VECTOR %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32)
+    PseudoRET implicit $lr, implicit %0
+...
+---
+name:       test_broadcast_constant_0_and_undef_mix_to_v16s32
+alignment:       16
+body:             |
+  bb.1.entry:
+    ; CHECK-LABEL: name: test_broadcast_constant_0_and_undef_mix_to_v16s32
+    ; CHECK: [[C:%[0-9]+]]:_(s32) = G_CONSTANT i32 0
+    ; CHECK-NEXT: [[AIE_BROADCAST_VECTOR:%[0-9]+]]:_(<16 x s32>) = G_AIE_BROADCAST_VECTOR [[C]](s32)
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[AIE_BROADCAST_VECTOR]](<16 x s32>)
+    %1:_(s32) = G_CONSTANT i32 0
+    %2:_(s32) = G_IMPLICIT_DEF
+    %0:_(<16 x s32>) = G_BUILD_VECTOR %1(s32), %2(s32), %1(s32), %2(s32), %1(s32), %1(s32), %1(s32), %1(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32)
+    PseudoRET implicit $lr, implicit %0
+...
+---
+name:       test_broadcast_to_v16s32_invalid
+alignment:       16
+body:             |
+  bb.1.entry:
+    ; CHECK-LABEL: name: test_broadcast_to_v16s32_invalid
+    ; CHECK: [[C:%[0-9]+]]:_(s32) = G_CONSTANT i32 0
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(s32) = COPY $r1
+    ; CHECK-NEXT: [[DEF:%[0-9]+]]:_(s32) = G_IMPLICIT_DEF
+    ; CHECK-NEXT: [[BUILD_VECTOR:%[0-9]+]]:_(<16 x s32>) = G_BUILD_VECTOR [[C]](s32), [[COPY]](s32), [[C]](s32), [[COPY]](s32), [[C]](s32), [[C]](s32), [[DEF]](s32), [[C]](s32), [[DEF]](s32), [[COPY]](s32), [[COPY]](s32), [[COPY]](s32), [[COPY]](s32), [[COPY]](s32), [[COPY]](s32), [[C]](s32)
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[BUILD_VECTOR]](<16 x s32>)
+    %1:_(s32) = G_CONSTANT i32 0
+    %2:_(s32) = COPY $r1
+    %3:_(s32) = G_IMPLICIT_DEF
+    %0:_(<16 x s32>) = G_BUILD_VECTOR %1(s32), %2(s32), %1(s32), %2(s32), %1(s32), %1(s32), %3(s32), %1(s32), %3(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %1(s32)
+    PseudoRET implicit $lr, implicit %0
+
+...
+---
+name:       test_broadcast_constant_0_and_undef_to_v32s32
+alignment:       16
+body:             |
+  bb.1.entry:
+    ; CHECK-LABEL: name: test_broadcast_constant_0_and_undef_to_v32s32
+    ; CHECK: [[C:%[0-9]+]]:_(s32) = G_CONSTANT i32 0
+    ; CHECK-NEXT: [[AIE_BROADCAST_VECTOR:%[0-9]+]]:_(<16 x s32>) = G_AIE_BROADCAST_VECTOR [[C]](s32)
+    ; CHECK-NEXT: [[CONCAT_VECTORS:%[0-9]+]]:_(<32 x s32>) = G_CONCAT_VECTORS [[AIE_BROADCAST_VECTOR]](<16 x s32>), [[AIE_BROADCAST_VECTOR]](<16 x s32>)
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[CONCAT_VECTORS]](<32 x s32>)
+    %1:_(s32) = G_CONSTANT i32 0
+    %2:_(s32) = G_IMPLICIT_DEF
+    %0:_(<32 x s32>) = G_BUILD_VECTOR %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32)
+    PseudoRET implicit $lr, implicit %0
+
+...
+---
+name:       test_broadcast_undef_and_reg_to_v32s32
+alignment:       16
+body:             |
+  bb.1.entry:
+    ; CHECK-LABEL: name: test_broadcast_undef_and_reg_to_v32s32
+    ; CHECK: [[COPY:%[0-9]+]]:_(s32) = COPY $r1
+    ; CHECK-NEXT: [[AIE_BROADCAST_VECTOR:%[0-9]+]]:_(<16 x s32>) = G_AIE_BROADCAST_VECTOR [[COPY]](s32)
+    ; CHECK-NEXT: [[CONCAT_VECTORS:%[0-9]+]]:_(<32 x s32>) = G_CONCAT_VECTORS [[AIE_BROADCAST_VECTOR]](<16 x s32>), [[AIE_BROADCAST_VECTOR]](<16 x s32>)
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[CONCAT_VECTORS]](<32 x s32>)
+    %1:_(s32) = COPY $r1
+    %2:_(s32) = G_IMPLICIT_DEF
+    %0:_(<32 x s32>) = G_BUILD_VECTOR %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32)
+    PseudoRET implicit $lr, implicit %0
+
+...
+---
+name:       test_broadcast_reg_and_undef_to_v32s32
+alignment:       16
+body:             |
+  bb.1.entry:
+    ; CHECK-LABEL: name: test_broadcast_reg_and_undef_to_v32s32
+    ; CHECK: [[COPY:%[0-9]+]]:_(s32) = COPY $r1
+    ; CHECK-NEXT: [[AIE_BROADCAST_VECTOR:%[0-9]+]]:_(<16 x s32>) = G_AIE_BROADCAST_VECTOR [[COPY]](s32)
+    ; CHECK-NEXT: [[CONCAT_VECTORS:%[0-9]+]]:_(<32 x s32>) = G_CONCAT_VECTORS [[AIE_BROADCAST_VECTOR]](<16 x s32>), [[AIE_BROADCAST_VECTOR]](<16 x s32>)
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[CONCAT_VECTORS]](<32 x s32>)
+    %1:_(s32) = G_IMPLICIT_DEF
+    %2:_(s32) = COPY $r1
+    %0:_(<32 x s32>) = G_BUILD_VECTOR %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32)
+    PseudoRET implicit $lr, implicit %0
+
+...
+---
+name:       test_broadcast_reg_and_undef_mix_to_v32s32
+alignment:       16
+body:             |
+  bb.1.entry:
+    ; CHECK-LABEL: name: test_broadcast_reg_and_undef_mix_to_v32s32
+    ; CHECK: [[COPY:%[0-9]+]]:_(s32) = COPY $r1
+    ; CHECK-NEXT: [[AIE_BROADCAST_VECTOR:%[0-9]+]]:_(<16 x s32>) = G_AIE_BROADCAST_VECTOR [[COPY]](s32)
+    ; CHECK-NEXT: [[CONCAT_VECTORS:%[0-9]+]]:_(<32 x s32>) = G_CONCAT_VECTORS [[AIE_BROADCAST_VECTOR]](<16 x s32>), [[AIE_BROADCAST_VECTOR]](<16 x s32>)
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[CONCAT_VECTORS]](<32 x s32>)
+    %1:_(s32) = G_IMPLICIT_DEF
+    %2:_(s32) = COPY $r1
+    %0:_(<32 x s32>) = G_BUILD_VECTOR %1(s32), %2(s32), %1(s32), %2(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %1(s32), %2(s32)
+    PseudoRET implicit $lr, implicit %0
+
+...
+---
+name:       test_broadcast_undef_and_constant_0_to_v32s32
+alignment:       16
+body:             |
+  bb.1.entry:
+    ; CHECK-LABEL: name: test_broadcast_undef_and_constant_0_to_v32s32
+    ; CHECK: [[C:%[0-9]+]]:_(s32) = G_CONSTANT i32 0
+    ; CHECK-NEXT: [[AIE_BROADCAST_VECTOR:%[0-9]+]]:_(<16 x s32>) = G_AIE_BROADCAST_VECTOR [[C]](s32)
+    ; CHECK-NEXT: [[CONCAT_VECTORS:%[0-9]+]]:_(<32 x s32>) = G_CONCAT_VECTORS [[AIE_BROADCAST_VECTOR]](<16 x s32>), [[AIE_BROADCAST_VECTOR]](<16 x s32>)
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[CONCAT_VECTORS]](<32 x s32>)
+    %1:_(s32) = G_IMPLICIT_DEF
+    %2:_(s32) = G_CONSTANT i32 0
+    %0:_(<32 x s32>) = G_BUILD_VECTOR %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32)
+    PseudoRET implicit $lr, implicit %0
+
+...
+---
+name:       test_broadcast_constant_0_and_undef_to_v64s32
+alignment:       16
+body:             |
+  bb.1.entry:
+    ; CHECK-LABEL: name: test_broadcast_constant_0_and_undef_to_v64s32
+    ; CHECK: [[C:%[0-9]+]]:_(s32) = G_FCONSTANT float 0.000000e+00
+    ; CHECK-NEXT: [[AIE_BROADCAST_VECTOR:%[0-9]+]]:_(<64 x s32>) = G_AIE_BROADCAST_VECTOR [[C]](s32)
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[AIE_BROADCAST_VECTOR]](<64 x s32>)
+    %1:_(s32) = G_FCONSTANT float 0.000000e+00
+    %2:_(s32) = G_IMPLICIT_DEF
+    %0:_(<64 x s32>) = G_BUILD_VECTOR %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32)
+    PseudoRET implicit $lr, implicit %0
+...
+---
+name:       test_broadcast_undef_and_constant_0_to_v64s32
+alignment:       16
+body:             |
+  bb.1.entry:
+    ; CHECK-LABEL: name: test_broadcast_undef_and_constant_0_to_v64s32
+    ; CHECK: [[C:%[0-9]+]]:_(s32) = G_CONSTANT i32 0
+    ; CHECK-NEXT: [[AIE_BROADCAST_VECTOR:%[0-9]+]]:_(<64 x s32>) = G_AIE_BROADCAST_VECTOR [[C]](s32)
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[AIE_BROADCAST_VECTOR]](<64 x s32>)
+    %1:_(s32) = G_IMPLICIT_DEF
+    %2:_(s32) = G_CONSTANT i32 0
+    %0:_(<64 x s32>) = G_BUILD_VECTOR %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %1(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32), %2(s32)
+    PseudoRET implicit $lr, implicit %0
+...
+---
+name:       test_shuffle_broadcast_combine_v64s8
+alignment:       16
+body:             |
+  bb.1.entry:
+    ; CHECK-LABEL: name: test_shuffle_broadcast_combine_v64s8
+    ; CHECK: [[COPY:%[0-9]+]]:_(s32) = COPY $r0
+    ; CHECK-NEXT: [[AIE_BROADCAST_VECTOR:%[0-9]+]]:_(<64 x s8>) = G_AIE_BROADCAST_VECTOR [[COPY]](s32)
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[AIE_BROADCAST_VECTOR]](<64 x s8>)
+  %1:_(s32) = COPY $r0
+  %2:_(<64 x s8>) = G_IMPLICIT_DEF
+  %3:_(<64 x s8>) = G_AIE_BROADCAST_VECTOR %1:_(s32)
+  %0:_(<64 x s8>) = G_SHUFFLE_VECTOR %3:_(<64 x s8>), %2:_, shufflemask(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+  PseudoRET implicit $lr, implicit %0
+
+...
+---
+name:       test_shuffle_broadcast_combine_v64s32
+alignment:       16
+body:             |
+  bb.1.entry:
+    ; CHECK-LABEL: name: test_shuffle_broadcast_combine_v64s32
+    ; CHECK: [[C:%[0-9]+]]:_(s32) = G_CONSTANT i32 0
+    ; CHECK-NEXT: [[AIE_BROADCAST_VECTOR:%[0-9]+]]:_(<64 x s32>) = G_AIE_BROADCAST_VECTOR [[C]](s32)
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[AIE_BROADCAST_VECTOR]](<64 x s32>)
+  %1:_(s32) = G_CONSTANT i32 0
+  %2:_(<64 x s32>) = G_IMPLICIT_DEF
+  %3:_(<64 x s32>) = G_AIE_BROADCAST_VECTOR %1:_(s32)
+  %0:_(<64 x s32>) = G_SHUFFLE_VECTOR %3:_(<64 x s32>), %2:_, shufflemask(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+  PseudoRET implicit $lr, implicit %0
+
+...
+---
+name:       test_shuffle_broadcast_combine_v64s8_und_mask
+alignment:       16
+body:             |
+  bb.1.entry:
+    ; CHECK-LABEL: name: test_shuffle_broadcast_combine_v64s8_und_mask
+    ; CHECK: [[DEF:%[0-9]+]]:_(<64 x s8>) = G_IMPLICIT_DEF
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[DEF]](<64 x s8>)
+  %1:_(s32) = COPY $r0
+  %2:_(<64 x s8>) = G_IMPLICIT_DEF
+  %3:_(<64 x s8>) = G_AIE_BROADCAST_VECTOR %1:_(s32)
+  %0:_(<64 x s8>) = G_SHUFFLE_VECTOR %3:_(<64 x s8>), %2:_, shufflemask(-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1)
+  PseudoRET implicit $lr, implicit %0


### PR DESCRIPTION
1. ) G_BUILD_VECTOR(undef, def) -> AIE_BROADCAST_VECTOR def
2. ) G_SHUFFLE_VECTOR (AIE_BROADCAST_VECTOR, src2, shufflemask(0)) -> AIE_BROADCAST_VECTOR