### PR TITLE
[AIEX][NFC] create `getProgramMemoryAlignmentBytes`

### DIFF
--- a/llvm/lib/Target/AIE/AIE2InstrInfo.h
+++ b/llvm/lib/Target/AIE/AIE2InstrInfo.h
@@ -78,6 +78,8 @@ public:
   virtual unsigned
   getNumReservedDelaySlots(const MachineInstr &MI) const override;
 
+  unsigned getMachineBlockAlignmentBytes() const override { return 16; }
+
   bool isJNZ(unsigned Opc) const override;
   bool isJZ(unsigned Opc) const override;
   bool isCall(unsigned Opc) const override;

--- a/llvm/lib/Target/AIE/AIEBaseInstrInfo.cpp
+++ b/llvm/lib/Target/AIE/AIEBaseInstrInfo.cpp
@@ -1198,7 +1198,9 @@ AIEBaseInstrInfo::getAlignmentBoundaries(MachineBasicBlock &MBB) const {
   auto ZOLSupport = getZOLSupport();
   const unsigned ZOLSetupToLoopEndDist =
       ZOLSupport.has_value() ? ZOLSupport->LoopSetupDistance : 0;
-  const unsigned LoopSetupSizeInBytes = 16 * ZOLSetupToLoopEndDist;
+  const unsigned LoopSetupSizeInBytes =
+      getMachineBlockAlignmentBytes() * ZOLSetupToLoopEndDist;
+  const unsigned MBBAlignment = getMachineBlockAlignmentBytes();
 
   auto GetPostZOLSetupRegionSize =
       [this](MachineBasicBlock &LoopMBB) -> std::pair<unsigned, unsigned> {
@@ -1230,9 +1232,9 @@ AIEBaseInstrInfo::getAlignmentBoundaries(MachineBasicBlock &MBB) const {
     assert(ZOLSupport);
 
     // Exclude the LoopEnd bundle as it must be placed in its own standalone
-    // region to guarantee 128-bit instruction alignment. Additionally, there
-    // must be a 112-byte gap (in PM address space) between writing to the ls,
-    // le, and lc registers and the LoopEnd instruction.
+    // region to guarantee alignment. Additionally, there must be a gap
+    // (in PM address space) between writing to the ls, le, and lc registers and
+    // the LoopEnd instruction.
     const unsigned LoopSize = LoopSizeExcludingLastBundle(MBB);
 
     if (LoopSize < LoopSetupSizeInBytes) {
@@ -1258,20 +1260,19 @@ AIEBaseInstrInfo::getAlignmentBoundaries(MachineBasicBlock &MBB) const {
       }
 
       // create regions of singleton bundle for schedule margin bundles,
-      // alignment algorithm will force fill each bundle to 128-bit due
-      // to the alignment requirement of 16-byte for the alignment region.
+      // alignment algorithm will force fill each bundle to the correct number
+      // of bits to fulfill the alignment requirement of the region.
       if (LoopPaddingInBytes > 0) {
         AlgnCandidates.emplace_back(MI);
         const int BundleSize = getAIEMachineBundleSize(MI);
-        LoopPaddingInBytes -= (16 - BundleSize);
+        LoopPaddingInBytes -= (MBBAlignment - BundleSize);
       }
 
       if (IsCall)
         DelaySlot = getNumDelaySlots(*MI);
 
-      // Distance in terms of fully-expanded 128-bit bundles that
-      // loop setup should maintain. We force each of these bundles to an
-      // alignment boundary, so that they will occupy 16 bytes.
+      // Distance in terms of fully-expanded bundles that loop setup should
+      // maintain. We force each of these bundles to an alignment boundary.
       if (ZOLSupport && isZOLSetupBundle(MI) && isLastZOLSetupBundleInMBB(MI)) {
         unsigned LoopSize = 0;
         // if we have only one MBB, it must be the loop.
@@ -1279,16 +1280,17 @@ AIEBaseInstrInfo::getAlignmentBoundaries(MachineBasicBlock &MBB) const {
           MachineBasicBlock *LoopSucc = *MBB.successors().begin();
           LoopSize = LoopSizeExcludingLastBundle(*LoopSucc);
           // If we have a loop size, we can consider that it will
-          // have, at least, 16 bytes (alignment).
-          if (LoopSize > 0 && LoopSize < 16)
-            LoopSize = 16;
+          // have, at least, the number of bytes required by alignment.
+          if (LoopSize > 0 && LoopSize < getMachineBlockAlignmentBytes())
+            LoopSize = getMachineBlockAlignmentBytes();
         }
 
         if (LoopSize < LoopSetupSizeInBytes) {
           const auto [PostZOLBundleCount, PostZOLSize] =
               getPostZOLRegionSizeInfo(MBB);
           const int AvailablePaddingSpace =
-              PostZOLBundleCount * 16 - PostZOLSize;
+              PostZOLBundleCount * getMachineBlockAlignmentBytes() -
+              PostZOLSize;
           const int NeededPadding =
               LoopSetupSizeInBytes - LoopSize - PostZOLSize;
           LoopPaddingInBytes = std::min(AvailablePaddingSpace, NeededPadding);

--- a/llvm/lib/Target/AIE/AIEBaseInstrInfo.h
+++ b/llvm/lib/Target/AIE/AIEBaseInstrInfo.h
@@ -521,6 +521,12 @@ struct AIEBaseInstrInfo : public TargetInstrInfo {
   virtual unsigned getRegionSizeInBytes(
       llvm::iterator_range<MachineBasicBlock::iterator> Region) const;
 
+  /// Return the required alignment in bytes of a machine basic block in a
+  /// specific target
+  virtual unsigned getMachineBlockAlignmentBytes() const {
+    llvm_unreachable("Target didn't implement getMachineBlockAlignmentBytes");
+  }
+
   /// Central place to compute RAW/WAR/WAW operand latencies.
   /// This uses itineraries when they exist. It returns std::nullopt for
   /// instructions that are not described.

--- a/llvm/lib/Target/AIE/AIEMachineAlignment.cpp
+++ b/llvm/lib/Target/AIE/AIEMachineAlignment.cpp
@@ -85,14 +85,15 @@ unsigned applyRegionAlignment(MachineBasicBlock::iterator MI,
   unsigned Size = 0;
   unsigned Stretchability = 0;
   unsigned f = 0;
+  const AIEBaseInstrInfo *TII = getTII(MI);
+  const unsigned MBBAlignment = TII->getMachineBlockAlignmentBytes();
   while (MI != EndMI) {
     if (MI->isBundle()) {
-      const AIEBaseInstrInfo *TII = getTII(MI);
       AIE::MachineBundle Bundle = TII->getAIEMachineBundle(MI);
       const VLIWFormat *Format = Bundle.getFormatOrNull();
       assert(Format);
       Size = Format->getSize();
-      Stretchability = 16 - Format->getSize();
+      Stretchability = MBBAlignment - Format->getSize();
       if (Stretchability == 0) {
         ++MI;
         continue;
@@ -116,7 +117,7 @@ unsigned applyRegionAlignment(MachineBasicBlock::iterator MI,
           if (Format->getSize() > Size) {
             elongateBundle(Bundle, *Format, &*MI, std::next(MI));
             Size = Format->getSize();
-            PadBytes = AllowCrossingPadBytes ? 16 - f : f;
+            PadBytes = AllowCrossingPadBytes ? MBBAlignment - f : f;
           }
         }
       } else {
@@ -140,13 +141,14 @@ void AIEMachineAlignment::applyBundlesAlignment(
     const std::vector<llvm::iterator_range<MachineBasicBlock::iterator>>
         &Regions,
     const AIEBaseInstrInfo *TII) {
+  const unsigned MBBAlignment = TII->getMachineBlockAlignmentBytes();
   for (auto Region : Regions) {
     unsigned Size = 0;
     unsigned PadBytes = 0;
     Size = TII->getRegionSizeInBytes(Region);
-    if ((Size % 16) == 0)
+    if ((Size % MBBAlignment) == 0)
       continue;
-    PadBytes = 16 - (Size % 16);
+    PadBytes = MBBAlignment - (Size % MBBAlignment);
     while (PadBytes) {
       PadBytes = applyRegionAlignment(Region.begin(), Region.end(), PadBytes,
                                       /*AllowCrossingPadBytes*/ false);

--- a/llvm/lib/Target/AIE/aie1/AIE1InstrInfo.h
+++ b/llvm/lib/Target/AIE/aie1/AIE1InstrInfo.h
@@ -90,6 +90,8 @@ public:
   bool canHoistCheapInst(const MachineInstr &MI) const override;
   unsigned getBasicVecRegSize() const override { return 256; };
 
+  unsigned getMachineBlockAlignmentBytes() const override { return 16; }
+
 protected:
   SmallVector<AIEPseudoExpandInfo, 4>
   getSpillPseudoExpandInfo(const MachineInstr &MI) const override;

--- a/llvm/lib/Target/AIE/aie2p/AIE2PInstrInfo.h
+++ b/llvm/lib/Target/AIE/aie2p/AIE2PInstrInfo.h
@@ -80,6 +80,8 @@ public:
   virtual unsigned
   getNumReservedDelaySlots(const MachineInstr &MI) const override;
 
+  unsigned getMachineBlockAlignmentBytes() const override { return 16; }
+
   bool isJNZ(unsigned Opc) const override;
   bool isJZ(unsigned Opc) const override;
   bool isCall(unsigned Opc) const override;


### PR DESCRIPTION
Future versions of AIE might have different alignment requirements for program memory. This PR enables configuring this for each specific AIE version.