### PR TITLE
[AIE2P] fixup! add check for implicit_def operand in matchShuffleBcstToCopy

### DIFF
--- a/llvm/lib/Target/AIE/AIECombinerHelper.cpp
+++ b/llvm/lib/Target/AIE/AIECombinerHelper.cpp
@@ -2866,17 +2866,21 @@ bool llvm::matchShuffleBcstToCopy(MachineInstr &MI, MachineRegisterInfo &MRI,
 
   const Register DstReg = MI.getOperand(0).getReg();
   const Register Src1Reg = MI.getOperand(1).getReg();
+  const Register Src2Reg = MI.getOperand(2).getReg();
   const LLT DstTy = MRI.getType(DstReg);
   const LLT Src1Ty = MRI.getType(Src1Reg);
-
   if (DstTy != Src1Ty)
     return false;
 
   ArrayRef<int> Mask = MI.getOperand(3).getShuffleMask();
   const AIEBaseInstrInfo &AIETII = (const AIEBaseInstrInfo &)TII;
-  MachineInstr *SrcVec = MRI.getVRegDef(Src1Reg);
+  MachineInstr *SrcVec1 = MRI.getVRegDef(Src1Reg);
+  MachineInstr *SrcVec2 = MRI.getVRegDef(Src2Reg);
   // Check if the first source is defined by a Broadcast.
-  if (SrcVec->getOpcode() != AIETII.getGenericBroadcastVectorOpcode())
+  if (SrcVec1->getOpcode() != AIETII.getGenericBroadcastVectorOpcode())
+    return false;
+  // Check if the second source is an undef.
+  if (SrcVec2->getOpcode() != TargetOpcode::G_IMPLICIT_DEF)
     return false;
 
   const unsigned NumSrcElems = Src1Ty.isVector() ? Src1Ty.getNumElements() : 1;

--- a/llvm/test/CodeGen/AIE/aie2p/GlobalIsel/prelegalizercombiner-vector-broadcast.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/GlobalIsel/prelegalizercombiner-vector-broadcast.mir
@@ -454,6 +454,24 @@ body:             |
 
 ...
 ---
+name:       test_shuffle_broadcast_combine_v64s32_invalid
+alignment:       16
+body:             |
+  bb.1.entry:
+    ; CHECK-LABEL: name: test_shuffle_broadcast_combine_v64s32_invalid
+    ; CHECK: [[C:%[0-9]+]]:_(s32) = G_CONSTANT i32 0
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<64 x s32>) = COPY $dm0
+    ; CHECK-NEXT: [[AIE_BROADCAST_VECTOR:%[0-9]+]]:_(<64 x s32>) = G_AIE_BROADCAST_VECTOR [[C]](s32)
+    ; CHECK-NEXT: [[SHUF:%[0-9]+]]:_(<64 x s32>) = G_SHUFFLE_VECTOR [[AIE_BROADCAST_VECTOR]](<64 x s32>), [[COPY]], shufflemask(32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[SHUF]](<64 x s32>)
+  %1:_(s32) = G_CONSTANT i32 0
+  %2:_(<64 x s32>) = COPY $dm0
+  %3:_(<64 x s32>) = G_AIE_BROADCAST_VECTOR %1:_(s32)
+  %0:_(<64 x s32>) = G_SHUFFLE_VECTOR %3:_(<64 x s32>), %2:_, shufflemask(32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+  PseudoRET implicit $lr, implicit %0
+
+...
+---
 name:       test_shuffle_broadcast_combine_v64s8_und_mask
 alignment:       16
 body:             |


### PR DESCRIPTION
This is the fixup commit of the PR - https://github.com/Xilinx/llvm-aie/pull/388 , add the checks for G_IMPLICIT_DEF operand.