### PR TITLE
[AIEX] Increase PostPipelinerMaxTryII to 20

### DIFF
--- a/llvm/lib/Target/AIE/AIEInterBlockScheduling.cpp
+++ b/llvm/lib/Target/AIE/AIEInterBlockScheduling.cpp
@@ -67,7 +67,7 @@ static cl::opt<bool> EnableMultiSlotInstrMaterialization(
              "loops."));
 
 static cl::opt<int> PostPipelinerMaxTryII(
-    "aie-postpipeliner-maxtry-ii", cl::init(10),
+    "aie-postpipeliner-maxtry-ii", cl::init(20),
     cl::desc("[AIE] Maximum II steps to be tried in the post-ra pipeliner"));
 
 namespace llvm::AIE {


### PR DESCRIPTION
ReduceSum starts at 5 to reach an II of 19 currently, thus requiring 14 tries. We increase the maximum number of tries to 20 while still expecting compilation time to remain under control.