### PR TITLE
[AIE2] Alias Analysis using AddrSpace Info

### DIFF
--- a/llvm/lib/Target/AIE/AIE2TargetTransformInfo.cpp
+++ b/llvm/lib/Target/AIE/AIE2TargetTransformInfo.cpp
@@ -21,9 +21,9 @@ using namespace llvm;
 #define DEBUG_TYPE "aie2tti"
 
 static std::optional<Instruction *>
-instCombineDemandedBits(InstCombiner &IC, IntrinsicInst &II, unsigned numBits) {
+instCombineDemandedBits(InstCombiner &IC, IntrinsicInst &II, unsigned NumBits) {
   KnownBits ScalarKnown(32);
-  if (IC.SimplifyDemandedBits(&II, 0, APInt::getLowBitsSet(32, numBits),
+  if (IC.SimplifyDemandedBits(&II, 0, APInt::getLowBitsSet(32, NumBits),
                               ScalarKnown, 0)) {
     return &II;
   }
@@ -62,4 +62,19 @@ bool AIE2TTIImpl::isHardwareLoopProfitable(Loop *L, ScalarEvolution &SE,
 
 bool AIE2TTIImpl::isProfitableOuterLSR(const Loop &L) const {
   return Common.isProfitableOuterLSR(L);
+}
+
+bool AIE2TTIImpl::addrspacesMayAlias(unsigned AS0, unsigned AS1) const {
+  if (AS0 == AS1)
+    return true;
+
+  // Tile Memory and Data Memory are disjoint, since we allways annotate Tile
+  // Memory access even if another address space is not annotated we can assume
+  // that they are disjoint.
+  const unsigned TileMemoryAS = static_cast<unsigned>(AIE2::AddressSpaces::TM);
+  if (AS0 == TileMemoryAS || AS1 == TileMemoryAS)
+    return false;
+
+  const AIEBaseAddrSpaceInfo &ASI = getST()->getAddrSpaceInfo();
+  return ASI.addrspacesMayAlias(AS0, AS1);
 }

--- a/llvm/lib/Target/AIE/AIE2TargetTransformInfo.h
+++ b/llvm/lib/Target/AIE/AIE2TargetTransformInfo.h
@@ -53,6 +53,8 @@ public:
                                 AssumptionCache &AC, TargetLibraryInfo *LibInfo,
                                 HardwareLoopInfo &HWLoopInfo);
   bool isProfitableOuterLSR(const Loop &L) const;
+
+  bool addrspacesMayAlias(unsigned AS0, unsigned AS1) const;
 };
 
 } // end namespace llvm

--- a/llvm/lib/Target/AIE/AIEBaseAddrSpaceInfo.h
+++ b/llvm/lib/Target/AIE/AIEBaseAddrSpaceInfo.h
@@ -35,6 +35,11 @@ public:
     // By default assume conflicts.
     return ~0;
   }
+
+  virtual bool addrspacesMayAlias(unsigned AS1, unsigned AS2) const {
+    return getMemoryBanksFromAddressSpace(AS1) &
+           getMemoryBanksFromAddressSpace(AS2);
+  }
 };
 
 } // end namespace llvm

--- a/llvm/lib/Target/AIE/AIEBaseAliasAnalysis.cpp
+++ b/llvm/lib/Target/AIE/AIEBaseAliasAnalysis.cpp
@@ -41,6 +41,11 @@ static cl::opt<bool> DisambiguateAccessSameOriginPointers(
     cl::desc("Disambiguate pointers derived from the same origin"),
     cl::init(true), cl::Hidden);
 
+static cl::opt<bool>
+    AddrSpaceAA("aie-alias-analysis-addrspace",
+                cl::desc("Disambiguate pointers based on address space"),
+                cl::init(false), cl::Hidden);
+
 #define DEBUG_TYPE "aie-aa"
 
 AnalysisKey AIEBaseAA::Key;
