### PR TITLE
[NFC] Some improvements in pipeliner compile time

### DIFF
--- a/llvm/lib/Target/AIE/AIEPostPipeliner.cpp
+++ b/llvm/lib/Target/AIE/AIEPostPipeliner.cpp
@@ -141,7 +141,8 @@ int PostPipeliner::getResMII(MachineBasicBlock &LoopBlock) {
 
 // This assigns Cycle of SU, Earliest of its successors and Latest of its
 // predecessors
-void PostPipeliner::scheduleNode(SUnit &SU, int Cycle) {
+void PostPipeliner::scheduleNode(SUnit &SU, int Cycle,
+                                 PostPipelinerStrategy &Strategy) {
   LLVM_DEBUG(dbgs() << "PostPipelined SU" << SU.NodeNum << " in cycle " << Cycle
                     << ": " << *SU.getInstr());
   Info[SU.NodeNum].Cycle = Cycle;
@@ -161,6 +162,7 @@ void PostPipeliner::scheduleNode(SUnit &SU, int Cycle) {
       Info[SNum].LastEarliestPusher = SU.NodeNum;
       Info[SNum].Earliest = NewEarliest;
       Info[SU.NodeNum].NumPushedEarliest++;
+      Strategy.setChanged();
     }
   }
   LLVM_DEBUG(dbgs() << "\n  Pushed preds Latest: ");
@@ -178,6 +180,7 @@ void PostPipeliner::scheduleNode(SUnit &SU, int Cycle) {
       Info[PNum].LastLatestPusher = SU.NodeNum;
       Info[PNum].Latest = NewLatest;
       Info[SU.NodeNum].NumPushedLatest++;
+      Strategy.setChanged();
     }
   }
   LLVM_DEBUG(dbgs() << "\n");
@@ -578,7 +581,7 @@ bool PostPipeliner::scheduleFirstIteration(PostPipelinerStrategy &Strategy) {
       Cycle += II;
     }
 
-    scheduleNode(SU, Actual);
+    scheduleNode(SU, Actual, Strategy);
     Info[N].Scheduled = true;
     DEBUG_FULL(dbgs() << "Scoreboard\n"; Scoreboard.dumpFull(););
   }
