### PR TITLE
Report core postpipeliner results as optimization remarks.

### DIFF
--- a/llvm/lib/Target/AIE/AIEInterBlockScheduling.cpp
+++ b/llvm/lib/Target/AIE/AIEInterBlockScheduling.cpp
@@ -22,6 +22,7 @@
 #include "Utils/AIELoopUtils.h"
 #include "llvm/ADT/PostOrderIterator.h"
 #include "llvm/CodeGen/MachineBasicBlock.h"
+#include "llvm/CodeGen/MachineOptimizationRemarkEmitter.h"
 #include "llvm/CodeGen/MachineScheduler.h"
 #include "llvm/Support/ErrorHandling.h"
 #include <memory>
@@ -617,6 +618,15 @@ SchedulingStage InterBlockScheduling::updatePipelining(BlockState &BS) {
       ++BS.FixPoint.IITries <= PostPipelinerMaxTryII) {
     return BS.FixPoint.Stage = SchedulingStage::Pipelining;
   }
+
+  auto *BB = BS.TheBlock;
+  auto DbgLoc = BB->begin()->getDebugLoc();
+  MachineOptimizationRemarkEmitter More(*BB->getParent(), nullptr);
+  More.emit([&]() {
+    return MachineOptimizationRemarkMissed("postpipeliner", "schedule", DbgLoc,
+                                           BB)
+           << "No schedule found.";
+  });
 
   // Fall back to the loop schedule. Note that we can only have II != 0
   // after the loop schedule has stabilized.

--- a/llvm/lib/Target/AIE/AIEMachineScheduler.cpp
+++ b/llvm/lib/Target/AIE/AIEMachineScheduler.cpp
@@ -21,6 +21,7 @@
 #include "llvm/ADT/iterator_range.h"
 #include "llvm/CodeGen/MachineBasicBlock.h"
 #include "llvm/CodeGen/MachineInstr.h"
+#include "llvm/CodeGen/MachineOptimizationRemarkEmitter.h"
 #include "llvm/CodeGen/MachineScheduler.h"
 #include "llvm/CodeGen/ResourceScoreboard.h"
 #include "llvm/Support/Debug.h"