@@ -71,6 +76,7 @@ AIEBaseAAWrapperPass::AIEBaseAAWrapperPass() : ImmutablePass(ID) {
 
 void AIEBaseAAWrapperPass::getAnalysisUsage(AnalysisUsage &AU) const {
   AU.setPreservesAll();
+  AU.addRequired<TargetTransformInfoWrapperPass>();
 }
 
 static bool isAIEPtrAddIntrinsic(Intrinsic::ID ID, unsigned &InPtrIdx) {
@@ -596,6 +602,14 @@ AliasResult AIEBaseAAResult::alias(const MemoryLocation &LocA,
 
   const Value *BaseA = getUnderlyingObjectAIE(LocA.Ptr);
   const Value *BaseB = getUnderlyingObjectAIE(LocB.Ptr);
+
+  if (AddrSpaceAA) {
+    const unsigned AddrSpaceA = LocA.Ptr->getType()->getPointerAddressSpace();
+    const unsigned AddrSpaceB = LocB.Ptr->getType()->getPointerAddressSpace();
+
+    if (!TTI.addrspacesMayAlias(AddrSpaceA, AddrSpaceB))
+      return AliasResult::NoAlias;
+  }
 
   if (DisambiguateAccessSameOriginPointers &&
       aliasAIEIntrinsic(LocA.Ptr, LocB.Ptr, BaseA, BaseB, 0, 0

--- a/llvm/lib/Target/AIE/AIEBaseAliasAnalysis.h
+++ b/llvm/lib/Target/AIE/AIEBaseAliasAnalysis.h
@@ -16,6 +16,7 @@
 
 #include "AIE.h"
 #include "llvm/Analysis/AliasAnalysis.h"
+#include "llvm/Analysis/TargetTransformInfo.h"
 
 namespace llvm {
 
@@ -37,11 +38,13 @@ AliasResult aliasAcrossVirtualUnrolls(const MachineInstr *MIA,
 
 class AIEBaseAAResult : public AAResultBase {
   const DataLayout &DL;
+  const TargetTransformInfo &TTI;
 
 public:
-  explicit AIEBaseAAResult(const DataLayout &DL) : DL(DL) {}
+  explicit AIEBaseAAResult(const DataLayout &DL, const TargetTransformInfo &TTI)
+      : DL(DL), TTI(TTI) {}
   AIEBaseAAResult(AIEBaseAAResult &&Arg)
-      : AAResultBase(std::move(Arg)), DL(Arg.DL) {}
+      : AAResultBase(std::move(Arg)), DL(Arg.DL), TTI(Arg.TTI) {}
 
   /// Handle invalidation events from the new pass manager.
   ///
@@ -65,7 +68,8 @@ public:
   using Result = AIEBaseAAResult;
 
   AIEBaseAAResult run(Function &F, AnalysisManager<Function> &AM) {
-    return AIEBaseAAResult(F.getParent()->getDataLayout());
+    const TargetTransformInfo &TTI = AM.getResult<TargetIRAnalysis>(F);
+    return AIEBaseAAResult(F.getParent()->getDataLayout(), TTI);
   }
 };
 
@@ -82,7 +86,12 @@ public:
   const AIEBaseAAResult &getResult() const { return *Result; }
 
   bool doInitialization(Module &M) override {
-    Result.reset(new AIEBaseAAResult(M.getDataLayout()));
+    if (!M.getFunctionList().empty()) {
+      const TargetTransformInfo &TTI =
+          getAnalysis<TargetTransformInfoWrapperPass>().getTTI(
+              M.getFunctionList().front());
+      Result.reset(new AIEBaseAAResult(M.getDataLayout(), TTI));
+    }
     return false;
   }
 

--- a/llvm/lib/Target/AIE/AIEBaseTargetTransformInfo.h
+++ b/llvm/lib/Target/AIE/AIEBaseTargetTransformInfo.h
@@ -48,12 +48,12 @@ private:
   const AIESubtarget *ST;
   const AIEBaseTargetLowering *TLI;
 
-  const AIESubtarget *getST() const { return ST; }
   const AIEBaseTargetLowering *getTLI() const { return TLI; }
   /// Helper function to access this as a T.
   T *thisT() { return static_cast<T *>(this); }
 
 protected:
+  const AIESubtarget *getST() const { return ST; }
   explicit AIEBaseTTIImpl(const TargetMachine *TM, const DataLayout &DL,
                           const AIESubtarget *Subtarget)
       : BaseT(TM, DL), ST(Subtarget), TLI(Subtarget->getTargetLowering()) {}

--- a/llvm/lib/Target/AIE/AIETargetTransformInfo.h
+++ b/llvm/lib/Target/AIE/AIETargetTransformInfo.h
@@ -62,6 +62,14 @@ public:
     UP.Threshold = 200;
     BaseT::getUnrollingPreferences(L, SE, UP, ORE);
   }
+
+  bool addrspacesMayAlias(unsigned AS0, unsigned AS1) const {
+    if (AS0 == AS1)
+      return true;
+
+    const AIEBaseAddrSpaceInfo &ASI = ST->getAddrSpaceInfo();
+    return ASI.addrspacesMayAlias(AS0, AS1);
+  }
 };
 
 } // end namespace llvm

--- a/llvm/test/CodeGen/AIE/alias-analysis-AA.ll
+++ b/llvm/test/CodeGen/AIE/alias-analysis-AA.ll
@@ -1,0 +1,148 @@
+;
+; This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+; See https://llvm.org/LICENSE.txt for license information.
+; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+;
+; (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+; RUN: opt -mtriple=aie2 -passes=aa-eval -print-all-alias-modref-info --aie-alias-analysis-addrspace=true  -disable-output < %s 2>&1 | FileCheck %s --check-prefixes=CHECK,ENABLED-AIE-AS-AA
+; RUN: opt -mtriple=aie2 -passes=aa-eval -print-all-alias-modref-info --aie-alias-analysis-addrspace=false -disable-output < %s 2>&1 | FileCheck %s --check-prefixes=CHECK,DISABLED-AIE-AS-AA
+
+; CHECK-LABEL: Function: basic_without_AS
+; CHECK: MayAlias:      i8* %p, i8* %p1
+define void @basic_without_AS(ptr %p, ptr %p1) {
+  load i8, ptr %p
+  load i8, ptr %p1
+  ret void
+}
+
+; ENABLED-AIE-AS-AA-LABEL: Function: basic_withAS_56
+; ENABLED-AIE-AS-AA: NoAlias:	i8 addrspace(5)* %p, i8 addrspace(6)* %p1
+
+; DISABLED-AIE-AS-AA-LABEL: Function: basic_withAS_56
+; DISABLED-AIE-AS-AA: MayAlias:	  i8 addrspace(5)* %p, i8 addrspace(6)* %p1
+define void @basic_withAS_56(ptr addrspace(5) %p, ptr addrspace(6) %p1) {
+  load i8, ptr addrspace(5) %p 
+  load i8, ptr addrspace(6) %p1
+  ret void
+}
+
+; ENABLED-AIE-AS-AA-LABEL: Function: basic_withAS_67
+; ENABLED-AIE-AS-AA: NoAlias:	i8 addrspace(6)* %p, i8 addrspace(7)* %p1
+
+; DISABLED-AIE-AS-AA-LABEL: Function: basic_withAS_67
+; DISABLED-AIE-AS-AA: MayAlias:	  i8 addrspace(6)* %p, i8 addrspace(7)* %p1
+define void @basic_withAS_67(ptr addrspace(6) %p, ptr addrspace(7) %p1) {
+  load i8, ptr addrspace(6) %p 
+  load i8, ptr addrspace(7) %p1
+  ret void
+}
+
+; ENABLED-AIE-AS-AA-LABEL: Function: basic_withAS_78
+; ENABLED-AIE-AS-AA: NoAlias:	i8 addrspace(8)* %p, i8 addrspace(7)* %p1
+
+; DISABLED-AIE-AS-AA-LABEL: Function: basic_withAS_78
+; DISABLED-AIE-AS-AA: MayAlias:	  i8 addrspace(8)* %p, i8 addrspace(7)* %p1
+define void @basic_withAS_78(ptr addrspace(8) %p, ptr addrspace(7) %p1) {
+  load i8, ptr addrspace(8) %p 
+  load i8, ptr addrspace(7) %p1
+  ret void
+}
+
+; ENABLED-AIE-AS-AA-LABEL: Function: basic_withAS_58
+; ENABLED-AIE-AS-AA: NoAlias:	i8 addrspace(5)* %p, i8 addrspace(8)* %p1
+
+; DISABLED-AIE-AS-AA-LABEL: Function: basic_withAS_58
+; DISABLED-AIE-AS-AA: MayAlias:	  i8 addrspace(5)* %p, i8 addrspace(8)* %p1
+define void @basic_withAS_58(ptr addrspace(5) %p, ptr addrspace(8) %p1) {
+  load i8, ptr addrspace(5) %p 
+  load i8, ptr addrspace(8) %p1
+  ret void
+}
+
+; ENABLED-AIE-AS-AA-LABEL: Function: basic_withAS_compund_A_AB
+; ENABLED-AIE-AS-AA: MayAlias: 	i8 addrspace(5)* %p, i8 addrspace(9)* %p1
+
+; DISABLED-AIE-AS-AA-LABEL: Function: basic_withAS_compund_A_AB
+; DISABLED-AIE-AS-AA: MayAlias:	  i8 addrspace(5)* %p, i8 addrspace(9)* %p1
+define void @basic_withAS_compund_A_AB(ptr addrspace(5) %p, ptr addrspace(9) %p1) {
+  load i8, ptr addrspace(5) %p 
+  load i8, ptr addrspace(9) %p1
+  ret void
+}
+
+; ENABLED-AIE-AS-AA-LABEL: Function: basic_withAS_compund_B_AB
+; ENABLED-AIE-AS-AA: MayAlias: 	i8 addrspace(6)* %p, i8 addrspace(9)* %p1
+
+; DISABLED-AIE-AS-AA-LABEL: Function: basic_withAS_compund_B_AB
+; DISABLED-AIE-AS-AA: MayAlias:	  i8 addrspace(6)* %p, i8 addrspace(9)* %p1
+define void @basic_withAS_compund_B_AB(ptr addrspace(6) %p, ptr addrspace(9) %p1) {
+  load i8, ptr addrspace(6) %p 
+  load i8, ptr addrspace(9) %p1
+  ret void
+}
+
+; ENABLED-AIE-AS-AA-LABEL: Function: basic_withAS_compund_C_AB
+; ENABLED-AIE-AS-AA: NoAlias: 	i8 addrspace(7)* %p, i8 addrspace(9)* %p1
+
+; DISABLED-AIE-AS-AA-LABEL: Function: basic_withAS_compund_C_AB
+; DISABLED-AIE-AS-AA: MayAlias:	  i8 addrspace(7)* %p, i8 addrspace(9)* %p1
+define void @basic_withAS_compund_C_AB(ptr addrspace(7) %p, ptr addrspace(9) %p1) {
+  load i8, ptr addrspace(7) %p 
+  load i8, ptr addrspace(9) %p1
+  ret void
+}
+
+; ENABLED-AIE-AS-AA-LABEL: Function: basic_withAS_compund_AB_CD
+; ENABLED-AIE-AS-AA: NoAlias: 	i8 addrspace(9)* %p, i8 addrspace(14)* %p1
+
+; DISABLED-AIE-AS-AA-LABEL: Function: basic_withAS_compund_AB_CD
+; DISABLED-AIE-AS-AA: MayAlias:	  i8 addrspace(9)* %p, i8 addrspace(14)* %p1
+define void @basic_withAS_compund_AB_CD(ptr addrspace(9) %p, ptr addrspace(14) %p1) {
+  load i8, ptr addrspace(9) %p 
+  load i8, ptr addrspace(14) %p1
+  ret void
+}
+
+; ENABLED-AIE-AS-AA-LABEL: Function: basic_TM_noAS
+; ENABLED-AIE-AS-AA: NoAlias: 	i8 addrspace(15)* %p, i8* %p1
+
+; DISABLED-AIE-AS-AA-LABEL: Function: basic_TM_noAS
+; DISABLED-AIE-AS-AA: MayAlias:	  i8 addrspace(15)* %p, i8* %p1
+define void @basic_TM_noAS(ptr addrspace(15) %p, ptr %p1) {
+  load i8, ptr addrspace(15) %p 
+  load i8, ptr %p1
+  ret void
+}
+
+; ENABLED-AIE-AS-AA-LABEL: Function: basic_noAS_TM
+; ENABLED-AIE-AS-AA: NoAlias: 	i8* %p, i8 addrspace(15)* %p1
+
+; DISABLED-AIE-AS-AA-LABEL: Function: basic_noAS_TM
+; DISABLED-AIE-AS-AA: MayAlias:	  i8* %p, i8 addrspace(15)* %p1
+define void @basic_noAS_TM(ptr %p, ptr  addrspace(15) %p1) {
+  load i8, ptr %p 
+  load i8, ptr addrspace(15) %p1
+  ret void
+}
+
+; ENABLED-AIE-AS-AA-LABEL: Function: basic_withAS_TM_TM
+; ENABLED-AIE-AS-AA: MayAlias: 	i8 addrspace(15)* %p, i8 addrspace(15)* %p1
+
+; DISABLED-AIE-AS-AA-LABEL: Function: basic_withAS_TM_TM
+; DISABLED-AIE-AS-AA: MayAlias:	  i8 addrspace(15)* %p, i8 addrspace(15)* %p1
+define void @basic_withAS_TM_TM(ptr addrspace(15) %p, ptr addrspace(15) %p1) {
+  load i8, ptr addrspace(15) %p 
+  load i8, ptr addrspace(15) %p1
+  ret void
+}
+
+; ENABLED-AIE-AS-AA-LABEL: Function: basic_withAS_A_TM
+; ENABLED-AIE-AS-AA: NoAlias: 	i8 addrspace(5)* %p, i8 addrspace(15)* %p1
+
+; DISABLED-AIE-AS-AA-LABEL: Function: basic_withAS_A_TM
+; DISABLED-AIE-AS-AA: MayAlias:	  i8 addrspace(5)* %p, i8 addrspace(15)* %p1
+define void @basic_withAS_A_TM(ptr addrspace(5) %p, ptr addrspace(15) %p1) {
+  load i8, ptr addrspace(5) %p 
+  load i8, ptr addrspace(15) %p1
+  ret void
+}


### PR DESCRIPTION
This is a port of Krishnam's original PR https://github.com/Xilinx/llvm-aie/pull/173 which I will close.
I'll be running QoR today-ish.

QoR results are varying. Also, memory bank annotations may not always be respected by the buffer allocation. Although it can be argued that intent of the programmer will usually be to have different objects be designated by pointers to non-overlapping banks, the gain we see doesn't make it worth to take the risk. I converted to draft.  