### PR TITLE
Upgrade workflows from `windows-2019` to `windows-2022`

### DIFF
--- a/.github/workflows/amd-aie-distro.yml
+++ b/.github/workflows/amd-aie-distro.yml
@@ -11,7 +11,7 @@ on:
       DEBUG_OS:
         description: 'which runner os to run the tmate action in (if the tmate action is run)'
         type: string
-        default: 'windows-2019'
+        default: 'windows-2022'
         required: false
       DEBUG_ARCH:
         description: 'which runner arch to run the tmate action in (if the tmate action is run)'
@@ -154,7 +154,7 @@ jobs:
         include:
           - OS: ubuntu-latest
             ARCH: x86_64
-          - OS: windows-2019
+          - OS: windows-2022
             ARCH: AMD64
 
     defaults:

--- a/.github/workflows/amd-upstream-tests.yml
+++ b/.github/workflows/amd-upstream-tests.yml
@@ -30,7 +30,7 @@ jobs:
       projects: clang
       cache-key: amd-upstream
       extra_cmake_args: '-DLLVM_USE_LINKER=gold -DLLVM_TARGETS_TO_BUILD="X86;ARM;AArch64;AMDGPU" -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=""'
-      os_list: ${{ github.ref_name == 'aie-public' && '["ubuntu-22.04", "windows-2019"]' || '["ubuntu-22.04"]' }}
+      os_list: ${{ github.ref_name == 'aie-public' && '["ubuntu-22.04", "windows-2022"]' || '["ubuntu-22.04"]' }}
 
   check_lld:
     if: github.repository_owner == 'Xilinx'
@@ -41,5 +41,5 @@ jobs:
       projects: lld
       cache-key: amd-upstream
       extra_cmake_args: '-DLLVM_USE_LINKER=gold -DLLVM_TARGETS_TO_BUILD="X86;ARM;AArch64;AMDGPU" -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=""'
-      os_list: ${{ github.ref_name == 'aie-public' && '["ubuntu-22.04", "windows-2019"]' || '["ubuntu-22.04"]' }}
+      os_list: ${{ github.ref_name == 'aie-public' && '["ubuntu-22.04", "windows-2022"]' || '["ubuntu-22.04"]' }}
 

--- a/.github/workflows/amd_aie_releases/scripts/build_local.sh
+++ b/.github/workflows/amd_aie_releases/scripts/build_local.sh
@@ -30,7 +30,7 @@ elif [ "$machine" == "macos" ]; then
   export ARCH=arm64
   export PARALLEL_LEVEL=32
 else
-  export MATRIX_OS=windows-2019
+  export MATRIX_OS=windows-2022
   export CIBW_ARCHS=AMD64
   export CIBW_BUILD=cp311-win_amd64
   export ARCH=AMD64
@@ -50,7 +50,7 @@ if [ -d "$HERE/../wheelhouse/.ccache" ]; then
 fi
 
 for TOOL in "llvm-tblgen" "mlir-tblgen" "mlir-linalg-ods-yaml-gen" "mlir-pdll" "llvm-config" "FileCheck"; do
-  if [ x"$MATRIX_OS" == x"windows-2019" ]; then
+  if [ x"$MATRIX_OS" == x"windows-2022" ]; then
     TOOL="$TOOL.exe"
   fi
   unzip -j "$HERE/../wheelhouse/"llvm-aie-*whl "mlir/bin/$TOOL" -d "$HERE/../native_tools/"
@@ -60,7 +60,7 @@ if [ x"$MATRIX_OS" == x"ubuntu-20.04" ]; then
   PLAT="manylinux_2_17"
 elif [ x"$MATRIX_OS" == x"macos-12" ]; then
   PLAT="macosx_12_0"
-elif [ x"$MATRIX_OS" == x"windows-2019" ]; then
+elif [ x"$MATRIX_OS" == x"windows-2022" ]; then
   PLAT="win"
 fi
 


### PR DESCRIPTION
That is necessary after deprecating the 2019 image. See this link for more information: https://github.com/actions/runner-images/issues/12045