### PR TITLE
[AIEX] Fix shared library build

### DIFF
--- a/llvm/lib/Target/AIE/Utils/CMakeLists.txt
+++ b/llvm/lib/Target/AIE/Utils/CMakeLists.txt
@@ -9,6 +9,7 @@ add_llvm_component_library(LLVMAIEUtils
   AIELoopUtils.cpp
 
   LINK_COMPONENTS
+  Analysis
   CodeGen
   Core
   Support


### PR DESCRIPTION
Commit 8978b1c started using getLoopID from the Analysis library. We now need to add this library to the dependencies of the AIEUtils library.