### PR TITLE
Decouple register classes in rewriting

### DIFF
--- a/llvm/lib/Target/AIE/AIEWawRegRewriter.cpp
+++ b/llvm/lib/Target/AIE/AIEWawRegRewriter.cpp
@@ -271,13 +271,17 @@ bool AIEWawRegRewriter::renameMBBPhysRegs(const MachineBasicBlock *MBB) {
   }
 
   // Free physregs of all candidates and register their regclasses
-  std::set<const TargetRegisterClass *> RegClasses;
+  // RegClasses is a map that tracks successful reallocation for all
+  // registers in that class. If there's a failure in a register class, all
+  // allocations for register classes that overlap with the failed ones are
+  // reverted
+  std::map<const TargetRegisterClass *, bool> RegClasses;
   for (auto &[MO, Org] : Candidates) {
     auto VReg = MO->getReg();
     if (VRM->hasPhys(VReg))
       unassignReg(VReg);
     auto *RC = MRI->getRegClass(VReg);
-    RegClasses.insert(RC);
+    RegClasses.emplace(RC, true);
   }
   LLVM_DEBUG(dbgs() << "Renaming " << Candidates.size() << " candidates in "
                     << RegClasses.size() << " classes\n");
@@ -298,6 +302,7 @@ bool AIEWawRegRewriter::renameMBBPhysRegs(const MachineBasicBlock *MBB) {
   // Reallocate all virtual registers in Candidates.
   // Return true if successful.
   auto ReAllocate = [&](OriginalAllocation &Candidates, RoundRobin &Registers) {
+    bool AnyFails = false;
     BitVector UsedUnits;
     UsedUnits.resize(TRI->getNumRegUnits());
     for (auto &[MO, Org] : Candidates) {
@@ -305,25 +310,53 @@ bool AIEWawRegRewriter::renameMBBPhysRegs(const MachineBasicBlock *MBB) {
       if (!replaceReg(VReg, Registers, UsedUnits)) {
         LLVM_DEBUG(dbgs() << "Renaming " << printReg(VReg, TRI, 0, MRI)
                           << " failed\n");
-        return false;
+        auto *RC = MRI->getRegClass(VReg);
+        AnyFails = true;
+        RegClasses[RC] = false;
       }
     }
-    return true;
+    return !AnyFails;
   };
 
-  // Reapply the original allocation to all Candidates
-  auto RevertAllocation = [&](OriginalAllocation &Candidates) {
-    // The partial allocation may conflict with the original one in ugly ways.
-    // To be safe, reset all allocations first.
-    for (auto &[MO, Org] : Candidates) {
-      auto VReg = MO->getReg();
-      if (VRM->hasPhys(VReg)) {
-        unassignReg(VReg);
+  auto Overlaps = [this](MCRegister Reg, const TargetRegisterClass *RC) {
+    for (auto RCReg : RC->getRegisters()) {
+      if (TRI->regsOverlap(Reg, RCReg)) {
+        return true;
       }
     }
-    for (auto &[MO, Org] : Candidates) {
-      auto VReg = MO->getReg();
-      assignReg(VReg, Org);
+    return false;
+  };
+
+  // Reapply the original allocation to all Candidates involved in failed
+  // register classes.
+  auto RevertAllocation = [&](OriginalAllocation &Candidates) {
+    // We revert all allocations whose original have an overlap
+    // with a failed register class.
+    // The partial allocation may conflict with the original one in ugly ways,
+    // which means we may not be able to reassign in arbitrary order
+    // To be safe, reset all allocations first.
+    for (auto [RC, Success] : RegClasses) {
+      LLVM_DEBUG(dbgs() << "RC=" << TRI->getRegClassName(RC)
+                        << (Success ? " Succeeded\n" : " Failed\n"));
+      if (Success) {
+        continue;
+      }
+      for (auto &[MO, Org] : Candidates) {
+        if (Overlaps(Org, RC)) {
+          auto VReg = MO->getReg();
+          if (VRM->hasPhys(VReg)) {
+            unassignReg(VReg);
+          }
+        }
+      }
+      for (auto &[MO, Org] : Candidates) {
+        if (Overlaps(Org, RC)) {
+          auto VReg = MO->getReg();
+          LLVM_DEBUG(dbgs() << "Reverting " << printReg(VReg, TRI) << " to "
+                            << printReg(Org, TRI) << "\n");
+          assignReg(VReg, Org);
+        }
+      }
     }
   };
 
@@ -339,7 +372,7 @@ bool AIEWawRegRewriter::renameMBBPhysRegs(const MachineBasicBlock *MBB) {
   for (const MCPhysReg *CSR = MRI->getCalleeSavedRegs(); CSR && *CSR; ++CSR)
     ExcludedPhysRegs[*CSR] = true;
 
-  for (const auto *RC : RegClasses) {
+  for (const auto [RC, Success] : RegClasses) {
 
     LLVM_DEBUG(dbgs() << "Allowed registers in RC=" << TRI->getRegClassName(RC)
                       << ":");
@@ -352,6 +385,7 @@ bool AIEWawRegRewriter::renameMBBPhysRegs(const MachineBasicBlock *MBB) {
     }
     LLVM_DEBUG(dbgs() << "\n");
   }
+
   if (!ReAllocate(Candidates, LRURegisters)) {
     RevertAllocation(Candidates);
     return false;

--- a/llvm/lib/Target/AIE/AIEWawRegRewriter.cpp
+++ b/llvm/lib/Target/AIE/AIEWawRegRewriter.cpp
@@ -47,6 +47,10 @@ static cl::opt<bool> AggressiveReAlloc(
 static cl::opt<bool> GPRRealloc("aie-gpr-realloc", cl::Hidden, cl::init(false),
                                 cl::desc("Re-allocate GPRs as well"));
 
+static cl::opt<bool> PreAlloc(
+    "aie-realloc-loopaware", cl::Hidden, cl::init(false),
+    cl::desc("Prime the LRU queue to make the allocations more loop-aware"));
+
 namespace {
 
 using RoundRobin = std::list<MCPhysReg>;
@@ -299,12 +303,28 @@ bool AIEWawRegRewriter::renameMBBPhysRegs(const MachineBasicBlock *MBB) {
     }
   }
 
+  // Pre-allocate all virtual registers in Candidates. The sole purpose of
+  // this is to prime the LRURegisters, so that the end of the loop is
+  // considered to be near to the start. No actual allocations are made.
+  // The ultimate allocation is expected to be different from this initial
+  // run -- that's the whole purpose.
+  auto PreAllocate = [&](OriginalAllocation &Candidates,
+                         RoundRobin &LRURegisters) {
+    // This is tracking any used register unit across the entire loop.
+    BitVector UsedUnits(TRI->getNumRegUnits());
+    for (auto &[MO, Org] : Candidates) {
+      auto VReg = MO->getReg();
+      assert(VReg.isVirtual());
+      (void)getReplacementPhysReg(VReg, LRURegisters, UsedUnits);
+    }
+  };
+
   // Reallocate all virtual registers in Candidates.
   // Return true if successful.
   auto ReAllocate = [&](OriginalAllocation &Candidates, RoundRobin &Registers) {
     bool AnyFails = false;
-    BitVector UsedUnits;
-    UsedUnits.resize(TRI->getNumRegUnits());
+    // This is tracking any used register unit across the entire loop.
+    BitVector UsedUnits(TRI->getNumRegUnits());
     for (auto &[MO, Org] : Candidates) {
       auto VReg = MO->getReg();
       if (!replaceReg(VReg, Registers, UsedUnits)) {
@@ -386,6 +406,10 @@ bool AIEWawRegRewriter::renameMBBPhysRegs(const MachineBasicBlock *MBB) {
     LLVM_DEBUG(dbgs() << "\n");
   }
 
+  // Prime the LRURegisters, so that the allocation is loop-aware.
+  if (PreAlloc) {
+    PreAllocate(Candidates, LRURegisters);
+  }
   if (!ReAllocate(Candidates, LRURegisters)) {
     RevertAllocation(Candidates);
     return false;

--- a/llvm/lib/Target/AIE/AIEWawRegRewriter.cpp
+++ b/llvm/lib/Target/AIE/AIEWawRegRewriter.cpp
@@ -13,7 +13,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "AIEBaseInstrInfo.h"
+#include "AIE.h"
 #include "AIEBaseRegisterInfo.h"
 #include "Utils/AIELoopUtils.h"
 
@@ -35,6 +35,7 @@
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/raw_ostream.h"
 #include <llvm/CodeGen/MachineBasicBlock.h>
+#include <map>
 
 using namespace llvm;
 
@@ -53,7 +54,15 @@ static cl::opt<bool> PreAlloc(
 
 namespace {
 
+// Defines the next register to use in reallocation.
 using RoundRobin = std::list<MCPhysReg>;
+
+// Record the candidates and their original allocation.
+using OriginalAllocation =
+    std::vector<std::pair<const MachineOperand *, Register>>;
+
+// Record success for a whole register class.
+using RegClassSuccess = std::map<const TargetRegisterClass *, bool>;
 
 ///
 /// This pass rewrites physical register assignments in critical parts of the
@@ -99,6 +108,25 @@ private:
   const TargetInstrInfo *TII = nullptr;
 
   bool renameMBBPhysRegs(const MachineBasicBlock *MBB);
+
+  /// Pre-allocate all virtual registers in Candidates. The sole purpose of
+  /// this is to prime the LRURegisters, so that the end of the loop is
+  /// considered to be near to the start. No actual allocations are made.
+  /// The ultimate allocation is expected to be different from this initial
+  /// run -- that's the whole purpose.
+  void preAllocate(OriginalAllocation &Candidates, RoundRobin &LRURegisters);
+
+  /// Reallocate all virtual registers in Candidates.
+  /// Return true if successful for all classes.
+  bool reAllocate(OriginalAllocation &Candidates, RoundRobin &LRURegisters,
+                  RegClassSuccess &RegClasses);
+
+  /// If reallocation fails for a particular register class, we can't trust the
+  /// partial allocation for that class to be correct. Therefore, we have to
+  /// revert all reallocations that are in a register class that overlaps with
+  /// the failed one.
+  void revertAllocation(OriginalAllocation &Candidates,
+                        RegClassSuccess &RegClasses);
 
   /// Get all the defined physical registers that the MachineBasicBlock already
   /// uses. These physical registers should not be used for replacement
@@ -218,6 +246,75 @@ AIEWawRegRewriter::getVRegWithCopies(const MachineBasicBlock &MBB) const {
   return VRegWithCopies;
 }
 
+void AIEWawRegRewriter::preAllocate(OriginalAllocation &Candidates,
+                                    RoundRobin &LRURegisters) {
+  // This is tracking any used register unit across the entire loop.
+  BitVector UsedUnits(TRI->getNumRegUnits());
+  for (auto &[MO, Org] : Candidates) {
+    auto VReg = MO->getReg();
+    assert(VReg.isVirtual());
+    (void)getReplacementPhysReg(VReg, LRURegisters, UsedUnits);
+  }
+}
+
+bool AIEWawRegRewriter::reAllocate(OriginalAllocation &Candidates,
+                                   RoundRobin &Registers,
+                                   RegClassSuccess &RegClasses) {
+  bool Success = true;
+  // This is tracking any used register unit across the entire loop.
+  BitVector UsedUnits(TRI->getNumRegUnits());
+  for (auto &[MO, Org] : Candidates) {
+    auto VReg = MO->getReg();
+    if (!replaceReg(VReg, Registers, UsedUnits)) {
+      LLVM_DEBUG(dbgs() << "Renaming " << printReg(VReg, TRI, 0, MRI)
+                        << " failed\n");
+      auto *RC = MRI->getRegClass(VReg);
+      Success = false;
+      RegClasses[RC] = false;
+    }
+  }
+  return Success;
+}
+
+void AIEWawRegRewriter::revertAllocation(OriginalAllocation &Candidates,
+                                         RegClassSuccess &RegClasses) {
+
+  auto Overlaps = [this](MCRegister Reg, const TargetRegisterClass *RC) {
+    return any_of(RC->getRegisters(), [this, Reg](MCRegister RCReg) {
+      return TRI->regsOverlap(Reg, RCReg);
+    });
+  };
+
+  // We revert all allocations whose original have an overlap
+  // with a failed register class.
+  // The partial allocation may conflict with the original one in ugly ways,
+  // which means we may not be able to reassign in arbitrary order.
+  // To be safe, reset all allocations first.
+  for (auto [RC, Success] : RegClasses) {
+    LLVM_DEBUG(dbgs() << "RC=" << TRI->getRegClassName(RC)
+                      << (Success ? " Succeeded\n" : " Failed\n"));
+    if (Success) {
+      continue;
+    }
+    for (auto &[MO, Org] : Candidates) {
+      if (Overlaps(Org, RC)) {
+        auto VReg = MO->getReg();
+        if (VRM->hasPhys(VReg)) {
+          unassignReg(VReg);
+        }
+      }
+    }
+    for (auto &[MO, Org] : Candidates) {
+      if (Overlaps(Org, RC)) {
+        auto VReg = MO->getReg();
+        LLVM_DEBUG(dbgs() << "Reverting " << printReg(VReg, TRI) << " to "
+                          << printReg(Org, TRI) << "\n");
+        assignReg(VReg, Org);
+      }
+    }
+  }
+}
+
 bool AIEWawRegRewriter::renameMBBPhysRegs(const MachineBasicBlock *MBB) {
   LLVM_DEBUG(dbgs() << "WAW Reg Renaming BasicBlock "; MBB->dump();
              dbgs() << "\n");
@@ -232,9 +329,6 @@ bool AIEWawRegRewriter::renameMBBPhysRegs(const MachineBasicBlock *MBB) {
   IndexedMap<const MachineInstr *, VirtReg2IndexFunctor> LastVRegDef =
       getLastVRegDef(*MBB);
 
-  // Record the candidates and their original allocation
-  using OriginalAllocation =
-      std::vector<std::pair<const MachineOperand *, Register>>;
   OriginalAllocation Candidates;
 
   for (const MachineInstr &MI : *MBB) {
@@ -303,86 +397,9 @@ bool AIEWawRegRewriter::renameMBBPhysRegs(const MachineBasicBlock *MBB) {
     }
   }
 
-  // Pre-allocate all virtual registers in Candidates. The sole purpose of
-  // this is to prime the LRURegisters, so that the end of the loop is
-  // considered to be near to the start. No actual allocations are made.
-  // The ultimate allocation is expected to be different from this initial
-  // run -- that's the whole purpose.
-  auto PreAllocate = [&](OriginalAllocation &Candidates,
-                         RoundRobin &LRURegisters) {
-    // This is tracking any used register unit across the entire loop.
-    BitVector UsedUnits(TRI->getNumRegUnits());
-    for (auto &[MO, Org] : Candidates) {
-      auto VReg = MO->getReg();
-      assert(VReg.isVirtual());
-      (void)getReplacementPhysReg(VReg, LRURegisters, UsedUnits);
-    }
-  };
-
-  // Reallocate all virtual registers in Candidates.
-  // Return true if successful.
-  auto ReAllocate = [&](OriginalAllocation &Candidates, RoundRobin &Registers) {
-    bool AnyFails = false;
-    // This is tracking any used register unit across the entire loop.
-    BitVector UsedUnits(TRI->getNumRegUnits());
-    for (auto &[MO, Org] : Candidates) {
-      auto VReg = MO->getReg();
-      if (!replaceReg(VReg, Registers, UsedUnits)) {
-        LLVM_DEBUG(dbgs() << "Renaming " << printReg(VReg, TRI, 0, MRI)
-                          << " failed\n");
-        auto *RC = MRI->getRegClass(VReg);
-        AnyFails = true;
-        RegClasses[RC] = false;
-      }
-    }
-    return !AnyFails;
-  };
-
-  auto Overlaps = [this](MCRegister Reg, const TargetRegisterClass *RC) {
-    for (auto RCReg : RC->getRegisters()) {
-      if (TRI->regsOverlap(Reg, RCReg)) {
-        return true;
-      }
-    }
-    return false;
-  };
-
-  // Reapply the original allocation to all Candidates involved in failed
-  // register classes.
-  auto RevertAllocation = [&](OriginalAllocation &Candidates) {
-    // We revert all allocations whose original have an overlap
-    // with a failed register class.
-    // The partial allocation may conflict with the original one in ugly ways,
-    // which means we may not be able to reassign in arbitrary order
-    // To be safe, reset all allocations first.
-    for (auto [RC, Success] : RegClasses) {
-      LLVM_DEBUG(dbgs() << "RC=" << TRI->getRegClassName(RC)
-                        << (Success ? " Succeeded\n" : " Failed\n"));
-      if (Success) {
-        continue;
-      }
-      for (auto &[MO, Org] : Candidates) {
-        if (Overlaps(Org, RC)) {
-          auto VReg = MO->getReg();
-          if (VRM->hasPhys(VReg)) {
-            unassignReg(VReg);
-          }
-        }
-      }
-      for (auto &[MO, Org] : Candidates) {
-        if (Overlaps(Org, RC)) {
-          auto VReg = MO->getReg();
-          LLVM_DEBUG(dbgs() << "Reverting " << printReg(VReg, TRI) << " to "
-                            << printReg(Org, TRI) << "\n");
-          assignReg(VReg, Org);
-        }
-      }
-    }
-  };
-
   // Least-Recently-Used list of physical registers for assignments to VRegs.
   // Physical registers that have recently been used are moved to the back.
-  std::list<MCPhysReg> LRURegisters;
+  RoundRobin LRURegisters;
 
   // For each reg class, allocate the candidates in round-robin fashion.
   // If we fail, we fall back to the original allocation
@@ -393,7 +410,6 @@ bool AIEWawRegRewriter::renameMBBPhysRegs(const MachineBasicBlock *MBB) {
     ExcludedPhysRegs[*CSR] = true;
 
   for (const auto [RC, Success] : RegClasses) {
-
     LLVM_DEBUG(dbgs() << "Allowed registers in RC=" << TRI->getRegClassName(RC)
                       << ":");
     for (MCPhysReg PhysReg : RC->getRegisters()) {
@@ -408,10 +424,10 @@ bool AIEWawRegRewriter::renameMBBPhysRegs(const MachineBasicBlock *MBB) {
 
   // Prime the LRURegisters, so that the allocation is loop-aware.
   if (PreAlloc) {
-    PreAllocate(Candidates, LRURegisters);
+    preAllocate(Candidates, LRURegisters);
   }
-  if (!ReAllocate(Candidates, LRURegisters)) {
-    RevertAllocation(Candidates);
+  if (!reAllocate(Candidates, LRURegisters, RegClasses)) {
+    revertAllocation(Candidates, RegClasses);
     return false;
   }
 

--- a/llvm/test/CodeGen/AIE/aie2/end-to-end/Conv2D-red-swp.ll
+++ b/llvm/test/CodeGen/AIE/aie2/end-to-end/Conv2D-red-swp.ll
@@ -297,16 +297,16 @@ define dso_local void @conv2d.loop.nest(ptr %add.ptr6.i51, ptr %add.ptr5, ptr %c
 ; DCL-NEXT:    vldb.3d wh7, [p0], d0
 ; DCL-NEXT:    vlda.ups.s32.s16 bmh3, s0, [p2, #32]; mov m2, r15
 ; DCL-NEXT:    vlda.ups.s32.s16 bml3, s0, [p2], m2
-; DCL-NEXT:    vlda.ups.s32.s16 bmh4, s0, [p2, #32]
-; DCL-NEXT:    vlda.ups.s32.s16 bml4, s0, [p2], m5
 ; DCL-NEXT:    vlda.ups.s32.s16 bmh5, s0, [p2, #32]
-; DCL-NEXT:    vlda.ups.s32.s16 bml5, s0, [p2], m1
-; DCL-NEXT:    vlda.ups.s32.s16 bmh6, s0, [p2, #32]
-; DCL-NEXT:    vlda.ups.s32.s16 bml6, s0, [p2], m5
+; DCL-NEXT:    vlda.ups.s32.s16 bml5, s0, [p2], m5
+; DCL-NEXT:    vlda.ups.s32.s16 bmh4, s0, [p2, #32]
+; DCL-NEXT:    vlda.ups.s32.s16 bml4, s0, [p2], m1
 ; DCL-NEXT:    vlda.ups.s32.s16 bmh7, s0, [p2, #32]
+; DCL-NEXT:    vlda.ups.s32.s16 bml7, s0, [p2], m5
+; DCL-NEXT:    vlda.ups.s32.s16 bmh6, s0, [p2, #32]
 ; DCL-NEXT:    vldb wh8, [p1], #32
 ; DCL-NEXT:    vldb wl5, [p0], m6; mov r1, p0
-; DCL-NEXT:    vlda.ups.s32.s16 bml7, s0, [p2, #0]; and r0, r0, r9
+; DCL-NEXT:    vlda.ups.s32.s16 bml6, s0, [p2, #0]; and r0, r0, r9
 ; DCL-NEXT:    vldb wh5, [p0], m6; add r0, r0, #33
 ; DCL-NEXT:    vldb wl3, [p0], m6; vshift.align x4, x4, s1, x3, r0
 ; DCL-NEXT:    vldb.3d wh3, [p0], d0; and r10, r1, r9; vshift.align x2, x2, s1, x7, r0
@@ -319,15 +319,15 @@ define dso_local void @conv2d.loop.nest(ptr %add.ptr6.i51, ptr %add.ptr5, ptr %c
 ; DCL-NEXT:    // Parent Loop BB0_1 Depth=1
 ; DCL-NEXT:    // => This Inner Loop Header: Depth=2
 ; DCL-NEXT:    nopb ; nopa ; nops ; nopx ; vshuffle x9, x4, x2, r3; vmac cm1, cm1, x9, x6, r4
-; DCL-NEXT:    nopa ; nopb ; nopx ; vshift.align x4, x4, s1, x5, r0; vmac cm5, cm5, x9, x8, r4
+; DCL-NEXT:    nopa ; nopb ; nopx ; vshift.align x4, x4, s1, x5, r0; vmac cm4, cm4, x9, x8, r4
 ; DCL-NEXT:    vldb wl5, [p0], m6; vshift.align x2, x2, s1, x3, r0
 ; DCL-NEXT:    vldb wh5, [p0], m6; add r1, r1, #-1; vshuffle x11, x9, x0, r8
 ; DCL-NEXT:    vldb wl3, [p0], m6; jnz r1, #.LBB0_2; vmac cm0, cm0, x7, x6, r4
-; DCL-NEXT:    vldb.3d wh3, [p0], d0; vshuffle x7, x4, x2, r2; vmac cm4, cm4, x7, x8, r4 // Delay Slot 5
+; DCL-NEXT:    vldb.3d wh3, [p0], d0; vshuffle x7, x4, x2, r2; vmac cm5, cm5, x7, x8, r4 // Delay Slot 5
 ; DCL-NEXT:    vldb wl1, [p1], #32; vshuffle x9, x7, x0, r8; vmac cm2, cm2, x9, x6, r4 // Delay Slot 4
-; DCL-NEXT:    vldb wh1, [p1], #32; vmov x6, x1; vmac cm6, cm6, x9, x8, r4 // Delay Slot 3
+; DCL-NEXT:    vldb wh1, [p1], #32; vmov x6, x1; vmac cm7, cm7, x9, x8, r4 // Delay Slot 3
 ; DCL-NEXT:    vldb wl10, [p1], #32; add r0, r10, #33; mov r10, p0; vmac cm3, cm3, x11, x6, r4 // Delay Slot 2
-; DCL-NEXT:    vldb wh10, [p1], #32; and r10, r10, r9; vmov x8, x10; vmac cm7, cm7, x11, x8, r4 // Delay Slot 1
+; DCL-NEXT:    vldb wh10, [p1], #32; and r10, r10, r9; vmov x8, x10; vmac cm6, cm6, x11, x8, r4 // Delay Slot 1
 ; DCL-NEXT:  // %bb.3: // in Loop: Header=BB0_1 Depth=1
 ; DCL-NEXT:    nopx ; vmov x11, x0
 ; DCL-NEXT:    vshuffle x0, x4, x2, r3
@@ -338,14 +338,14 @@ define dso_local void @conv2d.loop.nest(ptr %add.ptr6.i51, ptr %add.ptr5, ptr %c
 ; DCL-NEXT:    vlda wl11, [sp, #-160] // 32-byte Folded Reload
 ; DCL-NEXT:    vlda wh11, [sp, #-128] // 32-byte Folded Reload
 ; DCL-NEXT:    vlda wl6, [sp, #-160]; vmac cm2, cm2, x0, x6, r4 // 32-byte Folded Reload
-; DCL-NEXT:    vlda wh6, [sp, #-128]; vmac cm5, cm6, x0, x8, r4 // 32-byte Folded Reload
-; DCL-NEXT:    vlda wh0, [sp, #-32]; vmac cm4, cm5, x9, x8, r4 // 32-byte Folded Reload
-; DCL-NEXT:    lda dn7, [sp, #-92]; vmac cm8, cm4, x7, x8, r4 // 4-byte Folded Reload
+; DCL-NEXT:    vlda wh6, [sp, #-128]; vmac cm5, cm7, x0, x8, r4 // 32-byte Folded Reload
+; DCL-NEXT:    vlda wh0, [sp, #-32]; vmac cm8, cm5, x7, x8, r4 // 32-byte Folded Reload
+; DCL-NEXT:    lda dn7, [sp, #-92] // 4-byte Folded Reload
 ; DCL-NEXT:    vmac cm0, cm0, x7, x6, r4
 ; DCL-NEXT:    lda dj7, [sp, #-88]; vshift.align x4, x4, s1, x5, r0; vmac cm1, cm1, x9, x6, r4 // 4-byte Folded Reload
 ; DCL-NEXT:    vshift.align x2, x2, s1, x3, r0; vmac cm3, cm3, x11, x6, r4
-; DCL-NEXT:    vshuffle x6, x4, x2, r2
-; DCL-NEXT:    vmac cm6, cm7, x6, x8, r4
+; DCL-NEXT:    vshuffle x6, x4, x2, r2; vmac cm4, cm4, x9, x8, r4
+; DCL-NEXT:    vmac cm6, cm6, x6, x8, r4
 ; DCL-NEXT:    vshuffle x8, x6, x0, r8; vmac cm7, cm0, x6, x1, r4
 ; DCL-NEXT:    st dn7, [sp, #-92] // 4-byte Folded Spill
 ; DCL-NEXT:    vshuffle x3, x4, x2, r3; vmac cm0, cm1, x8, x1, r4
@@ -461,18 +461,18 @@ define dso_local void @conv2d.loop.nest(ptr %add.ptr6.i51, ptr %add.ptr5, ptr %c
 ; ZOL-NEXT:    vlda.ups.s32.s16 bmh3, s0, [p2, #32]; mov m2, r14
 ; ZOL-NEXT:    vlda.ups.s32.s16 bml3, s0, [p2], m2
 ; ZOL-NEXT:    vldb wl1, [p1], #32
-; ZOL-NEXT:    vlda.ups.s32.s16 bmh4, s0, [p2, #32]
-; ZOL-NEXT:    vlda.ups.s32.s16 bml4, s0, [p2], m5
 ; ZOL-NEXT:    vlda.ups.s32.s16 bmh5, s0, [p2, #32]
-; ZOL-NEXT:    vlda.ups.s32.s16 bml5, s0, [p2], m1
-; ZOL-NEXT:    vlda.ups.s32.s16 bmh6, s0, [p2, #32]
-; ZOL-NEXT:    vlda.ups.s32.s16 bml6, s0, [p2], m5; movxm ls, #.LBB0_2
+; ZOL-NEXT:    vlda.ups.s32.s16 bml5, s0, [p2], m5
+; ZOL-NEXT:    vlda.ups.s32.s16 bmh4, s0, [p2, #32]
+; ZOL-NEXT:    vlda.ups.s32.s16 bml4, s0, [p2], m1
+; ZOL-NEXT:    vlda.ups.s32.s16 bmh7, s0, [p2, #32]
+; ZOL-NEXT:    vlda.ups.s32.s16 bml7, s0, [p2], m5; movxm ls, #.LBB0_2
 ; ZOL-NEXT:    vldb wl5, [p0], m6; mov r1, p0
 ; ZOL-NEXT:    vldb wh5, [p0], m6; movxm le, #.L_LEnd0
-; ZOL-NEXT:    vlda.ups.s32.s16 bmh7, s0, [p2, #32]; and r0, r0, r9; add.nc lc, r5, #-2
+; ZOL-NEXT:    vlda.ups.s32.s16 bmh6, s0, [p2, #32]; and r0, r0, r9; add.nc lc, r5, #-2
 ; ZOL-NEXT:    vldb wl3, [p0], m6; nopa ; nops ; add r0, r0, #33; nopm ; nopv
 ; ZOL-NEXT:    vldb.3d wh3, [p0], d0; nopa ; nops ; nopx ; vshift.align x4, x4, s1, x3, r0; nopv
-; ZOL-NEXT:    nopb ; vlda.ups.s32.s16 bml7, s0, [p2, #0]; nops ; and r1, r1, r9; vshift.align x2, x2, s1, x7, r0; nopv
+; ZOL-NEXT:    nopb ; vlda.ups.s32.s16 bml6, s0, [p2, #0]; nops ; and r1, r1, r9; vshift.align x2, x2, s1, x7, r0; nopv
 ; ZOL-NEXT:    vldb wh1, [p1], #32; nopa ; nops ; add r0, r1, #33; mov r1, p0; nopv
 ; ZOL-NEXT:    vldb wl10, [p1], #32; nopa ; nops ; nopx ; vshuffle x7, x4, x2, r2; nopv
 ; ZOL-NEXT:    vldb wh10, [p1], #32; nopa ; nops ; nopx ; vshuffle x9, x7, x0, r8; nopv
@@ -482,15 +482,15 @@ define dso_local void @conv2d.loop.nest(ptr %add.ptr6.i51, ptr %add.ptr5, ptr %c
 ; ZOL-NEXT:    // Parent Loop BB0_1 Depth=1
 ; ZOL-NEXT:    // => This Inner Loop Header: Depth=2
 ; ZOL-NEXT:    nopa ; nopx ; vshuffle x9, x4, x2, r3; vmac cm1, cm1, x9, x6, r4
-; ZOL-NEXT:    vldb wl5, [p0], m6; vshift.align x4, x4, s1, x5, r0; vmac cm5, cm5, x9, x8, r4
+; ZOL-NEXT:    vldb wl5, [p0], m6; vshift.align x4, x4, s1, x5, r0; vmac cm4, cm4, x9, x8, r4
 ; ZOL-NEXT:    vldb wh5, [p0], m6; vshift.align x2, x2, s1, x3, r0
 ; ZOL-NEXT:    vldb wl3, [p0], m6; vshuffle x11, x9, x0, r8; vmac cm0, cm0, x7, x6, r4
-; ZOL-NEXT:    vldb.3d wh3, [p0], d0; vshuffle x7, x4, x2, r2; vmac cm4, cm4, x7, x8, r4
+; ZOL-NEXT:    vldb.3d wh3, [p0], d0; vshuffle x7, x4, x2, r2; vmac cm5, cm5, x7, x8, r4
 ; ZOL-NEXT:    vldb wl1, [p1], #32; vshuffle x9, x7, x0, r8; vmac cm2, cm2, x9, x6, r4
-; ZOL-NEXT:    vldb wh1, [p1], #32; vmov x6, x1; vmac cm6, cm6, x9, x8, r4
+; ZOL-NEXT:    vldb wh1, [p1], #32; vmov x6, x1; vmac cm7, cm7, x9, x8, r4
 ; ZOL-NEXT:    vldb wl10, [p1], #32; add r0, r1, #33; mov r1, p0; vmac cm3, cm3, x11, x6, r4
 ; ZOL-NEXT:  .L_LEnd0:
-; ZOL-NEXT:    vldb wh10, [p1], #32; nopa ; nops ; and r1, r1, r9; vmov x8, x10; vmac cm7, cm7, x11, x8, r4
+; ZOL-NEXT:    vldb wh10, [p1], #32; nopa ; nops ; and r1, r1, r9; vmov x8, x10; vmac cm6, cm6, x11, x8, r4
 ; ZOL-NEXT:  // %bb.3: // in Loop: Header=BB0_1 Depth=1
 ; ZOL-NEXT:    nopx ; vmov x11, x0
 ; ZOL-NEXT:    vshuffle x0, x4, x2, r3
@@ -501,14 +501,14 @@ define dso_local void @conv2d.loop.nest(ptr %add.ptr6.i51, ptr %add.ptr5, ptr %c
 ; ZOL-NEXT:    vlda wl11, [sp, #-160] // 32-byte Folded Reload
 ; ZOL-NEXT:    vlda wh11, [sp, #-128] // 32-byte Folded Reload
 ; ZOL-NEXT:    vlda wl6, [sp, #-160]; vmac cm2, cm2, x0, x6, r4 // 32-byte Folded Reload
-; ZOL-NEXT:    vlda wh6, [sp, #-128]; vmac cm5, cm6, x0, x8, r4 // 32-byte Folded Reload
-; ZOL-NEXT:    vlda wh0, [sp, #-32]; vmac cm4, cm5, x9, x8, r4 // 32-byte Folded Reload
-; ZOL-NEXT:    lda dn7, [sp, #-92]; vmac cm8, cm4, x7, x8, r4 // 4-byte Folded Reload
+; ZOL-NEXT:    vlda wh6, [sp, #-128]; vmac cm5, cm7, x0, x8, r4 // 32-byte Folded Reload
+; ZOL-NEXT:    vlda wh0, [sp, #-32]; vmac cm8, cm5, x7, x8, r4 // 32-byte Folded Reload
+; ZOL-NEXT:    lda dn7, [sp, #-92] // 4-byte Folded Reload
 ; ZOL-NEXT:    vmac cm0, cm0, x7, x6, r4
 ; ZOL-NEXT:    lda dj7, [sp, #-88]; vshift.align x4, x4, s1, x5, r0; vmac cm1, cm1, x9, x6, r4 // 4-byte Folded Reload
 ; ZOL-NEXT:    vshift.align x2, x2, s1, x3, r0; vmac cm3, cm3, x11, x6, r4
-; ZOL-NEXT:    vshuffle x6, x4, x2, r2
-; ZOL-NEXT:    vmac cm6, cm7, x6, x8, r4
+; ZOL-NEXT:    vshuffle x6, x4, x2, r2; vmac cm4, cm4, x9, x8, r4
+; ZOL-NEXT:    vmac cm6, cm6, x6, x8, r4
 ; ZOL-NEXT:    vshuffle x8, x6, x0, r8; vmac cm7, cm0, x6, x1, r4
 ; ZOL-NEXT:    st dn7, [sp, #-92] // 4-byte Folded Spill
 ; ZOL-NEXT:    vshuffle x3, x4, x2, r3; vmac cm0, cm1, x8, x1, r4


### PR DESCRIPTION
Register reallocation was split into non-overlapping register classes. That means that if one class fails, the others can still reap benefit.
The loop-aware option is an attempt at a 'circular LRU', but there were no immediate benefits/

![image](https://github.com/user-attachments/assets/36cc6cf6-bcd6-4bcb-9c57-8d17de6683cf)
