### PR TITLE
Introduce `-mno-vitis-headers` to accelerate compiler checks for RT libs

### DIFF
--- a/clang/cmake/caches/Peano-AIE-runtime-libraries.cmake
+++ b/clang/cmake/caches/Peano-AIE-runtime-libraries.cmake
@@ -58,6 +58,8 @@ foreach(target ${LLVM_BUILTIN_TARGETS})
   set(RUNTIMES_${target}_LIBCXX_INCLUDE_BENCHMARKS OFF CACHE STRING "")
   set(RUNTIMES_${target}_LIBCXX_INCLUDE_TESTS OFF CACHE STRING "")
   set(RUNTIMES_${target}_LIBCXX_EXTRA_SITE_DEFINES "_LIBCPP_REMOVE_TRANSITIVE_INCLUDES" CACHE STRING "")
+  # disable inclusion of vitis headers for compiler checks
+  set(RUNTIMES_${target}_CMAKE_REQUIRED_FLAGS "-mno-vitis-headers" CACHE STRING "")
 
   set(RUNTIMES_${target}_LIBC_ENABLE_USE_BY_CLANG ON CACHE STRING "")
   # LIBC includes C++ sources which by default trigger inclusion of standard libc++ headers


### PR DESCRIPTION
Configuring the CMake project for RT libs takes more time than needed as `compiler-rt` standard compile checks are conducted with the inclusion of all Vitis headers. 

This PR disables the inclusion of those headers through the `CMAKE_REQUIRED_FLAGS` cache entry inspected by the [CheckCXXSourceCompiles](https://cmake.org/cmake/help/latest/module/CheckCXXSourceCompiles.html) module that is internally used to conduct these checks. 

From my observations, this change drops the time to conduct a debug build by 1-2 hours, depending on the exact CMake configuration.