### PR TITLE
[AIEX] legalize unaligned ptr-stores

### DIFF
--- a/llvm/lib/Target/AIE/AIE2LegalizerInfo.cpp
+++ b/llvm/lib/Target/AIE/AIE2LegalizerInfo.cpp
@@ -376,6 +376,10 @@ AIE2LegalizerInfo::AIE2LegalizerInfo(const AIE2Subtarget &ST) : AIEHelper(ST) {
           {ACC512, P0, ACC512, 32}, {ACC1024, P0, ACC1024, 32},
           {S128, P0, S128, 16},
       })
+      // Storing a pointer to an un-aligned address.
+      .customIf([=](const LegalityQuery &Query) {
+        return AIEHelper.isUnaligned20BitStore(Query);
+      })
       .widenScalarToNextPow2(0)
       .lowerIfMemSizeNotPow2()
       .bitcastIf(
@@ -393,7 +397,6 @@ AIE2LegalizerInfo::AIE2LegalizerInfo(const AIE2Subtarget &ST) : AIEHelper(ST) {
       .clampScalar(0, S32, S32)
       .lower();
 
-  // FIXME: Storing a pointer to an un-aligned address isn't supported.
   getActionDefinitionsBuilder({G_ZEXTLOAD, G_SEXTLOAD})
       .legalForTypesWithMemDesc({{S32, P0, S8, 8}, {S32, P0, S16, 16}})
       .widenScalarToNextPow2(0)
@@ -530,6 +533,8 @@ bool AIE2LegalizerInfo::legalizeCustom(
   switch (MI.getOpcode()) {
   default:
     break;
+  case TargetOpcode::G_STORE:
+    return AIEHelper.legalize_G_STORE(Helper, cast<GStore>(MI));
   case TargetOpcode::G_VASTART:
     return AIEHelper.legalizeG_VASTART(Helper, MI);
   case TargetOpcode::G_VAARG:

--- a/llvm/lib/Target/AIE/AIELegalizerHelper.cpp
+++ b/llvm/lib/Target/AIE/AIELegalizerHelper.cpp
@@ -416,6 +416,69 @@ bool AIELegalizerHelper::legalizeG_VASTART(LegalizerHelper &Helper,
   return true;
 }
 
+bool AIELegalizerHelper::isUnaligned20BitStore(
+    const LegalityQuery &Query) const {
+  const LLT &DstTy = Query.Types[0];
+  if (DstTy.getSizeInBits() != 20)
+    return false;
+
+  if (Query.MMODescrs.empty())
+    return false;
+
+  if (Query.Opcode != TargetOpcode::G_STORE)
+    return false;
+
+  if (!DstTy.isPointer() && !DstTy.isScalar())
+    return false;
+
+  const bool Is32BitAligned = Query.MMODescrs.begin()->AlignInBits % 32 == 0;
+  if (Is32BitAligned)
+    return false;
+
+  return true;
+}
+
+bool AIELegalizerHelper::legalize_G_STORE(LegalizerHelper &Helper,
+                                          GStore &StoreI) const {
+  MachineRegisterInfo &MRI = StoreI.getMF()->getRegInfo();
+  Register DstReg = StoreI.getOperand(0).getReg();
+  LLT DestLLT = MRI.getType(DstReg);
+
+  const LLT S20 = LLT::scalar(20);
+
+  GISelObserverWrapper DummyObserver;
+  MachineIRBuilder HelperBuilder(StoreI, DummyObserver);
+  DummyObserver.changedInstr(StoreI);
+
+  // PtrtoInt cast.
+  Register InputReg = DstReg;
+  if (DestLLT.isPointer()) {
+    InputReg = MRI.createGenericVirtualRegister(S20);
+    HelperBuilder.buildPtrToInt(InputReg, DstReg);
+  }
+
+  // EXT new PtrtoInt-Cast.
+  Register ExtReg = MRI.createGenericVirtualRegister(S32);
+  if (DestLLT.isPointer())
+    HelperBuilder.buildZExt(ExtReg, InputReg);
+  else {
+    // FIXME: implement with G_SEXT once instruction legalization works
+    Register TempExtReg = MRI.createGenericVirtualRegister(S32);
+    HelperBuilder.buildZExt(TempExtReg, InputReg);
+    HelperBuilder.buildSExtInReg(ExtReg, TempExtReg, 20);
+  }
+
+  // Replace ptr with EXT Result.
+  StoreI.getOperand(0).setReg(ExtReg);
+
+  // Update MMO Type.
+  MachineMemOperand &MMO = **StoreI.memoperands_begin();
+  MMO.setType(S32);
+
+  Helper.lowerStore(StoreI);
+  return true;
+}
+
 bool AIELegalizerHelper::legalizeG_VAARG(LegalizerHelper &Helper,
                                          MachineInstr &MI) const {
   MachineIRBuilder &MIRBuilder = Helper.MIRBuilder;

--- a/llvm/lib/Target/AIE/AIELegalizerHelper.h
+++ b/llvm/lib/Target/AIE/AIELegalizerHelper.h
@@ -15,6 +15,7 @@
 #define LLVM_LIB_TARGET_AIE_AIELEGALIZERHELPER_H
 
 #include "llvm/CodeGen/GlobalISel/LegalizerHelper.h"
+#include "llvm/CodeGen/GlobalISel/LegalizerInfo.h"
 #include "llvm/IR/InstrTypes.h"
 
 namespace llvm {
@@ -91,6 +92,8 @@ public:
                                         MachineInstr &MI,
                                         const unsigned LegalVectorSize) const;
   bool legalizeG_TRUNC(LegalizerHelper &Helper, MachineInstr &MI) const;
+  bool isUnaligned20BitStore(const LegalityQuery &Query) const;
+  bool legalize_G_STORE(LegalizerHelper &Helper, GStore &StoreI) const;
 };
 
 } // namespace llvm

--- a/llvm/lib/Target/AIE/aie1/AIE1LegalizerInfo.cpp
+++ b/llvm/lib/Target/AIE/aie1/AIE1LegalizerInfo.cpp
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// (c) Copyright 2023-2024 Advanced Micro Devices, Inc. or its affiliates
+// (c) Copyright 2023-2025 Advanced Micro Devices, Inc. or its affiliates
 //
 //===----------------------------------------------------------------------===//
 /// \file
@@ -17,6 +17,7 @@
 #include "AIEBaseSubtarget.h"
 #include "AIELegalizerHelper.h"
 #include "llvm/Analysis/VectorUtils.h"
+#include "llvm/CodeGen/GlobalISel/GenericMachineInstrs.h"
 #include "llvm/CodeGen/GlobalISel/LegalizerInfo.h"
 #include "llvm/CodeGen/MachineOperand.h"
 #include "llvm/CodeGen/TargetOpcodes.h"
@@ -221,6 +222,10 @@ AIE1LegalizerInfo::AIE1LegalizerInfo(const AIEBaseSubtarget &ST)
           {ACC512, P0, ACC512, 32}, {ACC1024, P0, ACC1024, 32},
           {S128, P0, S128, 16},
       })
+      // Storing a pointer to an un-aligned address.
+      .customIf([=](const LegalityQuery &Query) {
+        return AIEHelper.isUnaligned20BitStore(Query);
+      })
       .widenScalarToNextPow2(0)
       .lowerIfMemSizeNotPow2()
       .bitcastIf(
@@ -238,7 +243,6 @@ AIE1LegalizerInfo::AIE1LegalizerInfo(const AIEBaseSubtarget &ST)
       .clampScalar(0, S32, S32)
       .lower();
 
-  // FIXME: Storing a pointer to an un-aligned address isn't supported.
   getActionDefinitionsBuilder({G_ZEXTLOAD, G_SEXTLOAD})
       .legalForTypesWithMemDesc({{S32, P0, S8, 8}, {S32, P0, S16, 16}})
       .widenScalarToNextPow2(0)
@@ -275,6 +279,8 @@ bool AIE1LegalizerInfo::legalizeCustom(
   switch (MI.getOpcode()) {
   default:
     break;
+  case TargetOpcode::G_STORE:
+    return AIEHelper.legalize_G_STORE(Helper, cast<GStore>(MI));
   case TargetOpcode::G_VASTART:
     return AIEHelper.legalizeG_VASTART(Helper, MI);
   case TargetOpcode::G_VAARG:

--- a/llvm/lib/Target/AIE/aie2p/AIE2PLegalizerInfo.cpp
+++ b/llvm/lib/Target/AIE/aie2p/AIE2PLegalizerInfo.cpp
@@ -519,6 +519,10 @@ AIE2PLegalizerInfo::AIE2PLegalizerInfo(const AIE2PSubtarget &ST)
                 0, LLT::fixed_vector(MemoryType.getNumElements() / SplitFactor,
                                      MemoryType.getElementType()));
           })
+      // Storing a pointer/S20 to an un-aligned address.
+      .customIf([=](const LegalityQuery &Query) {
+        return AIEHelper.isUnaligned20BitStore(Query);
+      })
       .widenScalarToNextPow2(0)
       .lowerIfMemSizeNotPow2()
       .bitcastIf(
@@ -536,7 +540,6 @@ AIE2PLegalizerInfo::AIE2PLegalizerInfo(const AIE2PSubtarget &ST)
       .clampScalar(0, S32, S32)
       .lower();
 
-  // FIXME: Storing a pointer to an un-aligned address isn't supported.
   getActionDefinitionsBuilder({G_ZEXTLOAD, G_SEXTLOAD})
       .legalForTypesWithMemDesc({{S32, P0, S8, 8}, {S32, P0, S16, 16}})
       .widenScalarToNextPow2(0)
@@ -735,6 +738,8 @@ bool AIE2PLegalizerInfo::legalizeCustom(
   switch (MI.getOpcode()) {
   default:
     break;
+  case TargetOpcode::G_STORE:
+    return AIEHelper.legalize_G_STORE(Helper, cast<GStore>(MI));
   case TargetOpcode::G_VASTART:
     return AIEHelper.legalizeG_VASTART(Helper, MI);
   case TargetOpcode::G_VAARG:

--- a/llvm/test/CodeGen/AIE/GlobalISel/legalize-store.mir
+++ b/llvm/test/CodeGen/AIE/GlobalISel/legalize-store.mir
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2023-2024 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2023-2025 Advanced Micro Devices, Inc. or its affiliates
 # RUN: llc -mtriple aie -run-pass=legalizer %s -verify-machineinstrs -o - | FileCheck %s
 # RUN: llc -mtriple aie2 -run-pass=legalizer %s -verify-machineinstrs -o - | FileCheck %s
 # RUN: llc -mtriple aie2p -run-pass=legalizer %s -verify-machineinstrs -o - | FileCheck %s
@@ -116,6 +116,87 @@ body: |
     %0:_(p0) = COPY $p0
     %1:_(p0) = COPY $p1
     G_STORE %1, %0 :: (store (p0))
+...
+
+---
+name: test_store_p0_aligned
+body: |
+  bb.0:
+    liveins: $p0, $p1
+    ; CHECK-LABEL: name: test_store_p0_aligned
+    ; CHECK: liveins: $p0, $p1
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(p0) = COPY $p0
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(p0) = COPY $p1
+    ; CHECK-NEXT: G_STORE [[COPY1]](p0), [[COPY]](p0) :: (store (p0), align 4)
+    %0:_(p0) = COPY $p0
+    %1:_(p0) = COPY $p1
+    G_STORE %1, %0 :: (store (p0), align 4)
+...
+
+---
+name: test_store_p0_unaligned
+body: |
+  bb.0:
+    liveins: $p0, $p1
+    ; CHECK-LABEL: name: test_store_p0_unaligned
+    ; CHECK: liveins: $p0, $p1
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(p0) = COPY $p0
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(p0) = COPY $p1
+    ; CHECK-NEXT: [[PTRTOINT:%[0-9]+]]:_(s20) = G_PTRTOINT [[COPY1]](p0)
+    ; CHECK-NEXT: [[ZEXT:%[0-9]+]]:_(s32) = G_ZEXT [[PTRTOINT]](s20)
+    ; CHECK-NEXT: [[COPY2:%[0-9]+]]:_(s32) = COPY [[ZEXT]](s32)
+    ; CHECK-NEXT: [[C:%[0-9]+]]:_(s32) = G_CONSTANT i32 16
+    ; CHECK-NEXT: [[LSHR:%[0-9]+]]:_(s32) = G_LSHR [[COPY2]], [[C]](s32)
+    ; CHECK-NEXT: [[C1:%[0-9]+]]:_(s20) = G_CONSTANT i20 2
+    ; CHECK-NEXT: [[PTR_ADD:%[0-9]+]]:_(p0) = G_PTR_ADD [[COPY]], [[C1]](s20)
+    ; CHECK-NEXT: G_STORE [[COPY2]](s32), [[COPY]](p0) :: (store (s16))
+    ; CHECK-NEXT: G_STORE [[LSHR]](s32), [[PTR_ADD]](p0) :: (store (s16) into unknown-address + 2)
+    %0:_(p0) = COPY $p0
+    %1:_(p0) = COPY $p1
+    G_STORE %1, %0 :: (store (p0), align 2)
+...
+
+---
+name: test_store_s20_aligned
+body: |
+  bb.0:
+    liveins: $p0, $p1
+    ; CHECK-LABEL: name: test_store_s20_aligned
+    ; CHECK: liveins: $p0, $p1
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(p0) = COPY $p0
+    ; CHECK-NEXT: [[DEF:%[0-9]+]]:_(s20) = G_IMPLICIT_DEF
+    ; CHECK-NEXT: G_STORE [[DEF]](s20), [[COPY]](p0) :: (store (s20), align 4)
+    %0:_(p0) = COPY $p0
+    %1:_(s20) = G_IMPLICIT_DEF
+    G_STORE %1, %0 :: (store (s20), align 4)
+...
+
+---
+name: test_store_s20_unaligned
+body: |
+  bb.0:
+    liveins: $p0, $p1
+    ; CHECK-LABEL: name: test_store_s20_unaligned
+    ; CHECK: liveins: $p0, $p1
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(p0) = COPY $p0
+    ; CHECK-NEXT: [[C:%[0-9]+]]:_(s32) = G_CONSTANT i32 0
+    ; CHECK-NEXT: [[C1:%[0-9]+]]:_(s32) = G_CONSTANT i32 12
+    ; CHECK-NEXT: [[SHL:%[0-9]+]]:_(s32) = G_SHL [[C]], [[C1]](s32)
+    ; CHECK-NEXT: [[ASHR:%[0-9]+]]:_(s32) = G_ASHR [[SHL]], [[C1]](s32)
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(s32) = COPY [[ASHR]](s32)
+    ; CHECK-NEXT: [[C2:%[0-9]+]]:_(s32) = G_CONSTANT i32 16
+    ; CHECK-NEXT: [[LSHR:%[0-9]+]]:_(s32) = G_LSHR [[COPY1]], [[C2]](s32)
+    ; CHECK-NEXT: [[C3:%[0-9]+]]:_(s20) = G_CONSTANT i20 2
+    ; CHECK-NEXT: [[PTR_ADD:%[0-9]+]]:_(p0) = G_PTR_ADD [[COPY]], [[C3]](s20)
+    ; CHECK-NEXT: G_STORE [[COPY1]](s32), [[COPY]](p0) :: (store (s16))
+    ; CHECK-NEXT: G_STORE [[LSHR]](s32), [[PTR_ADD]](p0) :: (store (s16) into unknown-address + 2)
+    %0:_(p0) = COPY $p0
+    %1:_(s20) = G_IMPLICIT_DEF
+    G_STORE %1, %0 :: (store (s20), align 2)
 ...
 
 ---


### PR DESCRIPTION
Fix crashes when storing unaligned pointers, such as 

`G_STORE %1, %0 :: (store (p0), align 2)`