### PR TITLE
[AIE2P] Add shuffle mask range checks in matchShuffleBcstToCopy combiner

### DIFF
--- a/llvm/lib/Target/AIE/AIECombinerHelper.cpp
+++ b/llvm/lib/Target/AIE/AIECombinerHelper.cpp
@@ -96,6 +96,16 @@ bool MaskMatch::isMaskWithAllUndefs(ArrayRef<int> Mask) {
   return true;
 }
 
+// Checks if the mask is in range, allowing some values to be
+// undef (-1), but not all.
+bool MaskMatch::isMaskWithinRangeOrUndef(ArrayRef<int> Mask, int MinValue,
+                                         int MaxValue) {
+  return llvm::any_of(Mask, [](int v) { return v != -1; }) &&
+         llvm::all_of(Mask, [=](int v) {
+           return v == -1 || (v >= MinValue && v <= MaxValue);
+         });
+}
+
 std::optional<unsigned> MaskMatch::getHeight(ArrayRef<int> Mask,
                                              unsigned Period) {
   for (unsigned I = 0; I < Mask.size(); ++I) {
@@ -2869,8 +2879,9 @@ bool llvm::matchShuffleToConcatExtractedSubvectors(MachineInstr &MI,
   return true;
 }
 
+/// Match something like this:
 ///  %1:_(s32) = COPY $r0
-///  %2:_(<16 x s32>) = G_IMPLICIT_DEF
+///  %2:_(<16 x s32>) = COPY $x0
 ///  %3:_(<16 x s32>) = G_AIE_BROADCAST_VECTOR %1:_(s32)
 ///  %0:_(<16 x s32>) = G_SHUFFLE_VECTOR %3(<16 x s32>), %2(<16 x s32>),
 ///  shufflemask(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
@@ -2891,23 +2902,43 @@ bool llvm::matchShuffleBcstToCopy(MachineInstr &MI, MachineRegisterInfo &MRI,
 
   ArrayRef<int> Mask = MI.getOperand(3).getShuffleMask();
   const AIEBaseInstrInfo &AIETII = (const AIEBaseInstrInfo &)TII;
-  MachineInstr *SrcVec1 = MRI.getVRegDef(Src1Reg);
-  MachineInstr *SrcVec2 = MRI.getVRegDef(Src2Reg);
-  // Check if the first source is defined by a Broadcast.
-  if (SrcVec1->getOpcode() != AIETII.getGenericBroadcastVectorOpcode())
-    return false;
-  // Check if the second source is an undef.
-  if (SrcVec2->getOpcode() != TargetOpcode::G_IMPLICIT_DEF)
+  MachineInstr *Src1Vec = MRI.getVRegDef(Src1Reg);
+  MachineInstr *Src2Vec = MRI.getVRegDef(Src2Reg);
+  unsigned BcstOpcode = AIETII.getGenericBroadcastVectorOpcode();
+  bool IsSrc1Bcst = (Src1Vec->getOpcode() == BcstOpcode);
+  bool IsSrc2Bcst = (Src2Vec->getOpcode() == BcstOpcode);
+
+  // Check if the first or second source is defined by a Broadcast.
+  if (!IsSrc1Bcst && !IsSrc2Bcst)
     return false;
 
-  const unsigned NumSrcElems = Src1Ty.isVector() ? Src1Ty.getNumElements() : 1;
+  if (!DstTy.isVector() || !Src1Ty.isVector())
+    return false;
+
+  const unsigned NumSrcElems = Src1Ty.getNumElements();
   if (Mask.size() != NumSrcElems)
     return false;
 
-  if (MaskMatch::isMaskWithAllUndefs(Mask))
+  // Determine the valid mask range
+  const int MinSrc1Value = 0, MaxSrc1Value = NumSrcElems - 1;
+  const int MinSrc2Value = NumSrcElems, MaxSrc2Value = 2 * NumSrcElems - 1;
+  const bool IsValidSrc1Mask =
+      IsSrc1Bcst ? MaskMatch(0).isMaskWithinRangeOrUndef(Mask, MinSrc1Value,
+                                                         MaxSrc1Value)
+                 : false;
+  const bool IsValidSrc2Mask =
+      IsSrc2Bcst ? MaskMatch(0).isMaskWithinRangeOrUndef(Mask, MinSrc2Value,
+                                                         MaxSrc2Value)
+                 : false;
+  Register SrcReg;
+  if (IsSrc1Bcst && IsValidSrc1Mask)
+    SrcReg = Src1Reg;
+  else if (IsSrc2Bcst && IsValidSrc2Mask)
+    SrcReg = Src2Reg;
+  else
     return false;
 
-  MatchInfo = [=](MachineIRBuilder &B) { B.buildCopy(DstReg, Src1Reg); };
+  MatchInfo = [=](MachineIRBuilder &B) { B.buildCopy(DstReg, SrcReg); };
 
   return true;
 }

--- a/llvm/lib/Target/AIE/AIECombinerHelper.h
+++ b/llvm/lib/Target/AIE/AIECombinerHelper.h
@@ -56,6 +56,8 @@ public:
   static bool isMaskWithAllUndefs(ArrayRef<int> Mask);
   static std::optional<unsigned> getHeight(ArrayRef<int> Mask, unsigned Period);
   static std::optional<int> getUniqueIndex(ArrayRef<int> Mask);
+  static bool isMaskWithinRangeOrUndef(ArrayRef<int> Mask, int MinValue,
+                                       int MaxValue);
 
   unsigned getMaskValue(unsigned Idx) const {
     unsigned BaseIdx = Period == 0 ? Idx : Idx % Period;

--- a/llvm/test/CodeGen/AIE/aie2p/GlobalIsel/prelegalizercombiner-vector-broadcast.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/GlobalIsel/prelegalizercombiner-vector-broadcast.mir
@@ -454,16 +454,14 @@ body:             |
 
 ...
 ---
-name:       test_shuffle_broadcast_combine_v64s32_invalid
+name:       test_shuffle_broadcast_combine_v64s32_with_defsrc
 alignment:       16
 body:             |
   bb.1.entry:
-    ; CHECK-LABEL: name: test_shuffle_broadcast_combine_v64s32_invalid
+    ; CHECK-LABEL: name: test_shuffle_broadcast_combine_v64s32_with_defsrc
     ; CHECK: [[C:%[0-9]+]]:_(s32) = G_CONSTANT i32 0
-    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<64 x s32>) = COPY $dm0
     ; CHECK-NEXT: [[AIE_BROADCAST_VECTOR:%[0-9]+]]:_(<64 x s32>) = G_AIE_BROADCAST_VECTOR [[C]](s32)
-    ; CHECK-NEXT: [[SHUF:%[0-9]+]]:_(<64 x s32>) = G_SHUFFLE_VECTOR [[AIE_BROADCAST_VECTOR]](<64 x s32>), [[COPY]], shufflemask(32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
-    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[SHUF]](<64 x s32>)
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[AIE_BROADCAST_VECTOR]](<64 x s32>)
   %1:_(s32) = G_CONSTANT i32 0
   %2:_(<64 x s32>) = COPY $dm0
   %3:_(<64 x s32>) = G_AIE_BROADCAST_VECTOR %1:_(s32)
@@ -484,3 +482,191 @@ body:             |
   %3:_(<64 x s8>) = G_AIE_BROADCAST_VECTOR %1:_(s32)
   %0:_(<64 x s8>) = G_SHUFFLE_VECTOR %3:_(<64 x s8>), %2:_, shufflemask(-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1)
   PseudoRET implicit $lr, implicit %0
+
+...
+---
+name:       test_shuffle_broadcast_combine_v16s32
+alignment:       16
+body:             |
+  bb.1.entry:
+    ; CHECK-LABEL: name: test_shuffle_broadcast_combine_v16s32
+    ; CHECK: [[COPY:%[0-9]+]]:_(s32) = COPY $r0
+    ; CHECK-NEXT: [[AIE_BROADCAST_VECTOR:%[0-9]+]]:_(<16 x s32>) = G_AIE_BROADCAST_VECTOR [[COPY]](s32)
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[AIE_BROADCAST_VECTOR]](<16 x s32>)
+  %1:_(s32) = COPY $r0
+  %2:_(<16 x s32>) = COPY $x0
+  %3:_(<16 x s32>) = G_AIE_BROADCAST_VECTOR %1:_(s32)
+  %0:_(<16 x s32>) = G_SHUFFLE_VECTOR %3:_(<16 x s32>), %2:_, shufflemask(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+  PseudoRET implicit $lr, implicit %0
+
+...
+---
+name:       test_shuffle_broadcast_combine_v16s32_src1_bcst
+alignment:       16
+body:             |
+  bb.1.entry:
+    ; CHECK-LABEL: name: test_shuffle_broadcast_combine_v16s32_src1_bcst
+    ; CHECK: [[COPY:%[0-9]+]]:_(s32) = COPY $r0
+    ; CHECK-NEXT: [[AIE_BROADCAST_VECTOR:%[0-9]+]]:_(<16 x s32>) = G_AIE_BROADCAST_VECTOR [[COPY]](s32)
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[AIE_BROADCAST_VECTOR]](<16 x s32>)
+  %1:_(s32) = COPY $r0
+  %2:_(<16 x s32>) = COPY $x0
+  %3:_(<16 x s32>) = G_AIE_BROADCAST_VECTOR %1:_(s32)
+  %0:_(<16 x s32>) = G_SHUFFLE_VECTOR %3:_(<16 x s32>), %2:_, shufflemask(0, 11, 15, 0, 0, 0, 0, 0, 10, 0, 8, 0, 0, 0, 0, 0)
+  PseudoRET implicit $lr, implicit %0
+
+...
+---
+name:       test_shuffle_broadcast_combine_v16s32_src2_bcst
+alignment:       16
+body:             |
+  bb.1.entry:
+    ; CHECK-LABEL: name: test_shuffle_broadcast_combine_v16s32_src2_bcst
+    ; CHECK: [[COPY:%[0-9]+]]:_(s32) = COPY $r0
+    ; CHECK-NEXT: [[AIE_BROADCAST_VECTOR:%[0-9]+]]:_(<16 x s32>) = G_AIE_BROADCAST_VECTOR [[COPY]](s32)
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[AIE_BROADCAST_VECTOR]](<16 x s32>)
+  %1:_(s32) = COPY $r0
+  %2:_(<16 x s32>) = COPY $x0
+  %3:_(<16 x s32>) = G_AIE_BROADCAST_VECTOR %1:_(s32)
+  %0:_(<16 x s32>) = G_SHUFFLE_VECTOR %2:_(<16 x s32>), %3:_, shufflemask(16, 16, 16, 17, 18, 20, 31, 16, 16, 16, 16, 16, 16, 16, 24, 25)
+  PseudoRET implicit $lr, implicit %0
+
+...
+---
+name:       test_shuffle_broadcast_combine_v16s32_src1_bcst_invalid
+alignment:       16
+body:             |
+  bb.1.entry:
+    ; CHECK-LABEL: name: test_shuffle_broadcast_combine_v16s32_src1_bcst_invalid
+    ; CHECK: [[COPY:%[0-9]+]]:_(s32) = COPY $r0
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(<16 x s32>) = COPY $x0
+    ; CHECK-NEXT: [[AIE_BROADCAST_VECTOR:%[0-9]+]]:_(<16 x s32>) = G_AIE_BROADCAST_VECTOR [[COPY]](s32)
+    ; CHECK-NEXT: [[SHUF:%[0-9]+]]:_(<16 x s32>) = G_SHUFFLE_VECTOR [[AIE_BROADCAST_VECTOR]](<16 x s32>), [[COPY1]], shufflemask(16, 11, 15, 0, 0, 0, 0, 0, 10, 0, 8, 0, 0, 0, 0, 0)
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[SHUF]](<16 x s32>)
+  %1:_(s32) = COPY $r0
+  %2:_(<16 x s32>) = COPY $x0
+  %3:_(<16 x s32>) = G_AIE_BROADCAST_VECTOR %1:_(s32)
+  %0:_(<16 x s32>) = G_SHUFFLE_VECTOR %3:_(<16 x s32>), %2:_, shufflemask(16, 11, 15, 0, 0, 0, 0, 0, 10, 0, 8, 0, 0, 0, 0, 0)
+  PseudoRET implicit $lr, implicit %0
+
+...
+---
+name:       test_shuffle_broadcast_combine_v16s32_src2_bcst_invalid
+alignment:       16
+body:             |
+  bb.1.entry:
+    ; CHECK-LABEL: name: test_shuffle_broadcast_combine_v16s32_src2_bcst_invalid
+    ; CHECK: [[COPY:%[0-9]+]]:_(s32) = COPY $r0
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(<16 x s32>) = COPY $x0
+    ; CHECK-NEXT: [[AIE_BROADCAST_VECTOR:%[0-9]+]]:_(<16 x s32>) = G_AIE_BROADCAST_VECTOR [[COPY]](s32)
+    ; CHECK-NEXT: [[SHUF:%[0-9]+]]:_(<16 x s32>) = G_SHUFFLE_VECTOR [[COPY1]](<16 x s32>), [[AIE_BROADCAST_VECTOR]], shufflemask(0, 16, 16, 17, 18, 20, 31, 16, 16, 16, 16, 16, 16, 16, 24, 25)
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[SHUF]](<16 x s32>)
+  %1:_(s32) = COPY $r0
+  %2:_(<16 x s32>) = COPY $x0
+  %3:_(<16 x s32>) = G_AIE_BROADCAST_VECTOR %1:_(s32)
+  %0:_(<16 x s32>) = G_SHUFFLE_VECTOR %2:_(<16 x s32>), %3:_, shufflemask(0, 16, 16, 17, 18, 20, 31, 16, 16, 16, 16, 16, 16, 16, 24, 25)
+  PseudoRET implicit $lr, implicit %0
+
+...
+---
+name:       test_shuffle_broadcast_combine_v16s32_src1_and_src2_bcst_invalid
+alignment:       16
+body:             |
+  bb.1.entry:
+    ; CHECK-LABEL: name: test_shuffle_broadcast_combine_v16s32_src1_and_src2_bcst_invalid
+    ; CHECK: [[COPY:%[0-9]+]]:_(s32) = COPY $r0
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(s32) = COPY $r1
+    ; CHECK-NEXT: [[AIE_BROADCAST_VECTOR:%[0-9]+]]:_(<16 x s32>) = G_AIE_BROADCAST_VECTOR [[COPY]](s32)
+    ; CHECK-NEXT: [[AIE_BROADCAST_VECTOR1:%[0-9]+]]:_(<16 x s32>) = G_AIE_BROADCAST_VECTOR [[COPY1]](s32)
+    ; CHECK-NEXT: [[SHUF:%[0-9]+]]:_(<16 x s32>) = G_SHUFFLE_VECTOR [[AIE_BROADCAST_VECTOR1]](<16 x s32>), [[AIE_BROADCAST_VECTOR]], shufflemask(1, 18, 18, 18, 18, 18, 18, 18, 18, 2, 18, 18, 18, 18, 18, 18)
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[SHUF]](<16 x s32>)
+  %1:_(s32) = COPY $r0
+  %6:_(s32) = COPY $r1
+  %2:_(<16 x s32>) = G_AIE_BROADCAST_VECTOR %1:_(s32)
+  %3:_(<16 x s32>) = G_AIE_BROADCAST_VECTOR %6:_(s32)
+  %0:_(<16 x s32>) = G_SHUFFLE_VECTOR %3:_(<16 x s32>), %2:_, shufflemask(1, 18, 18, 18, 18, 18, 18, 18, 18, 2, 18, 18, 18, 18, 18, 18)
+  PseudoRET implicit $lr, implicit %0
+...
+---
+name:       test_shuffle_broadcast_combine_v16s32_src1_and_src2_bcst_src1_mask
+alignment:       16
+body:             |
+  bb.1.entry:
+    ; CHECK-LABEL: name: test_shuffle_broadcast_combine_v16s32_src1_and_src2_bcst_src1_mask
+    ; CHECK: [[COPY:%[0-9]+]]:_(s32) = COPY $r1
+    ; CHECK-NEXT: [[AIE_BROADCAST_VECTOR:%[0-9]+]]:_(<16 x s32>) = G_AIE_BROADCAST_VECTOR [[COPY]](s32)
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[AIE_BROADCAST_VECTOR]](<16 x s32>)
+  %1:_(s32) = COPY $r0
+  %6:_(s32) = COPY $r1
+  %2:_(<16 x s32>) = G_AIE_BROADCAST_VECTOR %1:_(s32)
+  %3:_(<16 x s32>) = G_AIE_BROADCAST_VECTOR %6:_(s32)
+  %0:_(<16 x s32>) = G_SHUFFLE_VECTOR %3:_(<16 x s32>), %2:_, shufflemask(1, 15, 15, 15, 15, 15, 15, 15, 15, 2, 15, 15, 15, 15, 15, 15)
+  PseudoRET implicit $lr, implicit %0
+...
+---
+name:       test_shuffle_broadcast_combine_v16s32_src1_and_src2_bcst_src2_mask
+alignment:       16
+body:             |
+  bb.1.entry:
+    ; CHECK-LABEL: name: test_shuffle_broadcast_combine_v16s32_src1_and_src2_bcst_src2_mask
+    ; CHECK: [[COPY:%[0-9]+]]:_(s32) = COPY $r0
+    ; CHECK-NEXT: [[AIE_BROADCAST_VECTOR:%[0-9]+]]:_(<16 x s32>) = G_AIE_BROADCAST_VECTOR [[COPY]](s32)
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[AIE_BROADCAST_VECTOR]](<16 x s32>)
+  %1:_(s32) = COPY $r0
+  %6:_(s32) = COPY $r1
+  %2:_(<16 x s32>) = G_AIE_BROADCAST_VECTOR %1:_(s32)
+  %3:_(<16 x s32>) = G_AIE_BROADCAST_VECTOR %6:_(s32)
+  %0:_(<16 x s32>) = G_SHUFFLE_VECTOR %3:_(<16 x s32>), %2:_, shufflemask(16, 18, 18, 18, 18, 18, 18, 18, 18, 22, 18, 18, 18, 18, 18, 18)
+  PseudoRET implicit $lr, implicit %0
+...
+---
+name:       test_shuffle_broadcast_combine_v16s32_src1_and_src2_bcst_src1_mask_undef
+alignment:       16
+body:             |
+  bb.1.entry:
+    ; CHECK-LABEL: name: test_shuffle_broadcast_combine_v16s32_src1_and_src2_bcst_src1_mask_undef
+    ; CHECK: [[COPY:%[0-9]+]]:_(s32) = COPY $r1
+    ; CHECK-NEXT: [[AIE_BROADCAST_VECTOR:%[0-9]+]]:_(<16 x s32>) = G_AIE_BROADCAST_VECTOR [[COPY]](s32)
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[AIE_BROADCAST_VECTOR]](<16 x s32>)
+  %1:_(s32) = COPY $r0
+  %6:_(s32) = COPY $r1
+  %2:_(<16 x s32>) = G_AIE_BROADCAST_VECTOR %1:_(s32)
+  %3:_(<16 x s32>) = G_AIE_BROADCAST_VECTOR %6:_(s32)
+  %0:_(<16 x s32>) = G_SHUFFLE_VECTOR %3:_(<16 x s32>), %2:_, shufflemask(-1, 1, -1, 10, -1, -1, -1, -1, -1, 1, 0, -1, -1, -1, -1, -1)
+  PseudoRET implicit $lr, implicit %0
+...
+---
+name:       test_shuffle_broadcast_combine_v16s32_src1_and_src2_bcst_src2_mask_undef
+alignment:       16
+body:             |
+  bb.1.entry:
+    ; CHECK-LABEL: name: test_shuffle_broadcast_combine_v16s32_src1_and_src2_bcst_src2_mask_undef
+    ; CHECK: [[COPY:%[0-9]+]]:_(s32) = COPY $r0
+    ; CHECK-NEXT: [[AIE_BROADCAST_VECTOR:%[0-9]+]]:_(<16 x s32>) = G_AIE_BROADCAST_VECTOR [[COPY]](s32)
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[AIE_BROADCAST_VECTOR]](<16 x s32>)
+  %1:_(s32) = COPY $r0
+  %6:_(s32) = COPY $r1
+  %2:_(<16 x s32>) = G_AIE_BROADCAST_VECTOR %1:_(s32)
+  %3:_(<16 x s32>) = G_AIE_BROADCAST_VECTOR %6:_(s32)
+  %0:_(<16 x s32>) = G_SHUFFLE_VECTOR %3:_(<16 x s32>), %2:_, shufflemask(16, 18, -1, 18, 18, 18, 18, 18, 18, 22, -1, 18, 18, 18, 18, 18)
+  PseudoRET implicit $lr, implicit %0
+...
+---
+name:       test_shuffle_broadcast_combine_v16s32_src1_and_src2_bcst_src2_mask_undef_invalid
+alignment:       16
+body:             |
+  bb.1.entry:
+    ; CHECK-LABEL: name: test_shuffle_broadcast_combine_v16s32_src1_and_src2_bcst_src2_mask_undef_invalid
+    ; CHECK: [[COPY:%[0-9]+]]:_(s32) = COPY $r0
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(s32) = COPY $r1
+    ; CHECK-NEXT: [[AIE_BROADCAST_VECTOR:%[0-9]+]]:_(<16 x s32>) = G_AIE_BROADCAST_VECTOR [[COPY]](s32)
+    ; CHECK-NEXT: [[AIE_BROADCAST_VECTOR1:%[0-9]+]]:_(<16 x s32>) = G_AIE_BROADCAST_VECTOR [[COPY1]](s32)
+    ; CHECK-NEXT: [[SHUF:%[0-9]+]]:_(<16 x s32>) = G_SHUFFLE_VECTOR [[AIE_BROADCAST_VECTOR1]](<16 x s32>), [[AIE_BROADCAST_VECTOR]], shufflemask(16, 0, undef, 18, 5, 18, 18, 18, 18, 22, undef, 18, 18, 18, 18, 18)
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[SHUF]](<16 x s32>)
+  %1:_(s32) = COPY $r0
+  %6:_(s32) = COPY $r1
+  %2:_(<16 x s32>) = G_AIE_BROADCAST_VECTOR %1:_(s32)
+  %3:_(<16 x s32>) = G_AIE_BROADCAST_VECTOR %6:_(s32)
+  %0:_(<16 x s32>) = G_SHUFFLE_VECTOR %3:_(<16 x s32>), %2:_, shufflemask(16, 0, -1, 18, 5, 18, 18, 18, 18, 22, -1, 18, 18, 18, 18, 18)
+  PseudoRET implicit $lr, implicit %0
+...


### PR DESCRIPTION
If either vector source of `G_SHUFFLE_VECTOR` is defined by `G_AIE_BROADCAST_VECTOR`, combine it into a `COPY` operation if the mask falls within a valid range.