### PR TITLE
[AIE2P] Move AIE2P slot decoders to a namespace to avoid link-time conflicts with AIE2 ones.

### DIFF
--- a/llvm/lib/Target/AIE/Disassembler/AIE2PDisassembler.cpp
+++ b/llvm/lib/Target/AIE/Disassembler/AIE2PDisassembler.cpp
@@ -53,6 +53,7 @@ MCDisassembler *createAIE2PDisassembler(const Target &T,
 // Include generated operand decoder tables and methods.
 #include "AIE2PDisassembler.inc"
 
+namespace {
 SLOTDECODERDecl(Lda);
 SLOTDECODERDecl(Ldb);
 SLOTDECODERDecl(Alu);
@@ -61,6 +62,7 @@ SLOTDECODERDecl(Mv);
 SLOTDECODERDecl(Vec);
 SLOTDECODERDecl(Lng);
 SLOTDECODERDecl(Nop);
+} // namespace
 
 #include "AIE2PGenDecoderMethods.h"
 
@@ -68,6 +70,7 @@ SLOTDECODERDecl(Nop);
 
 #include "AIE2PGenDecoderMethods.inc"
 
+namespace {
 /// Slot decoders
 template <typename InsnType>
 DecodeStatus decodeAIE2PSlot(const uint8_t *DecoderTable, MCInst &Inst,
@@ -138,8 +141,6 @@ DecodeStatus decodeLngSlot(MCInst &Inst, InsnType &Imm, int64_t Address,
   LLVM_DEBUG(dbgs() << "Decode Lng Instruction\n");
   return decodeAIE2PSlot(DecoderTableLng48, Inst, Imm, Address, Decoder);
 }
-
-namespace {
 
 /// Interpret the code bits to determine the format size.
 int formatSize(ArrayRef<uint8_t> Bytes) {


### PR DESCRIPTION
Apparently MSVC linker thought it was okay to remove one of the conflicting decoder definitions at link time. (On the other hand, it is dubious as to how this didn't show up with other compilers). 