### PR TITLE
[AIEX][NFC] refactor Load/Store Imm check

### DIFF
--- a/llvm/lib/Target/AIE/AIE2InstrInfo.cpp
+++ b/llvm/lib/Target/AIE/AIE2InstrInfo.cpp
@@ -1434,6 +1434,75 @@ AIE2InstrInfo::getZOLSupport() const {
   return Result;
 }
 
+bool AIE2InstrInfo::isOffsetInImmediateRange(
+    unsigned Opcode, unsigned LoadStoreSize,
+    std::optional<APInt> Offset) const {
+  if (!Offset)
+    return false;
+
+  switch (Opcode) {
+  case AIE2::G_AIE_OFFSET_LOAD:
+  case AIE2::G_AIE_OFFSET_STORE: {
+    switch (LoadStoreSize) {
+    case 8:
+    case 16:
+      return checkSignedImmediateRange<3, 1>(Offset);
+    case 20:
+    case 32:
+      return checkSignedImmediateRange<6, 4>(Offset);
+    case 128:
+      return checkSignedImmediateRange<6, 16>(Offset);
+    case 256:
+      return checkSignedImmediateRange<6, 32>(Offset);
+    case 512:
+      return checkSignedImmediateRangeSplitting<6, 32, 32>(Offset);
+    default:
+      return false;
+    }
+  }
+  case AIE2::G_AIE_POSTINC_LOAD:
+  case AIE2::G_AIE_POSTINC_STORE: {
+    switch (LoadStoreSize) {
+    case 8:
+    case 16:
+      return checkSignedImmediateRange<4, 1>(Offset);
+    case 20:
+    case 32:
+      return checkSignedImmediateRange<7, 4>(Offset);
+    case 128:
+      return checkSignedImmediateRange<7, 16>(Offset);
+    case 256:
+    case 512:
+      return checkSignedImmediateRange<7, 32>(Offset);
+    default:
+      return false;
+    }
+  }
+  case AIE2::G_AIE_OFFSET_ZEXTLOAD:
+  case AIE2::G_AIE_OFFSET_SEXTLOAD: {
+    switch (LoadStoreSize) {
+    case 8:
+    case 16:
+      return checkSignedImmediateRange<3, 1>(Offset);
+    default:
+      return false;
+    }
+  }
+  case AIE2::G_AIE_POSTINC_SEXTLOAD:
+  case AIE2::G_AIE_POSTINC_ZEXTLOAD: {
+    switch (LoadStoreSize) {
+    case 8:
+    case 16:
+      return checkSignedImmediateRange<4, 1>(Offset);
+    default:
+      return false;
+    }
+  }
+  default:
+    return false;
+  }
+}
+
 unsigned AIE2InstrInfo::getPseudoJNZDOpcode() const { return AIE2::PseudoJNZD; }
 
 unsigned AIE2InstrInfo::getNumBypassedCycles(const InstrItineraryData *ItinData,

--- a/llvm/lib/Target/AIE/AIE2InstrInfo.h
+++ b/llvm/lib/Target/AIE/AIE2InstrInfo.h
@@ -105,6 +105,10 @@ public:
 
   virtual std::optional<ZOLSupport> getZOLSupport() const override;
 
+  virtual bool
+  isOffsetInImmediateRange(unsigned Opcode, unsigned LoadStoreSize,
+                           std::optional<APInt> Immediate) const override;
+
   virtual unsigned getPseudoJNZDOpcode() const override;
 
   unsigned getNumBypassedCycles(const InstrItineraryData *ItinData,

--- a/llvm/lib/Target/AIE/AIE2InstructionSelector.cpp
+++ b/llvm/lib/Target/AIE/AIE2InstructionSelector.cpp
@@ -1050,14 +1050,14 @@ AIE2InstructionSelector::getCombinedOpcodeSRSUPS(const MachineInstr &MemOp,
         switch (cast<GIntrinsic>(CombOp).getIntrinsicID()) {
         case Intrinsic::aie2_I512_v32_acc32_srs:
           FitsImmediateRange =
-              checkImmediateRangeSplitting<3, 32, 32>(Immediate);
+              checkSignedImmediateRangeSplitting<3, 32, 32>(Immediate);
           return LoadStoreOpcodes{
               /*ISelOpcode=*/AIE2::VST_SRS_S16_S32_ag_idx_imm,
               FitsImmediateRange,
               /*OffsetOpcode=*/AIE2::VST_SRS_S16_S32_ag_idx_imm};
         case Intrinsic::aie2_I512_v16_acc64_srs:
           FitsImmediateRange =
-              checkImmediateRangeSplitting<3, 32, 32>(Immediate);
+              checkSignedImmediateRangeSplitting<3, 32, 32>(Immediate);
           return LoadStoreOpcodes{
               /*ISelOpcode=*/AIE2::VST_SRS_S32_S64_ag_idx_imm,
               FitsImmediateRange,
@@ -1067,25 +1067,25 @@ AIE2InstructionSelector::getCombinedOpcodeSRSUPS(const MachineInstr &MemOp,
       if (getLoadStoreSize(MemOp) == 256) {
         switch (cast<GIntrinsic>(CombOp).getIntrinsicID()) {
         case Intrinsic::aie2_I256_v16_acc32_srs:
-          FitsImmediateRange = checkImmediateRange<3, 32>(Immediate);
+          FitsImmediateRange = checkSignedImmediateRange<3, 32>(Immediate);
           ISelOpcode = FitsImmediateRange ? AIE2::VST_SRS_S16_S32_ag_idx_imm
                                           : AIE2::VST_SRS_S16_S32_ag_idx;
           return LoadStoreOpcodes{ISelOpcode, FitsImmediateRange,
                                   /*OffsetOpcode=*/{}};
         case Intrinsic::aie2_I256_v16_acc64_srs:
-          FitsImmediateRange = checkImmediateRange<3, 32>(Immediate);
+          FitsImmediateRange = checkSignedImmediateRange<3, 32>(Immediate);
           ISelOpcode = FitsImmediateRange ? AIE2::VST_SRS_S16_S64_ag_idx_imm
                                           : AIE2::VST_SRS_S16_S64_ag_idx;
           return LoadStoreOpcodes{ISelOpcode, FitsImmediateRange,
                                   /*OffsetOpcode=*/{}};
         case Intrinsic::aie2_I256_v32_acc32_srs:
-          FitsImmediateRange = checkImmediateRange<3, 32>(Immediate);
+          FitsImmediateRange = checkSignedImmediateRange<3, 32>(Immediate);
           ISelOpcode = FitsImmediateRange ? AIE2::VST_SRS_S8_S32_ag_idx_imm
                                           : AIE2::VST_SRS_S8_S32_ag_idx;
           return LoadStoreOpcodes{ISelOpcode, FitsImmediateRange,
                                   /*OffsetOpcode=*/{}};
         case Intrinsic::aie2_I256_v8_acc64_srs:
-          FitsImmediateRange = checkImmediateRange<3, 32>(Immediate);
+          FitsImmediateRange = checkSignedImmediateRange<3, 32>(Immediate);
           ISelOpcode = FitsImmediateRange ? AIE2::VST_SRS_S32_S64_ag_idx_imm
                                           : AIE2::VST_SRS_S32_S64_ag_idx;
           return LoadStoreOpcodes{ISelOpcode, FitsImmediateRange,
@@ -1097,7 +1097,7 @@ AIE2InstructionSelector::getCombinedOpcodeSRSUPS(const MachineInstr &MemOp,
       if (getLoadStoreSize(MemOp) == 512) {
         switch (cast<GIntrinsic>(CombOp).getIntrinsicID()) {
         case Intrinsic::aie2_I512_v32_acc32_srs:
-          FitsImmediateRange = checkImmediateRange<4, 32>(Immediate);
+          FitsImmediateRange = checkSignedImmediateRange<4, 32>(Immediate);
           ISelOpcode = FitsImmediateRange
                            ? AIE2::VST_SRS_S16_S32_ag_pstm_nrm_imm
                            : AIE2::VST_SRS_S16_S32_ag_pstm_nrm;
@@ -1105,7 +1105,7 @@ AIE2InstructionSelector::getCombinedOpcodeSRSUPS(const MachineInstr &MemOp,
               ISelOpcode, FitsImmediateRange,
               /*OffsetOpcode=*/AIE2::VST_SRS_S16_S32_ag_idx_imm};
         case Intrinsic::aie2_I512_v16_acc64_srs:
-          FitsImmediateRange = checkImmediateRange<4, 32>(Immediate);
+          FitsImmediateRange = checkSignedImmediateRange<4, 32>(Immediate);
           ISelOpcode = FitsImmediateRange
                            ? AIE2::VST_SRS_S32_S64_ag_pstm_nrm_imm
                            : AIE2::VST_SRS_S32_S64_ag_pstm_nrm;
@@ -1117,27 +1117,27 @@ AIE2InstructionSelector::getCombinedOpcodeSRSUPS(const MachineInstr &MemOp,
       if (getLoadStoreSize(MemOp) == 256) {
         switch (cast<GIntrinsic>(CombOp).getIntrinsicID()) {
         case Intrinsic::aie2_I256_v16_acc32_srs:
-          FitsImmediateRange = checkImmediateRange<4, 32>(Immediate);
+          FitsImmediateRange = checkSignedImmediateRange<4, 32>(Immediate);
           ISelOpcode = FitsImmediateRange
                            ? AIE2::VST_SRS_S16_S32_ag_pstm_nrm_imm
                            : AIE2::VST_SRS_S16_S32_ag_pstm_nrm;
           return LoadStoreOpcodes{ISelOpcode, FitsImmediateRange,
                                   /*OffsetOpcode=*/{}};
         case Intrinsic::aie2_I256_v16_acc64_srs:
-          FitsImmediateRange = checkImmediateRange<4, 32>(Immediate);
+          FitsImmediateRange = checkSignedImmediateRange<4, 32>(Immediate);
           ISelOpcode = FitsImmediateRange
                            ? AIE2::VST_SRS_S16_S64_ag_pstm_nrm_imm
                            : AIE2::VST_SRS_S16_S64_ag_pstm_nrm;
           return LoadStoreOpcodes{ISelOpcode, FitsImmediateRange,
                                   /*OffsetOpcode=*/{}};
         case Intrinsic::aie2_I256_v32_acc32_srs:
-          FitsImmediateRange = checkImmediateRange<4, 32>(Immediate);
+          FitsImmediateRange = checkSignedImmediateRange<4, 32>(Immediate);
           ISelOpcode = FitsImmediateRange ? AIE2::VST_SRS_S8_S32_ag_pstm_nrm_imm
                                           : AIE2::VST_SRS_S8_S32_ag_pstm_nrm;
           return LoadStoreOpcodes{ISelOpcode, FitsImmediateRange,
                                   /*OffsetOpcode=*/{}};
         case Intrinsic::aie2_I256_v8_acc64_srs:
-          FitsImmediateRange = checkImmediateRange<4, 32>(Immediate);
+          FitsImmediateRange = checkSignedImmediateRange<4, 32>(Immediate);
           ISelOpcode = FitsImmediateRange
                            ? AIE2::VST_SRS_S32_S64_ag_pstm_nrm_imm
                            : AIE2::VST_SRS_S32_S64_ag_pstm_nrm;
@@ -1255,14 +1255,14 @@ AIE2InstructionSelector::getCombinedOpcodeSRSUPS(const MachineInstr &MemOp,
         switch (cast<GIntrinsic>(CombOp).getIntrinsicID()) {
         case Intrinsic::aie2_acc64_v16_I512_ups:
           FitsImmediateRange =
-              checkImmediateRangeSplitting<3, 32, 32>(Immediate);
+              checkSignedImmediateRangeSplitting<3, 32, 32>(Immediate);
           return LoadStoreOpcodes{
               /*ISelOpcode=*/AIE2::VLDA_UPS_S64_S32_ag_idx_imm,
               FitsImmediateRange,
               /*OffsetOpcode=*/AIE2::VLDA_UPS_S64_S32_ag_idx_imm};
         case Intrinsic::aie2_acc32_v32_I512_ups:
           FitsImmediateRange =
-              checkImmediateRangeSplitting<3, 32, 32>(Immediate);
+              checkSignedImmediateRangeSplitting<3, 32, 32>(Immediate);
           return LoadStoreOpcodes{
               /*ISelOpcode=*/AIE2::VLDA_UPS_S32_S16_ag_idx_imm,
               FitsImmediateRange,
@@ -1272,25 +1272,25 @@ AIE2InstructionSelector::getCombinedOpcodeSRSUPS(const MachineInstr &MemOp,
       if (getLoadStoreSize(MemOp) == 256) {
         switch (cast<GIntrinsic>(CombOp).getIntrinsicID()) {
         case Intrinsic::aie2_acc32_v16_I256_ups:
-          FitsImmediateRange = checkImmediateRange<3, 32>(Immediate);
+          FitsImmediateRange = checkSignedImmediateRange<3, 32>(Immediate);
           ISelOpcode = FitsImmediateRange ? AIE2::VLDA_UPS_S32_S16_ag_idx_imm
                                           : AIE2::VLDA_UPS_S32_S16_ag_idx;
           return LoadStoreOpcodes{ISelOpcode, FitsImmediateRange,
                                   /*OffsetOpcode=*/{}};
         case Intrinsic::aie2_acc64_v16_I256_ups:
-          FitsImmediateRange = checkImmediateRange<3, 32>(Immediate);
+          FitsImmediateRange = checkSignedImmediateRange<3, 32>(Immediate);
           ISelOpcode = FitsImmediateRange ? AIE2::VLDA_UPS_S64_S16_ag_idx_imm
                                           : AIE2::VLDA_UPS_S64_S16_ag_idx;
           return LoadStoreOpcodes{ISelOpcode, FitsImmediateRange,
                                   /*OffsetOpcode=*/{}};
         case Intrinsic::aie2_acc32_v32_I256_ups:
-          FitsImmediateRange = checkImmediateRange<3, 32>(Immediate);
+          FitsImmediateRange = checkSignedImmediateRange<3, 32>(Immediate);
           ISelOpcode = FitsImmediateRange ? AIE2::VLDA_UPS_S32_S8_ag_idx_imm
                                           : AIE2::VLDA_UPS_S32_S8_ag_idx;
           return LoadStoreOpcodes{ISelOpcode, FitsImmediateRange,
                                   /*OffsetOpcode=*/{}};
         case Intrinsic::aie2_acc64_v8_I256_ups:
-          FitsImmediateRange = checkImmediateRange<3, 32>(Immediate);
+          FitsImmediateRange = checkSignedImmediateRange<3, 32>(Immediate);
           ISelOpcode = FitsImmediateRange ? AIE2::VLDA_UPS_S64_S32_ag_idx_imm
                                           : AIE2::VLDA_UPS_S64_S32_ag_idx;
           return LoadStoreOpcodes{ISelOpcode, FitsImmediateRange,
@@ -1302,7 +1302,7 @@ AIE2InstructionSelector::getCombinedOpcodeSRSUPS(const MachineInstr &MemOp,
       if (getLoadStoreSize(MemOp) == 512) {
         switch (cast<GIntrinsic>(CombOp).getIntrinsicID()) {
         case Intrinsic::aie2_acc64_v16_I512_ups:
-          FitsImmediateRange = checkImmediateRange<4, 32>(Immediate);
+          FitsImmediateRange = checkSignedImmediateRange<4, 32>(Immediate);
           ISelOpcode = FitsImmediateRange
                            ? AIE2::VLDA_UPS_S64_S32_ag_pstm_nrm_imm
                            : AIE2::VLDA_UPS_S64_S32_ag_pstm_nrm;
@@ -1310,7 +1310,7 @@ AIE2InstructionSelector::getCombinedOpcodeSRSUPS(const MachineInstr &MemOp,
               ISelOpcode, FitsImmediateRange,
               /*OffsetOpcode=*/AIE2::VLDA_UPS_S64_S32_ag_idx_imm};
         case Intrinsic::aie2_acc32_v32_I512_ups:
-          FitsImmediateRange = checkImmediateRange<4, 32>(Immediate);
+          FitsImmediateRange = checkSignedImmediateRange<4, 32>(Immediate);
           ISelOpcode = FitsImmediateRange
                            ? AIE2::VLDA_UPS_S32_S16_ag_pstm_nrm_imm
                            : AIE2::VLDA_UPS_S32_S16_ag_pstm_nrm;
@@ -1322,28 +1322,28 @@ AIE2InstructionSelector::getCombinedOpcodeSRSUPS(const MachineInstr &MemOp,
       if (getLoadStoreSize(MemOp) == 256) {
         switch (cast<GIntrinsic>(CombOp).getIntrinsicID()) {
         case Intrinsic::aie2_acc32_v16_I256_ups:
-          FitsImmediateRange = checkImmediateRange<4, 32>(Immediate);
+          FitsImmediateRange = checkSignedImmediateRange<4, 32>(Immediate);
           ISelOpcode = FitsImmediateRange
                            ? AIE2::VLDA_UPS_S32_S16_ag_pstm_nrm_imm
                            : AIE2::VLDA_UPS_S32_S16_ag_pstm_nrm;
           return LoadStoreOpcodes{ISelOpcode, FitsImmediateRange,
                                   /*OffsetOpcode=*/{}};
         case Intrinsic::aie2_acc64_v16_I256_ups:
-          FitsImmediateRange = checkImmediateRange<4, 32>(Immediate);
+          FitsImmediateRange = checkSignedImmediateRange<4, 32>(Immediate);
           ISelOpcode = FitsImmediateRange
                            ? AIE2::VLDA_UPS_S64_S16_ag_pstm_nrm_imm
                            : AIE2::VLDA_UPS_S64_S16_ag_pstm_nrm;
           return LoadStoreOpcodes{ISelOpcode, FitsImmediateRange,
                                   /*OffsetOpcode=*/{}};
         case Intrinsic::aie2_acc32_v32_I256_ups:
-          FitsImmediateRange = checkImmediateRange<4, 32>(Immediate);
+          FitsImmediateRange = checkSignedImmediateRange<4, 32>(Immediate);
           ISelOpcode = FitsImmediateRange
                            ? AIE2::VLDA_UPS_S32_S8_ag_pstm_nrm_imm
                            : AIE2::VLDA_UPS_S32_S8_ag_pstm_nrm;
           return LoadStoreOpcodes{ISelOpcode, FitsImmediateRange,
                                   /*OffsetOpcode=*/{}};
         case Intrinsic::aie2_acc64_v8_I256_ups:
-          FitsImmediateRange = checkImmediateRange<4, 32>(Immediate);
+          FitsImmediateRange = checkSignedImmediateRange<4, 32>(Immediate);
           ISelOpcode = FitsImmediateRange
                            ? AIE2::VLDA_UPS_S64_S32_ag_pstm_nrm_imm
                            : AIE2::VLDA_UPS_S64_S32_ag_pstm_nrm;
@@ -1465,14 +1465,14 @@ AIE2InstructionSelector::getCombinedOpcodeSRSUPS(const MachineInstr &MemOp,
         switch (cast<GIntrinsic>(CombOp).getIntrinsicID()) {
         case Intrinsic::aie2_I512_v32_acc32_srs:
           FitsImmediateRange =
-              checkImmediateRangeSplitting<3, 32, 32>(Immediate);
+              checkSignedImmediateRangeSplitting<3, 32, 32>(Immediate);
           return LoadStoreOpcodes{
               /*ISelOpcode=*/AIE2::VST_SRS_D16_S32_ag_idx_imm,
               FitsImmediateRange,
               /*OffsetOpcode=*/AIE2::VST_SRS_D16_S32_ag_idx_imm};
         case Intrinsic::aie2_I512_v16_acc64_srs:
           FitsImmediateRange =
-              checkImmediateRangeSplitting<3, 32, 32>(Immediate);
+              checkSignedImmediateRangeSplitting<3, 32, 32>(Immediate);
           return LoadStoreOpcodes{
               /*ISelOpcode=*/AIE2::VST_SRS_D32_S64_ag_idx_imm,
               FitsImmediateRange,
@@ -1482,25 +1482,25 @@ AIE2InstructionSelector::getCombinedOpcodeSRSUPS(const MachineInstr &MemOp,
       if (getLoadStoreSize(MemOp) == 256) {
         switch (cast<GIntrinsic>(CombOp).getIntrinsicID()) {
         case Intrinsic::aie2_I256_v16_acc32_srs:
-          FitsImmediateRange = checkImmediateRange<3, 32>(Immediate);
+          FitsImmediateRange = checkSignedImmediateRange<3, 32>(Immediate);
           ISelOpcode = FitsImmediateRange ? AIE2::VST_SRS_D16_S32_ag_idx_imm
                                           : AIE2::VST_SRS_D16_S32_ag_idx;
           return LoadStoreOpcodes{ISelOpcode, FitsImmediateRange,
                                   /*OffsetOpcode=*/{}};
         case Intrinsic::aie2_I256_v16_acc64_srs:
-          FitsImmediateRange = checkImmediateRange<3, 32>(Immediate);
+          FitsImmediateRange = checkSignedImmediateRange<3, 32>(Immediate);
           ISelOpcode = FitsImmediateRange ? AIE2::VST_SRS_D16_S64_ag_idx_imm
                                           : AIE2::VST_SRS_D16_S64_ag_idx;
           return LoadStoreOpcodes{ISelOpcode, FitsImmediateRange,
                                   /*OffsetOpcode=*/{}};
         case Intrinsic::aie2_I256_v32_acc32_srs:
-          FitsImmediateRange = checkImmediateRange<3, 32>(Immediate);
+          FitsImmediateRange = checkSignedImmediateRange<3, 32>(Immediate);
           ISelOpcode = FitsImmediateRange ? AIE2::VST_SRS_D8_S32_ag_idx_imm
                                           : AIE2::VST_SRS_D8_S32_ag_idx;
           return LoadStoreOpcodes{ISelOpcode, FitsImmediateRange,
                                   /*OffsetOpcode=*/{}};
         case Intrinsic::aie2_I256_v8_acc64_srs:
-          FitsImmediateRange = checkImmediateRange<3, 32>(Immediate);
+          FitsImmediateRange = checkSignedImmediateRange<3, 32>(Immediate);
           ISelOpcode = FitsImmediateRange ? AIE2::VST_SRS_D32_S64_ag_idx_imm
                                           : AIE2::VST_SRS_D32_S64_ag_idx;
           return LoadStoreOpcodes{ISelOpcode, FitsImmediateRange,
@@ -1512,7 +1512,7 @@ AIE2InstructionSelector::getCombinedOpcodeSRSUPS(const MachineInstr &MemOp,
       if (getLoadStoreSize(MemOp) == 512) {
         switch (cast<GIntrinsic>(CombOp).getIntrinsicID()) {
         case Intrinsic::aie2_I512_v32_acc32_srs:
-          FitsImmediateRange = checkImmediateRange<4, 32>(Immediate);
+          FitsImmediateRange = checkSignedImmediateRange<4, 32>(Immediate);
           ISelOpcode = FitsImmediateRange
                            ? AIE2::VST_SRS_D16_S32_ag_pstm_nrm_imm
                            : AIE2::VST_SRS_D16_S32_ag_pstm_nrm;
@@ -1520,7 +1520,7 @@ AIE2InstructionSelector::getCombinedOpcodeSRSUPS(const MachineInstr &MemOp,
               ISelOpcode, FitsImmediateRange,
               /*OffsetOpcode=*/AIE2::VST_SRS_D16_S32_ag_idx_imm};
         case Intrinsic::aie2_I512_v16_acc64_srs:
-          FitsImmediateRange = checkImmediateRange<4, 32>(Immediate);
+          FitsImmediateRange = checkSignedImmediateRange<4, 32>(Immediate);
           ISelOpcode = FitsImmediateRange
                            ? AIE2::VST_SRS_D32_S64_ag_pstm_nrm_imm
                            : AIE2::VST_SRS_D32_S64_ag_pstm_nrm;
@@ -1532,27 +1532,27 @@ AIE2InstructionSelector::getCombinedOpcodeSRSUPS(const MachineInstr &MemOp,
       if (getLoadStoreSize(MemOp) == 256) {
         switch (cast<GIntrinsic>(CombOp).getIntrinsicID()) {
         case Intrinsic::aie2_I256_v16_acc32_srs:
-          FitsImmediateRange = checkImmediateRange<4, 32>(Immediate);
+          FitsImmediateRange = checkSignedImmediateRange<4, 32>(Immediate);
           ISelOpcode = FitsImmediateRange
                            ? AIE2::VST_SRS_D16_S32_ag_pstm_nrm_imm
                            : AIE2::VST_SRS_D16_S32_ag_pstm_nrm;
           return LoadStoreOpcodes{ISelOpcode, FitsImmediateRange,
                                   /*OffsetOpcode=*/{}};
         case Intrinsic::aie2_I256_v16_acc64_srs:
-          FitsImmediateRange = checkImmediateRange<4, 32>(Immediate);
+          FitsImmediateRange = checkSignedImmediateRange<4, 32>(Immediate);
           ISelOpcode = FitsImmediateRange
                            ? AIE2::VST_SRS_D16_S64_ag_pstm_nrm_imm
                            : AIE2::VST_SRS_D16_S64_ag_pstm_nrm;
           return LoadStoreOpcodes{ISelOpcode, FitsImmediateRange,
                                   /*OffsetOpcode=*/{}};
         case Intrinsic::aie2_I256_v32_acc32_srs:
-          FitsImmediateRange = checkImmediateRange<4, 32>(Immediate);
+          FitsImmediateRange = checkSignedImmediateRange<4, 32>(Immediate);
           ISelOpcode = FitsImmediateRange ? AIE2::VST_SRS_D8_S32_ag_pstm_nrm_imm
                                           : AIE2::VST_SRS_D8_S32_ag_pstm_nrm;
           return LoadStoreOpcodes{ISelOpcode, FitsImmediateRange,
                                   /*OffsetOpcode=*/{}};
         case Intrinsic::aie2_I256_v8_acc64_srs:
-          FitsImmediateRange = checkImmediateRange<4, 32>(Immediate);
+          FitsImmediateRange = checkSignedImmediateRange<4, 32>(Immediate);
           ISelOpcode = FitsImmediateRange
                            ? AIE2::VST_SRS_D32_S64_ag_pstm_nrm_imm
                            : AIE2::VST_SRS_D32_S64_ag_pstm_nrm;
@@ -1670,14 +1670,14 @@ AIE2InstructionSelector::getCombinedOpcodeSRSUPS(const MachineInstr &MemOp,
         switch (cast<GIntrinsic>(CombOp).getIntrinsicID()) {
         case Intrinsic::aie2_acc64_v16_I512_ups:
           FitsImmediateRange =
-              checkImmediateRangeSplitting<3, 32, 32>(Immediate);
+              checkSignedImmediateRangeSplitting<3, 32, 32>(Immediate);
           return LoadStoreOpcodes{
               /*ISelOpcode=*/AIE2::VLDA_UPS_S64_D32_ag_idx_imm,
               FitsImmediateRange,
               /*OffsetOpcode=*/AIE2::VLDA_UPS_S64_D32_ag_idx_imm};
         case Intrinsic::aie2_acc32_v32_I512_ups:
           FitsImmediateRange =
-              checkImmediateRangeSplitting<3, 32, 32>(Immediate);
+              checkSignedImmediateRangeSplitting<3, 32, 32>(Immediate);
           return LoadStoreOpcodes{
               /*ISelOpcode=*/AIE2::VLDA_UPS_S32_D16_ag_idx_imm,
               FitsImmediateRange,
@@ -1687,25 +1687,25 @@ AIE2InstructionSelector::getCombinedOpcodeSRSUPS(const MachineInstr &MemOp,
       if (getLoadStoreSize(MemOp) == 256) {
         switch (cast<GIntrinsic>(CombOp).getIntrinsicID()) {
         case Intrinsic::aie2_acc32_v16_I256_ups:
-          FitsImmediateRange = checkImmediateRange<3, 32>(Immediate);
+          FitsImmediateRange = checkSignedImmediateRange<3, 32>(Immediate);
           ISelOpcode = FitsImmediateRange ? AIE2::VLDA_UPS_S32_D16_ag_idx_imm
                                           : AIE2::VLDA_UPS_S32_D16_ag_idx;
           return LoadStoreOpcodes{ISelOpcode, FitsImmediateRange,
                                   /*OffsetOpcode=*/{}};
         case Intrinsic::aie2_acc64_v16_I256_ups:
-          FitsImmediateRange = checkImmediateRange<3, 32>(Immediate);
+          FitsImmediateRange = checkSignedImmediateRange<3, 32>(Immediate);
           ISelOpcode = FitsImmediateRange ? AIE2::VLDA_UPS_S64_D16_ag_idx_imm
                                           : AIE2::VLDA_UPS_S64_D16_ag_idx;
           return LoadStoreOpcodes{ISelOpcode, FitsImmediateRange,
                                   /*OffsetOpcode=*/{}};
         case Intrinsic::aie2_acc32_v32_I256_ups:
-          FitsImmediateRange = checkImmediateRange<3, 32>(Immediate);
+          FitsImmediateRange = checkSignedImmediateRange<3, 32>(Immediate);
           ISelOpcode = FitsImmediateRange ? AIE2::VLDA_UPS_S32_D8_ag_idx_imm
                                           : AIE2::VLDA_UPS_S32_D8_ag_idx;
           return LoadStoreOpcodes{ISelOpcode, FitsImmediateRange,
                                   /*OffsetOpcode=*/{}};
         case Intrinsic::aie2_acc64_v8_I256_ups:
-          FitsImmediateRange = checkImmediateRange<3, 32>(Immediate);
+          FitsImmediateRange = checkSignedImmediateRange<3, 32>(Immediate);
           ISelOpcode = FitsImmediateRange ? AIE2::VLDA_UPS_S64_D32_ag_idx_imm
                                           : AIE2::VLDA_UPS_S64_D32_ag_idx;
           return LoadStoreOpcodes{ISelOpcode, FitsImmediateRange,
@@ -1717,7 +1717,7 @@ AIE2InstructionSelector::getCombinedOpcodeSRSUPS(const MachineInstr &MemOp,
       if (getLoadStoreSize(MemOp) == 512) {
         switch (cast<GIntrinsic>(CombOp).getIntrinsicID()) {
         case Intrinsic::aie2_acc64_v16_I512_ups:
-          FitsImmediateRange = checkImmediateRange<4, 32>(Immediate);
+          FitsImmediateRange = checkSignedImmediateRange<4, 32>(Immediate);
           ISelOpcode = FitsImmediateRange
                            ? AIE2::VLDA_UPS_S64_D32_ag_pstm_nrm_imm
                            : AIE2::VLDA_UPS_S64_D32_ag_pstm_nrm;
@@ -1725,7 +1725,7 @@ AIE2InstructionSelector::getCombinedOpcodeSRSUPS(const MachineInstr &MemOp,
               ISelOpcode, FitsImmediateRange,
               /*OffsetOpcode=*/AIE2::VLDA_UPS_S64_D32_ag_idx_imm};
         case Intrinsic::aie2_acc32_v32_I512_ups:
-          FitsImmediateRange = checkImmediateRange<4, 32>(Immediate);
+          FitsImmediateRange = checkSignedImmediateRange<4, 32>(Immediate);
           ISelOpcode = FitsImmediateRange
                            ? AIE2::VLDA_UPS_S32_D16_ag_pstm_nrm_imm
                            : AIE2::VLDA_UPS_S32_D16_ag_pstm_nrm;
@@ -1737,28 +1737,28 @@ AIE2InstructionSelector::getCombinedOpcodeSRSUPS(const MachineInstr &MemOp,
       if (getLoadStoreSize(MemOp) == 256) {
         switch (cast<GIntrinsic>(CombOp).getIntrinsicID()) {
         case Intrinsic::aie2_acc32_v16_I256_ups:
-          FitsImmediateRange = checkImmediateRange<4, 32>(Immediate);
+          FitsImmediateRange = checkSignedImmediateRange<4, 32>(Immediate);
           ISelOpcode = FitsImmediateRange
                            ? AIE2::VLDA_UPS_S32_D16_ag_pstm_nrm_imm
                            : AIE2::VLDA_UPS_S32_D16_ag_pstm_nrm;
           return LoadStoreOpcodes{ISelOpcode, FitsImmediateRange,
                                   /*OffsetOpcode=*/{}};
         case Intrinsic::aie2_acc64_v16_I256_ups:
-          FitsImmediateRange = checkImmediateRange<4, 32>(Immediate);
+          FitsImmediateRange = checkSignedImmediateRange<4, 32>(Immediate);
           ISelOpcode = FitsImmediateRange
                            ? AIE2::VLDA_UPS_S64_D16_ag_pstm_nrm_imm
                            : AIE2::VLDA_UPS_S64_D16_ag_pstm_nrm;
           return LoadStoreOpcodes{ISelOpcode, FitsImmediateRange,
                                   /*OffsetOpcode=*/{}};
         case Intrinsic::aie2_acc32_v32_I256_ups:
-          FitsImmediateRange = checkImmediateRange<4, 32>(Immediate);
+          FitsImmediateRange = checkSignedImmediateRange<4, 32>(Immediate);
           ISelOpcode = FitsImmediateRange
                            ? AIE2::VLDA_UPS_S32_D8_ag_pstm_nrm_imm
                            : AIE2::VLDA_UPS_S32_D8_ag_pstm_nrm;
           return LoadStoreOpcodes{ISelOpcode, FitsImmediateRange,
                                   /*OffsetOpcode=*/{}};
         case Intrinsic::aie2_acc64_v8_I256_ups:
-          FitsImmediateRange = checkImmediateRange<4, 32>(Immediate);
+          FitsImmediateRange = checkSignedImmediateRange<4, 32>(Immediate);
           ISelOpcode = FitsImmediateRange
                            ? AIE2::VLDA_UPS_S64_D32_ag_pstm_nrm_imm
                            : AIE2::VLDA_UPS_S64_D32_ag_pstm_nrm;
@@ -2402,7 +2402,8 @@ LoadStoreOpcodes AIE2InstructionSelector::getLoadStoreOpcode(
   const bool NoImmediate = false;
 
   unsigned ISelOpcode;
-  bool FitsImmediateRange = false;
+  bool FitsImmediateRange =
+      TII.isOffsetInImmediateRange(I.getOpcode(), getLoadStoreSize(I), Offset);
 
   switch (I.getOpcode()) {
   case AIE2::G_STORE:
@@ -2469,13 +2470,11 @@ LoadStoreOpcodes AIE2InstructionSelector::getLoadStoreOpcode(
     if (getLoadStoreSize(I) == 512) {
       unsigned RBID = deriveRegBankID(I.getOperand(0).getReg(), MRI, RBI);
       if (RBID == AIE2::AccRegBankID) {
-        FitsImmediateRange = checkImmediateRangeSplitting<6, 32, 32>(Offset);
         return {/*ISelOpcode=*/AIE2::VST_dmw_sts_am_ag_idx_imm,
                 FitsImmediateRange,
                 /*OffsetOpcode=*/AIE2::VST_dmw_sts_am_ag_idx_imm};
       }
       if (RBID == AIE2::VRegBankID) {
-        FitsImmediateRange = checkImmediateRangeSplitting<6, 32, 32>(Offset);
         return {/*ISelOpcode=*/AIE2::VST_dmw_sts_w_ag_idx_imm,
                 FitsImmediateRange,
                 /*OffsetOpcode=*/AIE2::VST_dmw_sts_w_ag_idx_imm};
@@ -2485,14 +2484,12 @@ LoadStoreOpcodes AIE2InstructionSelector::getLoadStoreOpcode(
     if (getLoadStoreSize(I) == 256) {
       unsigned RBID = deriveRegBankID(I.getOperand(0).getReg(), MRI, RBI);
       if (RBID == AIE2::AccRegBankID) {
-        FitsImmediateRange = checkImmediateRange<6, 32>(Offset);
         ISelOpcode = FitsImmediateRange ? AIE2::VST_dmw_sts_am_ag_idx_imm
                                         : AIE2::VST_dmw_sts_am_ag_idx;
         return {ISelOpcode, FitsImmediateRange,
                 /*OffsetOpcode=*/AIE2::VST_dmw_sts_am_ag_idx_imm};
       }
       if (RBID == AIE2::VRegBankID) {
-        FitsImmediateRange = checkImmediateRange<6, 32>(Offset);
         ISelOpcode = FitsImmediateRange ? AIE2::VST_dmw_sts_w_ag_idx_imm
                                         : AIE2::VST_dmw_sts_w_ag_idx;
         return {ISelOpcode, FitsImmediateRange,
@@ -2501,25 +2498,21 @@ LoadStoreOpcodes AIE2InstructionSelector::getLoadStoreOpcode(
       llvm_unreachable("Vector type not in AccRegBank nor VRegBank");
     }
     if (getLoadStoreSize(I) == 128) {
-      FitsImmediateRange = checkImmediateRange<6, 16>(Offset);
       ISelOpcode = FitsImmediateRange ? AIE2::ST_dmv_sts_q_ag_idx_imm
                                       : AIE2::ST_dmv_sts_q_ag_idx;
       return {ISelOpcode, FitsImmediateRange, /*OffsetOpcode=*/{}};
     }
     if (getLoadStoreSize(I) == 20 || getLoadStoreSize(I) == 32) {
-      FitsImmediateRange = checkImmediateRange<6, 4>(Offset);
       ISelOpcode =
           FitsImmediateRange ? AIE2::ST_dms_sts_idx_imm : AIE2::ST_dms_sts_idx;
       return {ISelOpcode, FitsImmediateRange, /*OffsetOpcode=*/{}};
     }
     if (getLoadStoreSize(I) == 16) {
-      FitsImmediateRange = checkImmediateRange<3, 1>(Offset);
       ISelOpcode =
           FitsImmediateRange ? AIE2::ST_S16_ag_idx_imm : AIE2::ST_S16_ag_idx;
       return {ISelOpcode, FitsImmediateRange, /*OffsetOpcode=*/{}};
     }
     if (getLoadStoreSize(I) == 8) {
-      FitsImmediateRange = checkImmediateRange<3, 1>(Offset);
       ISelOpcode =
           FitsImmediateRange ? AIE2::ST_S8_ag_idx_imm : AIE2::ST_S8_ag_idx;
       return {ISelOpcode, FitsImmediateRange, /*OffsetOpcode=*/{}};
@@ -2529,7 +2522,6 @@ LoadStoreOpcodes AIE2InstructionSelector::getLoadStoreOpcode(
     if (getLoadStoreSize(I) == 128) {
       unsigned RBID = deriveRegBankID(I.getOperand(1).getReg(), MRI, RBI);
       if (RBID == AIE2::VRegBankID) {
-        FitsImmediateRange = checkImmediateRange<7, 16>(Offset);
         ISelOpcode = FitsImmediateRange ? AIE2::ST_dmv_sts_q_ag_pstm_nrm_imm
                                         : AIE2::ST_dmv_sts_q_ag_pstm_nrm;
         return {ISelOpcode, FitsImmediateRange, /*OffsetOpcode=*/{}};
@@ -2539,14 +2531,12 @@ LoadStoreOpcodes AIE2InstructionSelector::getLoadStoreOpcode(
     if (getLoadStoreSize(I) == 256 || getLoadStoreSize(I) == 512) {
       unsigned RBID = deriveRegBankID(I.getOperand(1).getReg(), MRI, RBI);
       if (RBID == AIE2::AccRegBankID) {
-        FitsImmediateRange = checkImmediateRange<7, 32>(Offset);
         ISelOpcode = FitsImmediateRange ? AIE2::VST_dmw_sts_am_ag_pstm_nrm_imm
                                         : AIE2::VST_dmw_sts_am_ag_pstm_nrm;
         return {ISelOpcode, FitsImmediateRange,
                 /*OffsetOpcode=*/AIE2::VST_dmw_sts_am_ag_idx_imm};
       }
       if (RBID == AIE2::VRegBankID) {
-        FitsImmediateRange = checkImmediateRange<7, 32>(Offset);
         ISelOpcode = FitsImmediateRange ? AIE2::VST_dmw_sts_w_ag_pstm_nrm_imm
                                         : AIE2::VST_dmw_sts_w_ag_pstm_nrm;
         return {ISelOpcode, FitsImmediateRange,
@@ -2555,19 +2545,16 @@ LoadStoreOpcodes AIE2InstructionSelector::getLoadStoreOpcode(
       llvm_unreachable("Vector type not in AccRegBank nor VRegBank");
     }
     if (getLoadStoreSize(I) == 20 || getLoadStoreSize(I) == 32) {
-      FitsImmediateRange = checkImmediateRange<7, 4>(Offset);
       ISelOpcode = FitsImmediateRange ? AIE2::ST_dms_sts_pstm_nrm_imm
                                       : AIE2::ST_dms_sts_pstm_nrm;
       return {ISelOpcode, FitsImmediateRange, /*OffsetOpcode=*/{}};
     }
     if (getLoadStoreSize(I) == 16) {
-      FitsImmediateRange = checkImmediateRange<4, 1>(Offset);
       ISelOpcode = FitsImmediateRange ? AIE2::ST_S16_ag_pstm_nrm_imm
                                       : AIE2::ST_S16_ag_pstm_nrm;
       return {ISelOpcode, FitsImmediateRange, /*OffsetOpcode=*/{}};
     }
     if (getLoadStoreSize(I) == 8) {
-      FitsImmediateRange = checkImmediateRange<4, 1>(Offset);
       ISelOpcode = FitsImmediateRange ? AIE2::ST_S8_ag_pstm_nrm_imm
                                       : AIE2::ST_S8_ag_pstm_nrm;
       return {ISelOpcode, FitsImmediateRange, /*OffsetOpcode=*/{}};
@@ -2696,7 +2683,6 @@ LoadStoreOpcodes AIE2InstructionSelector::getLoadStoreOpcode(
     if (getLoadStoreSize(I) == 512) {
       unsigned RBID = deriveRegBankID(I.getOperand(0).getReg(), MRI, RBI);
       if (RBID == AIE2::AccRegBankID) {
-        FitsImmediateRange = checkImmediateRangeSplitting<6, 32, 32>(Offset);
         return {/*ISelOpcode=*/AIE2::VLDA_dmw_lda_am_ag_idx_imm,
                 FitsImmediateRange,
                 /*OffsetOpcode=*/AIE2::VLDA_dmw_lda_am_ag_idx_imm};
@@ -2705,23 +2691,22 @@ LoadStoreOpcodes AIE2InstructionSelector::getLoadStoreOpcode(
         unsigned OffsetOpcode;
         // First try if the Instruction can be selected as multi-slot offset
         // load
-        if (checkImmediateRangeSplitting<3, 32, 32>(Offset)) {
+        if (checkSignedImmediateRangeSplitting<3, 32, 32>(Offset)) {
           FitsImmediateRange = true;
           ISelOpcode = OffsetOpcode = AIE2::VLD_idx_imm_3x32_pseudo;
-        } else if (checkImmediateRange<3, 32>(Offset)) {
+        } else if (checkSignedImmediateRange<3, 32>(Offset)) {
           // When Offset is positive and one of the offset is in range of SlotB
           ISelOpcode = AIE2::VLD_idx_imm_3x32_pseudo;
           OffsetOpcode = AIE2::VLDA_dmw_lda_w_ag_idx_imm;
           FitsImmediateRange = true;
         } else if (Offset.has_value() && (*Offset).isNegative() &&
-                   checkImmediateRange<3, 32>((*Offset) + 32)) {
+                   checkSignedImmediateRange<3, 32>((*Offset) + 32)) {
           // When Offset is negative and one of the offset is in range of SlotB
           ISelOpcode = AIE2::VLDA_dmw_lda_w_ag_idx_imm;
           OffsetOpcode = AIE2::VLD_idx_imm_3x32_pseudo;
           FitsImmediateRange = true;
         } else {
           // When Offset & Offset+32 are out of range of SlotB
-          FitsImmediateRange = checkImmediateRangeSplitting<6, 32, 32>(Offset);
           ISelOpcode = OffsetOpcode = AIE2::VLDA_dmw_lda_w_ag_idx_imm;
         }
         return {/*ISelOpcode=*/ISelOpcode, FitsImmediateRange,
@@ -2732,7 +2717,6 @@ LoadStoreOpcodes AIE2InstructionSelector::getLoadStoreOpcode(
     if (getLoadStoreSize(I) == 256) {
       unsigned RBID = deriveRegBankID(I.getOperand(0).getReg(), MRI, RBI);
       if (RBID == AIE2::AccRegBankID) {
-        FitsImmediateRange = checkImmediateRange<6, 32>(Offset);
         ISelOpcode = FitsImmediateRange ? AIE2::VLDA_dmw_lda_am_ag_idx_imm
                                         : AIE2::VLDA_dmw_lda_am_ag_idx;
         return {ISelOpcode, FitsImmediateRange,
@@ -2741,11 +2725,10 @@ LoadStoreOpcodes AIE2InstructionSelector::getLoadStoreOpcode(
       if (RBID == AIE2::VRegBankID) {
         // First try if the Instruction can be selected as multi-slot offset
         // load
-        if (checkImmediateRange<3, 32>(Offset)) {
+        if (checkSignedImmediateRange<3, 32>(Offset)) {
           FitsImmediateRange = true;
           ISelOpcode = AIE2::VLD_idx_imm_3x32_pseudo;
         } else {
-          FitsImmediateRange = checkImmediateRange<6, 32>(Offset);
           ISelOpcode = FitsImmediateRange ? AIE2::VLDA_dmw_lda_w_ag_idx_imm
                                           : AIE2::VLD_idx_pseudo;
         }
@@ -2760,13 +2743,11 @@ LoadStoreOpcodes AIE2InstructionSelector::getLoadStoreOpcode(
        * which instruction to select between the available LDA_dmv_lda_q_ag_idx
        * which has 128-bit destination operand vs VLDB_128_ag_idx which has
        * 256-bit destination operand. */
-      FitsImmediateRange = checkImmediateRange<6, 16>(Offset);
       ISelOpcode = FitsImmediateRange ? AIE2::LDA_dmv_lda_q_ag_idx_imm
                                       : AIE2::VLDB_128_ag_idx;
       return {ISelOpcode, FitsImmediateRange, /*OffsetOpcode=*/{}};
     }
     if (getLoadStoreSize(I) == 20 || getLoadStoreSize(I) == 32) {
-      FitsImmediateRange = checkImmediateRange<6, 4>(Offset);
       ISelOpcode = FitsImmediateRange ? AIE2::LDA_dms_lda_idx_imm
                                       : AIE2::LDA_dms_lda_idx;
       return {ISelOpcode, FitsImmediateRange, /*OffsetOpcode=*/{}};
@@ -2774,13 +2755,11 @@ LoadStoreOpcodes AIE2InstructionSelector::getLoadStoreOpcode(
     [[fallthrough]];
   case AIE2::G_AIE_OFFSET_SEXTLOAD:
     if (getLoadStoreSize(I) == 16) {
-      FitsImmediateRange = checkImmediateRange<3, 1>(Offset);
       ISelOpcode =
           FitsImmediateRange ? AIE2::LDA_S16_ag_idx_imm : AIE2::LDA_S16_ag_idx;
       return {ISelOpcode, FitsImmediateRange, /*OffsetOpcode=*/{}};
     }
     if (getLoadStoreSize(I) == 8) {
-      FitsImmediateRange = checkImmediateRange<3, 1>(Offset);
       ISelOpcode =
           FitsImmediateRange ? AIE2::LDA_S8_ag_idx_imm : AIE2::LDA_S8_ag_idx;
       return {ISelOpcode, FitsImmediateRange, /*OffsetOpcode=*/{}};
@@ -2788,13 +2767,11 @@ LoadStoreOpcodes AIE2InstructionSelector::getLoadStoreOpcode(
     break;
   case AIE2::G_AIE_OFFSET_ZEXTLOAD:
     if (getLoadStoreSize(I) == 16) {
-      FitsImmediateRange = checkImmediateRange<3, 1>(Offset);
       ISelOpcode =
           FitsImmediateRange ? AIE2::LDA_U16_ag_idx_imm : AIE2::LDA_U16_ag_idx;
       return {ISelOpcode, FitsImmediateRange, /*OffsetOpcode=*/{}};
     }
     if (getLoadStoreSize(I) == 8) {
-      FitsImmediateRange = checkImmediateRange<3, 1>(Offset);
       ISelOpcode =
           FitsImmediateRange ? AIE2::LDA_U8_ag_idx_imm : AIE2::LDA_U8_ag_idx;
       return {ISelOpcode, FitsImmediateRange, /*OffsetOpcode=*/{}};
@@ -2890,7 +2867,6 @@ LoadStoreOpcodes AIE2InstructionSelector::getLoadStoreOpcode(
     if (getLoadStoreSize(I) == 256 || getLoadStoreSize(I) == 512) {
       unsigned RBID = deriveRegBankID(I.getOperand(0).getReg(), MRI, RBI);
       if (RBID == AIE2::AccRegBankID) {
-        FitsImmediateRange = checkImmediateRange<7, 32>(Offset);
         ISelOpcode = FitsImmediateRange ? AIE2::VLDA_dmw_lda_am_ag_pstm_nrm_imm
                                         : AIE2::VLDA_dmw_lda_am_ag_pstm_nrm;
         return {ISelOpcode, FitsImmediateRange,
@@ -2899,11 +2875,10 @@ LoadStoreOpcodes AIE2InstructionSelector::getLoadStoreOpcode(
       if (RBID == AIE2::VRegBankID) {
         // First try if the Instruction can be selected as multi-slot offset
         // load
-        if (checkImmediateRange<4, 32>(Offset)) {
+        if (checkSignedImmediateRange<4, 32>(Offset)) {
           FitsImmediateRange = true;
           ISelOpcode = AIE2::VLD_pstm_imm_4x32_pseudo;
         } else {
-          FitsImmediateRange = checkImmediateRange<7, 32>(Offset);
           ISelOpcode = FitsImmediateRange ? AIE2::VLDA_dmw_lda_w_ag_pstm_nrm_imm
                                           : AIE2::VLD_pstm_pseudo;
         }
@@ -2921,7 +2896,6 @@ LoadStoreOpcodes AIE2InstructionSelector::getLoadStoreOpcode(
          * between the available LDA_dmv_lda_q_ag_pstm_nrm which has
          * 128-bit destination operand vs VLDB_dmv_ldb_ag_pstm_nrm which
          * has 256-bit destination operand. */
-        FitsImmediateRange = checkImmediateRange<7, 16>(Offset);
         ISelOpcode = FitsImmediateRange ? AIE2::LDA_dmv_lda_q_ag_pstm_nrm_imm
                                         : AIE2::VLDB_128_ag_pstm_nrm;
         return {ISelOpcode, FitsImmediateRange,
@@ -2930,7 +2904,6 @@ LoadStoreOpcodes AIE2InstructionSelector::getLoadStoreOpcode(
       llvm_unreachable("Vector type not in VRegBank");
     }
     if (getLoadStoreSize(I) == 20 || getLoadStoreSize(I) == 32) {
-      FitsImmediateRange = checkImmediateRange<7, 4>(Offset);
       ISelOpcode = FitsImmediateRange ? AIE2::LDA_dms_lda_pstm_nrm_imm
                                       : AIE2::LDA_dms_lda_pstm_nrm;
       return {ISelOpcode, FitsImmediateRange, /*OffsetOpcode=*/{}};
@@ -2938,13 +2911,11 @@ LoadStoreOpcodes AIE2InstructionSelector::getLoadStoreOpcode(
     [[fallthrough]];
   case AIE2::G_AIE_POSTINC_SEXTLOAD:
     if (getLoadStoreSize(I) == 16) {
-      FitsImmediateRange = checkImmediateRange<4, 1>(Offset);
       ISelOpcode = FitsImmediateRange ? AIE2::LDA_S16_ag_pstm_nrm_imm
                                       : AIE2::LDA_S16_ag_pstm_nrm;
       return {ISelOpcode, FitsImmediateRange, /*OffsetOpcode=*/{}};
     }
     if (getLoadStoreSize(I) == 8) {
-      FitsImmediateRange = checkImmediateRange<4, 1>(Offset);
       ISelOpcode = FitsImmediateRange ? AIE2::LDA_S8_ag_pstm_nrm_imm
                                       : AIE2::LDA_S8_ag_pstm_nrm;
       return {ISelOpcode, FitsImmediateRange, /*OffsetOpcode=*/{}};
@@ -2952,13 +2923,11 @@ LoadStoreOpcodes AIE2InstructionSelector::getLoadStoreOpcode(
     break;
   case AIE2::G_AIE_POSTINC_ZEXTLOAD:
     if (getLoadStoreSize(I) == 16) {
-      FitsImmediateRange = checkImmediateRange<4, 1>(Offset);
       ISelOpcode = FitsImmediateRange ? AIE2::LDA_U16_ag_pstm_nrm_imm
                                       : AIE2::LDA_U16_ag_pstm_nrm;
       return {ISelOpcode, FitsImmediateRange, /*OffsetOpcode=*/{}};
     }
     if (getLoadStoreSize(I) == 8) {
-      FitsImmediateRange = checkImmediateRange<4, 1>(Offset);
       ISelOpcode = FitsImmediateRange ? AIE2::LDA_U8_ag_pstm_nrm_imm
                                       : AIE2::LDA_U8_ag_pstm_nrm;
       return {ISelOpcode, FitsImmediateRange, /*OffsetOpcode=*/{}};
@@ -3002,13 +2971,13 @@ std::optional<LoadStoreOpcodes> AIE2InstructionSelector::getCombinedOpcodePACK(
       break;
     case AIE2::G_AIE_OFFSET_STORE:
       if (Is32Lanes) {
-        FitsImmediateRange = checkImmediateRange<3, 32>(Immediate);
+        FitsImmediateRange = checkSignedImmediateRange<3, 32>(Immediate);
         ISelOpcode = FitsImmediateRange ? AIE2::VST_PACK_S8_S16_ag_idx_imm
                                         : AIE2::VST_PACK_S8_S16_ag_idx;
         return LoadStoreOpcodes{ISelOpcode, FitsImmediateRange,
                                 /*OffsetOpcode=*/{}};
       } else {
-        FitsImmediateRange = checkImmediateRange<3, 32>(Immediate);
+        FitsImmediateRange = checkSignedImmediateRange<3, 32>(Immediate);
         ISelOpcode = FitsImmediateRange ? AIE2::VST_PACK_S4_S8_ag_idx_imm
                                         : AIE2::VST_PACK_S4_S8_ag_idx;
         return LoadStoreOpcodes{ISelOpcode, FitsImmediateRange,
@@ -3016,7 +2985,7 @@ std::optional<LoadStoreOpcodes> AIE2InstructionSelector::getCombinedOpcodePACK(
       }
       break;
     case AIE2::G_AIE_POSTINC_STORE:
-      FitsImmediateRange = checkImmediateRange<4, 32>(Immediate);
+      FitsImmediateRange = checkSignedImmediateRange<4, 32>(Immediate);
       if (Is32Lanes) {
         ISelOpcode = FitsImmediateRange ? AIE2::VST_PACK_S8_S16_ag_pstm_nrm_imm
                                         : AIE2::VST_PACK_S8_S16_ag_pstm_nrm;
@@ -3067,13 +3036,13 @@ std::optional<LoadStoreOpcodes> AIE2InstructionSelector::getCombinedOpcodePACK(
       break;
     case AIE2::G_AIE_OFFSET_STORE:
       if (Is32Lanes) {
-        FitsImmediateRange = checkImmediateRange<3, 32>(Immediate);
+        FitsImmediateRange = checkSignedImmediateRange<3, 32>(Immediate);
         ISelOpcode = FitsImmediateRange ? AIE2::VST_PACK_D8_D16_ag_idx_imm
                                         : AIE2::VST_PACK_D8_D16_ag_idx;
         return LoadStoreOpcodes{ISelOpcode, FitsImmediateRange,
                                 /*OffsetOpcode=*/{}};
       } else {
-        FitsImmediateRange = checkImmediateRange<3, 32>(Immediate);
+        FitsImmediateRange = checkSignedImmediateRange<3, 32>(Immediate);
         ISelOpcode = FitsImmediateRange ? AIE2::VST_PACK_D4_D8_ag_idx_imm
                                         : AIE2::VST_PACK_D4_D8_ag_idx;
         return LoadStoreOpcodes{ISelOpcode, FitsImmediateRange,
@@ -3081,7 +3050,7 @@ std::optional<LoadStoreOpcodes> AIE2InstructionSelector::getCombinedOpcodePACK(
       }
       break;
     case AIE2::G_AIE_POSTINC_STORE:
-      FitsImmediateRange = checkImmediateRange<4, 32>(Immediate);
+      FitsImmediateRange = checkSignedImmediateRange<4, 32>(Immediate);
       if (Is32Lanes) {
         ISelOpcode = FitsImmediateRange ? AIE2::VST_PACK_D8_D16_ag_pstm_nrm_imm
                                         : AIE2::VST_PACK_D8_D16_ag_pstm_nrm;
@@ -3368,13 +3337,13 @@ AIE2InstructionSelector::getCombinedOpcodeCONV(const MachineInstr &MemOp,
     return LoadStoreOpcodes{/*ISelOpcode=*/AIE2::VST_CONV_BF16_FP32_ag_idx_imm,
                             AlwaysFitsImmediateRange, /*OffsetOpcode=*/{}};
   case AIE2::G_AIE_OFFSET_STORE:
-    FitsImmediateRange = checkImmediateRange<3, 32>(Immediate);
+    FitsImmediateRange = checkSignedImmediateRange<3, 32>(Immediate);
     ISelOpcode = FitsImmediateRange ? AIE2::VST_CONV_BF16_FP32_ag_idx_imm
                                     : AIE2::VST_CONV_BF16_FP32_ag_idx;
     return LoadStoreOpcodes{ISelOpcode, FitsImmediateRange,
                             /*OffsetOpcode=*/{}};
   case AIE2::G_AIE_POSTINC_STORE:
-    FitsImmediateRange = checkImmediateRange<4, 32>(Immediate);
+    FitsImmediateRange = checkSignedImmediateRange<4, 32>(Immediate);
     ISelOpcode = FitsImmediateRange ? AIE2::VST_CONV_BF16_FP32_ag_pstm_nrm_imm
                                     : AIE2::VST_CONV_BF16_FP32_ag_pstm_nrm;
     return LoadStoreOpcodes{ISelOpcode, FitsImmediateRange,
@@ -3605,12 +3574,12 @@ static bool getVLDA_CONVOpcode(const MachineInstr &MemOp,
     FitsImmediateRange = true;
     return true;
   case AIE2::G_AIE_OFFSET_LOAD:
-    FitsImmediateRange = checkImmediateRange<3, 32>(Immediate);
+    FitsImmediateRange = checkSignedImmediateRange<3, 32>(Immediate);
     ISelOpcode = FitsImmediateRange ? AIE2::VLDA_CONV_FP32_BF16_ag_idx_imm
                                     : AIE2::VLDA_CONV_FP32_BF16_ag_idx;
     return true;
   case AIE2::G_AIE_POSTINC_LOAD:
-    FitsImmediateRange = checkImmediateRange<4, 32>(Immediate);
+    FitsImmediateRange = checkSignedImmediateRange<4, 32>(Immediate);
     ISelOpcode = FitsImmediateRange ? AIE2::VLDA_CONV_FP32_BF16_pstm_nrm_imm
                                     : AIE2::VLDA_CONV_FP32_BF16_pstm_nrm;
     return true;

--- a/llvm/lib/Target/AIE/AIEBaseInstrInfo.h
+++ b/llvm/lib/Target/AIE/AIEBaseInstrInfo.h
@@ -59,6 +59,10 @@ struct AIEBaseInstrInfo : public TargetInstrInfo {
     // of bundles.
     unsigned LoopSetupDistance;
   };
+  virtual bool isOffsetInImmediateRange(unsigned Opcode, unsigned LoadStoreSize,
+                                        std::optional<APInt> Offset) const {
+    llvm_unreachable("Target didn't implement OffsetFitImmRange");
+  }
 
   /// Return the opcode for a return instruction
   virtual unsigned getReturnOpcode() const {
@@ -748,6 +752,24 @@ protected:
   const MIRFormatter *getMIRFormatter() const override;
   mutable std::unique_ptr<AIEMIRFormatter> Formatter;
 };
+
+template <unsigned NumEncodingBits, unsigned Step>
+bool checkSignedImmediateRange(std::optional<APInt> Immediate) {
+  const unsigned MaxPow2 = NumEncodingBits + llvm::Log2_64(Step);
+  if (Immediate && isIntN(MaxPow2, Immediate->getSExtValue()) &&
+      Immediate->getSExtValue() % Step == 0) {
+    return true;
+  }
+  return false;
+}
+
+template <unsigned NumEncodingBits, unsigned Step, unsigned SplitOffset>
+bool checkSignedImmediateRangeSplitting(std::optional<APInt> Immediate) {
+  return Immediate &&
+         checkSignedImmediateRange<NumEncodingBits, Step>(Immediate) &&
+         checkSignedImmediateRange<NumEncodingBits, Step>(*Immediate +
+                                                          SplitOffset);
+}
 } // namespace llvm
 
 #endif // LLVM_LIB_TARGET_AIE_AIEBASEINSTRRINFO_H

--- a/llvm/lib/Target/AIE/AIEBaseInstructionSelector.h
+++ b/llvm/lib/Target/AIE/AIEBaseInstructionSelector.h
@@ -198,24 +198,6 @@ inline unsigned getLoadStoreSize(const MachineInstr &MI) {
   return (*MI.memoperands_begin())->getSizeInBits().getValue();
 }
 
-template <unsigned NumEncodingBits, unsigned Step>
-bool checkImmediateRange(std::optional<APInt> Immediate) {
-  unsigned MaxPow2 = NumEncodingBits + llvm::Log2_64(Step);
-  if (Immediate && isIntN(MaxPow2, Immediate->getSExtValue()) &&
-      Immediate->getSExtValue() % Step == 0) {
-    LLVM_DEBUG(dbgs() << "Immediate " << Immediate << " is valid for MaxPow2 "
-                      << MaxPow2 << " and Step " << Step << ".\n");
-    return true;
-  }
-  return false;
-}
-
-template <unsigned NumEncodingBits, unsigned Step, unsigned SplitOffset>
-bool checkImmediateRangeSplitting(std::optional<APInt> Immediate) {
-  return Immediate && checkImmediateRange<NumEncodingBits, Step>(Immediate) &&
-         checkImmediateRange<NumEncodingBits, Step>(*Immediate + SplitOffset);
-}
-
 inline unsigned deriveRegBankID(Register Reg, const MachineRegisterInfo &MRI,
                                 const RegisterBankInfo &RBI) {
   const RegisterBank *RB = MRI.getRegBankOrNull(Reg);

--- a/llvm/lib/Target/AIE/aie2p/AIE2PInstrInfo.cpp
+++ b/llvm/lib/Target/AIE/aie2p/AIE2PInstrInfo.cpp
@@ -1733,6 +1733,77 @@ AIE2PInstrInfo::getZOLSupport() const {
   return Result;
 }
 
+bool AIE2PInstrInfo::isOffsetInImmediateRange(
+    unsigned Opcode, unsigned LoadStoreSize,
+    std::optional<APInt> Offset) const {
+  if (!Offset)
+    return false;
+
+  switch (Opcode) {
+  case AIE2P::G_AIE_OFFSET_STORE:
+  case AIE2P::G_AIE_OFFSET_LOAD: {
+    switch (LoadStoreSize) {
+    case 8:
+      return checkSignedImmediateRange<4, 1>(Offset);
+    case 16:
+      return checkSignedImmediateRange<4, 2>(Offset);
+    case 20:
+    case 32:
+      return checkSignedImmediateRange<4, 4>(Offset);
+    case 128:
+      return checkSignedImmediateRange<4, 16>(Offset);
+    case 256:
+      return checkSignedImmediateRange<4, 32>(Offset);
+    case 512:
+      return checkSignedImmediateRange<4, 64>(Offset);
+    case 1024:
+      return checkSignedImmediateRangeSplitting<4, 64, 64>(Offset);
+    case 2048:
+      return checkSignedImmediateRangeSplitting<4, 64, 192>(Offset);
+    default:
+      return false;
+    }
+  }
+  case AIE2P::G_AIE_OFFSET_SEXTLOAD:
+  case AIE2P::G_AIE_OFFSET_ZEXTLOAD:
+  case AIE2P::G_AIE_POSTINC_ZEXTLOAD:
+  case AIE2P::G_AIE_POSTINC_SEXTLOAD: {
+    switch (LoadStoreSize) {
+    case 8:
+      return checkSignedImmediateRange<4, 1>(Offset);
+    case 16:
+      return checkSignedImmediateRange<4, 2>(Offset);
+    default:
+      return false;
+    }
+  }
+  case AIE2P::G_AIE_POSTINC_STORE:
+  case AIE2P::G_AIE_POSTINC_LOAD: {
+    switch (LoadStoreSize) {
+    case 8:
+      return checkSignedImmediateRange<4, 1>(Offset);
+    case 16:
+      return checkSignedImmediateRange<4, 2>(Offset);
+    case 20:
+    case 32:
+      return checkSignedImmediateRange<4, 4>(Offset);
+    case 128:
+      return checkSignedImmediateRange<4, 16>(Offset);
+    case 256:
+      return checkSignedImmediateRange<4, 32>(Offset);
+    case 512:
+    case 1024:
+    case 2048:
+      return checkSignedImmediateRange<4, 64>(Offset);
+    default:
+      return false;
+    }
+  }
+  default:
+    return false;
+  }
+}
+
 unsigned AIE2PInstrInfo::getGenericAddVectorEltOpcode() const {
   return AIE2P::G_AIE_ADD_VECTOR_ELT_HI;
 }

--- a/llvm/lib/Target/AIE/aie2p/AIE2PInstrInfo.h
+++ b/llvm/lib/Target/AIE/aie2p/AIE2PInstrInfo.h
@@ -110,6 +110,9 @@ public:
 
   virtual std::optional<ZOLSupport> getZOLSupport() const override;
 
+  bool isOffsetInImmediateRange(unsigned Opcode, unsigned LoadStoreSize,
+                                std::optional<APInt> Immediate) const override;
+
   unsigned getNumBypassedCycles(const InstrItineraryData *ItinData,
                                 const MachineInstr &DefMI, unsigned DefIdx,
                                 const MachineInstr &UseMI,

--- a/llvm/lib/Target/AIE/aie2p/AIE2PInstructionSelector.cpp
+++ b/llvm/lib/Target/AIE/aie2p/AIE2PInstructionSelector.cpp
@@ -1731,9 +1731,10 @@ LoadStoreOpcodes AIE2PInstructionSelector::getLoadStoreOpcode(
   const bool NoImmediate = false;
 
   unsigned ISelOpcode;
-  bool FitsImmediateRange = false;
   unsigned RBID = deriveRegBankID(I.getOperand(0).getReg(), MRI, RBI);
   unsigned LoadStoreSize = getLoadStoreSize(I);
+  bool FitsImmediateRange =
+      TII.isOffsetInImmediateRange(I.getOpcode(), LoadStoreSize, Offset);
 
   switch (I.getOpcode()) {
   case AIE2P::G_LOAD: {
@@ -1830,7 +1831,6 @@ LoadStoreOpcodes AIE2PInstructionSelector::getLoadStoreOpcode(
     if (LoadStoreSize == 128) {
       assert(RBID == AIE2P::VRegBankID &&
              "128-bit vectors should be in the Vector Register Bank");
-      FitsImmediateRange = checkImmediateRange<4, 16>(Offset);
       ISelOpcode = FitsImmediateRange ? AIE2P::VLD_128_idx_imm_pseudo
                                       : AIE2P::VLD_128_idx_pseudo;
       return {ISelOpcode, FitsImmediateRange,
@@ -1839,13 +1839,11 @@ LoadStoreOpcodes AIE2PInstructionSelector::getLoadStoreOpcode(
     if (LoadStoreSize == 256) {
       assert(RBID == AIE2P::VRegBankID &&
              "256-bit vectors should be in the Vector Register Bank");
-      FitsImmediateRange = checkImmediateRange<4, 32>(Offset);
       ISelOpcode = FitsImmediateRange ? AIE2P::VLD_w_idx_imm_pseudo
                                       : AIE2P::VLD_w_idx_pseudo;
       return {ISelOpcode, FitsImmediateRange,
               /*OffsetOpcode=*/AIE2P::VLD_w_idx_imm_pseudo};
     } else if (LoadStoreSize == 512) {
-      FitsImmediateRange = checkImmediateRange<4, 64>(Offset);
       if (RBID == AIE2P::AccRegBankID) {
         ISelOpcode = FitsImmediateRange ? AIE2P::VLDA_dmx_lda_bm_idx_imm
                                         : AIE2P::VLDA_dmx_lda_bm_idx;
@@ -1867,10 +1865,6 @@ LoadStoreOpcodes AIE2PInstructionSelector::getLoadStoreOpcode(
       llvm_unreachable("Vector type must be in AccRegBank or VRegBank "
                        "or FifoRegBank");
     } else if (LoadStoreSize == 1024 || LoadStoreSize == 2048) {
-      FitsImmediateRange =
-          (LoadStoreSize == 1024)
-              ? checkImmediateRangeSplitting<4, 64, 64>(Offset)
-              : checkImmediateRangeSplitting<4, 64, 192>(Offset);
       if (RBID == AIE2P::AccRegBankID) {
         return {/*ISelOpcode=*/AIE2P::VLDA_dmx_lda_bm_idx_imm,
                 FitsImmediateRange,
@@ -1889,7 +1883,6 @@ LoadStoreOpcodes AIE2PInstructionSelector::getLoadStoreOpcode(
                        "or FifoRegBank");
     }
     if (LoadStoreSize == 20 || LoadStoreSize == 32) {
-      FitsImmediateRange = checkImmediateRange<4, 4>(Offset);
       ISelOpcode = FitsImmediateRange ? AIE2P::LDA_dms_lda_idx_imm
                                       : AIE2P::LDA_dms_lda_idx;
       return {ISelOpcode, FitsImmediateRange, /*OffsetOpcode=*/{}};
@@ -1898,13 +1891,11 @@ LoadStoreOpcodes AIE2PInstructionSelector::getLoadStoreOpcode(
     [[fallthrough]];
   case AIE2P::G_AIE_OFFSET_SEXTLOAD: {
     if (LoadStoreSize == 16) {
-      FitsImmediateRange = checkImmediateRange<4, 2>(Offset);
       ISelOpcode =
           FitsImmediateRange ? AIE2P::LDA_s16_idx_imm : AIE2P::LDA_s16_idx;
       return {ISelOpcode, FitsImmediateRange, /*OffsetOpcode=*/{}};
     }
     if (LoadStoreSize == 8) {
-      FitsImmediateRange = checkImmediateRange<4, 1>(Offset);
       ISelOpcode =
           FitsImmediateRange ? AIE2P::LDA_s8_idx_imm : AIE2P::LDA_s8_idx;
       return {ISelOpcode, FitsImmediateRange, /*OffsetOpcode=*/{}};
@@ -1913,13 +1904,11 @@ LoadStoreOpcodes AIE2PInstructionSelector::getLoadStoreOpcode(
   }
   case AIE2P::G_AIE_OFFSET_ZEXTLOAD: {
     if (LoadStoreSize == 16) {
-      FitsImmediateRange = checkImmediateRange<4, 2>(Offset);
       ISelOpcode =
           FitsImmediateRange ? AIE2P::LDA_u16_idx_imm : AIE2P::LDA_u16_idx;
       return {ISelOpcode, FitsImmediateRange, /*OffsetOpcode=*/{}};
     }
     if (LoadStoreSize == 8) {
-      FitsImmediateRange = checkImmediateRange<4, 1>(Offset);
       ISelOpcode =
           FitsImmediateRange ? AIE2P::LDA_u8_idx_imm : AIE2P::LDA_u8_idx;
       return {ISelOpcode, FitsImmediateRange, /*OffsetOpcode=*/{}};
@@ -1930,7 +1919,6 @@ LoadStoreOpcodes AIE2PInstructionSelector::getLoadStoreOpcode(
     if (LoadStoreSize == 128) {
       assert(RBID == AIE2P::VRegBankID &&
              "128-bit vectors should be in the Vector Register Bank");
-      FitsImmediateRange = checkImmediateRange<4, 16>(Offset);
       ISelOpcode = FitsImmediateRange ? AIE2P::VLD_128_pstm_nrm_imm_pseudo
                                       : AIE2P::VLD_128_pstm_nrm_pseudo;
       return {ISelOpcode, FitsImmediateRange,
@@ -1939,14 +1927,12 @@ LoadStoreOpcodes AIE2PInstructionSelector::getLoadStoreOpcode(
     if (LoadStoreSize == 256) {
       assert(RBID == AIE2P::VRegBankID &&
              "256-bit vectors should be in the Vector Register Bank");
-      FitsImmediateRange = checkImmediateRange<4, 32>(Offset);
       ISelOpcode = FitsImmediateRange ? AIE2P::VLD_w_pstm_nrm_imm_pseudo
                                       : AIE2P::VLD_w_pstm_nrm_pseudo;
       return {ISelOpcode, FitsImmediateRange,
               /*OffsetOpcode=*/AIE2P::VLD_w_idx_imm_pseudo};
     } else if (LoadStoreSize == 512 || LoadStoreSize == 1024 ||
                LoadStoreSize == 2048) {
-      FitsImmediateRange = checkImmediateRange<4, 64>(Offset);
       if (RBID == AIE2P::AccRegBankID) {
         ISelOpcode = FitsImmediateRange ? AIE2P::VLDA_dmx_lda_bm_pstm_nrm_imm
                                         : AIE2P::VLDA_dmx_lda_bm_pstm_nrm;
@@ -1970,7 +1956,6 @@ LoadStoreOpcodes AIE2PInstructionSelector::getLoadStoreOpcode(
                        "or FifoRegBank");
     }
     if (LoadStoreSize == 20 || LoadStoreSize == 32) {
-      FitsImmediateRange = checkImmediateRange<4, 4>(Offset);
       ISelOpcode = FitsImmediateRange ? AIE2P::LDA_dms_lda_pstm_nrm_imm
                                       : AIE2P::LDA_dms_lda_pstm_nrm;
       return {ISelOpcode, FitsImmediateRange, /*OffsetOpcode=*/{}};
@@ -1979,13 +1964,11 @@ LoadStoreOpcodes AIE2PInstructionSelector::getLoadStoreOpcode(
     [[fallthrough]];
   case AIE2P::G_AIE_POSTINC_SEXTLOAD: {
     if (LoadStoreSize == 16) {
-      FitsImmediateRange = checkImmediateRange<4, 2>(Offset);
       ISelOpcode = FitsImmediateRange ? AIE2P::LDA_s16_pstm_nrm_imm
                                       : AIE2P::LDA_s16_pstm_nrm;
       return {ISelOpcode, FitsImmediateRange, /*OffsetOpcode=*/{}};
     }
     if (LoadStoreSize == 8) {
-      FitsImmediateRange = checkImmediateRange<4, 1>(Offset);
       ISelOpcode = FitsImmediateRange ? AIE2P::LDA_s8_pstm_nrm_imm
                                       : AIE2P::LDA_s8_pstm_nrm;
       return {ISelOpcode, FitsImmediateRange, /*OffsetOpcode=*/{}};
@@ -1994,13 +1977,11 @@ LoadStoreOpcodes AIE2PInstructionSelector::getLoadStoreOpcode(
   }
   case AIE2P::G_AIE_POSTINC_ZEXTLOAD: {
     if (LoadStoreSize == 16) {
-      FitsImmediateRange = checkImmediateRange<4, 2>(Offset);
       ISelOpcode = FitsImmediateRange ? AIE2P::LDA_u16_pstm_nrm_imm
                                       : AIE2P::LDA_u16_pstm_nrm;
       return {ISelOpcode, FitsImmediateRange, /*OffsetOpcode=*/{}};
     }
     if (LoadStoreSize == 8) {
-      FitsImmediateRange = checkImmediateRange<4, 1>(Offset);
       ISelOpcode = FitsImmediateRange ? AIE2P::LDA_u8_pstm_nrm_imm
                                       : AIE2P::LDA_u8_pstm_nrm;
       return {ISelOpcode, FitsImmediateRange, /*OffsetOpcode=*/{}};
@@ -2203,7 +2184,6 @@ LoadStoreOpcodes AIE2PInstructionSelector::getLoadStoreOpcode(
     if (LoadStoreSize == 128) {
       assert(RBID == AIE2P::VRegBankID &&
              "128-bit vectors should be in the Vector Register Bank");
-      FitsImmediateRange = checkImmediateRange<4, 16>(Offset);
       ISelOpcode = FitsImmediateRange ? AIE2P::VST_128_dmv_sts_w_idx_imm
                                       : AIE2P::VST_128_dmv_sts_w_idx;
       return {ISelOpcode, FitsImmediateRange,
@@ -2212,13 +2192,11 @@ LoadStoreOpcodes AIE2PInstructionSelector::getLoadStoreOpcode(
     if (LoadStoreSize == 256) {
       assert(RBID == AIE2P::VRegBankID &&
              "256-bit vectors should be in the Vector Register Bank");
-      FitsImmediateRange = checkImmediateRange<4, 32>(Offset);
       ISelOpcode = FitsImmediateRange ? AIE2P::VST_dmw_sts_w_idx_imm
                                       : AIE2P::VST_dmw_sts_w_idx;
       return {ISelOpcode, FitsImmediateRange,
               /*OffsetOpcode=*/AIE2P::VST_dmw_sts_w_idx_imm};
     } else if (LoadStoreSize == 512) {
-      FitsImmediateRange = checkImmediateRange<4, 64>(Offset);
       if (RBID == AIE2P::AccRegBankID) {
         ISelOpcode = FitsImmediateRange ? AIE2P::VST_dmx_sts_bm_idx_imm
                                         : AIE2P::VST_dmx_sts_bm_idx;
@@ -2240,10 +2218,6 @@ LoadStoreOpcodes AIE2PInstructionSelector::getLoadStoreOpcode(
       llvm_unreachable("512-bit vector type must be in AccRegBank or "
                        "VRegBank or FifoRegBank");
     } else if (LoadStoreSize == 1024 || LoadStoreSize == 2048) {
-      FitsImmediateRange =
-          (LoadStoreSize == 1024)
-              ? checkImmediateRangeSplitting<4, 64, 64>(Offset)
-              : checkImmediateRangeSplitting<4, 64, 192>(Offset);
       if (RBID == AIE2P::AccRegBankID) {
         return {/*ISelOpcode=*/AIE2P::VST_dmx_sts_bm_idx_imm,
                 FitsImmediateRange,
@@ -2262,19 +2236,16 @@ LoadStoreOpcodes AIE2PInstructionSelector::getLoadStoreOpcode(
                        "VRegBank or FifoRegBank");
     }
     if (LoadStoreSize == 20 || LoadStoreSize == 32) {
-      FitsImmediateRange = checkImmediateRange<4, 4>(Offset);
       ISelOpcode = FitsImmediateRange ? AIE2P::ST_dms_sts_idx_imm
                                       : AIE2P::ST_dms_sts_idx;
       return {ISelOpcode, FitsImmediateRange, /*OffsetOpcode=*/{}};
     }
     if (LoadStoreSize == 16) {
-      FitsImmediateRange = checkImmediateRange<4, 2>(Offset);
       ISelOpcode =
           FitsImmediateRange ? AIE2P::ST_s16_idx_imm : AIE2P::ST_s16_idx;
       return {ISelOpcode, FitsImmediateRange, /*OffsetOpcode=*/{}};
     }
     if (LoadStoreSize == 8) {
-      FitsImmediateRange = checkImmediateRange<4, 1>(Offset);
       ISelOpcode = FitsImmediateRange ? AIE2P::ST_s8_idx_imm : AIE2P::ST_s8_idx;
       return {ISelOpcode, FitsImmediateRange, /*OffsetOpcode=*/{}};
     }
@@ -2285,7 +2256,6 @@ LoadStoreOpcodes AIE2PInstructionSelector::getLoadStoreOpcode(
     if (LoadStoreSize == 128) {
       assert(RBID == AIE2P::VRegBankID &&
              "128-bit vectors should be in the Vector Register Bank");
-      FitsImmediateRange = checkImmediateRange<4, 16>(Offset);
       ISelOpcode = FitsImmediateRange ? AIE2P::VST_128_dmv_sts_w_pstm_nrm_imm
                                       : AIE2P::VST_128_dmv_sts_w_pstm_nrm;
       return {ISelOpcode, FitsImmediateRange,
@@ -2294,14 +2264,12 @@ LoadStoreOpcodes AIE2PInstructionSelector::getLoadStoreOpcode(
     if (LoadStoreSize == 256) {
       assert(RBID == AIE2P::VRegBankID &&
              "256-bit vectors should be in the Vector Register Bank");
-      FitsImmediateRange = checkImmediateRange<4, 32>(Offset);
       ISelOpcode = FitsImmediateRange ? AIE2P::VST_dmw_sts_w_pstm_nrm_imm
                                       : AIE2P::VST_dmw_sts_w_pstm_nrm;
       return {ISelOpcode, FitsImmediateRange,
               /*OffsetOpcode=*/AIE2P::VST_dmw_sts_w_pstm_nrm_imm};
     } else if (LoadStoreSize == 512 || LoadStoreSize == 1024 ||
                LoadStoreSize == 2048) {
-      FitsImmediateRange = checkImmediateRange<4, 64>(Offset);
       if (RBID == AIE2P::AccRegBankID) {
         ISelOpcode = FitsImmediateRange ? AIE2P::VST_dmx_sts_bm_pstm_nrm_imm
                                         : AIE2P::VST_dmx_sts_bm_pstm_nrm;
@@ -2324,19 +2292,16 @@ LoadStoreOpcodes AIE2PInstructionSelector::getLoadStoreOpcode(
                        "or FifoRegBank");
     }
     if (LoadStoreSize == 20 || LoadStoreSize == 32) {
-      FitsImmediateRange = checkImmediateRange<4, 4>(Offset);
       ISelOpcode = FitsImmediateRange ? AIE2P::ST_dms_sts_pstm_nrm_imm
                                       : AIE2P::ST_dms_sts_pstm_nrm;
       return {ISelOpcode, FitsImmediateRange, /*OffsetOpcode=*/{}};
     }
     if (LoadStoreSize == 16) {
-      FitsImmediateRange = checkImmediateRange<4, 2>(Offset);
       ISelOpcode = FitsImmediateRange ? AIE2P::ST_s16_pstm_nrm_imm
                                       : AIE2P::ST_s16_pstm_nrm;
       return {ISelOpcode, FitsImmediateRange, /*OffsetOpcode=*/{}};
     }
     if (LoadStoreSize == 8) {
-      FitsImmediateRange = checkImmediateRange<4, 1>(Offset);
       ISelOpcode = FitsImmediateRange ? AIE2P::ST_s8_pstm_nrm_imm
                                       : AIE2P::ST_s8_pstm_nrm;
       return {ISelOpcode, FitsImmediateRange, /*OffsetOpcode=*/{}};
@@ -3076,12 +3041,12 @@ static bool getVLDA_CONVOpcode(const MachineInstr &MemOp,
     return true;
   case AIE2P::G_AIE_OFFSET_LOAD:
     if (getLoadStoreSize(MemOp) == 256) {
-      FitsImmediateRange = checkImmediateRange<4, 32>(Immediate);
+      FitsImmediateRange = checkSignedImmediateRange<4, 32>(Immediate);
       ISelOpcode = FitsImmediateRange
                        ? AIE2P::VLDA_CONV_fp32_bf16_dmw_lda_ups_bf_idx_imm
                        : AIE2P::VLDA_CONV_fp32_bf16_dmw_lda_ups_bf_idx;
     } else if (getLoadStoreSize(MemOp) == 512) {
-      FitsImmediateRange = checkImmediateRange<4, 64>(Immediate);
+      FitsImmediateRange = checkSignedImmediateRange<4, 64>(Immediate);
       ISelOpcode = FitsImmediateRange
                        ? AIE2P::VLDA_CONV_fp32_bf16_dmx_lda_ups_bf_idx_imm
                        : AIE2P::VLDA_CONV_fp32_bf16_dmx_lda_ups_bf_idx;
@@ -3089,12 +3054,12 @@ static bool getVLDA_CONVOpcode(const MachineInstr &MemOp,
     return true;
   case AIE2P::G_AIE_POSTINC_LOAD:
     if (getLoadStoreSize(MemOp) == 256) {
-      FitsImmediateRange = checkImmediateRange<4, 32>(Immediate);
+      FitsImmediateRange = checkSignedImmediateRange<4, 32>(Immediate);
       ISelOpcode = FitsImmediateRange
                        ? AIE2P::VLDA_CONV_fp32_bf16_dmw_lda_ups_bf_pstm_nrm_imm
                        : AIE2P::VLDA_CONV_fp32_bf16_dmw_lda_ups_bf_pstm_nrm;
     } else if (getLoadStoreSize(MemOp) == 512) {
-      FitsImmediateRange = checkImmediateRange<4, 64>(Immediate);
+      FitsImmediateRange = checkSignedImmediateRange<4, 64>(Immediate);
       ISelOpcode = FitsImmediateRange
                        ? AIE2P::VLDA_CONV_fp32_bf16_dmx_lda_ups_bf_pstm_nrm_imm
                        : AIE2P::VLDA_CONV_fp32_bf16_dmx_lda_ups_bf_pstm_nrm;
@@ -3187,7 +3152,7 @@ std::optional<LoadStoreOpcodes> AIE2PInstructionSelector::getCombinedOpcodePACK(
       switch (CombOpIntrinsicID) {
       case Intrinsic::aie2p_pack_I512_I8_I16:
       case Intrinsic::aie2p_pack_I512_I4_I8:
-        FitsImmediateRange = checkImmediateRange<4, 32>(Immediate);
+        FitsImmediateRange = checkSignedImmediateRange<4, 32>(Immediate);
         ISelOpcode = FitsImmediateRange
                          ? AIE2P::VST_PACK_dmw_sts_pack_idx_imm_packSign1
                          : AIE2P::VST_PACK_dmw_sts_pack_idx_packSign1;
@@ -3195,7 +3160,7 @@ std::optional<LoadStoreOpcodes> AIE2PInstructionSelector::getCombinedOpcodePACK(
                                 /*OffsetOpcode=*/{}};
       case Intrinsic::aie2p_pack_I1024_I8_I16:
       case Intrinsic::aie2p_pack_I1024_I4_I8:
-        FitsImmediateRange = checkImmediateRange<4, 64>(Immediate);
+        FitsImmediateRange = checkSignedImmediateRange<4, 64>(Immediate);
         ISelOpcode = FitsImmediateRange
                          ? AIE2P::VST_PACK_dmx_sts_pack_idx_imm_packSign1
                          : AIE2P::VST_PACK_dmx_sts_pack_idx_packSign1;
@@ -3207,7 +3172,7 @@ std::optional<LoadStoreOpcodes> AIE2PInstructionSelector::getCombinedOpcodePACK(
       switch (CombOpIntrinsicID) {
       case Intrinsic::aie2p_pack_I512_I8_I16:
       case Intrinsic::aie2p_pack_I512_I4_I8:
-        FitsImmediateRange = checkImmediateRange<4, 32>(Immediate);
+        FitsImmediateRange = checkSignedImmediateRange<4, 32>(Immediate);
         ISelOpcode = FitsImmediateRange
                          ? AIE2P::VST_PACK_dmw_sts_pack_pstm_nrm_imm_packSign1
                          : AIE2P::VST_PACK_dmw_sts_pack_pstm_nrm_packSign1;
@@ -3215,7 +3180,7 @@ std::optional<LoadStoreOpcodes> AIE2PInstructionSelector::getCombinedOpcodePACK(
                                 /*OffsetOpcode=*/{}};
       case Intrinsic::aie2p_pack_I1024_I8_I16:
       case Intrinsic::aie2p_pack_I1024_I4_I8:
-        FitsImmediateRange = checkImmediateRange<4, 64>(Immediate);
+        FitsImmediateRange = checkSignedImmediateRange<4, 64>(Immediate);
         ISelOpcode = FitsImmediateRange
                          ? AIE2P::VST_PACK_dmx_sts_pack_pstm_nrm_imm_packSign1
                          : AIE2P::VST_PACK_dmx_sts_pack_pstm_nrm_packSign1;
@@ -3278,7 +3243,7 @@ std::optional<LoadStoreOpcodes> AIE2PInstructionSelector::getCombinedOpcodePACK(
       switch (CombOpIntrinsicID) {
       case Intrinsic::aie2p_pack_I512_I8_I16:
       case Intrinsic::aie2p_pack_I512_I4_I8:
-        FitsImmediateRange = checkImmediateRange<4, 32>(Immediate);
+        FitsImmediateRange = checkSignedImmediateRange<4, 32>(Immediate);
         ISelOpcode = FitsImmediateRange
                          ? AIE2P::VST_PACK_dmw_sts_pack_idx_imm_packSign0
                          : AIE2P::VST_PACK_dmw_sts_pack_idx_packSign0;
@@ -3286,7 +3251,7 @@ std::optional<LoadStoreOpcodes> AIE2PInstructionSelector::getCombinedOpcodePACK(
                                 /*OffsetOpcode=*/{}};
       case Intrinsic::aie2p_pack_I1024_I8_I16:
       case Intrinsic::aie2p_pack_I1024_I4_I8:
-        FitsImmediateRange = checkImmediateRange<4, 64>(Immediate);
+        FitsImmediateRange = checkSignedImmediateRange<4, 64>(Immediate);
         ISelOpcode = FitsImmediateRange
                          ? AIE2P::VST_PACK_dmx_sts_pack_idx_imm_packSign0
                          : AIE2P::VST_PACK_dmx_sts_pack_idx_packSign0;
@@ -3298,7 +3263,7 @@ std::optional<LoadStoreOpcodes> AIE2PInstructionSelector::getCombinedOpcodePACK(
       switch (CombOpIntrinsicID) {
       case Intrinsic::aie2p_pack_I512_I8_I16:
       case Intrinsic::aie2p_pack_I512_I4_I8:
-        FitsImmediateRange = checkImmediateRange<4, 32>(Immediate);
+        FitsImmediateRange = checkSignedImmediateRange<4, 32>(Immediate);
         ISelOpcode = FitsImmediateRange
                          ? AIE2P::VST_PACK_dmw_sts_pack_pstm_nrm_imm_packSign0
                          : AIE2P::VST_PACK_dmw_sts_pack_pstm_nrm_packSign0;
@@ -3306,7 +3271,7 @@ std::optional<LoadStoreOpcodes> AIE2PInstructionSelector::getCombinedOpcodePACK(
                                 /*OffsetOpcode=*/{}};
       case Intrinsic::aie2p_pack_I1024_I8_I16:
       case Intrinsic::aie2p_pack_I1024_I4_I8:
-        FitsImmediateRange = checkImmediateRange<4, 64>(Immediate);
+        FitsImmediateRange = checkSignedImmediateRange<4, 64>(Immediate);
         ISelOpcode = FitsImmediateRange
                          ? AIE2P::VST_PACK_dmx_sts_pack_pstm_nrm_imm_packSign0
                          : AIE2P::VST_PACK_dmx_sts_pack_pstm_nrm_packSign0;
@@ -3672,12 +3637,12 @@ std::optional<LoadStoreOpcodes> AIE2PInstructionSelector::getCombinedOpcodeCONV(
                             /*OffsetOpcode=*/{}};
   case AIE2P::G_AIE_OFFSET_STORE:
     if (getLoadStoreSize(MemOp) == 256) {
-      FitsImmediateRange = checkImmediateRange<4, 32>(Immediate);
+      FitsImmediateRange = checkSignedImmediateRange<4, 32>(Immediate);
       ISelOpcode = FitsImmediateRange
                        ? AIE2P::VST_CONV_bf16_fp32_dmw_sts_srs_bf_idx_imm
                        : AIE2P::VST_CONV_bf16_fp32_dmw_sts_srs_bf_idx;
     } else /* getLoadStoreSize(MemOp) == 512 */ {
-      FitsImmediateRange = checkImmediateRange<4, 64>(Immediate);
+      FitsImmediateRange = checkSignedImmediateRange<4, 64>(Immediate);
       ISelOpcode = FitsImmediateRange
                        ? AIE2P::VST_CONV_bf16_fp32_dmx_sts_srs_bf_idx_imm
                        : AIE2P::VST_CONV_bf16_fp32_dmx_sts_srs_bf_idx;
@@ -3686,12 +3651,12 @@ std::optional<LoadStoreOpcodes> AIE2PInstructionSelector::getCombinedOpcodeCONV(
                             /*OffsetOpcode=*/{}};
   case AIE2P::G_AIE_POSTINC_STORE:
     if (getLoadStoreSize(MemOp) == 256) {
-      FitsImmediateRange = checkImmediateRange<4, 32>(Immediate);
+      FitsImmediateRange = checkSignedImmediateRange<4, 32>(Immediate);
       ISelOpcode = FitsImmediateRange
                        ? AIE2P::VST_CONV_bf16_fp32_dmw_sts_srs_bf_pstm_nrm_imm
                        : AIE2P::VST_CONV_bf16_fp32_dmw_sts_srs_bf_pstm_nrm;
     } else /* getLoadStoreSize(MemOp) == 512 */ {
-      FitsImmediateRange = checkImmediateRange<4, 64>(Immediate);
+      FitsImmediateRange = checkSignedImmediateRange<4, 64>(Immediate);
       ISelOpcode = FitsImmediateRange
                        ? AIE2P::VST_CONV_bf16_fp32_dmx_sts_srs_bf_pstm_nrm_imm
                        : AIE2P::VST_CONV_bf16_fp32_dmx_sts_srs_bf_pstm_nrm;
@@ -3823,14 +3788,14 @@ AIE2PInstructionSelector::getCombinedOpcodeUNPACKLoad(
       switch (CombOpInstID) {
       case Intrinsic::aie2p_unpack_I1024_I8_I4:
       case Intrinsic::aie2p_unpack_I1024_I16_I8:
-        FitsImmediateRange = checkImmediateRange<4, 64>(Immediate);
+        FitsImmediateRange = checkSignedImmediateRange<4, 64>(Immediate);
         ISelOpcode = FitsImmediateRange
                          ? AIE2P::VLDB_UNPACK_dmx_ldb_unpack_idx_imm_unpackSign1
                          : AIE2P::VLDB_UNPACK_dmx_ldb_unpack_idx_unpackSign1;
         return LoadStoreOpcodes{ISelOpcode, FitsImmediateRange, {}};
       case Intrinsic::aie2p_unpack_I512_I8_I4:
       case Intrinsic::aie2p_unpack_I512_I16_I8:
-        FitsImmediateRange = checkImmediateRange<4, 32>(Immediate);
+        FitsImmediateRange = checkSignedImmediateRange<4, 32>(Immediate);
         ISelOpcode = FitsImmediateRange
                          ? AIE2P::VLDB_UNPACK_dmw_ldb_unpack_idx_imm_unpackSign1
                          : AIE2P::VLDB_UNPACK_dmw_ldb_unpack_idx_unpackSign1;
@@ -3841,7 +3806,7 @@ AIE2PInstructionSelector::getCombinedOpcodeUNPACKLoad(
       switch (CombOpInstID) {
       case Intrinsic::aie2p_unpack_I1024_I8_I4:
       case Intrinsic::aie2p_unpack_I1024_I16_I8:
-        FitsImmediateRange = checkImmediateRange<4, 64>(Immediate);
+        FitsImmediateRange = checkSignedImmediateRange<4, 64>(Immediate);
         ISelOpcode =
             FitsImmediateRange
                 ? AIE2P::VLDB_UNPACK_dmx_ldb_unpack_pstm_nrm_imm_unpackSign1
@@ -3849,7 +3814,7 @@ AIE2PInstructionSelector::getCombinedOpcodeUNPACKLoad(
         return LoadStoreOpcodes{ISelOpcode, FitsImmediateRange, {}};
       case Intrinsic::aie2p_unpack_I512_I8_I4:
       case Intrinsic::aie2p_unpack_I512_I16_I8:
-        FitsImmediateRange = checkImmediateRange<4, 32>(Immediate);
+        FitsImmediateRange = checkSignedImmediateRange<4, 32>(Immediate);
         ISelOpcode =
             FitsImmediateRange
                 ? AIE2P::VLDB_UNPACK_dmw_ldb_unpack_pstm_nrm_imm_unpackSign1
@@ -3904,14 +3869,14 @@ AIE2PInstructionSelector::getCombinedOpcodeUNPACKLoad(
       switch (CombOpInstID) {
       case Intrinsic::aie2p_unpack_I1024_I8_I4:
       case Intrinsic::aie2p_unpack_I1024_I16_I8:
-        FitsImmediateRange = checkImmediateRange<4, 64>(Immediate);
+        FitsImmediateRange = checkSignedImmediateRange<4, 64>(Immediate);
         ISelOpcode = FitsImmediateRange
                          ? AIE2P::VLDB_UNPACK_dmx_ldb_unpack_idx_imm_unpackSign0
                          : AIE2P::VLDB_UNPACK_dmx_ldb_unpack_idx_unpackSign0;
         return LoadStoreOpcodes{ISelOpcode, FitsImmediateRange, {}};
       case Intrinsic::aie2p_unpack_I512_I8_I4:
       case Intrinsic::aie2p_unpack_I512_I16_I8:
-        FitsImmediateRange = checkImmediateRange<4, 32>(Immediate);
+        FitsImmediateRange = checkSignedImmediateRange<4, 32>(Immediate);
         ISelOpcode = FitsImmediateRange
                          ? AIE2P::VLDB_UNPACK_dmw_ldb_unpack_idx_imm_unpackSign0
                          : AIE2P::VLDB_UNPACK_dmw_ldb_unpack_idx_unpackSign0;
@@ -3922,7 +3887,7 @@ AIE2PInstructionSelector::getCombinedOpcodeUNPACKLoad(
       switch (CombOpInstID) {
       case Intrinsic::aie2p_unpack_I1024_I8_I4:
       case Intrinsic::aie2p_unpack_I1024_I16_I8:
-        FitsImmediateRange = checkImmediateRange<4, 64>(Immediate);
+        FitsImmediateRange = checkSignedImmediateRange<4, 64>(Immediate);
         ISelOpcode =
             FitsImmediateRange
                 ? AIE2P::VLDB_UNPACK_dmx_ldb_unpack_pstm_nrm_imm_unpackSign0
@@ -3930,7 +3895,7 @@ AIE2PInstructionSelector::getCombinedOpcodeUNPACKLoad(
         return LoadStoreOpcodes{ISelOpcode, FitsImmediateRange, {}};
       case Intrinsic::aie2p_unpack_I512_I8_I4:
       case Intrinsic::aie2p_unpack_I512_I16_I8:
-        FitsImmediateRange = checkImmediateRange<4, 32>(Immediate);
+        FitsImmediateRange = checkSignedImmediateRange<4, 32>(Immediate);
         ISelOpcode =
             FitsImmediateRange
                 ? AIE2P::VLDB_UNPACK_dmw_ldb_unpack_pstm_nrm_imm_unpackSign0
@@ -4135,7 +4100,7 @@ std::optional<LoadStoreOpcodes> AIE2PInstructionSelector::getCombinedOpcodeUPS(
         switch (cast<GIntrinsic>(CombOp).getIntrinsicID()) {
         case Intrinsic::aie2p_acc32_v32_I512_ups:
         case Intrinsic::aie2p_acc64_v16_I512_ups:
-          FitsImmediateRange = checkImmediateRange<4, 64>(Immediate);
+          FitsImmediateRange = checkSignedImmediateRange<4, 64>(Immediate);
           ISelOpcode = FitsImmediateRange
                            ? AIE2P::VLDA_UPS_2x_dmx_lda_ups_x2c_idx_imm_upsSign1
                            : AIE2P::VLDA_UPS_2x_dmx_lda_ups_x2c_idx_upsSign1;
@@ -4143,7 +4108,7 @@ std::optional<LoadStoreOpcodes> AIE2PInstructionSelector::getCombinedOpcodeUPS(
                                   /*OffsetOpcode=*/{}};
         case Intrinsic::aie2p_acc32_v64_I512_ups:
         case Intrinsic::aie2p_acc64_v32_I512_ups:
-          FitsImmediateRange = checkImmediateRange<4, 64>(Immediate);
+          FitsImmediateRange = checkSignedImmediateRange<4, 64>(Immediate);
           ISelOpcode = FitsImmediateRange
                            ? AIE2P::VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign1
                            : AIE2P::VLDA_UPS_4x_dmx_lda_ups_x2d_idx_upsSign1;
@@ -4154,7 +4119,7 @@ std::optional<LoadStoreOpcodes> AIE2PInstructionSelector::getCombinedOpcodeUPS(
         switch (cast<GIntrinsic>(CombOp).getIntrinsicID()) {
         case Intrinsic::aie2p_acc32_v16_I256_ups:
         case Intrinsic::aie2p_acc64_v8_I256_ups:
-          FitsImmediateRange = checkImmediateRange<4, 32>(Immediate);
+          FitsImmediateRange = checkSignedImmediateRange<4, 32>(Immediate);
           ISelOpcode = FitsImmediateRange
                            ? AIE2P::VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign1
                            : AIE2P::VLDA_UPS_2x_dmw_lda_ups_w2b_idx_upsSign1;
@@ -4162,7 +4127,7 @@ std::optional<LoadStoreOpcodes> AIE2PInstructionSelector::getCombinedOpcodeUPS(
                                   /*OffsetOpcode=*/{}};
         case Intrinsic::aie2p_acc32_v32_I256_ups:
         case Intrinsic::aie2p_acc64_v16_I256_ups:
-          FitsImmediateRange = checkImmediateRange<4, 32>(Immediate);
+          FitsImmediateRange = checkSignedImmediateRange<4, 32>(Immediate);
           ISelOpcode = FitsImmediateRange
                            ? AIE2P::VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign1
                            : AIE2P::VLDA_UPS_4x_dmw_lda_ups_w2c_idx_upsSign1;
@@ -4176,7 +4141,7 @@ std::optional<LoadStoreOpcodes> AIE2PInstructionSelector::getCombinedOpcodeUPS(
         switch (cast<GIntrinsic>(CombOp).getIntrinsicID()) {
         case Intrinsic::aie2p_acc32_v32_I512_ups:
         case Intrinsic::aie2p_acc64_v16_I512_ups:
-          FitsImmediateRange = checkImmediateRange<4, 64>(Immediate);
+          FitsImmediateRange = checkSignedImmediateRange<4, 64>(Immediate);
           ISelOpcode =
               FitsImmediateRange
                   ? AIE2P::VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign1
@@ -4185,7 +4150,7 @@ std::optional<LoadStoreOpcodes> AIE2PInstructionSelector::getCombinedOpcodeUPS(
                                   /*OffsetOpcode=*/{}};
         case Intrinsic::aie2p_acc32_v64_I512_ups:
         case Intrinsic::aie2p_acc64_v32_I512_ups:
-          FitsImmediateRange = checkImmediateRange<4, 64>(Immediate);
+          FitsImmediateRange = checkSignedImmediateRange<4, 64>(Immediate);
           ISelOpcode =
               FitsImmediateRange
                   ? AIE2P::VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign1
@@ -4197,7 +4162,7 @@ std::optional<LoadStoreOpcodes> AIE2PInstructionSelector::getCombinedOpcodeUPS(
         switch (cast<GIntrinsic>(CombOp).getIntrinsicID()) {
         case Intrinsic::aie2p_acc32_v16_I256_ups:
         case Intrinsic::aie2p_acc64_v8_I256_ups:
-          FitsImmediateRange = checkImmediateRange<4, 32>(Immediate);
+          FitsImmediateRange = checkSignedImmediateRange<4, 32>(Immediate);
           ISelOpcode =
               FitsImmediateRange
                   ? AIE2P::VLDA_UPS_2x_dmw_lda_ups_w2b_pstm_nrm_imm_upsSign1
@@ -4206,7 +4171,7 @@ std::optional<LoadStoreOpcodes> AIE2PInstructionSelector::getCombinedOpcodeUPS(
                                   /*OffsetOpcode=*/{}};
         case Intrinsic::aie2p_acc32_v32_I256_ups:
         case Intrinsic::aie2p_acc64_v16_I256_ups:
-          FitsImmediateRange = checkImmediateRange<4, 32>(Immediate);
+          FitsImmediateRange = checkSignedImmediateRange<4, 32>(Immediate);
           ISelOpcode =
               FitsImmediateRange
                   ? AIE2P::VLDA_UPS_4x_dmw_lda_ups_w2c_pstm_nrm_imm_upsSign1
@@ -4316,7 +4281,7 @@ std::optional<LoadStoreOpcodes> AIE2PInstructionSelector::getCombinedOpcodeUPS(
         switch (cast<GIntrinsic>(CombOp).getIntrinsicID()) {
         case Intrinsic::aie2p_acc32_v32_I512_ups:
         case Intrinsic::aie2p_acc64_v16_I512_ups:
-          FitsImmediateRange = checkImmediateRange<4, 64>(Immediate);
+          FitsImmediateRange = checkSignedImmediateRange<4, 64>(Immediate);
           ISelOpcode = FitsImmediateRange
                            ? AIE2P::VLDA_UPS_2x_dmx_lda_ups_x2c_idx_imm_upsSign0
                            : AIE2P::VLDA_UPS_2x_dmx_lda_ups_x2c_idx_upsSign0;
@@ -4324,7 +4289,7 @@ std::optional<LoadStoreOpcodes> AIE2PInstructionSelector::getCombinedOpcodeUPS(
                                   /*OffsetOpcode=*/{}};
         case Intrinsic::aie2p_acc32_v64_I512_ups:
         case Intrinsic::aie2p_acc64_v32_I512_ups:
-          FitsImmediateRange = checkImmediateRange<4, 64>(Immediate);
+          FitsImmediateRange = checkSignedImmediateRange<4, 64>(Immediate);
           ISelOpcode = FitsImmediateRange
                            ? AIE2P::VLDA_UPS_4x_dmx_lda_ups_x2d_idx_imm_upsSign0
                            : AIE2P::VLDA_UPS_4x_dmx_lda_ups_x2d_idx_upsSign0;
@@ -4335,7 +4300,7 @@ std::optional<LoadStoreOpcodes> AIE2PInstructionSelector::getCombinedOpcodeUPS(
         switch (cast<GIntrinsic>(CombOp).getIntrinsicID()) {
         case Intrinsic::aie2p_acc32_v16_I256_ups:
         case Intrinsic::aie2p_acc64_v8_I256_ups:
-          FitsImmediateRange = checkImmediateRange<4, 32>(Immediate);
+          FitsImmediateRange = checkSignedImmediateRange<4, 32>(Immediate);
           ISelOpcode = FitsImmediateRange
                            ? AIE2P::VLDA_UPS_2x_dmw_lda_ups_w2b_idx_imm_upsSign0
                            : AIE2P::VLDA_UPS_2x_dmw_lda_ups_w2b_idx_upsSign0;
@@ -4343,7 +4308,7 @@ std::optional<LoadStoreOpcodes> AIE2PInstructionSelector::getCombinedOpcodeUPS(
                                   /*OffsetOpcode=*/{}};
         case Intrinsic::aie2p_acc32_v32_I256_ups:
         case Intrinsic::aie2p_acc64_v16_I256_ups:
-          FitsImmediateRange = checkImmediateRange<4, 32>(Immediate);
+          FitsImmediateRange = checkSignedImmediateRange<4, 32>(Immediate);
           ISelOpcode = FitsImmediateRange
                            ? AIE2P::VLDA_UPS_4x_dmw_lda_ups_w2c_idx_imm_upsSign0
                            : AIE2P::VLDA_UPS_4x_dmw_lda_ups_w2c_idx_upsSign0;
@@ -4357,7 +4322,7 @@ std::optional<LoadStoreOpcodes> AIE2PInstructionSelector::getCombinedOpcodeUPS(
         switch (cast<GIntrinsic>(CombOp).getIntrinsicID()) {
         case Intrinsic::aie2p_acc32_v32_I512_ups:
         case Intrinsic::aie2p_acc64_v16_I512_ups:
-          FitsImmediateRange = checkImmediateRange<4, 64>(Immediate);
+          FitsImmediateRange = checkSignedImmediateRange<4, 64>(Immediate);
           ISelOpcode =
               FitsImmediateRange
                   ? AIE2P::VLDA_UPS_2x_dmx_lda_ups_x2c_pstm_nrm_imm_upsSign0
@@ -4366,7 +4331,7 @@ std::optional<LoadStoreOpcodes> AIE2PInstructionSelector::getCombinedOpcodeUPS(
                                   /*OffsetOpcode=*/{}};
         case Intrinsic::aie2p_acc32_v64_I512_ups:
         case Intrinsic::aie2p_acc64_v32_I512_ups:
-          FitsImmediateRange = checkImmediateRange<4, 64>(Immediate);
+          FitsImmediateRange = checkSignedImmediateRange<4, 64>(Immediate);
           ISelOpcode =
               FitsImmediateRange
                   ? AIE2P::VLDA_UPS_4x_dmx_lda_ups_x2d_pstm_nrm_imm_upsSign0
@@ -4378,7 +4343,7 @@ std::optional<LoadStoreOpcodes> AIE2PInstructionSelector::getCombinedOpcodeUPS(
         switch (cast<GIntrinsic>(CombOp).getIntrinsicID()) {
         case Intrinsic::aie2p_acc32_v16_I256_ups:
         case Intrinsic::aie2p_acc64_v8_I256_ups:
-          FitsImmediateRange = checkImmediateRange<4, 32>(Immediate);
+          FitsImmediateRange = checkSignedImmediateRange<4, 32>(Immediate);
           ISelOpcode =
               FitsImmediateRange
                   ? AIE2P::VLDA_UPS_2x_dmw_lda_ups_w2b_pstm_nrm_imm_upsSign0
@@ -4387,7 +4352,7 @@ std::optional<LoadStoreOpcodes> AIE2PInstructionSelector::getCombinedOpcodeUPS(
                                   /*OffsetOpcode=*/{}};
         case Intrinsic::aie2p_acc32_v32_I256_ups:
         case Intrinsic::aie2p_acc64_v16_I256_ups:
-          FitsImmediateRange = checkImmediateRange<4, 32>(Immediate);
+          FitsImmediateRange = checkSignedImmediateRange<4, 32>(Immediate);
           ISelOpcode =
               FitsImmediateRange
                   ? AIE2P::VLDA_UPS_4x_dmw_lda_ups_w2c_pstm_nrm_imm_upsSign0
@@ -4534,7 +4499,7 @@ std::optional<LoadStoreOpcodes> AIE2PInstructionSelector::getCombinedOpcodeSRS(
         switch (CombOpIntrinsicID) {
         case Intrinsic::aie2p_I512_v64_acc32_srs:
         case Intrinsic::aie2p_I512_v32_acc64_srs:
-          FitsImmediateRange = checkImmediateRange<4, 64>(Immediate);
+          FitsImmediateRange = checkSignedImmediateRange<4, 64>(Immediate);
           ISelOpcode = FitsImmediateRange
                            ? AIE2P::VST_SRS_4x_dmx_sts_srs_dm_idx_imm_srsSign1
                            : AIE2P::VST_SRS_4x_dmx_sts_srs_dm_idx_srsSign1;
@@ -4542,7 +4507,7 @@ std::optional<LoadStoreOpcodes> AIE2PInstructionSelector::getCombinedOpcodeSRS(
                                   /*OffsetOpcode=*/{}};
         case Intrinsic::aie2p_I512_v32_acc32_srs:
         case Intrinsic::aie2p_I512_v16_acc64_srs:
-          FitsImmediateRange = checkImmediateRange<4, 64>(Immediate);
+          FitsImmediateRange = checkSignedImmediateRange<4, 64>(Immediate);
           ISelOpcode = FitsImmediateRange
                            ? AIE2P::VST_SRS_2x_dm_sts_srs_cm_idx_imm_srsSign1
                            : AIE2P::VST_SRS_2x_dm_sts_srs_cm_idx_srsSign1;
@@ -4553,7 +4518,7 @@ std::optional<LoadStoreOpcodes> AIE2PInstructionSelector::getCombinedOpcodeSRS(
         switch (CombOpIntrinsicID) {
         case Intrinsic::aie2p_I256_v16_acc32_srs:
         case Intrinsic::aie2p_I256_v8_acc64_srs:
-          FitsImmediateRange = checkImmediateRange<4, 32>(Immediate);
+          FitsImmediateRange = checkSignedImmediateRange<4, 32>(Immediate);
           ISelOpcode = FitsImmediateRange
                            ? AIE2P::VST_SRS_2x_dmw_sts_srs_bm_idx_imm_srsSign1
                            : AIE2P::VST_SRS_2x_dmw_sts_srs_bm_idx_srsSign1;
@@ -4561,7 +4526,7 @@ std::optional<LoadStoreOpcodes> AIE2PInstructionSelector::getCombinedOpcodeSRS(
                                   /*OffsetOpcode=*/{}};
         case Intrinsic::aie2p_I256_v32_acc32_srs:
         case Intrinsic::aie2p_I256_v16_acc64_srs:
-          FitsImmediateRange = checkImmediateRange<4, 32>(Immediate);
+          FitsImmediateRange = checkSignedImmediateRange<4, 32>(Immediate);
           ISelOpcode = FitsImmediateRange
                            ? AIE2P::VST_SRS_4x_dm_sts_srs_cm_idx_imm_srsSign1
                            : AIE2P::VST_SRS_4x_dm_sts_srs_cm_idx_srsSign1;
@@ -4575,7 +4540,7 @@ std::optional<LoadStoreOpcodes> AIE2PInstructionSelector::getCombinedOpcodeSRS(
         switch (CombOpIntrinsicID) {
         case Intrinsic::aie2p_I512_v64_acc32_srs:
         case Intrinsic::aie2p_I512_v32_acc64_srs:
-          FitsImmediateRange = checkImmediateRange<4, 64>(Immediate);
+          FitsImmediateRange = checkSignedImmediateRange<4, 64>(Immediate);
           ISelOpcode =
               FitsImmediateRange
                   ? AIE2P::VST_SRS_4x_dmx_sts_srs_dm_pstm_nrm_imm_srsSign1
@@ -4584,7 +4549,7 @@ std::optional<LoadStoreOpcodes> AIE2PInstructionSelector::getCombinedOpcodeSRS(
                                   /*OffsetOpcode=*/{}};
         case Intrinsic::aie2p_I512_v32_acc32_srs:
         case Intrinsic::aie2p_I512_v16_acc64_srs:
-          FitsImmediateRange = checkImmediateRange<4, 64>(Immediate);
+          FitsImmediateRange = checkSignedImmediateRange<4, 64>(Immediate);
           ISelOpcode =
               FitsImmediateRange
                   ? AIE2P::VST_SRS_2x_dm_sts_srs_cm_pstm_nrm_imm_srsSign1
@@ -4596,7 +4561,7 @@ std::optional<LoadStoreOpcodes> AIE2PInstructionSelector::getCombinedOpcodeSRS(
         switch (CombOpIntrinsicID) {
         case Intrinsic::aie2p_I256_v16_acc32_srs:
         case Intrinsic::aie2p_I256_v8_acc64_srs:
-          FitsImmediateRange = checkImmediateRange<4, 32>(Immediate);
+          FitsImmediateRange = checkSignedImmediateRange<4, 32>(Immediate);
           ISelOpcode =
               FitsImmediateRange
                   ? AIE2P::VST_SRS_2x_dmw_sts_srs_bm_pstm_nrm_imm_srsSign1
@@ -4605,7 +4570,7 @@ std::optional<LoadStoreOpcodes> AIE2PInstructionSelector::getCombinedOpcodeSRS(
                                   /*OffsetOpcode=*/{}};
         case Intrinsic::aie2p_I256_v32_acc32_srs:
         case Intrinsic::aie2p_I256_v16_acc64_srs:
-          FitsImmediateRange = checkImmediateRange<4, 32>(Immediate);
+          FitsImmediateRange = checkSignedImmediateRange<4, 32>(Immediate);
           ISelOpcode =
               FitsImmediateRange
                   ? AIE2P::VST_SRS_4x_dm_sts_srs_cm_pstm_nrm_imm_srsSign1
@@ -4711,7 +4676,7 @@ std::optional<LoadStoreOpcodes> AIE2PInstructionSelector::getCombinedOpcodeSRS(
         switch (CombOpIntrinsicID) {
         case Intrinsic::aie2p_I512_v64_acc32_srs:
         case Intrinsic::aie2p_I512_v32_acc64_srs:
-          FitsImmediateRange = checkImmediateRange<4, 64>(Immediate);
+          FitsImmediateRange = checkSignedImmediateRange<4, 64>(Immediate);
           ISelOpcode = FitsImmediateRange
                            ? AIE2P::VST_SRS_4x_dmx_sts_srs_dm_idx_imm_srsSign0
                            : AIE2P::VST_SRS_4x_dmx_sts_srs_dm_idx_srsSign0;
@@ -4719,7 +4684,7 @@ std::optional<LoadStoreOpcodes> AIE2PInstructionSelector::getCombinedOpcodeSRS(
                                   /*OffsetOpcode=*/{}};
         case Intrinsic::aie2p_I512_v32_acc32_srs:
         case Intrinsic::aie2p_I512_v16_acc64_srs:
-          FitsImmediateRange = checkImmediateRange<4, 64>(Immediate);
+          FitsImmediateRange = checkSignedImmediateRange<4, 64>(Immediate);
           ISelOpcode = FitsImmediateRange
                            ? AIE2P::VST_SRS_2x_dm_sts_srs_cm_idx_imm_srsSign0
                            : AIE2P::VST_SRS_2x_dm_sts_srs_cm_idx_srsSign0;
@@ -4730,7 +4695,7 @@ std::optional<LoadStoreOpcodes> AIE2PInstructionSelector::getCombinedOpcodeSRS(
         switch (CombOpIntrinsicID) {
         case Intrinsic::aie2p_I256_v16_acc32_srs:
         case Intrinsic::aie2p_I256_v8_acc64_srs:
-          FitsImmediateRange = checkImmediateRange<4, 32>(Immediate);
+          FitsImmediateRange = checkSignedImmediateRange<4, 32>(Immediate);
           ISelOpcode = FitsImmediateRange
                            ? AIE2P::VST_SRS_2x_dmw_sts_srs_bm_idx_imm_srsSign0
                            : AIE2P::VST_SRS_2x_dmw_sts_srs_bm_idx_srsSign0;
@@ -4738,7 +4703,7 @@ std::optional<LoadStoreOpcodes> AIE2PInstructionSelector::getCombinedOpcodeSRS(
                                   /*OffsetOpcode=*/{}};
         case Intrinsic::aie2p_I256_v32_acc32_srs:
         case Intrinsic::aie2p_I256_v16_acc64_srs:
-          FitsImmediateRange = checkImmediateRange<4, 32>(Immediate);
+          FitsImmediateRange = checkSignedImmediateRange<4, 32>(Immediate);
           ISelOpcode = FitsImmediateRange
                            ? AIE2P::VST_SRS_4x_dm_sts_srs_cm_idx_imm_srsSign0
                            : AIE2P::VST_SRS_4x_dm_sts_srs_cm_idx_srsSign0;
@@ -4752,7 +4717,7 @@ std::optional<LoadStoreOpcodes> AIE2PInstructionSelector::getCombinedOpcodeSRS(
         switch (CombOpIntrinsicID) {
         case Intrinsic::aie2p_I512_v64_acc32_srs:
         case Intrinsic::aie2p_I512_v32_acc64_srs:
-          FitsImmediateRange = checkImmediateRange<4, 64>(Immediate);
+          FitsImmediateRange = checkSignedImmediateRange<4, 64>(Immediate);
           ISelOpcode =
               FitsImmediateRange
                   ? AIE2P::VST_SRS_4x_dmx_sts_srs_dm_pstm_nrm_imm_srsSign0
@@ -4761,7 +4726,7 @@ std::optional<LoadStoreOpcodes> AIE2PInstructionSelector::getCombinedOpcodeSRS(
                                   /*OffsetOpcode=*/{}};
         case Intrinsic::aie2p_I512_v32_acc32_srs:
         case Intrinsic::aie2p_I512_v16_acc64_srs:
-          FitsImmediateRange = checkImmediateRange<4, 64>(Immediate);
+          FitsImmediateRange = checkSignedImmediateRange<4, 64>(Immediate);
           ISelOpcode =
               FitsImmediateRange
                   ? AIE2P::VST_SRS_2x_dm_sts_srs_cm_pstm_nrm_imm_srsSign0
@@ -4773,7 +4738,7 @@ std::optional<LoadStoreOpcodes> AIE2PInstructionSelector::getCombinedOpcodeSRS(
         switch (CombOpIntrinsicID) {
         case Intrinsic::aie2p_I256_v16_acc32_srs:
         case Intrinsic::aie2p_I256_v8_acc64_srs:
-          FitsImmediateRange = checkImmediateRange<4, 32>(Immediate);
+          FitsImmediateRange = checkSignedImmediateRange<4, 32>(Immediate);
           ISelOpcode =
               FitsImmediateRange
                   ? AIE2P::VST_SRS_2x_dmw_sts_srs_bm_pstm_nrm_imm_srsSign0
@@ -4782,7 +4747,7 @@ std::optional<LoadStoreOpcodes> AIE2PInstructionSelector::getCombinedOpcodeSRS(
                                   /*OffsetOpcode=*/{}};
         case Intrinsic::aie2p_I256_v32_acc32_srs:
         case Intrinsic::aie2p_I256_v16_acc64_srs:
-          FitsImmediateRange = checkImmediateRange<4, 32>(Immediate);
+          FitsImmediateRange = checkSignedImmediateRange<4, 32>(Immediate);
           ISelOpcode =
               FitsImmediateRange
                   ? AIE2P::VST_SRS_4x_dm_sts_srs_cm_pstm_nrm_imm_srsSign0


### PR DESCRIPTION
This is a Non Functional Change to Move Immediate Checks from Instruction Selection to TII. 
The global combiner PR (https://github.com/Xilinx/llvm-aie/pull/405 ) needs this refactor, as well as https://github.com/Xilinx/llvm-aie/pull/451 .