### PR TITLE
[AIE][AIE2] Use pattern to convert (special case) shufflevector to subvector extract

### DIFF
--- a/llvm/lib/Target/AIE/AIECombine.td
+++ b/llvm/lib/Target/AIE/AIECombine.td
@@ -9,7 +9,7 @@
 //===----------------------------------------------------------------------===//
 include "llvm/Target/GlobalISel/Combine.td"
 
-// Explicitly listing each generic combine here ensures direct visibility and 
+// Explicitly listing each generic combine here ensures direct visibility and
 // control over all functionalities.
 def aie_all_combines : GICombineGroup<[trivial_combines, vector_ops_combines,
   insert_vec_elt_combines, extract_vec_elt_combines, combines_for_extload,
@@ -175,7 +175,7 @@ def AIE2PreLegalizerCombiner
                                                                  aie_all_combines, combine_S20NarrowingOpt,
                                                                  combine_globalval_offset,
                                                                  combine_extract_vector_elt_and_zsa_ext,
-                                                                 combine_splat_vector, combine_concat_to_pad_vector, 
+                                                                 combine_splat_vector, combine_concat_to_pad_vector,
                                                                  combine_single_diff_build_vector,
                                                                  combine_symmetric_build_vector,
                                                                  combine_broadcast_shl_to_add]> {
@@ -189,10 +189,10 @@ def AIE2PPreLegalizerCombiner
                                                                  aie_all_combines, combine_S20NarrowingOpt,
                                                                  combine_globalval_offset,
                                                                  combine_extract_vector_elt_and_zsa_ext,
-                                                                 combine_splat_vector, 
+                                                                 combine_splat_vector,
                                                                  combine_vector_shuffle_bcst_to_copy,
                                                                  combine_vector_broadcast,
-                                                                 combine_concat_to_pad_vector, 
+                                                                 combine_concat_to_pad_vector,
                                                                  combine_vector_shuffle_vsel,
                                                                  combine_vector_shuffle_broadcast,
                                                                  combine_single_diff_build_vector,
@@ -294,14 +294,14 @@ def AIE2PostLegalizerCustomCombiner
                                                           combine_add_vector_elt_undef,
                                                           combine_extract_concat,
                                                           combine_unmerge_concat,
-                                                          combine_upd_to_concat 
+                                                          combine_upd_to_concat
                                                           ]> {
 }
 
 def AIE2PPostLegalizerCustomCombiner
     : GICombiner<"AIE2PPostLegalizerCustomCombinerImpl", [  combine_global_load_store_increment,
                                                             combine_load_store_increment,
-                                                            ptr_add_immed_chain, 
+                                                            ptr_add_immed_chain,
                                                             combine_offset_load_store_ptradd,
                                                             combine_offset_load_store_share_ptradd,
                                                             combine_add_vector_elt_undef ]> {

--- a/llvm/lib/Target/AIE/AIECombine.td
+++ b/llvm/lib/Target/AIE/AIECombine.td
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// (c) Copyright 2023-2024 Advanced Micro Devices, Inc. or its affiliates
+// (c) Copyright 2023-2025 Advanced Micro Devices, Inc. or its affiliates
 //
 //===----------------------------------------------------------------------===//
 include "llvm/Target/GlobalISel/Combine.td"

--- a/llvm/lib/Target/AIE/AIECombine.td
+++ b/llvm/lib/Target/AIE/AIECombine.td
@@ -181,13 +181,14 @@ def aie_additional_combines : GICombineGroup<[
   combine_concat_to_pad_vector,
   combine_single_diff_build_vector,
   combine_symmetric_build_vector,
-  combine_broadcast_shl_to_add
+  combine_broadcast_shl_to_add,
+  combine_vector_shuffle_extract_subvec
 ]>;
 
 // AIE2P-specific combines.
+// TODO: Move HW-agnostic combines to `aie_additional_combines`.
 def aie2p_additional_combines : GICombineGroup<[
   combine_vector_shuffle_to_copy,
-  combine_vector_shuffle_extract_subvec,
   combine_vector_shuffle_bcst_to_copy,
   combine_vector_broadcast,
   combine_vector_shuffle_vsel,

--- a/llvm/lib/Target/AIE/AIECombine.td
+++ b/llvm/lib/Target/AIE/AIECombine.td
@@ -11,7 +11,7 @@ include "llvm/Target/GlobalISel/Combine.td"
 
 // Explicitly listing each generic combine here ensures direct visibility and
 // control over all functionalities.
-def aie_all_combines : GICombineGroup<[trivial_combines, vector_ops_combines,
+def aie_generic_combines : GICombineGroup<[trivial_combines, vector_ops_combines,
   insert_vec_elt_combines, extract_vec_elt_combines, combines_for_extload,
   combine_extracted_vector_load,
   undef_combines, identity_combines, phi_combines,
@@ -170,47 +170,51 @@ def combine_broadcast_shl_to_add : GICombineRule<
          [{ return matchBroadcastToShl(*${root}, MRI, (const AIEBaseInstrInfo &)B.getTII(), ${matchinfo}); }]),
   (apply [{ Helper.applyBuildFn(*${root}, ${matchinfo}); }])>;
 
+// AIE-specifc combines (currently shared by AIE2 and AIE2P).
+def aie_additional_combines : GICombineGroup<[
+  combine_unpad_vector,
+  combine_pad_vector,
+  combine_S20NarrowingOpt,
+  combine_globalval_offset,
+  combine_extract_vector_elt_and_zsa_ext,
+  combine_splat_vector,
+  combine_concat_to_pad_vector,
+  combine_single_diff_build_vector,
+  combine_symmetric_build_vector,
+  combine_broadcast_shl_to_add
+]>;
+
+// AIE2P-specific combines.
+def aie2p_additional_combines : GICombineGroup<[
+  combine_vector_shuffle_to_copy,
+  combine_vector_shuffle_extract_subvec,
+  combine_vector_shuffle_bcst_to_copy,
+  combine_vector_broadcast,
+  combine_vector_shuffle_vsel,
+  combine_vector_shuffle_broadcast,
+  combine_vector_shuffle_to_extract_insert_elt,
+  combine_vector_shuffle_concat_extracted_subvectors,
+  combine_paired_extracts,
+  combine_vector_shuffle_to_extract_insert_elt_to_broadcast,
+]>;
+
 def AIE2PreLegalizerCombiner
-    : GICombiner<"AIE2PreLegalizerCombinerImpl", [ combine_unpad_vector, combine_pad_vector,
-                                                                 aie_all_combines, combine_S20NarrowingOpt,
-                                                                 combine_globalval_offset,
-                                                                 combine_extract_vector_elt_and_zsa_ext,
-                                                                 combine_splat_vector, combine_concat_to_pad_vector,
-                                                                 combine_single_diff_build_vector,
-                                                                 combine_symmetric_build_vector,
-                                                                 combine_broadcast_shl_to_add]> {
+    : GICombiner<"AIE2PreLegalizerCombinerImpl", [aie_generic_combines, aie_additional_combines]> {
   let CombineAllMethodName = "tryCombineAllImpl";
 }
 
 def AIE2PPreLegalizerCombiner
-    : GICombiner<"AIE2PPreLegalizerCombinerImpl", [ combine_unpad_vector, combine_pad_vector,
-                                                                 combine_vector_shuffle_to_copy,
-                                                                 combine_vector_shuffle_extract_subvec,
-                                                                 aie_all_combines, combine_S20NarrowingOpt,
-                                                                 combine_globalval_offset,
-                                                                 combine_extract_vector_elt_and_zsa_ext,
-                                                                 combine_splat_vector,
-                                                                 combine_vector_shuffle_bcst_to_copy,
-                                                                 combine_vector_broadcast,
-                                                                 combine_concat_to_pad_vector,
-                                                                 combine_vector_shuffle_vsel,
-                                                                 combine_vector_shuffle_broadcast,
-                                                                 combine_single_diff_build_vector,
-                                                                 combine_vector_shuffle_to_extract_insert_elt,
-                                                                 combine_vector_shuffle_concat_extracted_subvectors,
-                                                                 combine_paired_extracts,
-                                                                 combine_vector_shuffle_to_extract_insert_elt_to_broadcast,
-                                                                 combine_symmetric_build_vector,
-                                                                 combine_broadcast_shl_to_add]> {
+    : GICombiner<"AIE2PPreLegalizerCombinerImpl",
+                      [aie_generic_combines, aie_additional_combines, aie2p_additional_combines]> {
   let CombineAllMethodName = "tryCombineAllImpl";
 }
 
 def AIE2PostLegalizerGenericCombiner
-    : GICombiner<"AIE2PostLegalizerGenericCombinerImpl", [ aie_all_combines ]> {
+    : GICombiner<"AIE2PostLegalizerGenericCombinerImpl", [aie_generic_combines]> {
 }
 
 def AIE2PPostLegalizerGenericCombiner
-    : GICombiner<"AIE2PPostLegalizerGenericCombinerImpl", [ aie_all_combines ]> {
+    : GICombiner<"AIE2PPostLegalizerGenericCombinerImpl", [aie_generic_combines]> {
 }
 
 def combine_extract_concat_matchdata: GIDefMatchData<"Register">;
@@ -306,3 +310,4 @@ def AIE2PPostLegalizerCustomCombiner
                                                             combine_offset_load_store_share_ptradd,
                                                             combine_add_vector_elt_undef ]> {
 }
+

--- a/llvm/test/CodeGen/AIE/aie2/intrinsics-shufflevec.ll
+++ b/llvm/test/CodeGen/AIE/aie2/intrinsics-shufflevec.ll
@@ -7,76 +7,56 @@
 ; (c) Copyright 2023-2024 Advanced Micro Devices, Inc. or its affiliates
 ; RUN: llc -O2 -mtriple=aie2 -verify-machineinstrs --issue-limit=1 %s -o - | FileCheck %s
 
-define <8 x i32> @test_extract_vector(<16 x i32> noundef %a, i32 noundef %idx) {
-; CHECK-LABEL: test_extract_vector:
+define <8 x i32> @test_extract_bottom_half(<16 x i32> noundef %a) {
+; CHECK-LABEL: test_extract_bottom_half:
 ; CHECK:         .p2align 4
 ; CHECK-NEXT:  // %bb.0: // %entry
-; CHECK-NEXT:    nopb ; nopa ; nops ; jz r0, #.LBB0_2; nopv
+; CHECK-NEXT:    ret lr
+; CHECK-NEXT:    nop // Delay Slot 5
+; CHECK-NEXT:    nop // Delay Slot 4
+; CHECK-NEXT:    nop // Delay Slot 3
+; CHECK-NEXT:    vmov x0, x2 // Delay Slot 2
+; CHECK-NEXT:    nop // Delay Slot 1
+entry:
+  %shuffle = shufflevector <16 x i32> %a, <16 x i32> poison, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+  ret <8 x i32> %shuffle
+}
+
+define <8 x i32> @test_extract_top_half(<16 x i32> noundef %a) {
+; CHECK-LABEL: test_extract_top_half:
+; CHECK:         .p2align 4
+; CHECK-NEXT:  // %bb.0: // %entry
+; CHECK-NEXT:    ret lr
+; CHECK-NEXT:    nop // Delay Slot 5
+; CHECK-NEXT:    nop // Delay Slot 4
+; CHECK-NEXT:    nop // Delay Slot 3
+; CHECK-NEXT:    vmov wl0, wh2 // Delay Slot 2
+; CHECK-NEXT:    nop // Delay Slot 1
+entry:
+  %shuffle = shufflevector <16 x i32> %a, <16 x i32> poison, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
+  ret <8 x i32> %shuffle
+}
+
+define <8 x i32> @test_conditional_extract_vector(<16 x i32> noundef %a, i32 noundef %idx) {
+; CHECK-LABEL: test_conditional_extract_vector:
+; CHECK:         .p2align 4
+; CHECK-NEXT:  // %bb.0: // %entry
+; CHECK-NEXT:    nopb ; nopa ; nops ; jz r0, #.LBB2_2; nopv
 ; CHECK-NEXT:    nopa ; nopx // Delay Slot 5
 ; CHECK-NEXT:    nop // Delay Slot 4
 ; CHECK-NEXT:    nop // Delay Slot 3
-; CHECK-NEXT:    nop // Delay Slot 2
-; CHECK-NEXT:    mov r8, r16 // Delay Slot 1
+; CHECK-NEXT:    vmov x0, x2 // Delay Slot 2
+; CHECK-NEXT:    nop // Delay Slot 1
 ; CHECK-NEXT:  // %bb.1: // %if.end
-; CHECK-NEXT:    mova r16, #8; nopb ; nopxm ; nops
-; CHECK-NEXT:    vextract.s32 r0, x2, r16
-; CHECK-NEXT:    mova r16, #9
-; CHECK-NEXT:    vextract.s32 r1, x2, r16
-; CHECK-NEXT:    mova r16, #10
-; CHECK-NEXT:    vextract.s32 r2, x2, r16
-; CHECK-NEXT:    mova r16, #11
-; CHECK-NEXT:    vpush.hi.32 x0, x0, r0
-; CHECK-NEXT:    vextract.s32 r3, x2, r16
-; CHECK-NEXT:    mova r16, #12
-; CHECK-NEXT:    vpush.hi.32 x0, x0, r1
-; CHECK-NEXT:    vextract.s32 r4, x2, r16
-; CHECK-NEXT:    mova r16, #13
-; CHECK-NEXT:    vpush.hi.32 x0, x0, r2
-; CHECK-NEXT:    vextract.s32 r5, x2, r16
-; CHECK-NEXT:    mova r16, #14
-; CHECK-NEXT:    vpush.hi.32 x0, x0, r3
-; CHECK-NEXT:    vextract.s32 r6, x2, r16
-; CHECK-NEXT:    mova r16, #15
-; CHECK-NEXT:    j #.LBB0_3
-; CHECK-NEXT:    vpush.hi.32 x0, x0, r4 // Delay Slot 5
-; CHECK-NEXT:    vextract.s32 r7, x2, r16 // Delay Slot 4
-; CHECK-NEXT:    vpush.hi.32 x0, x0, r5 // Delay Slot 3
-; CHECK-NEXT:    vpush.hi.32 x0, x0, r6 // Delay Slot 2
-; CHECK-NEXT:    vpush.hi.32 x0, x0, r7 // Delay Slot 1
+; CHECK-NEXT:    nopb ; nopa ; nops ; nopx ; vmov wl0, wh0; nopv
 ; CHECK-NEXT:    .p2align 4
-; CHECK-NEXT:  .LBB0_2: // %if.then
-; CHECK-NEXT:    mova r16, #0
-; CHECK-NEXT:    vextract.s32 r0, x2, r16
-; CHECK-NEXT:    mova r16, #1
-; CHECK-NEXT:    vextract.s32 r1, x2, r16
-; CHECK-NEXT:    mova r16, #2
-; CHECK-NEXT:    vextract.s32 r2, x2, r16
-; CHECK-NEXT:    mova r16, #3
-; CHECK-NEXT:    vpush.hi.32 x0, x0, r0
-; CHECK-NEXT:    vextract.s32 r3, x2, r16
-; CHECK-NEXT:    mova r16, #4
-; CHECK-NEXT:    vpush.hi.32 x0, x0, r1
-; CHECK-NEXT:    vextract.s32 r4, x2, r16
-; CHECK-NEXT:    mova r16, #5
-; CHECK-NEXT:    vpush.hi.32 x0, x0, r2
-; CHECK-NEXT:    vextract.s32 r5, x2, r16
-; CHECK-NEXT:    mova r16, #6
-; CHECK-NEXT:    vpush.hi.32 x0, x0, r3
-; CHECK-NEXT:    vextract.s32 r6, x2, r16
-; CHECK-NEXT:    mova r16, #7
-; CHECK-NEXT:    vpush.hi.32 x0, x0, r4
-; CHECK-NEXT:    vextract.s32 r7, x2, r16
-; CHECK-NEXT:    vpush.hi.32 x0, x0, r5
-; CHECK-NEXT:    vpush.hi.32 x0, x0, r6
-; CHECK-NEXT:    vpush.hi.32 x0, x0, r7
-; CHECK-NEXT:    .p2align 4
-; CHECK-NEXT:  .LBB0_3: // %return
-; CHECK-NEXT:    nopb ; nopa ; nops ; ret lr ; nopm ; nopv
-; CHECK-NEXT:    nopx // Delay Slot 5
+; CHECK-NEXT:  .LBB2_2: // %return
+; CHECK-NEXT:    nopa ; ret lr
+; CHECK-NEXT:    nop // Delay Slot 5
 ; CHECK-NEXT:    nop // Delay Slot 4
 ; CHECK-NEXT:    nop // Delay Slot 3
-; CHECK-NEXT:    vmov wl0, wh0 // Delay Slot 2
-; CHECK-NEXT:    mov r16, r8 // Delay Slot 1
+; CHECK-NEXT:    nop // Delay Slot 2
+; CHECK-NEXT:    nop // Delay Slot 1
 entry:
   %cmp = icmp eq i32 %idx, 0
   br i1 %cmp, label %if.then, label %if.end
@@ -129,7 +109,7 @@ define <16 x i32> @test_insert_vector(<16 x i32> noundef %a, i32 noundef %idx, <
 ; CHECK-NEXT:    vpush.hi.32 x0, x0, r0
 ; CHECK-NEXT:    vpush.hi.32 x0, x0, r0
 ; CHECK-NEXT:    vpush.hi.32 x0, x0, r0
-; CHECK-NEXT:    jz r0, #.LBB1_2
+; CHECK-NEXT:    jz r0, #.LBB3_2
 ; CHECK-NEXT:    vpush.hi.32 x0, x0, r0 // Delay Slot 5
 ; CHECK-NEXT:    vpush.hi.32 x0, x0, r0 // Delay Slot 4
 ; CHECK-NEXT:    vpush.hi.32 x0, x0, r0 // Delay Slot 3
@@ -168,14 +148,14 @@ define <16 x i32> @test_insert_vector(<16 x i32> noundef %a, i32 noundef %idx, <
 ; CHECK-NEXT:    vpush.hi.32 x0, x0, r1
 ; CHECK-NEXT:    vpush.hi.32 x0, x0, r3
 ; CHECK-NEXT:    vpush.hi.32 x0, x0, r5
-; CHECK-NEXT:    j #.LBB1_3
+; CHECK-NEXT:    j #.LBB3_3
 ; CHECK-NEXT:    vpush.hi.32 x0, x0, r7 // Delay Slot 5
 ; CHECK-NEXT:    vpush.hi.32 x0, x0, r9 // Delay Slot 4
 ; CHECK-NEXT:    vpush.hi.32 x0, x0, r11 // Delay Slot 3
 ; CHECK-NEXT:    vpush.hi.32 x0, x0, r13 // Delay Slot 2
 ; CHECK-NEXT:    vpush.hi.32 x0, x0, r15 // Delay Slot 1
 ; CHECK-NEXT:    .p2align 4
-; CHECK-NEXT:  .LBB1_2: // %if.then
+; CHECK-NEXT:  .LBB3_2: // %if.then
 ; CHECK-NEXT:    nopb ; mova r16, #3; nops ; nopxm ; nopv
 ; CHECK-NEXT:    vextract.s32 r0, x0, r19
 ; CHECK-NEXT:    vextract.s32 r1, x2, r19
@@ -214,7 +194,7 @@ define <16 x i32> @test_insert_vector(<16 x i32> noundef %a, i32 noundef %idx, <
 ; CHECK-NEXT:    vpush.hi.32 x0, x0, r13
 ; CHECK-NEXT:    vpush.hi.32 x0, x0, r15
 ; CHECK-NEXT:    .p2align 4
-; CHECK-NEXT:  .LBB1_3: // %cleanup
+; CHECK-NEXT:  .LBB3_3: // %cleanup
 ; CHECK-NEXT:    nopa ; nopb ; ret lr ; nopm ; nops
 ; CHECK-NEXT:    nop // Delay Slot 5
 ; CHECK-NEXT:    mov r19, r27 // Delay Slot 4

--- a/llvm/test/CodeGen/AIE/aie2/intrinsics-shufflevec.ll
+++ b/llvm/test/CodeGen/AIE/aie2/intrinsics-shufflevec.ll
@@ -4,7 +4,7 @@
 ; See https://llvm.org/LICENSE.txt for license information.
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 ;
-; (c) Copyright 2023-2024 Advanced Micro Devices, Inc. or its affiliates
+; (c) Copyright 2023-2025 Advanced Micro Devices, Inc. or its affiliates
 ; RUN: llc -O2 -mtriple=aie2 -verify-machineinstrs --issue-limit=1 %s -o - | FileCheck %s
 
 define <8 x i32> @test_extract_bottom_half(<16 x i32> noundef %a) {


### PR DESCRIPTION

commit 1: whitespace NFC
commit 2: refactor NFC
commit 3: add one of the 'combiners' to AIE2 list

#### Testing: 
Currently all logic is tested for AIE2P in `GlobalISel/prelegalizercombiner-shuffle-vector.mir`, I could add a new file specific for AIE2 if requested

#### Question:
Should I just add all the 'combiners' to both? Is there any ISA change from AIE2 to AIE2P which means the other shuffle 'combiners' can only be used for AIE2P? 

#### Motivation:
I'm experimenting with lowerings from generic arithmetic ops to intrinsics. Consider

```LLVM
@buff_src = external global [128 x i32]
@buff_dst = external global [128 x i32]

define void @alpha() { 
  %1 = load <16 x i32>, ptr @buff_src, align 256
  %2 = trunc <16 x i32> %1 to <16 x i16>
  store <16 x i16> %2, ptr @buff_dst, align 256
  ret void
}

define void @beta() {
  %1 = load <16 x i32>, ptr @buff_src, align 256
  %2 = tail call <16 x i32> @llvm.aie2.vshuffle(<16 x i32> %1, <16 x i32> %1, i32 2)
  %3 = shufflevector <16 x i32> %2, <16 x i32> poison, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
  store <8 x i32> %3, ptr @buff_dst, align 256
  ret void
}
```



Currently compiling for aie2P (`llc -O2 -mtriple=aie2P test.ll -o -`)  `@alpha` and `@beta` lower to exactly the same asm (because of [this](https://github.com/Xilinx/llvm-aie/blob/aie-public/llvm/lib/Target/AIE/aie2p/AIE2PInstrPatterns.td#L1256) for trunc from @niwinanto and [this](https://github.com/Xilinx/llvm-aie/blob/f0bbcd15fe35370746aa0adfa7094b2511b65034/llvm/lib/Target/AIE/AIECombine.td#L125) for shufflevector from @katerynamuts). 


But for aie2 ... 

`@alpha` crashes (as already diagnosed in https://github.com/Xilinx/llvm-aie/issues/482) and for `@beta` 

before this PR) `shufflevector` is scalarized 
after this PR) `shufflevector` is handled correctly (`vst wl0` appears directly). 


