### PR TITLE
[AIE] Enable floatdidf builtin used by G_SITOFP

### DIFF
--- a/compiler-rt/lib/builtins/CMakeLists.txt
+++ b/compiler-rt/lib/builtins/CMakeLists.txt
@@ -423,7 +423,6 @@ list(REMOVE_ITEM aie2_GENERIC_SOURCES
   fixdfdi.c     # unsupported instruction : G_FCMP
   fixunsdfdi.c  # unsupported instruction : G_FPTOUI
   fixunssfdi.c  # unsupported instruction : G_FPTOUI
-  floatdidf.c   # unsupported instruction : G_SITOFP
   muldc3.c      # unsupported instruction : G_FCOPYSIGN
   mulsc3.c      # unsupported instruction : G_FCOPYSIGN
   udivmoddi4.c  # unsupported instruction : G_CTTZ_ZERO_UNDEF


### PR DESCRIPTION
Hi, for `G_SITOFP` instructions you seem to now emit calls to `__floatdidf` for `int64_t` -> `double`, however this builtin is disabled.
This causes a linker error when compiling some code that contains an `int64_t` -> `double` cast. I stumbled across this while trying to reuse Arm's `cosf` implementation.
Checked vs `floatdidf_test.c` values on AIE2 hardware.