@@ -1527,7 +1528,9 @@ void AIEScheduleDAGMI::schedule() {
     postProcessDAG();
 
     auto &PostSWP = BS.getPostSWP();
-    if (PostSWP.schedule(*this, BS.FixPoint.II)) {
+
+    MachineOptimizationRemarkEmitter More(*getBB()->getParent(), nullptr);
+    if (PostSWP.schedule(*this, BS.FixPoint.II, More)) {
       BS.setPipelined();
       LLVM_DEBUG(PostSWP.dump());
     }

--- a/llvm/lib/Target/AIE/AIEMachineScheduler.h
+++ b/llvm/lib/Target/AIE/AIEMachineScheduler.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// (c) Copyright 2023-2024 Advanced Micro Devices, Inc. or its affiliates
+// (c) Copyright 2023-2025 Advanced Micro Devices, Inc. or its affiliates
 //
 //===----------------------------------------------------------------------===//
 //
@@ -20,7 +20,6 @@
 #include "AIEPostPipeliner.h"
 #include "llvm/CodeGen/MachineBasicBlock.h"
 #include "llvm/CodeGen/MachineScheduler.h"
-#include <memory>
 
 namespace llvm {
 

--- a/llvm/lib/Target/AIE/AIEPostPipeliner.cpp
+++ b/llvm/lib/Target/AIE/AIEPostPipeliner.cpp
@@ -858,8 +858,14 @@ bool PostPipeliner::tryHeuristics() {
                            << "\n");
       if (scheduleFirstIteration(S) && scheduleOtherIterations(S)) {
         DEBUG_SUMMARY(dbgs() << "    Strategy " << S.name() << " run=" << Run
-                             << " found II=" << II << "\n");
-        return true;
+                             << " found schedule:\n");
+        const bool Success = checkStages();
+        DEBUG_SUMMARY(dbgs()
+                      << "    Strategy " << S.name() << " run=" << Run
+                      << " found NS=" << NStages << " II=" << II << "\n");
+        if (Success) {
+          return true;
+        }
       }
       resetSchedule(/*FullReset=*/false);
     }
@@ -905,9 +911,6 @@ bool PostPipeliner::schedule(ScheduleDAGMI &TheDAG, int InitiationInterval,
   LLVM_DEBUG(dumpIntervals(Info, MinLength, II));
   if (!tryHeuristics()) {
     LLVM_DEBUG(dbgs() << "PostPipeliner: No schedule found\n");
-    return false;
-  }
-  if (!checkStages()) {
     return false;
   }
 

--- a/llvm/lib/Target/AIE/AIEPostPipeliner.cpp
+++ b/llvm/lib/Target/AIE/AIEPostPipeliner.cpp
@@ -14,6 +14,8 @@
 #include "AIEPostPipeliner.h"
 #include "AIESlotCounts.h"
 #include "Utils/AIELoopUtils.h"
+#include "llvm/Analysis/OptimizationRemarkEmitter.h"
+#include "llvm/CodeGen/MachineOptimizationRemarkEmitter.h"
 #include "llvm/CodeGen/ScheduleDAG.h"
 #include "llvm/CodeGen/ScheduleDAGInstrs.h"
 #include "llvm/Support/MathExtras.h"
@@ -867,11 +869,21 @@ bool PostPipeliner::tryHeuristics() {
   return false;
 }
 
-bool PostPipeliner::schedule(ScheduleDAGMI &TheDAG, int InitiationInterval) {
+bool PostPipeliner::schedule(ScheduleDAGMI &TheDAG, int InitiationInterval,
+                             MachineOptimizationRemarkEmitter &More) {
   NTotalInstrs = TheDAG.SUnits.size();
   assert(NTotalInstrs % NInstr == 0);
   NCopies = NTotalInstrs / NInstr;
+
+  auto *BB = TheDAG.getBB();
+  auto DbgLoc = BB->begin()->getDebugLoc();
+
   if (NCopies == 1) {
+    More.emit([&]() {
+      return MachineOptimizationRemarkMissed("postpipeliner", "schedule",
+                                             DbgLoc, BB)
+             << "Not feasible.";
+    });
     LLVM_DEBUG(dbgs() << "PostPipeliner: Not feasible\n");
     return false;
   }
@@ -899,6 +911,11 @@ bool PostPipeliner::schedule(ScheduleDAGMI &TheDAG, int InitiationInterval) {
     return false;
   }
 
+  More.emit([&]() {
+    return MachineOptimizationRemark("postpipeliner", "schedule", DbgLoc, BB)
+           << "Schedule found: NS=" << ore::NV("NS", NStages)
+           << " II=" << ore::NV("II", II);
+  });
   LLVM_DEBUG(dbgs() << "PostPipeliner: Success\n");
   return true;
 }

--- a/llvm/lib/Target/AIE/AIEPostPipeliner.cpp
+++ b/llvm/lib/Target/AIE/AIEPostPipeliner.cpp
@@ -580,10 +580,12 @@ bool PostPipeliner::scheduleFirstIteration(PostPipelinerStrategy &Strategy) {
     Info[N].Scheduled = true;
     DEBUG_FULL(dbgs() << "Scoreboard\n"; Scoreboard.dumpFull(););
   }
+
+  const bool Success = checkStages();
   DEBUG_SUMMARY(dbgs() << "==== First iteration scheduled by "
                        << Strategy.name() << "====\n");
-  DEBUG_SUMMARY(dumpCycles(Info, MinLength, II));
-  return true;
+  DEBUG_SUMMARY(dumpCycles(Info, NStages * II, II));
+  return Success;
 }
 
 namespace {
@@ -916,14 +918,14 @@ bool PostPipeliner::checkStages() {
   // case we didn't reach steady state, and we may have missed conflicts.
   // We expect this to be rare.
   if (NStages > NCopies) {
-    LLVM_DEBUG(dbgs() << "PostPipeliner: Unsafe stage count, NCopies="
-                      << NCopies << "\n");
+    DEBUG_SUMMARY(dbgs() << "PostPipeliner: Unsafe stage count, NCopies="
+                         << NCopies << "\n");
     return false;
   }
 
   // Check that we have a positive trip count after adjusting
   if (MinTripCount - (NStages - 1) <= 0) {
-    LLVM_DEBUG(dbgs() << "PostPipeliner: MinTripCount insufficient\n");
+    DEBUG_SUMMARY(dbgs() << "PostPipeliner: MinTripCount insufficient\n");
     return false;
   }
   return true;

--- a/llvm/lib/Target/AIE/AIEPostPipeliner.h
+++ b/llvm/lib/Target/AIE/AIEPostPipeliner.h
@@ -24,6 +24,7 @@
 namespace llvm {
 class MachineInstr;
 class AIEHazardRecognizer;
+class MachineOptimizationRemarkEmitter;
 } // namespace llvm
 
 namespace llvm::AIE {
@@ -244,7 +245,8 @@ public:
 
   // Schedule using the given InitiationInterval. Return true when successful.
   // In that case calls to the query methods below are legitimate
-  bool schedule(ScheduleDAGMI &DAG, int InitiationInterval);
+  bool schedule(ScheduleDAGMI &DAG, int InitiationInterval,
+                MachineOptimizationRemarkEmitter &More);
 
   // quick query for the stage count
   int getStageCount() { return NStages; }

--- a/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/postpipeliner-ore.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/postpipeliner-ore.mir
@@ -1,0 +1,192 @@
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# (c) Copyright 2025 Advanced Micro Devices, Inc. or its affiliates
+
+# RUN: llc --mtriple=aie2p -O2 --start-before=postmisched %s \
+# RUN:   --aie-addrspace-none-is-safe=1	\
+# RUN:   -pass-remarks-output=- -pass-remarks-filter=postpipeliner -o /dev/null | FileCheck %s
+
+
+--- |
+  define dso_local void @gemm(ptr addrspace(5) noalias nocapture writeonly %d, ptr addrspace(6) noalias nocapture readonly %s, i32 noundef %n) local_unnamed_addr {
+  ; CHECK:--- !Passed
+  ; CHECK-NEXT:Pass:            postpipeliner
+  ; CHECK-NEXT:Name:            schedule
+  ; CHECK-NEXT:Function:        gemm
+  ; CHECK-NEXT:Args:
+  ; CHECK-NEXT:  - String:          'Schedule found: NS='
+  ; CHECK-NEXT:  - NS:              '5'
+  ; CHECK-NEXT:  - String:          ' II='
+  ; CHECK-NEXT:  - II:              '7'
+  ; CHECK-NEXT:...
+  entry:
+    %cmp5 = icmp sgt i32 %n, 0
+    br i1 %cmp5, label %for.body.preheader, label %for.cond.cleanup
+
+  for.body.preheader:                               ; preds = %entry
+    call void @llvm.set.loop.iterations.i32(i32 %n)
+    br label %for.body
+
+  for.body:                                         ; preds = %for.body.preheader, %for.body
+    %d.addr.07 = phi ptr addrspace(5) [ %incdec.ptr, %for.body ], [ %d, %for.body.preheader ]
+    %s.addr.06 = phi ptr addrspace(6) [ %incdec.ptr1, %for.body ], [ %s, %for.body.preheader ]
+    %0 = load i32, ptr addrspace(6) %s.addr.06, align 4
+    %add = add nsw i32 %0, 1
+    store i32 %add, ptr addrspace(5) %d.addr.07, align 4
+    %incdec.ptr = getelementptr inbounds i32, ptr addrspace(5) %d.addr.07, i20 1
+    %incdec.ptr1 = getelementptr inbounds i32, ptr addrspace(6) %s.addr.06, i20 1
+    %1 = call i1 @llvm.loop.decrement.i32(i32 1)
+    br i1 %1, label %for.body, label %for.cond.cleanup, !llvm.loop !0
+
+  for.cond.cleanup:                                 ; preds = %for.body, %entry
+    ret void
+
+  }
+
+
+  define dso_local void @gemm_lowitercount(ptr addrspace(5) noalias nocapture writeonly %d, ptr addrspace(6) noalias nocapture readonly %s, i32 noundef %n) local_unnamed_addr {
+  ; CHECK:--- !Missed
+  ; CHECK-NEXT:Pass:            postpipeliner
+  ; CHECK-NEXT:Name:            schedule
+  ; CHECK-NEXT:Function:        gemm_lowitercount
+  ; CHECK-NEXT:Args:
+  ; CHECK-NEXT:  - String:          No schedule found.
+  ; CHECK-NEXT:...
+  entry:
+    %cmp5 = icmp sgt i32 %n, 0
+    br i1 %cmp5, label %for.body.preheader, label %for.cond.cleanup
+
+  for.body.preheader:                               ; preds = %entry
+    call void @llvm.set.loop.iterations.i32(i32 %n)
+    br label %for.body
+
+  for.body:                                         ; preds = %for.body.preheader, %for.body
+    %d.addr.07 = phi ptr addrspace(5) [ %incdec.ptr, %for.body ], [ %d, %for.body.preheader ]
+    %s.addr.06 = phi ptr addrspace(6) [ %incdec.ptr1, %for.body ], [ %s, %for.body.preheader ]
+    %0 = load i32, ptr addrspace(6) %s.addr.06, align 4
+    %add = add nsw i32 %0, 1
+    store i32 %add, ptr addrspace(5) %d.addr.07, align 4
+    %incdec.ptr = getelementptr inbounds i32, ptr addrspace(5) %d.addr.07, i20 1
+    %incdec.ptr1 = getelementptr inbounds i32, ptr addrspace(6) %s.addr.06, i20 1
+    %1 = call i1 @llvm.loop.decrement.i32(i32 1)
+    br i1 %1, label %for.body, label %for.cond.cleanup, !llvm.loop !3
+
+  for.cond.cleanup:                                 ; preds = %for.body, %entry
+    ret void
+
+  }
+
+  declare void @llvm.set.loop.iterations.i32(i32)
+  declare i1 @llvm.loop.decrement.i32(i32)
+
+  !0 = distinct !{!0, !1, !2}
+  !1 = !{!"llvm.loop.mustprogress"}
+  !2 = !{!"llvm.loop.itercount.range", i64 10}
+  !3 = distinct !{!3, !1, !4}
+  !4 = !{!"llvm.loop.itercount.range", i64 2}
+
+...
+---
+name:            gemm
+alignment:       16
+tracksRegLiveness: true
+body:             |
+  bb.0.entry (align 16):
+    successors: %bb.2
+    liveins: $p0, $p1, $r0
+
+    $lc = ADD_NC_mv_add_ri $r0, 0
+    $ls = MOVXM %bb.2
+    $le = MOVXM <mcsymbol .L_LEnd0>
+
+  bb.2.for.body (align 16):
+    successors: %bb.2, %bb.3
+    liveins: $dc0, $dc1, $dc2, $dc3, $dc4, $dc5, $dj0, $dj1, $dj2, $dj3, $dj4, $dj5, $dj7, $dm0:0x000000001800000C, $dm1:0x000000001800000C, $dm2:0x000000001800000C, $dm3:0x000000001800000C, $dn0, $dn1, $dn2, $dn4, $dn5, $m0, $m1, $m2, $m3, $m4, $m5, $p0, $p1, $p2, $p4, $p6, $p7, $r0, $r1, $r2, $r3, $r4, $r8, $y5:0x0000000000000033, $d0_3d:0x0003C00000200E00, $d1_3d:0x0003C00000200E00, $dn3
+
+    $p5 = MOVS $p6
+    $x4 = VLDB_dmx_ldb_x_idx_imm $p6, 64 :: (load (<16 x s32>))
+    $x9, $p6, $dc0, $dc4 = VLDB_3D_dmx_ldb_x $p6, $d0_3d :: (load (<16 x s32>))
+    $p3 = MOVS $p7
+    $cmh4 = VLDA_CONV_fp32_bf16_dmx_lda_ups_bf_idx_imm $p7, 64 :: (load (<32 x s16>))
+    $cml4, $p7, $dc1, $dc5 = VLDA_3D_CONV_fp32_bf16_dmx_lda_ups_bf $p7, $d1_3d :: (load (<32 x s16>))
+    $x8 = VSHUFFLE_vec_shuffle_x $x9, $x4, $r0
+    $x9 = VSHUFFLE_vec_shuffle_x $x9, $x4, $r1
+    $p5 = PADDB_pstm_nrm $p5, $m4
+    $x6 = VLDB_dmx_ldb_x_idx_imm $p5, 0 :: (load (<16 x s32>))
+    $x1 = VLDB_dmx_ldb_x_idx_imm $p5, 64 :: (load (<16 x s32>))
+    $ex2 = VCONV_bfp16ebs8_fp32 $dm4, implicit-def $srf2bflags, implicit $crf2bmask, implicit $crrnd
+    $dm4 = VMUL_f_vmul_bf_vmul_bf_core_Y_Y $y4, $y5, $r2, implicit-def $srfpflags, implicit $crfpmask
+    $x0 = VSHUFFLE_vec_shuffle_x $x1, $x6, $r0
+    $x1 = VSHUFFLE_vec_shuffle_x $x1, $x6, $r1
+    $ex3 = VCONV_bfp16ebs8_fp32 $dm4, implicit-def $srf2bflags, implicit $crf2bmask, implicit $crrnd
+    $dm4 = VMUL_f_vmul_bf_vmul_bf_core_Y_Y $y0, $y5, $r2, implicit-def $srfpflags, implicit $crfpmask
+    $p3 = PADDA_pstm_nrm $p3, $m5
+    $ex5 = VCONV_bfp16ebs8_fp32 $dm4, implicit-def $srf2bflags, implicit $crf2bmask, implicit $crrnd
+    $cml4 = VLDA_CONV_fp32_bf16_dmx_lda_ups_bf_idx_imm $p3, 0 :: (load (<32 x s16>))
+    $cmh4 = VLDA_CONV_fp32_bf16_dmx_lda_ups_bf_idx_imm $p3, 64 :: (load (<32 x s16>))
+    $ex7 = VCONV_bfp16ebs8_fp32 $dm4, implicit-def $srf2bflags, implicit $crf2bmask, implicit $crrnd
+    $dm3 = VMAC_f_vmac_bfp_vmul_bfp_core_EX_EX $dm3, $ex2, $ex3, $r3, implicit-def $srfpflags, implicit $crfpmask
+    $dm2 = VMAC_f_vmac_bfp_vmul_bfp_core_EX_EX $dm2, $ex2, $ex5, $r3, implicit-def $srfpflags, implicit $crfpmask
+    $dm1 = VMAC_f_vmac_bfp_vmul_bfp_core_EX_EX $dm1, $ex7, $ex3, $r3, implicit-def $srfpflags, implicit $crfpmask
+    $dm0 = VMAC_f_vmac_bfp_vmul_bfp_core_EX_EX $dm0, $ex7, $ex5, $r3, implicit-def $srfpflags, implicit $crfpmask
+
+    PseudoLoopEnd <mcsymbol .L_LEnd2>, %bb.2
+
+  bb.3 (align 16):
+    RET implicit $lr
+    DelayedSchedBarrier
+
+...
+---
+name:            gemm_lowitercount
+alignment:       16
+tracksRegLiveness: true
+body:             |
+  bb.0.entry (align 16):
+    successors: %bb.2
+    liveins: $p0, $p1, $r0
+
+    $lc = ADD_NC_mv_add_ri $r0, 0
+    $ls = MOVXM %bb.2
+    $le = MOVXM <mcsymbol .L_LEnd1>
+
+  bb.2.for.body (align 16):
+    successors: %bb.2, %bb.3
+    liveins: $dc0, $dc1, $dc2, $dc3, $dc4, $dc5, $dj0, $dj1, $dj2, $dj3, $dj4, $dj5, $dj7, $dm0:0x000000001800000C, $dm1:0x000000001800000C, $dm2:0x000000001800000C, $dm3:0x000000001800000C, $dn0, $dn1, $dn2, $dn4, $dn5, $m0, $m1, $m2, $m3, $m4, $m5, $p0, $p1, $p2, $p4, $p6, $p7, $r0, $r1, $r2, $r3, $r4, $r8, $y5:0x0000000000000033, $d0_3d:0x0003C00000200E00, $d1_3d:0x0003C00000200E00, $dn3
+
+    $p5 = MOVS $p6
+    $x4 = VLDB_dmx_ldb_x_idx_imm $p6, 64 :: (load (<16 x s32>))
+    $x9, $p6, $dc0, $dc4 = VLDB_3D_dmx_ldb_x $p6, $d0_3d :: (load (<16 x s32>))
+    $p3 = MOVS $p7
+    $cmh4 = VLDA_CONV_fp32_bf16_dmx_lda_ups_bf_idx_imm $p7, 64 :: (load (<32 x s16>))
+    $cml4, $p7, $dc1, $dc5 = VLDA_3D_CONV_fp32_bf16_dmx_lda_ups_bf $p7, $d1_3d :: (load (<32 x s16>))
+    $x8 = VSHUFFLE_vec_shuffle_x $x9, $x4, $r0
+    $x9 = VSHUFFLE_vec_shuffle_x $x9, $x4, $r1
+    $p5 = PADDB_pstm_nrm $p5, $m4
+    $x6 = VLDB_dmx_ldb_x_idx_imm $p5, 0 :: (load (<16 x s32>))
+    $x1 = VLDB_dmx_ldb_x_idx_imm $p5, 64 :: (load (<16 x s32>))
+    $ex2 = VCONV_bfp16ebs8_fp32 $dm4, implicit-def $srf2bflags, implicit $crf2bmask, implicit $crrnd
+    $dm4 = VMUL_f_vmul_bf_vmul_bf_core_Y_Y $y4, $y5, $r2, implicit-def $srfpflags, implicit $crfpmask
+    $x0 = VSHUFFLE_vec_shuffle_x $x1, $x6, $r0
+    $x1 = VSHUFFLE_vec_shuffle_x $x1, $x6, $r1
+    $ex3 = VCONV_bfp16ebs8_fp32 $dm4, implicit-def $srf2bflags, implicit $crf2bmask, implicit $crrnd
+    $dm4 = VMUL_f_vmul_bf_vmul_bf_core_Y_Y $y0, $y5, $r2, implicit-def $srfpflags, implicit $crfpmask
+    $p3 = PADDA_pstm_nrm $p3, $m5
+    $ex5 = VCONV_bfp16ebs8_fp32 $dm4, implicit-def $srf2bflags, implicit $crf2bmask, implicit $crrnd
+    $cml4 = VLDA_CONV_fp32_bf16_dmx_lda_ups_bf_idx_imm $p3, 0 :: (load (<32 x s16>))
+    $cmh4 = VLDA_CONV_fp32_bf16_dmx_lda_ups_bf_idx_imm $p3, 64 :: (load (<32 x s16>))
+    $ex7 = VCONV_bfp16ebs8_fp32 $dm4, implicit-def $srf2bflags, implicit $crf2bmask, implicit $crrnd
+    $dm3 = VMAC_f_vmac_bfp_vmul_bfp_core_EX_EX $dm3, $ex2, $ex3, $r3, implicit-def $srfpflags, implicit $crfpmask
+    $dm2 = VMAC_f_vmac_bfp_vmul_bfp_core_EX_EX $dm2, $ex2, $ex5, $r3, implicit-def $srfpflags, implicit $crfpmask
+    $dm1 = VMAC_f_vmac_bfp_vmul_bfp_core_EX_EX $dm1, $ex7, $ex3, $r3, implicit-def $srfpflags, implicit $crfpmask
+    $dm0 = VMAC_f_vmac_bfp_vmul_bfp_core_EX_EX $dm0, $ex7, $ex5, $r3, implicit-def $srfpflags, implicit $crfpmask
+
+    PseudoLoopEnd <mcsymbol .L_LEnd1>, %bb.2
+
+  bb.3 (align 16):
+    RET implicit $lr
+    DelayedSchedBarrier
+
+...


### PR DESCRIPTION
This enables a yaml file with key statistics like stage count and initiation interval
Additionally the stage count vs minitercount checks have been moved earlier