### PR TITLE
[llvm][aie] Use LLVM_DEBUG when printing debug info

### DIFF
--- a/llvm/lib/Target/AIE/AIEPostPipeliner.cpp
+++ b/llvm/lib/Target/AIE/AIEPostPipeliner.cpp
@@ -1135,7 +1135,7 @@ void PostPipeliner::dump() const {
     const NodeInfo &Node = Info[I];
     dbgs() << I << " @" << Node.Cycle << " %" << Node.ModuloCycle << " S"
            << Node.Stage << " : ";
-    DAG->SUnits[I].getInstr()->dump();
+    LLVM_DEBUG(DAG->SUnits[I].getInstr()->dump());
   }
   PostPipelineDumper Dump;
   visitPipelineSchedule(Dump);


### PR DESCRIPTION
Without this, there is the following linker error when building with `-DCMAKE_BUILD_TYPE=RelWithDebInfo` :

```
llvm-aie/llvm/lib/Target/AIE/AIEPostPipeliner.cpp:1138: undefined reference to `llvm::MachineInstr::dump() const'
```

A grep in `llvm/lib/Target` suggests wrapping in LLVM_DEBUG is the standard approach when calling dump. 

See https://github.com/llvm/llvm-project/blob/main/llvm/include/llvm/Support/Debug.h for macro info (and where dbgs() goes). 