@@ -627,6 +630,7 @@ bool PostPipeliner::scheduleOtherIterations(PostPipelinerStrategy &Strategy) {
         if (Strategy.mobility(ModuloSU) > 0) {
           // The modulo Node can be delayed
           ModuloNode.TweakedEarliest = ModuloNode.Earliest + 1;
+          Strategy.setChanged();
           LLVM_DEBUG(dbgs() << "  Try to delay SU" << N - NInstr
                             << " with TweakedEarliest= "
                             << ModuloNode.TweakedEarliest << "\n");
@@ -639,6 +643,7 @@ bool PostPipeliner::scheduleOtherIterations(PostPipelinerStrategy &Strategy) {
           if (Strategy.mobility(DAG->SUnits[*Node.LastEarliestPusher]) > 0) {
             ModuloNode.TweakedEarliest = {};
             Pusher.TweakedLatest = Pusher.Latest - 1;
+            Strategy.setChanged();
             LLVM_DEBUG(dbgs()
                        << "  Try to prioritise SU" << *Node.LastEarliestPusher
                        << " with TweakedLatest= " << Pusher.TweakedLatest
@@ -649,7 +654,7 @@ bool PostPipeliner::scheduleOtherIterations(PostPipelinerStrategy &Strategy) {
         return false;
       }
 
-      scheduleNode(SU, Insert);
+      scheduleNode(SU, Insert, Strategy);
     }
   }
   return true;
@@ -776,6 +781,7 @@ private:
     while (Pushed->LastEarliestPusher) {
       Pushed = &Info[*Pushed->LastEarliestPusher];
       Pushed->NumPushedEarliest++;
+      setChanged();
     }
 
     // Promote my siblings
@@ -866,6 +872,10 @@ bool PostPipeliner::tryHeuristics() {
         if (Success) {
           return true;
         }
+      }
+      if (!S.checkAndResetChanged()) {
+        // If nothing changed, there's no use in rerunning.
+        break;
       }
       resetSchedule(/*FullReset=*/false);
     }

--- a/llvm/lib/Target/AIE/AIEPostPipeliner.cpp
+++ b/llvm/lib/Target/AIE/AIEPostPipeliner.cpp
@@ -321,6 +321,91 @@ bool PostPipeliner::computeBackward() {
   return Changed;
 }
 
+// This is a direct access cache. The outer optional says it's not present.
+// the inner says it's not a circuit.
+// Note that the height we compute is specific for a particular end node, so
+// it would be a bit bulky to save everything in NodeInfo.
+using HCache = std::vector<std::optional<std::optional<int>>>;
+
+namespace {
+std::optional<int> computeHeight(HCache &Heights, SUnit *Start, SUnit *End) {
+  if (Start == End) {
+    // We've reached our target, and we add nothing to the height.
+    // We can't conclude this is the longest path from start to end,
+    // but we will visit all paths.
+    return 0;
+  }
+  if (Start->NodeNum > End->NodeNum) {
+    // We are topologically ordered, so any forward edge to End will start
+    // from an earlier one. We can prune, knowing we will not find a circuit.
+    return {};
+  }
+  // We memoize the result, which prevents searching path suffixes
+  // multiple times.
+  auto Cached = Heights[Start->NodeNum];
+  if (Cached) {
+    return *Cached;
+  }
+  std::optional<int> Height;
+  for (auto &Dep : Start->Succs) {
+    SUnit *Dst = Dep.getSUnit();
+    auto SuccHeight = computeHeight(Heights, Dst, End);
+    if (SuccHeight) {
+      int NewHeight = *SuccHeight + Dep.getSignedLatency();
+      if (Height) {
+        Height = std::max(NewHeight, *Height);
+      } else {
+        Height = NewHeight;
+      }
+    }
+    // else not a cycle, so don't count
+  }
+  // We have definitely evaluated Height, even if it is none_opt
+  Heights[Start->NodeNum] = Height;
+  DEBUG_FULL(dbgs() << " Circuit height(" << Start->NodeNum << "->"
+                    << End->NodeNum << ")=" << Height << "\n");
+  return Height;
+}
+} // namespace
+
+// We compute the Minimum Initiation Interval given by recurrences (or
+// circuits) in the dependence graph.
+// A recurrence is identified by a backedge for which there is a path
+// between Dst and Src. Backedges are defined by edges between the
+// first and the second iteration.
+// The length of each circuit is computed by a depth-first traversal
+// starting from Dst, trying to find Src. Revisiting paths is prevented by
+// caching the height to Src.
+
+void PostPipeliner::computeRecMII() {
+  for (int K = 0; K < NInstr; K++) {
+    SUnit &Src = DAG->SUnits[K];
+    for (auto &Dep : Src.Succs) {
+      SUnit *Dst = Dep.getSUnit();
+      if (Dst->NodeNum >= unsigned(NInstr)) {
+        NodeInfo Me = Info[K];
+        int SNum = Dst->NodeNum - NInstr;
+        if (Me.Ancestors.count(SNum)) {
+          // The successor is represented by one of
+          // my ancestors. That means we have a circuit,
+          // which may be the longest one. We find the longest path between
+          // that ancestor and this node, adding the latency of the
+          // backedge.
+          HCache Heights(NInstr);
+          auto Height = computeHeight(Heights, &DAG->SUnits[SNum], &Src);
+          assert(Height);
+
+          int Circuit = *Height + Dep.getSignedLatency();
+          RecMII = std::max(Circuit, RecMII);
+          LLVM_DEBUG(dbgs() << "Backedge " << K << " -> " << SNum
+                            << " circuit=" << Circuit << "\n");
+        }
+      }
+    }
+  }
+  LLVM_DEBUG(dbgs() << "RecMII=" << RecMII << "\n");
+}
+
 bool PostPipeliner::computeLoopCarriedParameters() {
 
   // Initialize slot counts.
@@ -337,6 +422,11 @@ bool PostPipeliner::computeLoopCarriedParameters() {
   while (computeBackward()) {
     /* EMPTY */;
   }
+
+  // Compute the Recurrence Minimum Initiation Interval. The current code
+  // structure makes it difficult to use RecMII as the starting II for the
+  // main pipeliner loop, but it still can be used to reject very early on.
+  computeRecMII();
 
   // Adjust Earliest and Latest with resource requirements.
   // FIXME: We do not account for negative latencies here. This can lead to
@@ -918,8 +1008,21 @@ bool PostPipeliner::schedule(ScheduleDAGMI &TheDAG, int InitiationInterval,
   LLVM_DEBUG(dumpGraph(Info, DAG));
 
   computeLoopCarriedParameters();
+  if (II < RecMII) {
+    More.emit([&]() {
+      return MachineOptimizationRemarkMissed("postpipeliner", "schedule",
+                                             DbgLoc, BB)
+             << "Longest circuit doesn't fit II.";
+    });
+    return false;
+  }
   LLVM_DEBUG(dumpIntervals(Info, MinLength, II));
   if (!tryHeuristics()) {
+    More.emit([&]() {
+      return MachineOptimizationRemarkMissed("postpipeliner", "schedule",
+                                             DbgLoc, BB)
+             << "No schedule found.";
+    });
     LLVM_DEBUG(dbgs() << "PostPipeliner: No schedule found\n");
     return false;
   }

--- a/llvm/lib/Target/AIE/AIEPostPipeliner.cpp
+++ b/llvm/lib/Target/AIE/AIEPostPipeliner.cpp
@@ -979,15 +979,10 @@ bool PostPipeliner::tryHeuristics() {
       DEBUG_SUMMARY(dbgs() << "--- Strategy " << S.name() << " run=" << Run
                            << "\n");
       if (scheduleFirstIteration(S) && scheduleOtherIterations(S)) {
-        DEBUG_SUMMARY(dbgs() << "    Strategy " << S.name() << " run=" << Run
-                             << " found schedule:\n");
-        const bool Success = checkStages();
         DEBUG_SUMMARY(dbgs()
                       << "    Strategy " << S.name() << " run=" << Run
                       << " found NS=" << NStages << " II=" << II << "\n");
-        if (Success) {
-          return true;
-        }
+        return true;
       }
       if (!S.checkAndResetChanged()) {
         // If nothing changed, there's no use in rerunning.

--- a/llvm/lib/Target/AIE/AIEPostPipeliner.cpp
+++ b/llvm/lib/Target/AIE/AIEPostPipeliner.cpp
@@ -515,6 +515,18 @@ int PostPipeliner::computeMinScheduleLength() const {
 void dumpGraph(const ScheduleInfo &Info, ScheduleDAGInstrs *DAG) {
   dbgs() << "digraph {\n";
 
+  // Prescan backedge destinations and declare them to have a different shape.
+  for (int K = 0; K < Info.NInstr; K++) {
+    int K2 = K + Info.NInstr;
+    auto &SU = DAG->SUnits[K2];
+    if (any_of(SU.Preds, [Limit = Info.NInstr, K](const SDep &Dep) {
+          int P = Dep.getSUnit()->NodeNum;
+          return P < Limit && P != K;
+        })) {
+      dbgs() << "\tSU" << K2 << "_" << K << "[shape=rectangle]\n";
+    }
+  }
+
   for (int K = 0; K < Info.NInstr; K++) {
     auto &SU = DAG->SUnits[K];
     for (auto &Dep : SU.Succs) {
@@ -530,13 +542,22 @@ void dumpGraph(const ScheduleInfo &Info, ScheduleDAGInstrs *DAG) {
       if (S >= Info.NInstr) {
         dbgs() << "_" << S % Info.NInstr;
       }
-      if (Dep.getKind() == SDep::Data) {
-        dbgs() << " [color=red] ";
-      } else if (Dep.getKind() == SDep::Output) {
-        dbgs() << " [color=black] ";
-      } else if (Dep.getKind() == SDep::Anti) {
-        dbgs() << " [color=blue] ";
+      dbgs() << " [ label=\"" << Dep.getSignedLatency() << "\"";
+      switch (Dep.getKind()) {
+      case SDep::Data:
+        dbgs() << " color=red ";
+        break;
+      case SDep::Output:
+        dbgs() << " color=black ";
+        break;
+      case SDep::Anti:
+        dbgs() << " color=blue ";
+        break;
+      case SDep::Order:
+        dbgs() << " color=green ";
+        break;
       }
+      dbgs() << "] ";
 
       dbgs() << " # L=" << Dep.getSignedLatency();
       if (Dep.getKind() == SDep::Output) {

--- a/llvm/lib/Target/AIE/AIEPostPipeliner.cpp
+++ b/llvm/lib/Target/AIE/AIEPostPipeliner.cpp
@@ -664,7 +664,12 @@ bool PostPipeliner::scheduleFirstIteration(PostPipelinerStrategy &Strategy) {
     MachineInstr *MI = SU.getInstr();
     const int Earliest = Strategy.earliest(SU);
     const int Latest = Strategy.latest(SU);
-    // Find the first cycle that fits. We try every position modulo II
+    if (Earliest > Latest) {
+      LLVM_DEBUG(dbgs() << "Latency violation at node " << N << " interval=["
+                        << Earliest << ", " << Latest << "]\n");
+      return false;
+    }
+
     const int Actual = Strategy.fromTop() ? fit(MI, Earliest, Latest + 1, II)
                                           : fit(MI, Latest, Earliest - 1, II);
     if (Actual < 0) {

--- a/llvm/lib/Target/AIE/AIEPostPipeliner.h
+++ b/llvm/lib/Target/AIE/AIEPostPipeliner.h
@@ -179,6 +179,9 @@ class PostPipeliner {
   ScheduleInfo Info;
   int MinLength;
 
+  /// The length of the longest circuit in the graph
+  int RecMII = 0;
+
   // The scoreboard and its depth
   ResourceScoreboard<FuncUnitWrapper> Scoreboard;
   int Depth;
@@ -220,6 +223,7 @@ class PostPipeliner {
   void biasForLocalResourceContention(NodeInfo &NI, const SUnit &SU);
   void computeForward();
   bool computeBackward();
+  void computeRecMII();
 
   // Given Earliest and Latest of each node in the first iteration,
   // compute the smallest length of the linear schedule that is feasible.

--- a/llvm/lib/Target/AIE/AIEPostPipeliner.h
+++ b/llvm/lib/Target/AIE/AIEPostPipeliner.h
@@ -179,40 +179,40 @@ class PostPipeliner {
   ScheduleInfo Info;
   int MinLength;
 
-  /// The length of the longest circuit in the graph
+  /// The length of the longest circuit in the graph.
   int RecMII = 0;
 
-  // The scoreboard and its depth
+  // The scoreboard and its depth.
   ResourceScoreboard<FuncUnitWrapper> Scoreboard;
   int Depth;
 
-  /// The minimum tripcount, read from the pragma, or from an LC initialization
+  /// The minimum tripcount, read from the pragma, or from an LC initialization.
   int MinTripCount = 0;
 
-  /// The Preheader of the loop
+  /// The Preheader of the loop.
   MachineBasicBlock *Preheader = nullptr;
 
-  // The instruction defining the tripcount
+  /// The instruction defining the tripcount.
   MachineInstr *TripCountDef = nullptr;
 
-  // Basic modulo scheduling parameters
+  /// Basic modulo scheduling parameters.
   int NInstr;
   int NCopies;
   int II = 1;
   int NStages = 0;
 
   /// Place SU in cycle Cycle; update Earliest of successors and Latest
-  /// of predecessors
+  /// of predecessors.
   void scheduleNode(SUnit &SU, int Cycle, PostPipelinerStrategy &Strategy);
 
   /// Computes the stage in which each instruction runs and check the resulting
-  /// stage count against MinIterCount and the number of copies in the DAG
+  /// stage count against MinIterCount and the number of copies in the DAG.
   /// Returns true if these checks indicate that the schedule can be implmented.
   bool checkStages();
 
   // return the first Cycle: Earliest <= Cycle < Earliest+NTries where MI fits
   // in the scoreboard, -1 if it doesn't fit. The insertion point is taken
-  // module II.
+  // modulo II.
   int fit(MachineInstr *MI, int Earliest, int NTries, int II);
 
   /// Provide some look ahead by seeing the effect of the first iteration
@@ -225,9 +225,9 @@ class PostPipeliner {
   bool computeBackward();
   void computeRecMII();
 
-  // Given Earliest and Latest of each node in the first iteration,
-  // compute the smallest length of the linear schedule that is feasible.
-  // this length will be a multiple of the InitiationInterval
+  /// Given Earliest and Latest of each node in the first iteration,
+  /// compute the smallest length of the linear schedule that is feasible.
+  /// this length will be a multiple of the InitiationInterval.
   int computeMinScheduleLength() const;
 
   /// Try all heuristics, stop at the first that fits the II
@@ -235,11 +235,11 @@ class PostPipeliner {
   bool tryHeuristics();
 
   /// Find the first available unscheduled instruction with the highest
-  /// priority
+  /// priority.
   int mostUrgent(PostPipelinerStrategy &Strategy);
 
   /// Schedule the original instructions, taking the modulo scoreboard
-  /// into account
+  /// into account.
   bool scheduleFirstIteration(PostPipelinerStrategy &Strategy);
 
   /// Check that all copied instructions can run in the same modulo cycle
@@ -247,7 +247,7 @@ class PostPipeliner {
 
   /// Reset dynamic scheduling data.
   /// If FullReset is set, also reset information collected from earlier
-  /// data mining scheduling rounds
+  /// data mining scheduling rounds.
   void resetSchedule(bool FullReset);
 
 public:
@@ -262,11 +262,11 @@ public:
   int getResMII(MachineBasicBlock &LoopBlock);
 
   // Schedule using the given InitiationInterval. Return true when successful.
-  // In that case calls to the query methods below are legitimate
+  // In that case calls to the query methods below are legitimate.
   bool schedule(ScheduleDAGMI &DAG, int InitiationInterval,
                 MachineOptimizationRemarkEmitter &More);
 
-  // quick query for the stage count
+  // Quick query for the stage count.
   int getStageCount() { return NStages; }
 
   // After scheduling, interpret the results and call the appropriate methods

--- a/llvm/lib/Target/AIE/AIEPostPipeliner.h
+++ b/llvm/lib/Target/AIE/AIEPostPipeliner.h
@@ -115,6 +115,20 @@ protected:
   ScheduleInfo &Info;
   int LatestBias = 0;
 
+  // Report change to the scheduling data. This can be used for iterative
+  // refinement
+  bool Changed = false;
+
+public:
+  // Register a change
+  void setChanged() { Changed = true; }
+  // Return changed and reset it
+  bool checkAndResetChanged() {
+    bool Old = Changed;
+    Changed = false;
+    return Old;
+  }
+
 public:
   PostPipelinerStrategy(ScheduleDAGInstrs &DAG, ScheduleInfo &Info,
                         int LatestBias)
@@ -186,7 +200,7 @@ class PostPipeliner {
 
   /// Place SU in cycle Cycle; update Earliest of successors and Latest
   /// of predecessors
-  void scheduleNode(SUnit &SU, int Cycle);
+  void scheduleNode(SUnit &SU, int Cycle, PostPipelinerStrategy &Strategy);
 
   /// Computes the stage in which each instruction runs and check the resulting
   /// stage count against MinIterCount and the number of copies in the DAG


### PR DESCRIPTION
Don't iterate a strategy if nothing changed.
use RecMII to detect failure early, plus some spin-off in the graphviz dump of the DAG.
Detect empty intervals early. Especially important for alternating scheduling modes

