### PR TITLE
[AIE2P] Fix shuffle_concat_extracted_subvectors combine  

### DIFF
--- a/llvm/lib/Target/AIE/AIECombinerHelper.cpp
+++ b/llvm/lib/Target/AIE/AIECombinerHelper.cpp
@@ -2745,6 +2745,9 @@ bool llvm::matchShuffleToConcatExtractedSubvectors(MachineInstr &MI,
       CurrentMask = SubMask;
       CurrentHeight = *MaskMatch::getHeight(CurrentMask, /*Period*/ 0);
 
+      if (!isPowerOfTwoOrZero((CurrentHeight) % NumSrc1Elems))
+        return std::nullopt;
+
       MaskMatch SequentialMask{/*Height*/ CurrentHeight};
       // Check the sequential validity of the new Submask
       ShuffleMaskValidity SequentialMaskValidity =
@@ -2830,6 +2833,16 @@ bool llvm::matchShuffleToConcatExtractedSubvectors(MachineInstr &MI,
   if (SubVecSize <= 64)
     return false;
 
+  // Do not combine if any of the subvectors is not extractable with the
+  // determined NumSubVectors.
+  // FIXME: Dynamically adjust the NumSubVecs and thus the
+  // SubVecNumElts to have all subvectors extractable.
+  if (!all_of(IndicesToExtract, [=](const unsigned ExtractIdx) {
+        return !(ExtractIdx % SubVecNumElts);
+      })) {
+    return false;
+  }
+
   MatchInfo = [=, &MRI, &TII](MachineIRBuilder &B) {
     SmallVector<Register> ExtractedSubvectors;
     for (unsigned Idx : IndicesToExtract) {
@@ -2841,6 +2854,7 @@ bool llvm::matchShuffleToConcatExtractedSubvectors(MachineInstr &MI,
                               ExtractIdx);
       } else {
         unsigned UnmergeIdx = ExtractIdx / SubVecNumElts;
+        assert(!(ExtractIdx % SubVecNumElts));
         buildUnmergeVector(B, MRI, ExtractedSubVec, ExtractVec, NumSubVectors,
                            UnmergeIdx);
       }

--- a/llvm/test/CodeGen/AIE/GlobalISel/prelegalizercombiner-shuffle-vector.mir
+++ b/llvm/test/CodeGen/AIE/GlobalISel/prelegalizercombiner-shuffle-vector.mir
@@ -1563,10 +1563,9 @@ body:             |
     ; CHECK: liveins: $wl0, $wl1
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<8 x s32>) = COPY $wl0
-    ; CHECK-NEXT: [[AIE_UNPAD_VECTOR:%[0-9]+]]:_(<4 x s32>) = G_AIE_UNPAD_VECTOR [[COPY]](<8 x s32>)
-    ; CHECK-NEXT: [[AIE_UNPAD_VECTOR1:%[0-9]+]]:_(<4 x s32>) = G_AIE_UNPAD_VECTOR [[COPY]](<8 x s32>)
-    ; CHECK-NEXT: [[CONCAT_VECTORS:%[0-9]+]]:_(<8 x s32>) = G_CONCAT_VECTORS [[AIE_UNPAD_VECTOR]](<4 x s32>), [[AIE_UNPAD_VECTOR1]](<4 x s32>)
-    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[CONCAT_VECTORS]](<8 x s32>)
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(<8 x s32>) = COPY $wl1
+    ; CHECK-NEXT: [[SHUF:%[0-9]+]]:_(<8 x s32>) = G_SHUFFLE_VECTOR [[COPY]](<8 x s32>), [[COPY1]], shufflemask(0, 1, 2, 3, 1, 2, 3, 4)
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[SHUF]](<8 x s32>)
     %1:_(<8 x s32>) = COPY $wl0
     %2:_(<8 x s32>) = COPY $wl1
     %0:_(<8 x s32>) = G_SHUFFLE_VECTOR %1(<8 x s32>), %2(<8 x s32>), shufflemask(0, 1, 2, 3, 1, 2, 3, 4)

--- a/llvm/test/CodeGen/AIE/GlobalISel/prelegalizercombiner-shuffle-vector.mir
+++ b/llvm/test/CodeGen/AIE/GlobalISel/prelegalizercombiner-shuffle-vector.mir
@@ -1552,3 +1552,23 @@ body:             |
     %0:_(<8 x s32>) = G_SHUFFLE_VECTOR %1(<8 x s32>), %2(<8 x s32>), shufflemask(1, 2, 3, 4, 1, 2, 3, 4)
     PseudoRET implicit $lr, implicit %0
 ...
+
+---
+name: shuffle_concat_extracted_subvectors_height_in_submask_not_power2_no_combine
+tracksRegLiveness: true
+body:             |
+  bb.1:
+    liveins: $wl0, $wl1
+    ; CHECK-LABEL: name: shuffle_concat_extracted_subvectors_height_in_submask_not_power2_no_combine
+    ; CHECK: liveins: $wl0, $wl1
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<8 x s32>) = COPY $wl0
+    ; CHECK-NEXT: [[AIE_UNPAD_VECTOR:%[0-9]+]]:_(<4 x s32>) = G_AIE_UNPAD_VECTOR [[COPY]](<8 x s32>)
+    ; CHECK-NEXT: [[AIE_UNPAD_VECTOR1:%[0-9]+]]:_(<4 x s32>) = G_AIE_UNPAD_VECTOR [[COPY]](<8 x s32>)
+    ; CHECK-NEXT: [[CONCAT_VECTORS:%[0-9]+]]:_(<8 x s32>) = G_CONCAT_VECTORS [[AIE_UNPAD_VECTOR]](<4 x s32>), [[AIE_UNPAD_VECTOR1]](<4 x s32>)
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[CONCAT_VECTORS]](<8 x s32>)
+    %1:_(<8 x s32>) = COPY $wl0
+    %2:_(<8 x s32>) = COPY $wl1
+    %0:_(<8 x s32>) = G_SHUFFLE_VECTOR %1(<8 x s32>), %2(<8 x s32>), shufflemask(0, 1, 2, 3, 1, 2, 3, 4)
+    PseudoRET implicit $lr, implicit %0
+...


### PR DESCRIPTION
This fixes a bug where we try to extract at an index that is not a multiple of the number of detected subvector elements. See test file.
Note: The bug was found accidentally and didn't affect any of the kernels.