### PR TITLE
[AIE] Change the default of aie-addrspace-none-is-safe to true

### DIFF
--- a/llvm/lib/Target/AIE/AIEHazardRecognizer.cpp
+++ b/llvm/lib/Target/AIE/AIEHazardRecognizer.cpp
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// (c) Copyright 2023-2024 Advanced Micro Devices, Inc. or its affiliates
+// (c) Copyright 2023-2025 Advanced Micro Devices, Inc. or its affiliates
 //
 //===----------------------------------------------------------------------===//
 //
@@ -44,7 +44,7 @@ static cl::opt<unsigned>
                         cl::desc("Override maximum scoreboard depth to use."));
 
 static cl::opt<bool> AddressSpaceNoneIsSafe(
-    "aie-addrspace-none-is-safe", cl::Hidden, cl::init(false),
+    "aie-addrspace-none-is-safe", cl::Hidden, cl::init(true),
     cl::desc("Assume that addrspace(0) doesn't cause conflicts."));
 
 const AIEBaseMCFormats *FuncUnitWrapper::FormatInterface = nullptr;

--- a/llvm/test/CodeGen/AIE/aie2/end-to-end/Add2D-red.ll
+++ b/llvm/test/CodeGen/AIE/aie2/end-to-end/Add2D-red.ll
@@ -4,7 +4,7 @@
 ; See https://llvm.org/LICENSE.txt for license information.
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 ;
-; (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+; (c) Copyright 2024-2025 Advanced Micro Devices, Inc. or its affiliates
 ; RUN: llc -O2 -mtriple=aie2 %s -o - | FileCheck %s --check-prefix=ASM
 
 ; This is a reduced version of the Add2D_0 MLLib benchmark which only contains
@@ -35,60 +35,50 @@ define void @add2d(ptr noalias %params, ptr noalias %ifm1_data, ptr noalias %ifm
 ; ASM-LABEL: add2d:
 ; ASM:         .p2align 4
 ; ASM-NEXT:  // %bb.0: // %newFuncRoot
-; ASM-NEXT:    paddb [sp], #32; nopx
-; ASM-NEXT:    st p7, [sp, #-32] // 4-byte Folded Spill
-; ASM-NEXT:    paddb [p0], #40; st p6, [sp, #-28] // 4-byte Folded Spill
+; ASM-NEXT:    paddb [p0], #40; nopx
 ; ASM-NEXT:    lda m2, [p0], #-4
 ; ASM-NEXT:    lda m3, [p0], #8
 ; ASM-NEXT:    lda m5, [p0], #8
 ; ASM-NEXT:    lda m4, [p0], #-24
-; ASM-NEXT:    lda r4, [p0], #36
-; ASM-NEXT:    lda r2, [p0], #-32
-; ASM-NEXT:    lda r0, [p0], #-12; mov p6, sp
-; ASM-NEXT:    lda r1, [p0], #40; paddb [p6], #-36
-; ASM-NEXT:    lda p6, [p6, #0]; mov p7, sp
-; ASM-NEXT:    paddb [p7], #-40
-; ASM-NEXT:    lda r5, [p7, #0]
-; ASM-NEXT:    lda m1, [p0], #36
+; ASM-NEXT:    lda r4, [p0], #36; paddb [sp], #32
+; ASM-NEXT:    lda r2, [p0], #-32; st p7, [sp, #-32] // 4-byte Folded Spill
+; ASM-NEXT:    lda r0, [p0], #-12; st p6, [sp, #-28] // 4-byte Folded Spill
+; ASM-NEXT:    lda r1, [p0], #40; mov p6, sp
+; ASM-NEXT:    paddb [p6], #-36; mov p7, sp
+; ASM-NEXT:    lda r5, [p6, #0]; paddb [p7], #-40
+; ASM-NEXT:    lda p7, [p7, #0]; mov p6, sp
+; ASM-NEXT:    lda m1, [p0], #36; paddb [p6], #-44
+; ASM-NEXT:    lda p6, [p6, #0]
 ; ASM-NEXT:    lda m0, [p0], #-8
-; ASM-NEXT:    lda dn0, [p0], #-8
-; ASM-NEXT:    st r1, [p4, #0]
+; ASM-NEXT:    lda dn0, [p0], #-8; st r1, [p4, #0]
 ; ASM-NEXT:    lda dj0, [p0], #12; nez r3, r0; mov p4, sp
-; ASM-NEXT:    st r3, [p5, #0]
-; ASM-NEXT:    lda dn4, [p0], #-8; paddb [p4], #-44; mov p5, sp
-; ASM-NEXT:    lda p4, [p4, #0]; paddb [p5], #-48
-; ASM-NEXT:    lda p7, [p5, #0]; mov p5, sp
-; ASM-NEXT:    lda dj4, [p0], #-36; paddb [p5], #-52
-; ASM-NEXT:    lda p5, [p5, #0]
-; ASM-NEXT:    st m1, [p6, #0]
-; ASM-NEXT:    mov p6, r5
-; ASM-NEXT:    nop
-; ASM-NEXT:    st m0, [p6, #0]
-; ASM-NEXT:    st dj0, [p4, #0]
-; ASM-NEXT:    st dj4, [p7, #0]
-; ASM-NEXT:    st dn0, [p5, #0]
+; ASM-NEXT:    lda dn4, [p0], #-8; st r3, [p5, #0]
+; ASM-NEXT:    lda dj4, [p0], #-36; paddb [p4], #-48; mov p5, r5
+; ASM-NEXT:    lda p4, [p4, #0]; st m1, [p5, #0]
 ; ASM-NEXT:    lda r0, [p0], #-36; mov p5, sp
-; ASM-NEXT:    lda r5, [p0, #0]; paddb [p5], #-76; mov p6, sp
-; ASM-NEXT:    lda r9, [p5, #0]; paddb [p6], #-56; mov p5, sp
-; ASM-NEXT:    lda r6, [p6, #0]; paddb [p5], #-80; mov p4, sp
-; ASM-NEXT:    lda r10, [p5, #0]; paddb [p4], #-60; mov p5, sp
-; ASM-NEXT:    lda p6, [p4, #0]; paddb [p5], #-84
-; ASM-NEXT:    lda r11, [p5, #0]; mov p0, sp
-; ASM-NEXT:    paddb [p0], #-72; mov p4, sp
-; ASM-NEXT:    lda p0, [p0, #0]; paddb [p4], #-64; mov p5, sp
-; ASM-NEXT:    lda p7, [p4, #0]; paddb [p5], #-88; mov p4, sp
-; ASM-NEXT:    lda r12, [p5, #0]; paddb [p4], #-68; mov p5, sp
-; ASM-NEXT:    lda p4, [p4, #0]; paddb [p5], #-92
-; ASM-NEXT:    lda r13, [p5, #0]
-; ASM-NEXT:    mova r6, #1; add r7, r2, #-1; mov p5, r6
-; ASM-NEXT:    mova r6, #3; ne r4, r4, r6
-; ASM-NEXT:    ltu r7, r7, r6
-; ASM-NEXT:    jz r7, #.LBB0_2
-; ASM-NEXT:    st dn4, [p5, #0]; nez r0, r0 // Delay Slot 5
-; ASM-NEXT:    st r0, [p6, #0] // Delay Slot 4
-; ASM-NEXT:    paddb [p2], m3; st r5, [p7, #0] // Delay Slot 3
-; ASM-NEXT:    padda [p1], m2; paddb [p2], m5; and r8, r2, r6; st r4, [p4, #0] // Delay Slot 2
-; ASM-NEXT:    mova r6, #0; paddb [p2], m4; st r8, [p0, #0] // Delay Slot 1
+; ASM-NEXT:    lda r5, [p0, #0]; paddb [p5], #-52
+; ASM-NEXT:    lda p5, [p5, #0]; mov p0, sp
+; ASM-NEXT:    st m0, [p7, #0]
+; ASM-NEXT:    mov p7, sp
+; ASM-NEXT:    paddb [p7], #-56; st dj0, [p6, #0]
+; ASM-NEXT:    lda r6, [p7, #0]; mov p6, sp
+; ASM-NEXT:    paddb [p0], #-72; mov p7, sp
+; ASM-NEXT:    lda p0, [p0, #0]; paddb [p6], #-60; st dj4, [p4, #0]
+; ASM-NEXT:    lda r7, [p6, #0]; mov p4, sp
+; ASM-NEXT:    paddb [p4], #-76; mov p6, sp
+; ASM-NEXT:    lda r11, [p4, #0]; paddb [p7], #-64; mov p4, sp
+; ASM-NEXT:    lda p7, [p7, #0]; paddb [p6], #-68; st dn0, [p5, #0]
+; ASM-NEXT:    lda r8, [p6, #0]; paddb [p4], #-80; nez r0, r0; mov p5, r6
+; ASM-NEXT:    lda p6, [p4, #0]; st dn4, [p5, #0]; movx r6, #1
+; ASM-NEXT:    ne r4, r4, r6; mov p4, sp
+; ASM-NEXT:    mova r6, #3; paddb [p4], #-84; add r7, r2, #-1; mov p5, r7
+; ASM-NEXT:    lda r9, [p4, #0]; ltu r7, r7, r6; mov p4, sp
+; ASM-NEXT:    st r0, [p5, #0]; paddb [p4], #-88; jz r7, #.LBB0_2
+; ASM-NEXT:    lda r10, [p4, #0]; mov p4, sp // Delay Slot 5
+; ASM-NEXT:    paddb [p4], #-92; st r5, [p7, #0] // Delay Slot 4
+; ASM-NEXT:    lda p4, [p4, #0]; paddb [p2], m3; mov p7, r8 // Delay Slot 3
+; ASM-NEXT:    st r4, [p7, #0]; paddb [p2], m5; and r8, r2, r6 // Delay Slot 2
+; ASM-NEXT:    padda [p1], m2; paddb [p2], m4; movx r6, #0; st r8, [p0, #0] // Delay Slot 1
 ; ASM-NEXT:  // %bb.1:
 ; ASM-NEXT:    nopb ; nopa ; nops ; j #.LBB0_5; nopv
 ; ASM-NEXT:    nopa ; nopx // Delay Slot 5
@@ -137,23 +127,19 @@ define void @add2d(ptr noalias %params, ptr noalias %ifm1_data, ptr noalias %ifm
 ; ASM-NEXT:    nop
 ; ASM-NEXT:    nop
 ; ASM-NEXT:    vst.srs.d8.s32 cm0, s0, [p3], #32
-; ASM-NEXT:    vst.srs.d8.s32 cm1, s0, [p3], #32
-; ASM-NEXT:    vst.srs.d8.s32 cm2, s0, [p3], #32; mov crUPSSign, #0
-; ASM-NEXT:    vst.srs.d8.s32 cm3, s0, [p3], #32; mov r6, dc0
-; ASM-NEXT:    mov r0, dc4
+; ASM-NEXT:    vst.srs.d8.s32 cm1, s0, [p3], #32; mov crUPSSign, #0
+; ASM-NEXT:    vst.srs.d8.s32 cm2, s0, [p3], #32; mov r6, dc0
+; ASM-NEXT:    vst.srs.d8.s32 cm3, s0, [p3], #32; mov r0, dc4
 ; ASM-NEXT:    mov crSRSSign, #0
 ; ASM-NEXT:    .p2align 4
 ; ASM-NEXT:  .LBB0_5: // %for.cond.cleanup.unr-lcssa.split
-; ASM-NEXT:    nopb ; lda p7, [sp, #-32]; nops ; nopxm ; nopv // 4-byte Folded Reload
-; ASM-NEXT:    mov p0, r13
-; ASM-NEXT:    st r0, [p0, #0]
-; ASM-NEXT:    mov p0, r12
-; ASM-NEXT:    st r6, [p0, #0]
-; ASM-NEXT:    lda p6, [sp, #-28]; mov p0, r11 // 4-byte Folded Reload
-; ASM-NEXT:    st p3, [p0, #0]; ret lr
-; ASM-NEXT:    mov p0, r10 // Delay Slot 5
-; ASM-NEXT:    st p2, [p0, #0] // Delay Slot 4
-; ASM-NEXT:    mov p0, r9 // Delay Slot 3
+; ASM-NEXT:    nopx ; mov p0, r10
+; ASM-NEXT:    lda p7, [sp, #-32]; st r0, [p4, #0] // 4-byte Folded Reload
+; ASM-NEXT:    lda p6, [sp, #-28]; st r6, [p0, #0] // 4-byte Folded Reload
+; ASM-NEXT:    ret lr ; mov p0, r9
+; ASM-NEXT:    st p3, [p0, #0] // Delay Slot 5
+; ASM-NEXT:    mov p0, r11 // Delay Slot 4
+; ASM-NEXT:    st p2, [p6, #0] // Delay Slot 3
 ; ASM-NEXT:    st p1, [p0, #0] // Delay Slot 2
 ; ASM-NEXT:    paddb [sp], #-32 // Delay Slot 1
 newFuncRoot:

--- a/llvm/test/CodeGen/AIE/aie2/end-to-end/Conv2D-red-swp.ll
+++ b/llvm/test/CodeGen/AIE/aie2/end-to-end/Conv2D-red-swp.ll
@@ -4,7 +4,7 @@
 ; See https://llvm.org/LICENSE.txt for license information.
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 ;
-; (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+; (c) Copyright 2024-2025 Advanced Micro Devices, Inc. or its affiliates
 ; RUN: llc -O2 -mtriple=aie2 --enable-pipeliner=1 --enable-aie-hardware-loops=false \
 ; RUN:     --enable-aie-zero-overhead-loops=false %s -o - | FileCheck %s --check-prefix=DCL
 ; RUN: llc -O2 -mtriple=aie2 --enable-pipeliner=1 %s -o - | FileCheck %s --check-prefix=ZOL
@@ -224,7 +224,7 @@ define dso_local void @conv2d.loop.nest(ptr %add.ptr6.i51, ptr %add.ptr5, ptr %c
 ; DCL-LABEL: conv2d.loop.nest:
 ; DCL:         .p2align 4
 ; DCL-NEXT:  // %bb.0: // %newFuncRoot
-; DCL-NEXT:    nopa ; nopb ; nopx ; mov s0, r0
+; DCL-NEXT:    nopb ; nopa ; nops ; nopx ; mov s0, r0; nopv
 ; DCL-NEXT:    paddb [sp], #192; mov s1, r1
 ; DCL-NEXT:    st p6, [sp, #-188] // 4-byte Folded Spill
 ; DCL-NEXT:    mov p6, sp
@@ -250,11 +250,11 @@ define dso_local void @conv2d.loop.nest(ptr %add.ptr6.i51, ptr %add.ptr5, ptr %c
 ; DCL-NEXT:    lda dj1, [p6, #0]; mov p6, sp
 ; DCL-NEXT:    paddb [p6], #-236; mov dc2, dj3
 ; DCL-NEXT:    lda r12, [p6, #0]; mov p6, sp
-; DCL-NEXT:    paddb [p6], #-240; st p7, [sp, #-192] // 4-byte Folded Spill
+; DCL-NEXT:    paddb [p6], #-240; mov dc6, dj3
 ; DCL-NEXT:    lda dn1, [p6, #0]; mov p6, sp
-; DCL-NEXT:    vst wl0, [sp, #-64]; paddb [p6], #-244; mov dc6, dj3 // 32-byte Folded Spill
+; DCL-NEXT:    paddb [p6], #-244; st p7, [sp, #-192] // 4-byte Folded Spill
 ; DCL-NEXT:    lda dn5, [p6, #0]; mov p6, sp
-; DCL-NEXT:    vst wh0, [sp, #-32]; paddb [p6], #-248; mov p7, sp // 32-byte Folded Spill
+; DCL-NEXT:    paddb [p6], #-248; mov p7, sp
 ; DCL-NEXT:    lda r13, [p6, #0]; paddb [p7], #-272; mov p6, sp
 ; DCL-NEXT:    lda r25, [p7, #0]; paddb [p6], #-252; mov p7, sp
 ; DCL-NEXT:    lda dj2, [p6, #0]; paddb [p7], #-200; mov p6, sp
@@ -274,42 +274,34 @@ define dso_local void @conv2d.loop.nest(ptr %add.ptr6.i51, ptr %add.ptr5, ptr %c
 ; DCL-NEXT:    lda r15, [p6, #0]; mov p6, sp
 ; DCL-NEXT:    paddb [p6], #-224; st dn7, [sp, #-92] // 4-byte Folded Spill
 ; DCL-NEXT:    lda r24, [p6, #0]; paddb [p7], #-288; mov p6, sp
-; DCL-NEXT:    lda r27, [p7, #0]; paddb [p6], #-284; movx r8, #11; mov dj5, r12
-; DCL-NEXT:    lda m4, [p6, #0]; movx r9, #31; mov m3, r14
+; DCL-NEXT:    lda r27, [p7, #0]; paddb [p6], #-284; movx r8, #11; mov dj5, r12; vst wl0, [sp, #-64] // 32-byte Folded Spill
+; DCL-NEXT:    lda m4, [p6, #0]; vst wh0, [sp, #-32]; movx r9, #31; mov m3, r14 // 32-byte Folded Spill
 ; DCL-NEXT:    // implicit-def: $x4
 ; DCL-NEXT:    // implicit-def: $x2
 ; DCL-NEXT:    .p2align 4
 ; DCL-NEXT:  .LBB0_1: // %outer.loop.header
 ; DCL-NEXT:    // =>This Loop Header: Depth=1
 ; DCL-NEXT:    // Child Loop BB0_2 Depth 2
-; DCL-NEXT:    nopa ; vldb wl6, [p1], #32; nopxm
-; DCL-NEXT:    vldb wl3, [p0], m6; mov r0, p0
-; DCL-NEXT:    vlda.ups.s32.s16 bmh0, s0, [p2, #32]
+; DCL-NEXT:    vlda.ups.s32.s16 bmh0, s0, [p2, #32]; nopx
 ; DCL-NEXT:    vlda.ups.s32.s16 bml0, s0, [p2], m5
-; DCL-NEXT:    vldb wh6, [p1], #32
-; DCL-NEXT:    vldb wh3, [p0], m6
 ; DCL-NEXT:    vlda.ups.s32.s16 bmh1, s0, [p2, #32]; mov m1, p5
 ; DCL-NEXT:    vlda.ups.s32.s16 bml1, s0, [p2], m1
-; DCL-NEXT:    vldb wl8, [p1], #32
-; DCL-NEXT:    vldb wl7, [p0], m6
 ; DCL-NEXT:    vlda.ups.s32.s16 bmh2, s0, [p2, #32]
 ; DCL-NEXT:    vlda.ups.s32.s16 bml2, s0, [p2], m5
-; DCL-NEXT:    vldb.3d wh7, [p0], d0
 ; DCL-NEXT:    vlda.ups.s32.s16 bmh3, s0, [p2, #32]; mov m2, r15
 ; DCL-NEXT:    vlda.ups.s32.s16 bml3, s0, [p2], m2
 ; DCL-NEXT:    vlda.ups.s32.s16 bmh5, s0, [p2, #32]
-; DCL-NEXT:    vlda.ups.s32.s16 bml5, s0, [p2], m5
-; DCL-NEXT:    vlda.ups.s32.s16 bmh4, s0, [p2, #32]
-; DCL-NEXT:    vlda.ups.s32.s16 bml4, s0, [p2], m1
-; DCL-NEXT:    vlda.ups.s32.s16 bmh7, s0, [p2, #32]
+; DCL-NEXT:    vlda.ups.s32.s16 bml5, s0, [p2], m5; vldb wl3, [p0], m6; mov r0, p0
+; DCL-NEXT:    vlda.ups.s32.s16 bmh4, s0, [p2, #32]; vldb wh3, [p0], m6
+; DCL-NEXT:    vlda.ups.s32.s16 bml4, s0, [p2], m1; vldb wl7, [p0], m6
+; DCL-NEXT:    vlda.ups.s32.s16 bmh7, s0, [p2, #32]; vldb.3d wh7, [p0], d0
 ; DCL-NEXT:    vlda.ups.s32.s16 bml7, s0, [p2], m5
-; DCL-NEXT:    vlda.ups.s32.s16 bmh6, s0, [p2, #32]
-; DCL-NEXT:    vldb wh8, [p1], #32
-; DCL-NEXT:    vldb wl5, [p0], m6; mov r1, p0
-; DCL-NEXT:    vlda.ups.s32.s16 bml6, s0, [p2, #0]; and r0, r0, r9
-; DCL-NEXT:    vldb wh5, [p0], m6; add r0, r0, #33
-; DCL-NEXT:    vldb wl3, [p0], m6; vshift.align x4, x4, s1, x3, r0
-; DCL-NEXT:    vldb.3d wh3, [p0], d0; and r10, r1, r9; vshift.align x2, x2, s1, x7, r0
+; DCL-NEXT:    vldb wl6, [p1], #32
+; DCL-NEXT:    vldb wh6, [p1], #32
+; DCL-NEXT:    vlda.ups.s32.s16 bmh6, s0, [p2, #32]; vldb wl5, [p0], m6; and r0, r0, r9; mov r1, p0
+; DCL-NEXT:    vlda wl8, [p1], #32; vldb wh5, [p0], m6; add r0, r0, #33
+; DCL-NEXT:    vlda wh8, [p1], #32; vldb wl3, [p0], m6; vshift.align x4, x4, s1, x3, r0
+; DCL-NEXT:    vlda.ups.s32.s16 bml6, s0, [p2, #0]; vldb.3d wh3, [p0], d0; and r10, r1, r9; vshift.align x2, x2, s1, x7, r0
 ; DCL-NEXT:    vldb wl1, [p1], #32; add r0, r10, #33; mov r10, p0
 ; DCL-NEXT:    vldb wh1, [p1], #32; add r1, r5, #-1; vshuffle x7, x4, x2, r2
 ; DCL-NEXT:    vldb wl10, [p1], #32; add r1, r1, #-1; vshuffle x9, x7, x0, r8
@@ -322,8 +314,8 @@ define dso_local void @conv2d.loop.nest(ptr %add.ptr6.i51, ptr %add.ptr5, ptr %c
 ; DCL-NEXT:    nopa ; nopb ; nopx ; vshift.align x4, x4, s1, x5, r0; vmac cm4, cm4, x9, x8, r4
 ; DCL-NEXT:    vldb wl5, [p0], m6; vshift.align x2, x2, s1, x3, r0
 ; DCL-NEXT:    vldb wh5, [p0], m6; add r1, r1, #-1; vshuffle x11, x9, x0, r8
-; DCL-NEXT:    vldb wl3, [p0], m6; jnz r1, #.LBB0_2; vmac cm0, cm0, x7, x6, r4
-; DCL-NEXT:    vldb.3d wh3, [p0], d0; vshuffle x7, x4, x2, r2; vmac cm5, cm5, x7, x8, r4 // Delay Slot 5
+; DCL-NEXT:    vlda wl3, [p0], m6; jnz r1, #.LBB0_2; vmac cm0, cm0, x7, x6, r4
+; DCL-NEXT:    vlda.3d wh3, [p0], d0; vshuffle x7, x4, x2, r2; vmac cm5, cm5, x7, x8, r4 // Delay Slot 5
 ; DCL-NEXT:    vldb wl1, [p1], #32; vshuffle x9, x7, x0, r8; vmac cm2, cm2, x9, x6, r4 // Delay Slot 4
 ; DCL-NEXT:    vldb wh1, [p1], #32; vmov x6, x1; vmac cm7, cm7, x9, x8, r4 // Delay Slot 3
 ; DCL-NEXT:    vldb wl10, [p1], #32; add r0, r10, #33; mov r10, p0; vmac cm3, cm3, x11, x6, r4 // Delay Slot 2
@@ -332,16 +324,15 @@ define dso_local void @conv2d.loop.nest(ptr %add.ptr6.i51, ptr %add.ptr5, ptr %c
 ; DCL-NEXT:    nopx ; vmov x11, x0
 ; DCL-NEXT:    vshuffle x0, x4, x2, r3
 ; DCL-NEXT:    vshuffle x11, x0, x11, r8
-; DCL-NEXT:    vlda wl0, [sp, #-64] // 32-byte Folded Reload
-; DCL-NEXT:    vst wl11, [sp, #-160] // 32-byte Folded Spill
-; DCL-NEXT:    vst wh11, [sp, #-128] // 32-byte Folded Spill
-; DCL-NEXT:    vlda wl11, [sp, #-160] // 32-byte Folded Reload
+; DCL-NEXT:    nop
+; DCL-NEXT:    vlda wl0, [sp, #-64]; vst wl11, [sp, #-160] // 32-byte Folded Reload32-byte Folded Spill
+; DCL-NEXT:    vlda wl11, [sp, #-160]; vst wh11, [sp, #-128] // 32-byte Folded Reload32-byte Folded Spill
 ; DCL-NEXT:    vlda wh11, [sp, #-128] // 32-byte Folded Reload
-; DCL-NEXT:    vlda wl6, [sp, #-160]; vmac cm2, cm2, x0, x6, r4 // 32-byte Folded Reload
-; DCL-NEXT:    vlda wh6, [sp, #-128]; vmac cm5, cm7, x0, x8, r4 // 32-byte Folded Reload
-; DCL-NEXT:    vlda wh0, [sp, #-32]; vmac cm8, cm5, x7, x8, r4 // 32-byte Folded Reload
-; DCL-NEXT:    lda dn7, [sp, #-92] // 4-byte Folded Reload
-; DCL-NEXT:    vmac cm0, cm0, x7, x6, r4
+; DCL-NEXT:    vlda wl6, [sp, #-160] // 32-byte Folded Reload
+; DCL-NEXT:    vlda wh6, [sp, #-128]; vmac cm0, cm0, x7, x6, r4 // 32-byte Folded Reload
+; DCL-NEXT:    vlda wh0, [sp, #-32]; vmac cm2, cm2, x0, x6, r4 // 32-byte Folded Reload
+; DCL-NEXT:    lda dn7, [sp, #-92]; vmac cm5, cm7, x0, x8, r4 // 4-byte Folded Reload
+; DCL-NEXT:    vmac cm8, cm5, x7, x8, r4
 ; DCL-NEXT:    lda dj7, [sp, #-88]; vshift.align x4, x4, s1, x5, r0; vmac cm1, cm1, x9, x6, r4 // 4-byte Folded Reload
 ; DCL-NEXT:    vshift.align x2, x2, s1, x3, r0; vmac cm3, cm3, x11, x6, r4
 ; DCL-NEXT:    vshuffle x6, x4, x2, r2; vmac cm4, cm4, x9, x8, r4
@@ -351,19 +342,19 @@ define dso_local void @conv2d.loop.nest(ptr %add.ptr6.i51, ptr %add.ptr5, ptr %c
 ; DCL-NEXT:    vshuffle x3, x4, x2, r3; vmac cm0, cm1, x8, x1, r4
 ; DCL-NEXT:    st dj7, [sp, #-88] // 4-byte Folded Spill
 ; DCL-NEXT:    vshuffle x5, x3, x0, r8; vmac cm1, cm2, x3, x1, r4
-; DCL-NEXT:    lda m7, [sp, #-96]; vst.srs.s16.s32 bmh7, s2, [p3, #32] // 4-byte Folded Reload
-; DCL-NEXT:    lda dc7, [sp, #-84]; vst.srs.s16.s32 bml7, s3, [p3], #64; vmac cm2, cm3, x5, x1, r4 // 4-byte Folded Reload
+; DCL-NEXT:    vst.srs.s16.s32 bmh7, s2, [p3, #32]
+; DCL-NEXT:    vst.srs.s16.s32 bml7, s3, [p3], #64; vmac cm2, cm3, x5, x1, r4
 ; DCL-NEXT:    vst.srs.s16.s32 bmh0, s3, [p3, #32]
 ; DCL-NEXT:    vst.srs.s16.s32 bml0, s3, [p3], m4; vmac cm3, cm8, x6, x10, r4
 ; DCL-NEXT:    vst.srs.s16.s32 bmh1, s3, [p3, #32]
-; DCL-NEXT:    vst.srs.s16.s32 bml1, s3, [p3], #64; mov m1, r27; vmac cm8, cm4, x8, x10, r4
-; DCL-NEXT:    vst.srs.s16.s32 bmh2, s3, [p3, #32]
+; DCL-NEXT:    lda m7, [sp, #-96]; vst.srs.s16.s32 bml1, s3, [p3], #64; vmac cm8, cm4, x8, x10, r4 // 4-byte Folded Reload
+; DCL-NEXT:    lda dc7, [sp, #-84]; vst.srs.s16.s32 bmh2, s3, [p3, #32]; mov m1, r27 // 4-byte Folded Reload
 ; DCL-NEXT:    vst.srs.s16.s32 bml2, s3, [p3], m1; vmac cm5, cm5, x3, x10, r4
 ; DCL-NEXT:    vst.srs.s16.s32 bmh3, s3, [p3, #32]
 ; DCL-NEXT:    vst.srs.s16.s32 bml3, s3, [p3], #64; vmac cm4, cm6, x5, x10, r4
-; DCL-NEXT:    vst.srs.s16.s32 bmh8, s3, [p3, #32]
+; DCL-NEXT:    vst.srs.s16.s32 bmh8, s3, [p3, #32]; mov m2, r13
 ; DCL-NEXT:    vst.srs.s16.s32 bml8, s3, [p3], m4
-; DCL-NEXT:    vst.srs.s16.s32 bmh5, s3, [p3, #32]; mov m2, r13
+; DCL-NEXT:    vst.srs.s16.s32 bmh5, s3, [p3, #32]
 ; DCL-NEXT:    vst.srs.s16.s32 bml5, s3, [p3], #64; mov m1, r11
 ; DCL-NEXT:    padda.3d [p0], d1; vst.srs.s16.s32 bmh4, s3, [p3, #32]; mov m1, r24
 ; DCL-NEXT:    vst.2d.srs.s16.s32 bml4, s3, [p3], d7; add r7, r7, #-1; mov dj7, r25
@@ -386,7 +377,7 @@ define dso_local void @conv2d.loop.nest(ptr %add.ptr6.i51, ptr %add.ptr5, ptr %c
 ; ZOL-LABEL: conv2d.loop.nest:
 ; ZOL:         .p2align 4
 ; ZOL-NEXT:  // %bb.0: // %newFuncRoot
-; ZOL-NEXT:    nopa ; nopb ; nopx ; mov s0, r0
+; ZOL-NEXT:    nopb ; nopa ; nops ; nopx ; mov s0, r0; nopv
 ; ZOL-NEXT:    paddb [sp], #192; mov s1, r1
 ; ZOL-NEXT:    st p6, [sp, #-188] // 4-byte Folded Spill
 ; ZOL-NEXT:    mov p6, sp
@@ -412,11 +403,11 @@ define dso_local void @conv2d.loop.nest(ptr %add.ptr6.i51, ptr %add.ptr5, ptr %c
 ; ZOL-NEXT:    lda dj1, [p6, #0]; mov p6, sp
 ; ZOL-NEXT:    paddb [p6], #-236; mov dc2, dj3
 ; ZOL-NEXT:    lda r11, [p6, #0]; mov p6, sp
-; ZOL-NEXT:    paddb [p6], #-240; st p7, [sp, #-192] // 4-byte Folded Spill
+; ZOL-NEXT:    paddb [p6], #-240; mov dc6, dj3
 ; ZOL-NEXT:    lda dn1, [p6, #0]; mov p6, sp
-; ZOL-NEXT:    vst wl0, [sp, #-64]; paddb [p6], #-244; mov dc6, dj3 // 32-byte Folded Spill
+; ZOL-NEXT:    paddb [p6], #-244; st p7, [sp, #-192] // 4-byte Folded Spill
 ; ZOL-NEXT:    lda dn5, [p6, #0]; mov p6, sp
-; ZOL-NEXT:    vst wh0, [sp, #-32]; paddb [p6], #-248; mov p7, sp // 32-byte Folded Spill
+; ZOL-NEXT:    paddb [p6], #-248; mov p7, sp
 ; ZOL-NEXT:    lda r12, [p6, #0]; paddb [p7], #-272; mov p6, sp
 ; ZOL-NEXT:    lda r24, [p7, #0]; paddb [p6], #-252; mov p7, sp
 ; ZOL-NEXT:    lda dj2, [p6, #0]; paddb [p7], #-200; mov p6, sp
@@ -436,43 +427,34 @@ define dso_local void @conv2d.loop.nest(ptr %add.ptr6.i51, ptr %add.ptr5, ptr %c
 ; ZOL-NEXT:    lda r14, [p6, #0]; mov p6, sp
 ; ZOL-NEXT:    paddb [p6], #-224; st dn7, [sp, #-92] // 4-byte Folded Spill
 ; ZOL-NEXT:    lda r15, [p6, #0]; paddb [p7], #-288; mov p6, sp
-; ZOL-NEXT:    lda r26, [p7, #0]; paddb [p6], #-284; movx r8, #11; mov dj5, r11
-; ZOL-NEXT:    lda m4, [p6, #0]; movx r9, #31; mov m3, r13
+; ZOL-NEXT:    lda r26, [p7, #0]; paddb [p6], #-284; movx r8, #11; mov dj5, r11; vst wl0, [sp, #-64] // 32-byte Folded Spill
+; ZOL-NEXT:    lda m4, [p6, #0]; vst wh0, [sp, #-32]; movx r9, #31; mov m3, r13 // 32-byte Folded Spill
 ; ZOL-NEXT:    // implicit-def: $x4
 ; ZOL-NEXT:    // implicit-def: $x2
 ; ZOL-NEXT:    .p2align 4
 ; ZOL-NEXT:  .LBB0_1: // %outer.loop.header
 ; ZOL-NEXT:    // =>This Loop Header: Depth=1
 ; ZOL-NEXT:    // Child Loop BB0_2 Depth 2
-; ZOL-NEXT:    vldb wl6, [p1], #32; nopa ; nops ; nopxm ; nopv
-; ZOL-NEXT:    vldb wl3, [p0], m6; mov r0, p0
-; ZOL-NEXT:    vlda.ups.s32.s16 bmh0, s0, [p2, #32]; nopx
+; ZOL-NEXT:    vlda.ups.s32.s16 bmh0, s0, [p2, #32]; nopb ; nopxm ; nops
 ; ZOL-NEXT:    vlda.ups.s32.s16 bml0, s0, [p2], m5
-; ZOL-NEXT:    vldb wh6, [p1], #32
-; ZOL-NEXT:    vldb wh3, [p0], m6
 ; ZOL-NEXT:    vlda.ups.s32.s16 bmh1, s0, [p2, #32]; mov m1, p5
 ; ZOL-NEXT:    vlda.ups.s32.s16 bml1, s0, [p2], m1
-; ZOL-NEXT:    vldb wl8, [p1], #32
-; ZOL-NEXT:    vldb wl7, [p0], m6
 ; ZOL-NEXT:    vlda.ups.s32.s16 bmh2, s0, [p2, #32]
 ; ZOL-NEXT:    vlda.ups.s32.s16 bml2, s0, [p2], m5
-; ZOL-NEXT:    vldb wh8, [p1], #32
-; ZOL-NEXT:    vldb.3d wh7, [p0], d0
 ; ZOL-NEXT:    vlda.ups.s32.s16 bmh3, s0, [p2, #32]; mov m2, r14
 ; ZOL-NEXT:    vlda.ups.s32.s16 bml3, s0, [p2], m2
-; ZOL-NEXT:    vldb wl1, [p1], #32
 ; ZOL-NEXT:    vlda.ups.s32.s16 bmh5, s0, [p2, #32]
-; ZOL-NEXT:    vlda.ups.s32.s16 bml5, s0, [p2], m5
-; ZOL-NEXT:    vlda.ups.s32.s16 bmh4, s0, [p2, #32]
-; ZOL-NEXT:    vlda.ups.s32.s16 bml4, s0, [p2], m1
-; ZOL-NEXT:    vlda.ups.s32.s16 bmh7, s0, [p2, #32]
+; ZOL-NEXT:    vlda.ups.s32.s16 bml5, s0, [p2], m5; vldb wl3, [p0], m6; mov r0, p0
+; ZOL-NEXT:    vlda.ups.s32.s16 bmh4, s0, [p2, #32]; vldb wh3, [p0], m6
+; ZOL-NEXT:    vlda.ups.s32.s16 bml4, s0, [p2], m1; vldb wl7, [p0], m6
+; ZOL-NEXT:    vlda.ups.s32.s16 bmh7, s0, [p2, #32]; vldb.3d wh7, [p0], d0
 ; ZOL-NEXT:    vlda.ups.s32.s16 bml7, s0, [p2], m5; movxm ls, #.LBB0_2
-; ZOL-NEXT:    vldb wl5, [p0], m6; mov r1, p0
-; ZOL-NEXT:    vldb wh5, [p0], m6; movxm le, #.L_LEnd0
-; ZOL-NEXT:    vlda.ups.s32.s16 bmh6, s0, [p2, #32]; and r0, r0, r9
-; ZOL-NEXT:    vldb wl3, [p0], m6; add r0, r0, #33
-; ZOL-NEXT:    vldb.3d wh3, [p0], d0; vshift.align x4, x4, s1, x3, r0
-; ZOL-NEXT:    vlda.ups.s32.s16 bml6, s0, [p2, #0]; and r1, r1, r9; vshift.align x2, x2, s1, x7, r0
+; ZOL-NEXT:    vldb wl6, [p1], #32; movxm le, #.L_LEnd0
+; ZOL-NEXT:    vlda wh6, [p1], #32; vldb wl5, [p0], m6; mov r1, p0
+; ZOL-NEXT:    vlda.ups.s32.s16 bmh6, s0, [p2, #32]; vldb wh5, [p0], m6; and r0, r0, r9
+; ZOL-NEXT:    vlda wl8, [p1], #32; vldb wl3, [p0], m6; add r0, r0, #33
+; ZOL-NEXT:    vlda wh8, [p1], #32; vldb.3d wh3, [p0], d0; vshift.align x4, x4, s1, x3, r0
+; ZOL-NEXT:    vlda.ups.s32.s16 bml6, s0, [p2, #0]; vldb wl1, [p1], #32; and r1, r1, r9; vshift.align x2, x2, s1, x7, r0
 ; ZOL-NEXT:    vldb wh1, [p1], #32; add r0, r1, #33; mov r1, p0
 ; ZOL-NEXT:    vldb wl10, [p1], #32; vshuffle x7, x4, x2, r2
 ; ZOL-NEXT:    vldb wh10, [p1], #32; vshuffle x9, x7, x0, r8
@@ -484,8 +466,8 @@ define dso_local void @conv2d.loop.nest(ptr %add.ptr6.i51, ptr %add.ptr5, ptr %c
 ; ZOL-NEXT:    nopb ; nopa ; nops ; nopx ; vshuffle x9, x4, x2, r3; vmac cm1, cm1, x9, x6, r4
 ; ZOL-NEXT:    vldb wl5, [p0], m6; nopa ; nops ; nopx ; vshift.align x4, x4, s1, x5, r0; vmac cm4, cm4, x9, x8, r4
 ; ZOL-NEXT:    vldb wh5, [p0], m6; nopa ; nops ; nopx ; vshift.align x2, x2, s1, x3, r0; nopv
-; ZOL-NEXT:    vldb wl3, [p0], m6; nopa ; nops ; nopx ; vshuffle x11, x9, x0, r8; vmac cm0, cm0, x7, x6, r4
-; ZOL-NEXT:    vldb.3d wh3, [p0], d0; nopa ; nops ; nopx ; vshuffle x7, x4, x2, r2; vmac cm5, cm5, x7, x8, r4
+; ZOL-NEXT:    nopb ; vlda wl3, [p0], m6; nops ; nopx ; vshuffle x11, x9, x0, r8; vmac cm0, cm0, x7, x6, r4
+; ZOL-NEXT:    nopb ; vlda.3d wh3, [p0], d0; nops ; nopx ; vshuffle x7, x4, x2, r2; vmac cm5, cm5, x7, x8, r4
 ; ZOL-NEXT:    vldb wl1, [p1], #32; nopa ; nops ; nopx ; vshuffle x9, x7, x0, r8; vmac cm2, cm2, x9, x6, r4
 ; ZOL-NEXT:    vldb wh1, [p1], #32; nopa ; nops ; nopx ; vmov x6, x1; vmac cm7, cm7, x9, x8, r4
 ; ZOL-NEXT:    vldb wl10, [p1], #32; nopa ; nops ; add r0, r1, #33; mov r1, p0; vmac cm3, cm3, x11, x6, r4
@@ -495,16 +477,15 @@ define dso_local void @conv2d.loop.nest(ptr %add.ptr6.i51, ptr %add.ptr5, ptr %c
 ; ZOL-NEXT:    nopx ; vmov x11, x0
 ; ZOL-NEXT:    vshuffle x0, x4, x2, r3
 ; ZOL-NEXT:    vshuffle x11, x0, x11, r8
-; ZOL-NEXT:    vlda wl0, [sp, #-64] // 32-byte Folded Reload
-; ZOL-NEXT:    vst wl11, [sp, #-160] // 32-byte Folded Spill
-; ZOL-NEXT:    vst wh11, [sp, #-128] // 32-byte Folded Spill
-; ZOL-NEXT:    vlda wl11, [sp, #-160] // 32-byte Folded Reload
+; ZOL-NEXT:    nop
+; ZOL-NEXT:    vlda wl0, [sp, #-64]; vst wl11, [sp, #-160] // 32-byte Folded Reload32-byte Folded Spill
+; ZOL-NEXT:    vlda wl11, [sp, #-160]; vst wh11, [sp, #-128] // 32-byte Folded Reload32-byte Folded Spill
 ; ZOL-NEXT:    vlda wh11, [sp, #-128] // 32-byte Folded Reload
-; ZOL-NEXT:    vlda wl6, [sp, #-160]; vmac cm2, cm2, x0, x6, r4 // 32-byte Folded Reload
-; ZOL-NEXT:    vlda wh6, [sp, #-128]; vmac cm5, cm7, x0, x8, r4 // 32-byte Folded Reload
-; ZOL-NEXT:    vlda wh0, [sp, #-32]; vmac cm8, cm5, x7, x8, r4 // 32-byte Folded Reload
-; ZOL-NEXT:    lda dn7, [sp, #-92] // 4-byte Folded Reload
-; ZOL-NEXT:    vmac cm0, cm0, x7, x6, r4
+; ZOL-NEXT:    vlda wl6, [sp, #-160] // 32-byte Folded Reload
+; ZOL-NEXT:    vlda wh6, [sp, #-128]; vmac cm0, cm0, x7, x6, r4 // 32-byte Folded Reload
+; ZOL-NEXT:    vlda wh0, [sp, #-32]; vmac cm2, cm2, x0, x6, r4 // 32-byte Folded Reload
+; ZOL-NEXT:    lda dn7, [sp, #-92]; vmac cm5, cm7, x0, x8, r4 // 4-byte Folded Reload
+; ZOL-NEXT:    vmac cm8, cm5, x7, x8, r4
 ; ZOL-NEXT:    lda dj7, [sp, #-88]; vshift.align x4, x4, s1, x5, r0; vmac cm1, cm1, x9, x6, r4 // 4-byte Folded Reload
 ; ZOL-NEXT:    vshift.align x2, x2, s1, x3, r0; vmac cm3, cm3, x11, x6, r4
 ; ZOL-NEXT:    vshuffle x6, x4, x2, r2; vmac cm4, cm4, x9, x8, r4
@@ -514,19 +495,19 @@ define dso_local void @conv2d.loop.nest(ptr %add.ptr6.i51, ptr %add.ptr5, ptr %c
 ; ZOL-NEXT:    vshuffle x3, x4, x2, r3; vmac cm0, cm1, x8, x1, r4
 ; ZOL-NEXT:    st dj7, [sp, #-88] // 4-byte Folded Spill
 ; ZOL-NEXT:    vshuffle x5, x3, x0, r8; vmac cm1, cm2, x3, x1, r4
-; ZOL-NEXT:    lda m7, [sp, #-96]; vst.srs.s16.s32 bmh7, s2, [p3, #32] // 4-byte Folded Reload
-; ZOL-NEXT:    lda dc7, [sp, #-84]; vst.srs.s16.s32 bml7, s3, [p3], #64; vmac cm2, cm3, x5, x1, r4 // 4-byte Folded Reload
+; ZOL-NEXT:    vst.srs.s16.s32 bmh7, s2, [p3, #32]
+; ZOL-NEXT:    vst.srs.s16.s32 bml7, s3, [p3], #64; vmac cm2, cm3, x5, x1, r4
 ; ZOL-NEXT:    vst.srs.s16.s32 bmh0, s3, [p3, #32]
 ; ZOL-NEXT:    vst.srs.s16.s32 bml0, s3, [p3], m4; vmac cm3, cm8, x6, x10, r4
 ; ZOL-NEXT:    vst.srs.s16.s32 bmh1, s3, [p3, #32]
-; ZOL-NEXT:    vst.srs.s16.s32 bml1, s3, [p3], #64; mov m1, r26; vmac cm8, cm4, x8, x10, r4
-; ZOL-NEXT:    vst.srs.s16.s32 bmh2, s3, [p3, #32]
+; ZOL-NEXT:    lda m7, [sp, #-96]; vst.srs.s16.s32 bml1, s3, [p3], #64; vmac cm8, cm4, x8, x10, r4 // 4-byte Folded Reload
+; ZOL-NEXT:    lda dc7, [sp, #-84]; vst.srs.s16.s32 bmh2, s3, [p3, #32]; mov m1, r26 // 4-byte Folded Reload
 ; ZOL-NEXT:    vst.srs.s16.s32 bml2, s3, [p3], m1; vmac cm5, cm5, x3, x10, r4
 ; ZOL-NEXT:    vst.srs.s16.s32 bmh3, s3, [p3, #32]
 ; ZOL-NEXT:    vst.srs.s16.s32 bml3, s3, [p3], #64; vmac cm4, cm6, x5, x10, r4
-; ZOL-NEXT:    vst.srs.s16.s32 bmh8, s3, [p3, #32]
+; ZOL-NEXT:    vst.srs.s16.s32 bmh8, s3, [p3, #32]; mov m2, r12
 ; ZOL-NEXT:    vst.srs.s16.s32 bml8, s3, [p3], m4
-; ZOL-NEXT:    vst.srs.s16.s32 bmh5, s3, [p3, #32]; mov m2, r12
+; ZOL-NEXT:    vst.srs.s16.s32 bmh5, s3, [p3, #32]
 ; ZOL-NEXT:    vst.srs.s16.s32 bml5, s3, [p3], #64; mov m1, r10
 ; ZOL-NEXT:    padda.3d [p0], d1; vst.srs.s16.s32 bmh4, s3, [p3, #32]; mov m1, r15
 ; ZOL-NEXT:    vst.2d.srs.s16.s32 bml4, s3, [p3], d7; add r7, r7, #-1; mov dj7, r24

--- a/llvm/test/CodeGen/AIE/aie2/end-to-end/Memops.ll
+++ b/llvm/test/CodeGen/AIE/aie2/end-to-end/Memops.ll
@@ -4,7 +4,7 @@
 ; See https://llvm.org/LICENSE.txt for license information.
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 ;
-; (c) Copyright 2023-2024 Advanced Micro Devices, Inc. or its affiliates
+; (c) Copyright 2023-2025 Advanced Micro Devices, Inc. or its affiliates
 ; RUN: llc -O2 -mtriple=aie2 --enable-pipeliner=0 %s -o - | FileCheck %s
 
 @buffer1 = dso_local local_unnamed_addr global [1000 x i32] zeroinitializer, align 4
@@ -100,7 +100,7 @@ define dso_local void @lowerMemcpyUsingWordHalfByte() local_unnamed_addr #0 {
 ; CHECK-LABEL: lowerMemcpyUsingWordHalfByte:
 ; CHECK:         .p2align 4
 ; CHECK-NEXT:  // %bb.0: // %entry
-; CHECK-NEXT:    nopa ; nopb ; movxm p0, #(buffer2+8); nops
+; CHECK-NEXT:    nopb ; nopa ; nops ; movxm p0, #(buffer2+8); nopv
 ; CHECK-NEXT:    lda.s16 r0, [p0, #0]; movxm p1, #(buffer1+8)
 ; CHECK-NEXT:    st.s16 r0, [p1, #0]
 ; CHECK-NEXT:    nop
@@ -109,16 +109,15 @@ define dso_local void @lowerMemcpyUsingWordHalfByte() local_unnamed_addr #0 {
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    paddb [p0], #-8
-; CHECK-NEXT:    lda r0, [p0], #4
-; CHECK-NEXT:    mova m0, #6
+; CHECK-NEXT:    lda r0, [p0], #4; mov m0, #6
 ; CHECK-NEXT:    lda r1, [p0], m0
+; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    paddb [p1], #-8
 ; CHECK-NEXT:    st r0, [p1], #4
-; CHECK-NEXT:    lda.s8 r0, [p0, #0]
-; CHECK-NEXT:    st r1, [p1], m0
+; CHECK-NEXT:    lda.s8 r0, [p0, #0]; st r1, [p1], m0
 ; CHECK-NEXT:    st.s8 r0, [p1, #0]
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    ret lr

--- a/llvm/test/CodeGen/AIE/aie2/schedule/loopaware/Add2D-like.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/loopaware/Add2D-like.mir
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2024-2025 Advanced Micro Devices, Inc. or its affiliates
 
 # RUN: llc --mtriple=aie2 --run-pass=postmisched \
 # RUN:     %s -o - | FileCheck %s
@@ -47,25 +47,26 @@ body:             |
   ; CHECK-NEXT:   successors: %bb.1(0x40000000), %bb.2(0x40000000)
   ; CHECK-NEXT:   liveins: $cm0, $cm4, $dc0, $dc4, $dj0, $dj4, $dn0, $dn4, $m0, $m1, $p1, $p2, $p3, $r0, $r1, $s0, $s1, $d0_3d:0x000000000001C870
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT:   BUNDLE implicit-def $cm4, implicit-def $bml4, implicit-def $amll4, implicit-def $amlh4, implicit-def $bmh4, implicit-def $amhl4, implicit-def $amhh4, implicit-def $p2, implicit-def $dc0, implicit-def $dc4, implicit-def $srups_of, implicit-def $cm8, implicit-def $bml8, implicit-def $amll8, implicit-def $amlh8, implicit-def $bmh8, implicit-def $amhl8, implicit-def $amhh8, implicit $s1, implicit killed $p2, implicit $d0_3d, implicit $crsat, implicit $crupssign, implicit killed $cm0, implicit $r0 {
-  ; CHECK-NEXT:     $cm4, $p2, $dc0, $dc4 = VLDA_3D_UPS_S32_D8 $s1, killed $p2, $d0_3d, implicit-def $srups_of, implicit $crsat, implicit $crupssign :: (load (<32 x s8>) from stack - 64)
-  ; CHECK-NEXT:     renamable $cm8 = VADD internal renamable $cm4, killed renamable $cm0, renamable $r0
-  ; CHECK-NEXT:   }
   ; CHECK-NEXT:   BUNDLE implicit-def $cm0, implicit-def $bml0, implicit-def $amll0, implicit-def $amlh0, implicit-def $bmh0, implicit-def $amhl0, implicit-def $amhh0, implicit-def $p1, implicit-def $srups_of, implicit-def $r1, implicit-def dead $srcarry, implicit $s1, implicit killed $p1, implicit $m1, implicit $crsat, implicit $crupssign, implicit killed $r1 {
   ; CHECK-NEXT:     renamable $cm0, renamable $p1 = VLDA_UPS_S32_D8_ag_pstm_nrm renamable $s1, killed renamable $p1, renamable $m1, implicit-def $srups_of, implicit $crsat, implicit $crupssign :: (load (<32 x s8>) from stack - 32)
   ; CHECK-NEXT:     renamable $r1 = ADD_add_r_ri killed renamable $r1, -4, implicit-def dead $srcarry
   ; CHECK-NEXT:   }
-  ; CHECK-NEXT:   JNZ renamable $r1, %bb.1
+  ; CHECK-NEXT:   BUNDLE implicit-def $cm4, implicit-def $bml4, implicit-def $amll4, implicit-def $amlh4, implicit-def $bmh4, implicit-def $amhl4, implicit-def $amhh4, implicit-def $p2, implicit-def $dc0, implicit-def $dc4, implicit-def $srups_of, implicit-def $cm8, implicit-def $bml8, implicit-def $amll8, implicit-def $amlh8, implicit-def $bmh8, implicit-def $amhl8, implicit-def $amhh8, implicit $s1, implicit killed $p2, implicit $d0_3d, implicit $crsat, implicit $crupssign, implicit $r1, implicit $cm0, implicit $r0 {
+  ; CHECK-NEXT:     $cm4, $p2, $dc0, $dc4 = VLDA_3D_UPS_S32_D8 $s1, killed $p2, $d0_3d, implicit-def $srups_of, implicit $crsat, implicit $crupssign :: (load (<32 x s8>) from stack - 64)
+  ; CHECK-NEXT:     JNZ renamable $r1, %bb.1
+  ; CHECK-NEXT:     renamable $cm8 = VADD internal renamable $cm4, renamable $cm0, renamable $r0
+  ; CHECK-NEXT:   }
+  ; CHECK-NEXT:   NOP
+  ; CHECK-NEXT:   NOP
   ; CHECK-NEXT:   NOP
   ; CHECK-NEXT:   NOP
   ; CHECK-NEXT:   renamable $p3 = VST_SRS_D8_S32_ag_pstm_nrm_imm killed renamable $p3, 32, killed renamable $cm8, renamable $s0, implicit-def $srsrs_of, implicit $crsat, implicit $crrnd, implicit $crsrssign :: (store (<32 x s8>) into stack - 128)
-  ; CHECK-NEXT:   NOP
-  ; CHECK-NEXT:   NOP
   ; CHECK-NEXT:   DelayedSchedBarrier
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT: bb.2:
   ; CHECK-NEXT:   liveins: $cm0, $cm4, $p3, $r0, $s0
   ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT:   NOP
   ; CHECK-NEXT:   renamable $cm0 = VADD killed renamable $cm4, killed renamable $cm0, killed renamable $r0
   ; CHECK-NEXT:   NOP
   ; CHECK-NEXT:   NOP

--- a/llvm/test/CodeGen/AIE/aie2/schedule/pre_ra/add2d_inner.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/pre_ra/add2d_inner.mir
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2024-2025 Advanced Micro Devices, Inc. or its affiliates
 # RUN: llc -march=aie2 -run-pass=machine-scheduler %s -o - | FileCheck %s
 
 
@@ -52,13 +52,13 @@ body: |
   ; CHECK-NEXT:   [[VADD2:%[0-9]+]]:acc1024 = VADD [[COPY7]], [[COPY19]], [[COPY14]]
   ; CHECK-NEXT:   [[COPY20:%[0-9]+]]:acc1024 = COPY [[COPY1]]
   ; CHECK-NEXT:   [[VADD3:%[0-9]+]]:acc1024 = VADD [[COPY8]], [[COPY20]], [[COPY14]]
+  ; CHECK-NEXT:   [[COPY4:%[0-9]+]]:acc1024, [[COPY9:%[0-9]+]]:ep_as_32bit = VLDA_UPS_S32_D8_ag_pstm_nrm [[COPY15]], [[COPY9]], [[COPY]], implicit-def $srups_of, implicit $crsat, implicit $crupssign :: (load (<32 x s8>) from stack - 64)
   ; CHECK-NEXT:   [[COPY11:%[0-9]+]]:ep_as_32bit = VST_SRS_D8_S32_ag_pstm_nrm_imm [[COPY11]], 32, [[VADD]], [[COPY16]], implicit-def $srsrs_of, implicit $crsat, implicit $crrnd, implicit $crsrssign :: (store (<32 x s8>) into stack - 128)
   ; CHECK-NEXT:   [[COPY11:%[0-9]+]]:ep_as_32bit = VST_SRS_D8_S32_ag_pstm_nrm_imm [[COPY11]], 32, [[VADD1]], [[COPY16]], implicit-def $srsrs_of, implicit $crsat, implicit $crrnd, implicit $crsrssign :: (store (<32 x s8>) into stack - 128)
-  ; CHECK-NEXT:   [[COPY11:%[0-9]+]]:ep_as_32bit = VST_SRS_D8_S32_ag_pstm_nrm_imm [[COPY11]], 32, [[VADD2]], [[COPY16]], implicit-def $srsrs_of, implicit $crsat, implicit $crrnd, implicit $crsrssign :: (store (<32 x s8>) into stack - 128)
-  ; CHECK-NEXT:   [[COPY11:%[0-9]+]]:ep_as_32bit = VST_SRS_D8_S32_ag_pstm_nrm_imm [[COPY11]], 32, [[VADD3]], [[COPY16]], implicit-def $srsrs_of, implicit $crsat, implicit $crrnd, implicit $crsrssign :: (store (<32 x s8>) into stack - 128)
-  ; CHECK-NEXT:   [[COPY4:%[0-9]+]]:acc1024, [[COPY9:%[0-9]+]]:ep_as_32bit = VLDA_UPS_S32_D8_ag_pstm_nrm [[COPY15]], [[COPY9]], [[COPY]], implicit-def $srups_of, implicit $crsat, implicit $crupssign :: (load (<32 x s8>) from stack - 64)
   ; CHECK-NEXT:   [[COPY3:%[0-9]+]]:acc1024, [[COPY9:%[0-9]+]]:ep_as_32bit = VLDA_UPS_S32_D8_ag_pstm_nrm [[COPY15]], [[COPY9]], [[COPY]], implicit-def $srups_of, implicit $crsat, implicit $crupssign :: (load (<32 x s8>) from stack - 64)
   ; CHECK-NEXT:   [[COPY2:%[0-9]+]]:acc1024, [[COPY9:%[0-9]+]]:ep_as_32bit = VLDA_UPS_S32_D8_ag_pstm_nrm [[COPY15]], [[COPY9]], [[COPY]], implicit-def $srups_of, implicit $crsat, implicit $crupssign :: (load (<32 x s8>) from stack - 64)
+  ; CHECK-NEXT:   [[COPY11:%[0-9]+]]:ep_as_32bit = VST_SRS_D8_S32_ag_pstm_nrm_imm [[COPY11]], 32, [[VADD2]], [[COPY16]], implicit-def $srsrs_of, implicit $crsat, implicit $crrnd, implicit $crsrssign :: (store (<32 x s8>) into stack - 128)
+  ; CHECK-NEXT:   [[COPY11:%[0-9]+]]:ep_as_32bit = VST_SRS_D8_S32_ag_pstm_nrm_imm [[COPY11]], 32, [[VADD3]], [[COPY16]], implicit-def $srsrs_of, implicit $crsat, implicit $crrnd, implicit $crsrssign :: (store (<32 x s8>) into stack - 128)
   ; CHECK-NEXT:   [[COPY1:%[0-9]+]]:acc1024, [[COPY9:%[0-9]+]]:ep_as_32bit = VLDA_UPS_S32_D8_ag_pstm_nrm [[COPY15]], [[COPY9]], [[COPY]], implicit-def $srups_of, implicit $crsat, implicit $crupssign :: (load (<32 x s8>) from stack - 64)
   ; CHECK-NEXT:   [[COPY5:%[0-9]+]]:acc1024, [[COPY10:%[0-9]+]]:ep_as_32bit, [[COPY12:%[0-9]+]].sub_dim_count:eds, [[COPY12:%[0-9]+]].sub_hi_dim_then_sub_dim_count:eds = VLDA_3D_UPS_S32_D8 [[COPY15]], [[COPY10]], [[COPY12]], implicit-def $srups_of, implicit $crsat, implicit $crupssign :: (load (<32 x s8>) from stack - 32)
   ; CHECK-NEXT:   [[COPY6:%[0-9]+]]:acc1024, [[COPY10:%[0-9]+]]:ep_as_32bit, [[COPY12:%[0-9]+]].sub_dim_count:eds, [[COPY12:%[0-9]+]].sub_hi_dim_then_sub_dim_count:eds = VLDA_3D_UPS_S32_D8 [[COPY15]], [[COPY10]], [[COPY12]], implicit-def $srups_of, implicit $crsat, implicit $crupssign :: (load (<32 x s8>) from stack - 32)

--- a/llvm/test/CodeGen/AIE/aie2/schedule/resource/memory_bank.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/resource/memory_bank.mir
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2024-2025 Advanced Micro Devices, Inc. or its affiliates
 # RUN: llc -march=aie2 -run-pass=postmisched %s -o - | FileCheck %s
 
 # This test checks that we are scheduling loads from differnt banks in on VLIW bundle.
@@ -15,8 +15,10 @@ alignment:       16
 body:             |
   bb.0.entry:
     ; CHECK-LABEL: name: VLDA_VLDB_noBank_BankA
-    ; CHECK: $wl1 = VLDB_dmw_ldb_ag_idx_imm $p0, 0 :: (load (<8 x s32>), addrspace 5)
-    ; CHECK-NEXT: $wl2 = VLDA_dmw_lda_w_ag_idx_imm killed $p0, 0 :: (load (<8 x s32>))
+    ; CHECK: BUNDLE implicit-def $wl2, implicit-def $wl1, implicit killed $p0 {
+    ; CHECK-NEXT:   $wl2 = VLDA_dmw_lda_w_ag_idx_imm $p0, 0 :: (load (<8 x s32>))
+    ; CHECK-NEXT:   $wl1 = VLDB_dmw_ldb_ag_idx_imm killed $p0, 0 :: (load (<8 x s32>), addrspace 5)
+    ; CHECK-NEXT: }
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
@@ -33,8 +35,10 @@ alignment:       16
 body:             |
   bb.0.entry:
     ; CHECK-LABEL: name: VLDA_VLDB_BankA_noBank
-    ; CHECK: $wl1 = VLDB_dmw_ldb_ag_idx_imm $p0, 0 :: (load (<8 x s32>))
-    ; CHECK-NEXT: $wl2 = VLDA_dmw_lda_w_ag_idx_imm killed $p0, 0 :: (load (<8 x s32>), addrspace 5)
+    ; CHECK: BUNDLE implicit-def $wl2, implicit-def $wl1, implicit killed $p0 {
+    ; CHECK-NEXT:   $wl2 = VLDA_dmw_lda_w_ag_idx_imm $p0, 0 :: (load (<8 x s32>), addrspace 5)
+    ; CHECK-NEXT:   $wl1 = VLDB_dmw_ldb_ag_idx_imm killed $p0, 0 :: (load (<8 x s32>))
+    ; CHECK-NEXT: }
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP

--- a/llvm/test/CodeGen/AIE/aie2/schedule/vlda_vldb.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/vlda_vldb.mir
@@ -4,8 +4,10 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2023-2024 Advanced Micro Devices, Inc. or its affiliates
-# RUN: llc -march=aie2 -run-pass=postmisched %topdown-multi %s -o - | FileCheck %s
+# (c) Copyright 2023-2025 Advanced Micro Devices, Inc. or its affiliates
+# RUN: llc -march=aie2 -run-pass=postmisched %topdown-multi \
+# RUN:   --aie-addrspace-none-is-safe=0 \
+# RUN:   %s -o - | FileCheck %s
 
 # This test checks that we are able to schedule VLDA and VLDB at the same time.
 

--- a/llvm/test/CodeGen/AIE/aie2p/AA-unroll-iterations.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/AA-unroll-iterations.mir
@@ -16,31 +16,32 @@
   ; CHECK-LABEL: _Z1fPii:
   ; CHECK:         .p2align 4
   ; CHECK-NEXT:  // %bb.0: // %entry
-  ; CHECK-NEXT:    mova m0, #4; nopb ; nopxm ; nops
+  ; CHECK-NEXT:    mova m0, #4; nopxm
   ; CHECK-NEXT:    mova dn0, #16; mov m1, m0
   ; CHECK-NEXT:    mova dc1, #0; movx r1, #4; mov dn1, dn0
-  ; CHECK-NEXT:    movs p1, p0; add.nc lc, r1, #-2
+  ; CHECK-NEXT:    movs p1, p0; add.nc lc, r1, #-3
   ; CHECK-NEXT:    movs dj1, m0; mov dc0, dc1
   ; CHECK-NEXT:    lda.2d r1, [p1], d1
   ; CHECK-NEXT:    nop
   ; CHECK-NEXT:    movxm ls, #.LBB0_1
-  ; CHECK-NEXT:    movxm le, #.L_LEnd0
-  ; CHECK-NEXT:    lda.2d r1, [p1], d1; nopb ; nops ; nopxm ; nopv
+  ; CHECK-NEXT:    lda.2d r1, [p1], d1; movxm le, #.L_LEnd0
   ; CHECK-NEXT:    nopa ; nopb ; nops ; nopxm ; nopv
-  ; CHECK-NEXT:    nopa ; nopb ; nops ; movx r0, #10; nopm ; nopv
-  ; CHECK-NEXT:    nopa ; nopb ; nops ; mul r1, r1, r0; mov dj0, m0; nopv
+  ; CHECK-NEXT:    nopa ; nopb ; nops ; nopxm ; nopv
+  ; CHECK-NEXT:    lda.2d r1, [p1], d1; nopb ; nops ; movx r0, #10; nopm ; nopv
+  ; CHECK-NEXT:    nopa ; nopb ; nops ; mul r1, r1, r0; nopm ; nopv
+  ; CHECK-NEXT:    nopa ; nopb ; nops ; nopx ; mov dj0, m0; nopv
   ; CHECK-NEXT:    .p2align 4
   ; CHECK-NEXT:  .LBB0_1: // %for.body
   ; CHECK-NEXT:    // =>This Inner Loop Header: Depth=1
-  ; CHECK-NEXT:    lda.2d r1, [p1], d1; nopb ; nops ; nopxm ; nopv
-  ; CHECK-NEXT:    nopa ; nopb ; st.2d r1, [p0], d0; nopxm ; nopv
-  ; CHECK-NEXT:    nopa ; nopb ; nops ; nopxm ; nopv
-  ; CHECK-NEXT:  .L_LEnd0:
+  ; CHECK-NEXT:    lda.2d r1, [p1], d1; nopb ; st.2d r1, [p0], d0; nopxm ; nopv
   ; CHECK-NEXT:    nopa ; nopb ; nops ; mul r1, r1, r0; nopm ; nopv
+  ; CHECK-NEXT:  .L_LEnd0:
+  ; CHECK-NEXT:    nopa ; nopb ; nops ; nopxm ; nopv
   ; CHECK-NEXT:  // %bb.2: // %for.cond.cleanup
+  ; CHECK-NEXT:    nopa ; nopb ; nopxm ; st.2d r1, [p0], d0
+  ; CHECK-NEXT:    mul r1, r1, r0
   ; CHECK-NEXT:    nop
   ; CHECK-NEXT:    st.2d r1, [p0], d0
-  ; CHECK-NEXT:    nop
   ; CHECK-NEXT:    mul r1, r1, r0
   ; CHECK-NEXT:    nop
   ; CHECK-NEXT:    st.2d r1, [p0], d0

--- a/llvm/test/CodeGen/AIE/aie2p/Memops.ll
+++ b/llvm/test/CodeGen/AIE/aie2p/Memops.ll
@@ -4,7 +4,7 @@
 ; See https://llvm.org/LICENSE.txt for license information.
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 ;
-; (c) Copyright 2023-2024 Advanced Micro Devices, Inc. or its affiliates
+; (c) Copyright 2023-2025 Advanced Micro Devices, Inc. or its affiliates
 ; RUN: llc -O2 -mtriple=aie2p --enable-pipeliner=0 %s -o - | FileCheck %s
 
 @buffer1 = dso_local local_unnamed_addr global [1000 x i32] zeroinitializer, align 4
@@ -100,7 +100,7 @@ define dso_local void @lowerMemcpyUsingWordHalfByte() local_unnamed_addr #0 {
 ; CHECK-LABEL: lowerMemcpyUsingWordHalfByte:
 ; CHECK:         .p2align 4
 ; CHECK-NEXT:  // %bb.0: // %entry
-; CHECK-NEXT:    nopa ; nopb ; movxm p0, ##(buffer2+8)
+; CHECK-NEXT:    nopa ; nopb ; movxm p0, ##(buffer2+8); nops
 ; CHECK-NEXT:    lda.s16 r0, [p0, #0]; movxm p1, ##(buffer1+8)
 ; CHECK-NEXT:    st.s16 r0, [p1, #0]
 ; CHECK-NEXT:    nop
@@ -109,16 +109,15 @@ define dso_local void @lowerMemcpyUsingWordHalfByte() local_unnamed_addr #0 {
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    mova m0, #-8
 ; CHECK-NEXT:    padda [p0], m0
-; CHECK-NEXT:    lda r0, [p0], #4
-; CHECK-NEXT:    mova m1, #6
+; CHECK-NEXT:    lda r0, [p0], #4; mov m1, #6
 ; CHECK-NEXT:    lda r1, [p0], m1
+; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    padda [p1], m0
 ; CHECK-NEXT:    st r0, [p1], #4
-; CHECK-NEXT:    lda.s8 r0, [p0, #0]
-; CHECK-NEXT:    st r1, [p1], m1
+; CHECK-NEXT:    lda.s8 r0, [p0, #0]; st r1, [p1], m1
 ; CHECK-NEXT:    st.s8 r0, [p1, #0]
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    ret lr

--- a/llvm/test/CodeGen/AIE/aie2p/end-to-end/conv2d_bfp16_convert.ll
+++ b/llvm/test/CodeGen/AIE/aie2p/end-to-end/conv2d_bfp16_convert.ll
@@ -17,7 +17,7 @@ define weak_odr dso_local void @convert_bf16_to_bfp16(ptr noalias %in, ptr noali
 ; CHECK:         .p2align 4
 ; CHECK-NEXT:  // %bb.0: // %entry
 ; CHECK-NEXT:    lda r0, [p2, #0]; nopb ; nops ; nopx ; mov m0, #4; nopv
-; CHECK-NEXT:    padda [p2], m0
+; CHECK-NEXT:    padda [p2], m0; nopx
 ; CHECK-NEXT:    lda dn0, [p2], #4
 ; CHECK-NEXT:    lda m1, [p2], #4
 ; CHECK-NEXT:    nop
@@ -28,31 +28,31 @@ define weak_odr dso_local void @convert_bf16_to_bfp16(ptr noalias %in, ptr noali
 ; CHECK-NEXT:    movs dc1, dj0; vldb.pop.512 x0, [p0, lf0, r24]; mov dn1, dn0
 ; CHECK-NEXT:    vldb.pop.512.2d x2, [p0, lf0, r24, d1]
 ; CHECK-NEXT:    nop
-; CHECK-NEXT:    nop
-; CHECK-NEXT:    lda m0, [p2, #0]
-; CHECK-NEXT:    vldb.fill.512 [p0, lf0, r24]; movxm ls, #.LBB0_1
-; CHECK-NEXT:    vldb.pop.512 x0, [p0, lf0, r24]; movxm le, #.L_LEnd0
-; CHECK-NEXT:    vldb.pop.512.2d x2, [p0, lf0, r24, d1]; add.nc lc, r0, #-2
-; CHECK-NEXT:    nopa ; nopb ; nops ; nopx ; vconv.fp32.bf16 cml0, x0; nopv
-; CHECK-NEXT:    nops ; vconv.fp32.bf16 cmh0, x2
-; CHECK-NEXT:    movs dc0, dj0; mov p2, p1
+; CHECK-NEXT:    vldb.fill.512 [p0, lf0, r24]
+; CHECK-NEXT:    lda m0, [p2, #0]; vldb.pop.512 x0, [p0, lf0, r24]; movxm ls, #.LBB0_1
+; CHECK-NEXT:    vldb.pop.512.2d x2, [p0, lf0, r24, d1]; movxm le, #.L_LEnd0
+; CHECK-NEXT:    add.nc lc, r0, #-3
+; CHECK-NEXT:    nopa ; vldb.fill.512 [p0, lf0, r24]; nops ; nopxm ; nopv
+; CHECK-NEXT:    nopa ; vldb.pop.512 x0, [p0, lf0, r24]; nops ; nopx ; vconv.fp32.bf16 cml0, x0; nopv
+; CHECK-NEXT:    nopa ; vldb.pop.512.2d x2, [p0, lf0, r24, d1]; nops ; nopx ; vconv.fp32.bf16 cmh0, x2; nopv
+; CHECK-NEXT:    nopa ; nopb ; movs dc0, dj0; nopx ; mov p2, p1; nopv
 ; CHECK-NEXT:    // implicit-def: $sf
 ; CHECK-NEXT:    .p2align 4
 ; CHECK-NEXT:  .LBB0_1: // %for.body
 ; CHECK-NEXT:    // =>This Inner Loop Header: Depth=1
 ; CHECK-NEXT:    nopa ; vldb.fill.512 [p0, lf0, r24]; vst.push.576.conv.bfp16ebs8.fp32 dm0, [p2, sf, r26]; nopxm ; nopv
-; CHECK-NEXT:    nopa ; vldb.pop.512 x0, [p0, lf0, r24]; vst.flush.512.conv [p2, sf, r26]; nopxm ; nopv
-; CHECK-NEXT:    nopa ; vldb.pop.512.2d x2, [p0, lf0, r24, d1]; vst.flush.512.conv.2d [p2, sf, r26, d0]; nopxm ; nopv
-; CHECK-NEXT:    nopa ; nopb ; nops ; nopx ; vconv.fp32.bf16 cml0, x0; nopv
-; CHECK-NEXT:    nopa ; nopb ; nops ; nopx ; vconv.fp32.bf16 cmh0, x2; nopv
+; CHECK-NEXT:    nopa ; vldb.pop.512 x0, [p0, lf0, r24]; vst.flush.512.conv [p2, sf, r26]; nopx ; vconv.fp32.bf16 cml0, x0; nopv
+; CHECK-NEXT:    nopa ; vldb.pop.512.2d x2, [p0, lf0, r24, d1]; vst.flush.512.conv.2d [p2, sf, r26, d0]; nopx ; vconv.fp32.bf16 cmh0, x2; nopv
 ; CHECK-NEXT:  .L_LEnd0:
 ; CHECK-NEXT:    nopa ; nopb ; nops ; nopxm ; nopv
 ; CHECK-NEXT:  // %bb.2: // %for.cond.cleanup
+; CHECK-NEXT:    nopa ; nopb ; nopxm ; vst.push.576.conv.bfp16ebs8.fp32 dm0, [p2, sf, r26]
+; CHECK-NEXT:    vst.flush.512.conv [p2, sf, r26]; vconv.fp32.bf16 cml0, x0
+; CHECK-NEXT:    vst.flush.512.conv.2d [p2, sf, r26, d0]; vconv.fp32.bf16 cmh0, x2
+; CHECK-NEXT:    nop
 ; CHECK-NEXT:    vst.push.576.conv.bfp16ebs8.fp32 dm0, [p2, sf, r26]
-; CHECK-NEXT:    vst.flush.512.conv [p2, sf, r26]
-; CHECK-NEXT:    vst.flush.512.conv.2d [p2, sf, r26, d0]
-; CHECK-NEXT:    vconv.fp32.bf16 cml0, x0
-; CHECK-NEXT:    vconv.fp32.bf16 cmh0, x2
+; CHECK-NEXT:    vst.flush.512.conv [p2, sf, r26]; vconv.fp32.bf16 cml0, x0
+; CHECK-NEXT:    vst.flush.512.conv.2d [p2, sf, r26, d0]; vconv.fp32.bf16 cmh0, x2
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    vst.push.576.conv.bfp16ebs8.fp32 dm0, [p2, sf, r26]
 ; CHECK-NEXT:    vst.flush.512.conv [p2, sf, r26]

--- a/llvm/test/CodeGen/AIE/aie2p/end-to-end/conv2d_bfp16_kernel_red.ll
+++ b/llvm/test/CodeGen/AIE/aie2p/end-to-end/conv2d_bfp16_kernel_red.ll
@@ -19,7 +19,7 @@ define dso_local void @conv2d_bfp16.for.body90.i(<32 x i32> %fW.sroa.0.1489.i, i
 ; CHECK-LABEL: conv2d_bfp16.for.body90.i:
 ; CHECK:         .p2align 4
 ; CHECK-NEXT:  // %bb.0: // %newFuncRoot
-; CHECK-NEXT:    nopa ; paddxm [sp], #64
+; CHECK-NEXT:    nopa ; nopb ; nops ; paddxm [sp], #64; nopv
 ; CHECK-NEXT:    st p6, [sp, #-60] // 4-byte Folded Spill
 ; CHECK-NEXT:    mov p6, sp
 ; CHECK-NEXT:    padda [p6], #-320
@@ -49,22 +49,19 @@ define dso_local void @conv2d_bfp16.for.body90.i(<32 x i32> %fW.sroa.0.1489.i, i
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    mov p6, sp
 ; CHECK-NEXT:    padda [p7], m0; movxm m0, #-1112
-; CHECK-NEXT:    lda p7, [p7, #0]; paddb [p6], m0; movxm m0, #-1116
+; CHECK-NEXT:    padda [p6], m0; movxm m0, #-1116
 ; CHECK-NEXT:    lda r7, [p6, #0]; mov p6, sp
 ; CHECK-NEXT:    padda [p6], m0; movxm m0, #-1120
 ; CHECK-NEXT:    lda r3, [p6, #0]; mov p6, sp
 ; CHECK-NEXT:    padda [p6], m0; movxm m0, #-1088
 ; CHECK-NEXT:    lda r2, [p6, #0]; mov p6, sp
 ; CHECK-NEXT:    padda [p6], m0
-; CHECK-NEXT:    vlda bmll0, [p6, #0]
-; CHECK-NEXT:    vlda bmlh0, [p6, #64]
-; CHECK-NEXT:    vlda bmhl0, [p6, #128]
-; CHECK-NEXT:    vlda bmhh0, [p6, #192]; movx r25, #0
-; CHECK-NEXT:    mova dc4, #0; vldb.fill.512 [p1, lf1, r25]; mov dn0, p3
-; CHECK-NEXT:    mova r24, #0; vldb.fill.512 [p1, lf1, r25]; movs dj0, p4; mov dn4, p5
+; CHECK-NEXT:    vlda bmll0, [p6, #0]; movx r25, #0; mov dc4, #0
+; CHECK-NEXT:    vlda bmlh0, [p6, #64]; vldb.fill.512 [p1, lf1, r25]; mov dn0, p3
+; CHECK-NEXT:    vlda bmhl0, [p6, #128]; vldb.fill.512 [p1, lf1, r25]; movx r24, #0; mov dn4, p5; movs dj0, p4
 ; CHECK-NEXT:    vlda.fill.512 [p0, lf0, r24]; vldb.pop.576 ex0, [p1, lf1, r25]; movs dc0, dc4; mov m0, p2
 ; CHECK-NEXT:    vlda.pop.576 ex4, [p0, lf0, r24]; vldb.pop.576.3d ex2, [p1, lf1, r25, d0]
-; CHECK-NEXT:    vldb.fill.512 [p1, lf1, r25]
+; CHECK-NEXT:    vlda bmhh0, [p6, #192]; vldb.fill.512 [p1, lf1, r25]
 ; CHECK-NEXT:    vlda.pop.576 ex6, [p0, lf0, r24, m1]; vldb.fill.512 [p1, lf1, r25]
 ; CHECK-NEXT:    vlda.fill.512 [p0, lf0, r24]; vldb.pop.576 ex0, [p1, lf1, r25]
 ; CHECK-NEXT:    vlda.pop.576 ex4, [p0, lf0, r24]; vldb.pop.576.3d ex2, [p1, lf1, r25, d0]; add r1, r6, #-1
@@ -72,7 +69,7 @@ define dso_local void @conv2d_bfp16.for.body90.i(<32 x i32> %fW.sroa.0.1489.i, i
 ; CHECK-NEXT:    vlda.pop.576 ex6, [p0, lf0, r24, m1]; vldb.fill.512 [p1, lf1, r25]; movxm le, #.L_LEnd0
 ; CHECK-NEXT:    vlda.fill.512 [p0, lf0, r24]; vldb.pop.576 ex0, [p1, lf1, r25]; add.nc lc, r1, #-4
 ; CHECK-NEXT:    vlda.pop.576 ex4, [p0, lf0, r24]; vldb.pop.576.3d ex2, [p1, lf1, r25, d0]; nops ; nopx ; vshuffle ex8, ex0, ex2, r4; nopv
-; CHECK-NEXT:    mova r0, #780; vldb.fill.512 [p1, lf1, r25]; nops ; nopx ; vshuffle ex10, ex0, ex2, r5; nopv
+; CHECK-NEXT:    lda p7, [p7, #0]; vldb.fill.512 [p1, lf1, r25]; nops ; movx r0, #780; vshuffle ex10, ex0, ex2, r5; nopv
 ; CHECK-NEXT:    vlda.pop.576 ex6, [p0, lf0, r24, m1]; vldb.fill.512 [p1, lf1, r25]; nops ; nopxm ; vmac.f dm0, dm0, ex8, ex4, r0
 ; CHECK-NEXT:    vlda.fill.512 [p0, lf0, r24]; vldb.pop.576 ex0, [p1, lf1, r25]; nops ; nopxm ; vmac.f dm1, dm1, ex10, ex4, r0
 ; CHECK-NEXT:    vlda.pop.576 ex4, [p0, lf0, r24]; vldb.pop.576.3d ex2, [p1, lf1, r25, d0]; nops ; nopx ; vshuffle ex8, ex0, ex2, r4; vmac.f dm2, dm2, ex8, ex6, r0
@@ -85,7 +82,7 @@ define dso_local void @conv2d_bfp16.for.body90.i(<32 x i32> %fW.sroa.0.1489.i, i
 ; CHECK-NEXT:  .L_LEnd0:
 ; CHECK-NEXT:    vlda.pop.576 ex4, [p0, lf0, r24]; vldb.pop.576.3d ex2, [p1, lf1, r25, d0]; nops ; nopx ; vshuffle ex8, ex0, ex2, r4; vmac.f dm2, dm2, ex8, ex6, r0
 ; CHECK-NEXT:  // %bb.2: // %for.cond.cleanup89.i.exitStub
-; CHECK-NEXT:    lda p6, [sp, #-60]; nopb ; nopx ; vshuffle ex10, ex0, ex2, r5; vmac.f dm3, dm3, ex10, ex6, r0 // 4-byte Folded Reload
+; CHECK-NEXT:    lda p6, [sp, #-60]; nopb ; nops ; nopx ; vshuffle ex10, ex0, ex2, r5; vmac.f dm3, dm3, ex10, ex6, r0 // 4-byte Folded Reload
 ; CHECK-NEXT:    vlda.pop.576 ex6, [p0, lf0, r24, m1]; vmac.f dm0, dm0, ex8, ex4, r0
 ; CHECK-NEXT:    mov p0, r7; vmac.f dm1, dm1, ex10, ex4, r0
 ; CHECK-NEXT:    vshuffle ex8, ex0, ex2, r4; vmac.f dm2, dm2, ex8, ex6, r0
@@ -104,7 +101,6 @@ define dso_local void @conv2d_bfp16.for.body90.i(<32 x i32> %fW.sroa.0.1489.i, i
 ; CHECK-NEXT:    vst bmlh0, [p7, #64]
 ; CHECK-NEXT:    vst bmhl0, [p7, #128]
 ; CHECK-NEXT:    vst bmhh0, [p7, #192]
-; CHECK-NEXT:    lda p7, [sp, #-64] // 4-byte Folded Reload
 ; CHECK-NEXT:    vst bmll1, [p0, #0]
 ; CHECK-NEXT:    vst bmlh1, [p0, #64]
 ; CHECK-NEXT:    vst bmhl1, [p0, #128]
@@ -112,7 +108,7 @@ define dso_local void @conv2d_bfp16.for.body90.i(<32 x i32> %fW.sroa.0.1489.i, i
 ; CHECK-NEXT:    vst bmll2, [p0, #0]
 ; CHECK-NEXT:    vst bmlh2, [p0, #64]
 ; CHECK-NEXT:    vst bmhl2, [p0, #128]
-; CHECK-NEXT:    vst bmhh2, [p0, #192]
+; CHECK-NEXT:    lda p7, [sp, #-64]; vst bmhh2, [p0, #192] // 4-byte Folded Reload
 ; CHECK-NEXT:    movs p0, r2; ret lr
 ; CHECK-NEXT:    vst bmll3, [p0, #0] // Delay Slot 5
 ; CHECK-NEXT:    vst bmlh3, [p0, #64] // Delay Slot 4


### PR DESCRIPTION
This enables scheduling loads in A and B together if either of them doesn't have a memory bank annotation.

We use the fact that the hardware serializes the memory accesses when a bank conflict arises, and buffer allocation does its best to avoid conflicts. Thus we always generate correct code, and have a statistical advantage.

Impact on many end-to-end and unit tests is rather big in actual diff volume, which is the natural result of cascading local scheduling diffs. I couldn't find any serious problems.

For QoR justification I refer to a comparison run that was posted in the aie-scc-qor-team slack channel last April 10.