### PR TITLE
[AIE2P] add pseudo for scalar move (in M and S slot)

### DIFF
--- a/llvm/lib/Target/AIE/aie2p/AIE2PInstrInfo.cpp
+++ b/llvm/lib/Target/AIE/aie2p/AIE2PInstrInfo.cpp
@@ -556,7 +556,12 @@ void AIE2PInstrInfo::copyPhysReg(MachineBasicBlock &MBB,
 
   if (AIE2P::mMvSclSrcRegClass.contains(SrcReg) &&
       AIE2P::mMvSclDstRegClass.contains(DstReg)) {
-    BuildMI(MBB, MBBI, DL, get(AIE2P::MOV_alu_mv_mv_mv_scl), DstReg)
+    // Build MultiSlotPseudo in preference
+    unsigned Opcode = (AIE2P::mAguSrcRegClass.contains(SrcReg) &&
+                       AIE2P::mAguDstRegClass.contains(DstReg))
+                          ? AIE2P::MOV_scalar_pseudo
+                          : AIE2P::MOV_alu_mv_mv_mv_scl;
+    BuildMI(MBB, MBBI, DL, get(Opcode), DstReg)
         .addReg(SrcReg, getKillRegState(KillSrc));
   } else if ((AIE2P::eLRegClass.contains(SrcReg)) &&
              (AIE2P::eLRegClass.contains(DstReg))) {

--- a/llvm/lib/Target/AIE/aie2p/AIE2PMultiSlotPseudoInstrInfo.td
+++ b/llvm/lib/Target/AIE/aie2p/AIE2PMultiSlotPseudoInstrInfo.td
@@ -56,6 +56,12 @@ let isMoveImm = 1, isReMaterializable = 1, isAsCheapAsAMove = 1, Itinerary = II_
       "mov_scalar_imm11_pseudo ", "$dst, $i", [MOV_alu_mv_mv_mv_cg, MOVXM]>;
 }
 
+// Pseudo Scalar MOV. The MOVS register set is a strict subset
+let Itinerary = II_MOVS, hasSideEffects = false, mayLoad = false, mayStore = false in {
+  def MOV_scalar_pseudo : MultiSlot_Pseudo< (outs OP_mAguDst:$dst), (ins OP_mAguSrc:$src),
+      "MOV_scalar_pseudo", "$dst, $src", [MOV_alu_mv_mv_mv_scl, MOVS] >;
+}
+
 // Pseudo VLD
 let hasSideEffects = false, mayLoad = true, mayStore = false in {
   // Fifo fill.

--- a/llvm/test/CodeGen/AIE/aie2p/end-to-end/conv2d_bfp16_convert.ll
+++ b/llvm/test/CodeGen/AIE/aie2p/end-to-end/conv2d_bfp16_convert.ll
@@ -5,7 +5,7 @@
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 ;
 ; (c) Copyright 2025 Advanced Micro Devices, Inc. or its affiliates
-; RUN: llc -mtriple=aie2p --aie-force-postpipeliner \ 
+; RUN: llc -mtriple=aie2p --aie-force-postpipeliner \
 ; RUN:   -aie-preassign-multi-slot-instr=true %s -o - | FileCheck %s
 
 ; This is a bf16->bfp16 conversion function used by Conv2D kernels.
@@ -17,25 +17,25 @@ define weak_odr dso_local void @convert_bf16_to_bfp16(ptr noalias %in, ptr noali
 ; CHECK:         .p2align 4
 ; CHECK-NEXT:  // %bb.0: // %entry
 ; CHECK-NEXT:    lda r0, [p2, #0]; nopb ; nops ; nopx ; mov m0, #4; nopv
-; CHECK-NEXT:    padda [p2], m0; nopb ; nopx
+; CHECK-NEXT:    padda [p2], m0; nopx
 ; CHECK-NEXT:    lda dn0, [p2], #4
 ; CHECK-NEXT:    lda m1, [p2], #4
 ; CHECK-NEXT:    nop
-; CHECK-NEXT:    mova dj0, #0
-; CHECK-NEXT:    movx r24, #0; mov dj1, dj0
-; CHECK-NEXT:    mov r26, r24
-; CHECK-NEXT:    vldb.fill.512 [p0, lf0, r24]; mov dc1, dj0
-; CHECK-NEXT:    vldb.pop.512 x0, [p0, lf0, r24]; mov dn1, dn0
+; CHECK-NEXT:    nop
+; CHECK-NEXT:    movx r24, #0
+; CHECK-NEXT:    mova dj0, #0; mov r26, r24
+; CHECK-NEXT:    vldb.fill.512 [p0, lf0, r24]; mov dj1, dj0
+; CHECK-NEXT:    movs dc1, dj0; vldb.pop.512 x0, [p0, lf0, r24]; mov dn1, dn0
 ; CHECK-NEXT:    vldb.pop.512.2d x2, [p0, lf0, r24, d1]; movxm ls, #.LBB0_1
 ; CHECK-NEXT:    movxm le, #.L_LEnd0
 ; CHECK-NEXT:    add.nc lc, r0, #-2
 ; CHECK-NEXT:    lda m0, [p2, #0]; nopb ; nops ; nopxm ; nopv
 ; CHECK-NEXT:    nopa ; vldb.fill.512 [p0, lf0, r24]; nops ; nopxm ; nopv
 ; CHECK-NEXT:    nopa ; vldb.pop.512 x0, [p0, lf0, r24]; nops ; nopxm ; nopv
-; CHECK-NEXT:    nopa ; vldb.pop.512.2d x2, [p0, lf0, r24, d1]; nops ; nopx ; mov dc0, dj0; nopv
+; CHECK-NEXT:    nopa ; vldb.pop.512.2d x2, [p0, lf0, r24, d1]; nops ; nopxm ; nopv
 ; CHECK-NEXT:    nopa ; nopb ; nops ; nopx ; vconv.fp32.bf16 cml0, x0; nopv
 ; CHECK-NEXT:    nopa ; nopb ; nops ; nopx ; vconv.fp32.bf16 cmh0, x2; nopv
-; CHECK-NEXT:    nopa ; nopb ; nops ; nopx ; mov p2, p1; nopv
+; CHECK-NEXT:    nopa ; nopb ; movs dc0, dj0; nopx ; mov p2, p1; nopv
 ; CHECK-NEXT:    // implicit-def: $sf
 ; CHECK-NEXT:    .p2align 4
 ; CHECK-NEXT:  .LBB0_1: // %for.body

--- a/llvm/test/CodeGen/AIE/aie2p/end-to-end/conv2d_bfp16_kernel_red.ll
+++ b/llvm/test/CodeGen/AIE/aie2p/end-to-end/conv2d_bfp16_kernel_red.ll
@@ -20,7 +20,7 @@ define dso_local void @conv2d_bfp16.for.body90.i(<32 x i32> %fW.sroa.0.1489.i, i
 ; CHECK:         .p2align 4
 ; CHECK-NEXT:  // %bb.0: // %newFuncRoot
 ; CHECK-NEXT:    paddxm [sp], #64
-; CHECK-NEXT:    st p6, [sp, #-60] // 4-byte Folded Spill
+; CHECK-NEXT:    st p6, [sp, #-60]; nopx // 4-byte Folded Spill
 ; CHECK-NEXT:    mov p6, sp
 ; CHECK-NEXT:    padda [p6], #-320
 ; CHECK-NEXT:    vlda bmll3, [p6, #0]
@@ -58,11 +58,11 @@ define dso_local void @conv2d_bfp16.for.body90.i(<32 x i32> %fW.sroa.0.1489.i, i
 ; CHECK-NEXT:    padda [p6], m0
 ; CHECK-NEXT:    vlda bmll0, [p6, #0]
 ; CHECK-NEXT:    vlda bmlh0, [p6, #64]
-; CHECK-NEXT:    vlda bmhl0, [p6, #128]; mov dn0, p3
-; CHECK-NEXT:    vlda bmhh0, [p6, #192]; movx r25, #0; mov dj0, p4
-; CHECK-NEXT:    mova dc4, #0; vldb.fill.512 [p1, lf1, r25]; mov dn4, p5
-; CHECK-NEXT:    mova r24, #0; vldb.fill.512 [p1, lf1, r25]; mov dc0, dc4
-; CHECK-NEXT:    vlda.fill.512 [p0, lf0, r24]; vldb.pop.576 ex0, [p1, lf1, r25]; mov m0, p2
+; CHECK-NEXT:    vlda bmhl0, [p6, #128]
+; CHECK-NEXT:    vlda bmhh0, [p6, #192]; movx r25, #0
+; CHECK-NEXT:    mova dc4, #0; vldb.fill.512 [p1, lf1, r25]; mov dn0, p3
+; CHECK-NEXT:    mova r24, #0; vldb.fill.512 [p1, lf1, r25]; movs dj0, p4; mov dn4, p5
+; CHECK-NEXT:    vlda.fill.512 [p0, lf0, r24]; vldb.pop.576 ex0, [p1, lf1, r25]; movs dc0, dc4; mov m0, p2
 ; CHECK-NEXT:    vlda.pop.576 ex4, [p0, lf0, r24]; vldb.pop.576.3d ex2, [p1, lf1, r25, d0]
 ; CHECK-NEXT:    vldb.fill.512 [p1, lf1, r25]
 ; CHECK-NEXT:    vlda.pop.576 ex6, [p0, lf0, r24, m1]; vldb.fill.512 [p1, lf1, r25]; add r1, r6, #-1
@@ -85,7 +85,7 @@ define dso_local void @conv2d_bfp16.for.body90.i(<32 x i32> %fW.sroa.0.1489.i, i
 ; CHECK-NEXT:  .L_LEnd0:
 ; CHECK-NEXT:    vlda.pop.576 ex4, [p0, lf0, r24]; vldb.pop.576.3d ex2, [p1, lf1, r25, d0]; nops ; nopx ; vshuffle ex8, ex0, ex2, r4; vmac.f dm2, dm2, ex8, ex6, r0
 ; CHECK-NEXT:  // %bb.2: // %for.cond.cleanup89.i.exitStub
-; CHECK-NEXT:    lda p6, [sp, #-60]; nopx ; vshuffle ex10, ex0, ex2, r5; vmac.f dm3, dm3, ex10, ex6, r0 // 4-byte Folded Reload
+; CHECK-NEXT:    lda p6, [sp, #-60]; nopb ; nopx ; vshuffle ex10, ex0, ex2, r5; vmac.f dm3, dm3, ex10, ex6, r0 // 4-byte Folded Reload
 ; CHECK-NEXT:    vlda.pop.576 ex6, [p0, lf0, r24, m1]; vmac.f dm0, dm0, ex8, ex4, r0
 ; CHECK-NEXT:    mov p0, r7; vmac.f dm1, dm1, ex10, ex4, r0
 ; CHECK-NEXT:    vshuffle ex8, ex0, ex2, r4; vmac.f dm2, dm2, ex8, ex6, r0
@@ -112,8 +112,8 @@ define dso_local void @conv2d_bfp16.for.body90.i(<32 x i32> %fW.sroa.0.1489.i, i
 ; CHECK-NEXT:    vst bmll2, [p0, #0]
 ; CHECK-NEXT:    vst bmlh2, [p0, #64]
 ; CHECK-NEXT:    vst bmhl2, [p0, #128]
-; CHECK-NEXT:    vst bmhh2, [p0, #192]; mov p0, r2
-; CHECK-NEXT:    ret lr
+; CHECK-NEXT:    vst bmhh2, [p0, #192]
+; CHECK-NEXT:    movs p0, r2; ret lr
 ; CHECK-NEXT:    vst bmll3, [p0, #0] // Delay Slot 5
 ; CHECK-NEXT:    vst bmlh3, [p0, #64] // Delay Slot 4
 ; CHECK-NEXT:    vst bmhl3, [p0, #128] // Delay Slot 3

--- a/llvm/test/CodeGen/AIE/aie2p/fifo-loads.ll
+++ b/llvm/test/CodeGen/AIE/aie2p/fifo-loads.ll
@@ -20,8 +20,8 @@ define dso_local void @_Z17test_fifo_ld_fillRPDv64_DB8_R12fifo_state_t(ptr nocap
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
-; CHECK-NEXT:    mov p2, p0
-; CHECK-NEXT:    vlda lfl0, [p1, #0]
+; CHECK-NEXT:    nop
+; CHECK-NEXT:    vlda lfl0, [p1, #0]; movs p2, p0
 ; CHECK-NEXT:    vlda lfh0, [p1, #64]
 ; CHECK-NEXT:    vldb.fill.512 [p0, lf0, r24]
 ; CHECK-NEXT:    nop
@@ -59,8 +59,8 @@ define dso_local noundef <64 x i8> @_Z16test_fifo_ld_popRPDv64_DB8_R12fifo_state
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
-; CHECK-NEXT:    mov p2, p0
-; CHECK-NEXT:    vlda lfl0, [p1, #0]
+; CHECK-NEXT:    nop
+; CHECK-NEXT:    vlda lfl0, [p1, #0]; movs p2, p0
 ; CHECK-NEXT:    vlda lfh0, [p1, #64]
 ; CHECK-NEXT:    vldb.pop.512 x0, [p0, lf0, r24]
 ; CHECK-NEXT:    nop
@@ -99,8 +99,8 @@ define dso_local noundef <64 x i8> @_Z24test_fifo_ld_pop_1d_byteRPDv64_DB8_R12fi
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
-; CHECK-NEXT:    mov p2, p0
-; CHECK-NEXT:    vlda lfl0, [p1, #0]
+; CHECK-NEXT:    nop
+; CHECK-NEXT:    vlda lfl0, [p1, #0]; movs p2, p0
 ; CHECK-NEXT:    vlda lfh0, [p1, #64]; mov m0, r0
 ; CHECK-NEXT:    vldb.pop.512 x0, [p0, lf0, r24, m0]
 ; CHECK-NEXT:    nop
@@ -135,15 +135,15 @@ define dso_local noundef <64 x i8> @_Z24test_fifo_ld_pop_2d_byteRPDv64_DB8_R12fi
 ; CHECK-LABEL: _Z24test_fifo_ld_pop_2d_byteRPDv64_DB8_R12fifo_state_tiiRii:
 ; CHECK:         .p2align 4
 ; CHECK-NEXT:  // %bb.0: // %entry
-; CHECK-NEXT:    lda p0, [p0, #0]; nopb ; nopx
+; CHECK-NEXT:    lda p0, [p0, #0]; nopx
 ; CHECK-NEXT:    lda dc0, [p2, #0]; mov dj0, #128
 ; CHECK-NEXT:    lda r24, [p1, dj0]
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
-; CHECK-NEXT:    mov p3, p0
-; CHECK-NEXT:    mov m0, r0
-; CHECK-NEXT:    vlda lfl0, [p1, #0]; mov dn0, r1
-; CHECK-NEXT:    vlda lfh0, [p1, #64]; mov dj0, r2
+; CHECK-NEXT:    nop
+; CHECK-NEXT:    movs p3, p0
+; CHECK-NEXT:    vlda lfl0, [p1, #0]; mov m0, r0
+; CHECK-NEXT:    vlda lfh0, [p1, #64]; movs dn0, r1; mov dj0, r2
 ; CHECK-NEXT:    vldb.pop.512.2d x0, [p0, lf0, r24, d0]
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
@@ -184,16 +184,16 @@ define dso_local noundef <64 x i8> @_Z24test_fifo_ld_pop_3d_byteRPDv64_DB8_R12fi
 ; CHECK-LABEL: _Z24test_fifo_ld_pop_3d_byteRPDv64_DB8_R12fifo_state_tiiRiiiS5_i:
 ; CHECK:         .p2align 4
 ; CHECK-NEXT:  // %bb.0: // %entry
-; CHECK-NEXT:    lda p0, [p0, #0]; nopb ; nopxm ; nops
+; CHECK-NEXT:    lda p0, [p0, #0]; nopxm
 ; CHECK-NEXT:    lda dc0, [p2, #0]
 ; CHECK-NEXT:    lda dc4, [p3, #0]; mov dj0, #128
 ; CHECK-NEXT:    lda r24, [p1, dj0]
+; CHECK-NEXT:    nop
+; CHECK-NEXT:    nop
+; CHECK-NEXT:    movs p4, p0
 ; CHECK-NEXT:    mov m0, r0
-; CHECK-NEXT:    mov p4, p0
-; CHECK-NEXT:    mov dn0, r1
-; CHECK-NEXT:    mov dn4, r3
-; CHECK-NEXT:    vlda lfl0, [p1, #0]; mov dj4, r4
-; CHECK-NEXT:    vlda lfh0, [p1, #64]; mov dj0, r2
+; CHECK-NEXT:    vlda lfl0, [p1, #0]; movs dn0, r1; mov dj4, r4
+; CHECK-NEXT:    vlda lfh0, [p1, #64]; movs dn4, r3; mov dj0, r2
 ; CHECK-NEXT:    vldb.pop.512.3d x0, [p0, lf0, r24, d0]
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
@@ -247,8 +247,8 @@ define dso_local %struct.v64bfp16ebs8 @_Z16test_fifo_ld_popRP22v64bfp16ebs8_unal
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
-; CHECK-NEXT:    mov p2, p0
-; CHECK-NEXT:    vlda lfl0, [p1, #0]
+; CHECK-NEXT:    nop
+; CHECK-NEXT:    vlda lfl0, [p1, #0]; movs p2, p0
 ; CHECK-NEXT:    vlda lfh0, [p1, #64]
 ; CHECK-NEXT:    vldb.pop.576 ex0, [p0, lf0, r24]
 ; CHECK-NEXT:    nop
@@ -290,8 +290,8 @@ define dso_local %struct.v64bfp16ebs8 @_Z24test_fifo_ld_pop_1d_byteRP22v64bfp16e
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
-; CHECK-NEXT:    mov p2, p0
-; CHECK-NEXT:    vlda lfl0, [p1, #0]
+; CHECK-NEXT:    nop
+; CHECK-NEXT:    vlda lfl0, [p1, #0]; movs p2, p0
 ; CHECK-NEXT:    vlda lfh0, [p1, #64]; mov m0, r0
 ; CHECK-NEXT:    vldb.pop.576 ex0, [p0, lf0, r24, m0]
 ; CHECK-NEXT:    nop
@@ -329,15 +329,15 @@ define dso_local %struct.v64bfp16ebs8 @_Z24test_fifo_ld_pop_2d_byteRP22v64bfp16e
 ; CHECK-LABEL: _Z24test_fifo_ld_pop_2d_byteRP22v64bfp16ebs8_unalignedR12fifo_state_tiiRii:
 ; CHECK:         .p2align 4
 ; CHECK-NEXT:  // %bb.0: // %entry
-; CHECK-NEXT:    lda p0, [p0, #0]; nopb ; nopx
+; CHECK-NEXT:    lda p0, [p0, #0]; nopx
 ; CHECK-NEXT:    lda dc0, [p2, #0]; mov dj0, #128
 ; CHECK-NEXT:    lda r24, [p1, dj0]
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
-; CHECK-NEXT:    mov p3, p0
-; CHECK-NEXT:    mov m0, r0
-; CHECK-NEXT:    vlda lfl0, [p1, #0]; mov dn0, r1
-; CHECK-NEXT:    vlda lfh0, [p1, #64]; mov dj0, r2
+; CHECK-NEXT:    nop
+; CHECK-NEXT:    movs p3, p0
+; CHECK-NEXT:    vlda lfl0, [p1, #0]; mov m0, r0
+; CHECK-NEXT:    vlda lfh0, [p1, #64]; movs dn0, r1; mov dj0, r2
 ; CHECK-NEXT:    vldb.pop.576.2d ex0, [p0, lf0, r24, d0]
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
@@ -381,16 +381,16 @@ define dso_local %struct.v64bfp16ebs8 @_Z24test_fifo_ld_pop_3d_byteRP22v64bfp16e
 ; CHECK-LABEL: _Z24test_fifo_ld_pop_3d_byteRP22v64bfp16ebs8_unalignedR12fifo_state_tiiRiiiS4_i:
 ; CHECK:         .p2align 4
 ; CHECK-NEXT:  // %bb.0: // %entry
-; CHECK-NEXT:    lda p0, [p0, #0]; nopb ; nopxm ; nops
+; CHECK-NEXT:    lda p0, [p0, #0]; nopxm
 ; CHECK-NEXT:    lda dc0, [p2, #0]
 ; CHECK-NEXT:    lda dc4, [p3, #0]; mov dj0, #128
 ; CHECK-NEXT:    lda r24, [p1, dj0]
+; CHECK-NEXT:    nop
+; CHECK-NEXT:    nop
+; CHECK-NEXT:    movs p4, p0
 ; CHECK-NEXT:    mov m0, r0
-; CHECK-NEXT:    mov p4, p0
-; CHECK-NEXT:    mov dn0, r1
-; CHECK-NEXT:    mov dn4, r3
-; CHECK-NEXT:    vlda lfl0, [p1, #0]; mov dj4, r4
-; CHECK-NEXT:    vlda lfh0, [p1, #64]; mov dj0, r2
+; CHECK-NEXT:    vlda lfl0, [p1, #0]; movs dn0, r1; mov dj4, r4
+; CHECK-NEXT:    vlda lfh0, [p1, #64]; movs dn4, r3; mov dj0, r2
 ; CHECK-NEXT:    vldb.pop.576.3d ex0, [p0, lf0, r24, d0]
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
@@ -447,8 +447,8 @@ define dso_local %struct.v64bfp16ebs16 @_Z16test_fifo_ld_popRP23v64bfp16ebs16_un
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
-; CHECK-NEXT:    mov p2, p0
-; CHECK-NEXT:    vlda lfl0, [p1, #0]
+; CHECK-NEXT:    nop
+; CHECK-NEXT:    vlda lfl0, [p1, #0]; movs p2, p0
 ; CHECK-NEXT:    vlda lfh0, [p1, #64]
 ; CHECK-NEXT:    vldb.pop.544 ex0, [p0, lf0, r24]
 ; CHECK-NEXT:    nop
@@ -490,8 +490,8 @@ define dso_local %struct.v64bfp16ebs16 @_Z24test_fifo_ld_pop_1d_byteRP23v64bfp16
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
-; CHECK-NEXT:    mov p2, p0
-; CHECK-NEXT:    vlda lfl0, [p1, #0]
+; CHECK-NEXT:    nop
+; CHECK-NEXT:    vlda lfl0, [p1, #0]; movs p2, p0
 ; CHECK-NEXT:    vlda lfh0, [p1, #64]; mov m0, r0
 ; CHECK-NEXT:    vldb.pop.544 ex0, [p0, lf0, r24, m0]
 ; CHECK-NEXT:    nop
@@ -529,15 +529,15 @@ define dso_local %struct.v64bfp16ebs16 @_Z24test_fifo_ld_pop_2d_byteRP23v64bfp16
 ; CHECK-LABEL: _Z24test_fifo_ld_pop_2d_byteRP23v64bfp16ebs16_unalignedR12fifo_state_tiiRii:
 ; CHECK:         .p2align 4
 ; CHECK-NEXT:  // %bb.0: // %entry
-; CHECK-NEXT:    lda p0, [p0, #0]; nopb ; nopx
+; CHECK-NEXT:    lda p0, [p0, #0]; nopx
 ; CHECK-NEXT:    lda dc0, [p2, #0]; mov dj0, #128
 ; CHECK-NEXT:    lda r24, [p1, dj0]
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
-; CHECK-NEXT:    mov p3, p0
-; CHECK-NEXT:    mov m0, r0
-; CHECK-NEXT:    vlda lfl0, [p1, #0]; mov dn0, r1
-; CHECK-NEXT:    vlda lfh0, [p1, #64]; mov dj0, r2
+; CHECK-NEXT:    nop
+; CHECK-NEXT:    movs p3, p0
+; CHECK-NEXT:    vlda lfl0, [p1, #0]; mov m0, r0
+; CHECK-NEXT:    vlda lfh0, [p1, #64]; movs dn0, r1; mov dj0, r2
 ; CHECK-NEXT:    vldb.pop.544.2d ex0, [p0, lf0, r24, d0]
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
@@ -581,16 +581,16 @@ define dso_local %struct.v64bfp16ebs16 @_Z24test_fifo_ld_pop_3d_byteRP23v64bfp16
 ; CHECK-LABEL: _Z24test_fifo_ld_pop_3d_byteRP23v64bfp16ebs16_unalignedR12fifo_state_tiiRiiiS4_i:
 ; CHECK:         .p2align 4
 ; CHECK-NEXT:  // %bb.0: // %entry
-; CHECK-NEXT:    lda p0, [p0, #0]; nopb ; nopxm ; nops
+; CHECK-NEXT:    lda p0, [p0, #0]; nopxm
 ; CHECK-NEXT:    lda dc0, [p2, #0]
 ; CHECK-NEXT:    lda dc4, [p3, #0]; mov dj0, #128
 ; CHECK-NEXT:    lda r24, [p1, dj0]
+; CHECK-NEXT:    nop
+; CHECK-NEXT:    nop
+; CHECK-NEXT:    movs p4, p0
 ; CHECK-NEXT:    mov m0, r0
-; CHECK-NEXT:    mov p4, p0
-; CHECK-NEXT:    mov dn0, r1
-; CHECK-NEXT:    mov dn4, r3
-; CHECK-NEXT:    vlda lfl0, [p1, #0]; mov dj4, r4
-; CHECK-NEXT:    vlda lfh0, [p1, #64]; mov dj0, r2
+; CHECK-NEXT:    vlda lfl0, [p1, #0]; movs dn0, r1; mov dj4, r4
+; CHECK-NEXT:    vlda lfh0, [p1, #64]; movs dn4, r3; mov dj0, r2
 ; CHECK-NEXT:    vldb.pop.544.3d ex0, [p0, lf0, r24, d0]
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
@@ -646,8 +646,8 @@ define dso_local noundef <64 x i8> @_Z17test_fifo_ld_popxRPDv64_hR12fifo_state_t
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
-; CHECK-NEXT:    vlda lfl0, [p1, #0]; mov p2, p0
-; CHECK-NEXT:    vlda lfh0, [p1, #64]
+; CHECK-NEXT:    vlda lfl0, [p1, #0]
+; CHECK-NEXT:    vlda lfh0, [p1, #64]; movs p2, p0
 ; CHECK-NEXT:    vlda lfe, [p1, #192]; movxm r30, #2015
 ; CHECK-NEXT:    vldb.popx.512 x0, [p0, lf0, r24]
 ; CHECK-NEXT:    nop
@@ -686,13 +686,13 @@ define dso_local void @_Z18test_fifo_ld_fillxRP22v64bfp16ebs8_unalignedR12fifo_s
 ; CHECK-LABEL: _Z18test_fifo_ld_fillxRP22v64bfp16ebs8_unalignedR12fifo_state_tii:
 ; CHECK:         .p2align 4
 ; CHECK-NEXT:  // %bb.0: // %entry
-; CHECK-NEXT:    lda p0, [p0, #0]; nopx ; mov dj0, #128
-; CHECK-NEXT:    lda r24, [p1, dj0]
+; CHECK-NEXT:    lda p0, [p0, #0]; mov dj0, #128
+; CHECK-NEXT:    lda r24, [p1, dj0]; nopx
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    vlda lfl0, [p1, #0]
-; CHECK-NEXT:    mova r2, #6; mov p2, p0
-; CHECK-NEXT:    vlda lfh0, [p1, #64]; lshl r0, r0, r2
+; CHECK-NEXT:    mova r2, #6
+; CHECK-NEXT:    vlda lfh0, [p1, #64]; movs p2, p0; lshl r0, r0, r2
 ; CHECK-NEXT:    vlda lfe, [p1, #192]; or r30, r0, r1
 ; CHECK-NEXT:    vldb.fillx.512 [p0, lf0, r24]
 ; CHECK-NEXT:    nop

--- a/llvm/test/CodeGen/AIE/aie2p/ldst-fifo-stores.ll
+++ b/llvm/test/CodeGen/AIE/aie2p/ldst-fifo-stores.ll
@@ -156,15 +156,15 @@ define dso_local void @_Z26test_fifo_st_flush_2d_byteRPDv64_DB8_R12fifo_state_ti
 ; CHECK-LABEL: _Z26test_fifo_st_flush_2d_byteRPDv64_DB8_R12fifo_state_tiiRii:
 ; CHECK:         .p2align 4
 ; CHECK-NEXT:  // %bb.0: // %entry
-; CHECK-NEXT:    lda p4, [p0, #0]; nopxm
+; CHECK-NEXT:    lda p4, [p0, #0]; nopx
 ; CHECK-NEXT:    lda dc0, [p2, #0]; mov dj0, #128
 ; CHECK-NEXT:    lda r26, [p1, dj0]
 ; CHECK-NEXT:    nop
-; CHECK-NEXT:    vlda sfl, [p1, #0]; mov m0, r0
-; CHECK-NEXT:    vlda sfh, [p1, #64]; mov p3, p2
-; CHECK-NEXT:    mov dn0, r1
-; CHECK-NEXT:    mov dj0, r2
-; CHECK-NEXT:    mov p2, p4
+; CHECK-NEXT:    vlda sfl, [p1, #0]
+; CHECK-NEXT:    vlda sfh, [p1, #64]
+; CHECK-NEXT:    movs p3, p2
+; CHECK-NEXT:    movs m0, r0; mov dn0, r1
+; CHECK-NEXT:    movs dj0, r2; mov p2, p4
 ; CHECK-NEXT:    vst.flush.512.conv.2d [p2, sf, r26, d0]
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
@@ -203,17 +203,17 @@ define dso_local void @_Z26test_fifo_st_flush_3d_byteRPDv64_DB8_R12fifo_state_ti
 ; CHECK-LABEL: _Z26test_fifo_st_flush_3d_byteRPDv64_DB8_R12fifo_state_tiiRiiiS5_i:
 ; CHECK:         .p2align 4
 ; CHECK-NEXT:  // %bb.0: // %entry
-; CHECK-NEXT:    vlda sfl, [p1, #0]; nopb ; nops ; nopxm ; nopv
+; CHECK-NEXT:    vlda sfl, [p1, #0]; nopxm
 ; CHECK-NEXT:    lda p5, [p0, #0]
 ; CHECK-NEXT:    lda dc0, [p2, #0]
 ; CHECK-NEXT:    lda dc4, [p3, #0]; mov dj0, #128
-; CHECK-NEXT:    lda r26, [p1, dj0]; mov m0, r0
-; CHECK-NEXT:    vlda sfh, [p1, #64]; mov dn0, r1
-; CHECK-NEXT:    mov p4, p2
-; CHECK-NEXT:    mov dn4, r3
-; CHECK-NEXT:    mov dj4, r4
-; CHECK-NEXT:    mov dj0, r2
-; CHECK-NEXT:    mov p2, p5
+; CHECK-NEXT:    lda r26, [p1, dj0]
+; CHECK-NEXT:    vlda sfh, [p1, #64]
+; CHECK-NEXT:    nop
+; CHECK-NEXT:    movs p4, p2
+; CHECK-NEXT:    movs m0, r0; mov dn0, r1
+; CHECK-NEXT:    movs dn4, r3; mov dj4, r4
+; CHECK-NEXT:    movs dj0, r2; mov p2, p5
 ; CHECK-NEXT:    vst.flush.512.3d [p2, sf, r26, d0]
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    st dc0, [p4, #0]
@@ -333,16 +333,16 @@ define dso_local void @_Z31test_fifo_st_flush_conv_2d_byteRPDv64_DB8_R12fifo_sta
 ; CHECK-LABEL: _Z31test_fifo_st_flush_conv_2d_byteRPDv64_DB8_R12fifo_state_tiiRii:
 ; CHECK:         .p2align 4
 ; CHECK-NEXT:  // %bb.0: // %entry
-; CHECK-NEXT:    vlda sfl, [p1, #0]; nopb ; nopxm
+; CHECK-NEXT:    vlda sfl, [p1, #0]; nopb ; nopx
 ; CHECK-NEXT:    lda p4, [p0, #0]
 ; CHECK-NEXT:    lda dc0, [p2, #0]; mov dj0, #128
 ; CHECK-NEXT:    lda r26, [p1, dj0]
 ; CHECK-NEXT:    vlda sfh, [p1, #64]
-; CHECK-NEXT:    mov m0, r0
-; CHECK-NEXT:    mov p3, p2
-; CHECK-NEXT:    mov dn0, r1
-; CHECK-NEXT:    mov dj0, r2
-; CHECK-NEXT:    mov p2, p4
+; CHECK-NEXT:    nop
+; CHECK-NEXT:    nop
+; CHECK-NEXT:    movs p3, p2
+; CHECK-NEXT:    movs m0, r0; mov dn0, r1
+; CHECK-NEXT:    movs dj0, r2; mov p2, p4
 ; CHECK-NEXT:    vst.flush.512.2d [p2, sf, r26, d0]
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    st dc0, [p3, #0]; ret lr
@@ -379,16 +379,16 @@ define dso_local void @_Z31test_fifo_st_flush_conv_3d_byteRPDv64_DB8_R12fifo_sta
 ; CHECK-LABEL: _Z31test_fifo_st_flush_conv_3d_byteRPDv64_DB8_R12fifo_state_tiiRiiiS5_i:
 ; CHECK:         .p2align 4
 ; CHECK-NEXT:  // %bb.0: // %entry
-; CHECK-NEXT:    lda p5, [p0, #0]; nopb ; nopxm ; nops
+; CHECK-NEXT:    lda p5, [p0, #0]; nopb ; nopx
 ; CHECK-NEXT:    lda dc0, [p2, #0]
 ; CHECK-NEXT:    lda dc4, [p3, #0]; mov dj0, #128
-; CHECK-NEXT:    lda r26, [p1, dj0]; mov m0, r0
-; CHECK-NEXT:    mov dn0, r1
-; CHECK-NEXT:    vlda sfl, [p1, #0]; mov p4, p2
-; CHECK-NEXT:    vlda sfh, [p1, #64]; mov dn4, r3
-; CHECK-NEXT:    mov dj4, r4
-; CHECK-NEXT:    mov dj0, r2
-; CHECK-NEXT:    mov p2, p5
+; CHECK-NEXT:    lda r26, [p1, dj0]
+; CHECK-NEXT:    nop
+; CHECK-NEXT:    vlda sfl, [p1, #0]
+; CHECK-NEXT:    vlda sfh, [p1, #64]; movs p4, p2
+; CHECK-NEXT:    movs m0, r0; mov dn0, r1
+; CHECK-NEXT:    movs dn4, r3; mov dj4, r4
+; CHECK-NEXT:    movs dj0, r2; mov p2, p5
 ; CHECK-NEXT:    vst.flush.512.conv.3d [p2, sf, r26, d0]
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop

--- a/llvm/test/CodeGen/AIE/aie2p/run-physreg-copy.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/run-physreg-copy.mir
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2024-2025 Advanced Micro Devices, Inc. or its affiliates
 # RUN: llc -mtriple=aie2p -run-pass postrapseudos -verify-machineinstrs -o - %s | FileCheck %s
 
 # Verify AIE2PInstrInfo.cpp: copyPhysReg()
@@ -14,10 +14,10 @@ name:     test_copy_d
 body: |
   bb.0:
     ; CHECK-LABEL: name: test_copy_d
-    ; CHECK: $m1 = MOV_alu_mv_mv_mv_scl $m2
-    ; CHECK-NEXT: $dn1 = MOV_alu_mv_mv_mv_scl $dn2
-    ; CHECK-NEXT: $dj1 = MOV_alu_mv_mv_mv_scl $dj2
-    ; CHECK-NEXT: $dc1 = MOV_alu_mv_mv_mv_scl $dc2
+    ; CHECK: $m1 = MOV_scalar_pseudo $m2
+    ; CHECK-NEXT: $dn1 = MOV_scalar_pseudo $dn2
+    ; CHECK-NEXT: $dj1 = MOV_scalar_pseudo $dj2
+    ; CHECK-NEXT: $dc1 = MOV_scalar_pseudo $dc2
   $d1 = COPY $d2
 ...
 
@@ -26,14 +26,14 @@ name:     test_copy_ds
 body: |
   bb.0:
     ; CHECK-LABEL: name: test_copy_ds
-    ; CHECK: $m1 = MOV_alu_mv_mv_mv_scl $m2
-    ; CHECK-NEXT: $dn1 = MOV_alu_mv_mv_mv_scl $dn2
-    ; CHECK-NEXT: $dj1 = MOV_alu_mv_mv_mv_scl $dj2
-    ; CHECK-NEXT: $dc1 = MOV_alu_mv_mv_mv_scl $dc2
-    ; CHECK-NEXT: $m5 = MOV_alu_mv_mv_mv_scl $m6
-    ; CHECK-NEXT: $dn5 = MOV_alu_mv_mv_mv_scl $dn6
-    ; CHECK-NEXT: $dj5 = MOV_alu_mv_mv_mv_scl $dj6
-    ; CHECK-NEXT: $dc5 = MOV_alu_mv_mv_mv_scl $dc6
+    ; CHECK: $m1 = MOV_scalar_pseudo $m2
+    ; CHECK-NEXT: $dn1 = MOV_scalar_pseudo $dn2
+    ; CHECK-NEXT: $dj1 = MOV_scalar_pseudo $dj2
+    ; CHECK-NEXT: $dc1 = MOV_scalar_pseudo $dc2
+    ; CHECK-NEXT: $m5 = MOV_scalar_pseudo $m6
+    ; CHECK-NEXT: $dn5 = MOV_scalar_pseudo $dn6
+    ; CHECK-NEXT: $dj5 = MOV_scalar_pseudo $dj6
+    ; CHECK-NEXT: $dc5 = MOV_scalar_pseudo $dc6
   $d1_3d = COPY $d2_3d
 ...
 
@@ -162,11 +162,11 @@ name:            test_copy_plfr
 body: |
   bb.0:
     ; CHECK-LABEL: name: test_copy_plfr
-    ; CHECK: $p1 = MOV_alu_mv_mv_mv_scl $p0
+    ; CHECK: $p1 = MOV_scalar_pseudo $p0
     ; CHECK-NEXT: $lfl1 = VMOV_alu_mv_mv_x $lfl0
     ; CHECK-NEXT: $lfh1 = VMOV_alu_mv_mv_x $lfh0
     ; CHECK-NEXT: $r25 = MOV_alu_mv_mv_mv_scl $r24
-    ; CHECK-NEXT: $p0 = MOV_alu_mv_mv_mv_scl $p1
+    ; CHECK-NEXT: $p0 = MOV_scalar_pseudo $p1
     ; CHECK-NEXT: $lfl0 = VMOV_alu_mv_mv_x $lfl1
     ; CHECK-NEXT: $lfh0 = VMOV_alu_mv_mv_x $lfh1
     ; CHECK-NEXT: $r24 = MOV_alu_mv_mv_mv_scl $r25


### PR DESCRIPTION
The store unit can move address related registers (pointers and modifier regs), which enables two scalar moves in one cycle. 
This PR introduces a MultiSlotPseudo to represent that alternative, and it is used to implement scalar moves that result from materializing COPYs in regalloc.
I expect this to lead to higher code density in setup of multi-dim iterators and to unload the MOV slot for the occasional pointer copy that we see in kernel loops.
In particular, gemm has two pointer copies in the inner loop. 
As a follow up, we want to pre-materialize to MOVS in loops that underutilize the S slot.