### PR TITLE
[AIE2][AIE2P][NFC] remove unused unknown slot

### DIFF
--- a/llvm/lib/Target/AIE/AIE2PSlotInclude.td
+++ b/llvm/lib/Target/AIE/AIE2PSlotInclude.td
@@ -4,14 +4,12 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+// (c) Copyright 2024-2025 Advanced Micro Devices, Inc. or its affiliates
 //
 //===----------------------------------------------------------------------===//
 
 let Namespace = "AIE2P" in
 {
-    def unknown_slot : InstSlot<"unknown", 0, true>;
-
     // Cooked up Slot for 16-bit InsnFormat.
     // In AIE2P this has a single instruction nop. We keep the size small, so that
     // we can reuse it as artificial nop slot in other formats. This is another

--- a/llvm/lib/Target/AIE/AIE2Slots.td
+++ b/llvm/lib/Target/AIE/AIE2Slots.td
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// (c) Copyright 2023-2024 Advanced Micro Devices, Inc. or its affiliates
+// (c) Copyright 2023-2025 Advanced Micro Devices, Inc. or its affiliates
 //
 //===----------------------------------------------------------------------===//
 
@@ -20,8 +20,6 @@
 
 let Namespace = "AIE2" in
 {
-  def unknown_slot : InstSlot<"unknown", 0, true>;
-
   def lda_slot     : InstSlot<"Lda", 21> {
     let FieldToFind = "lda";
   }


### PR DESCRIPTION
Small PR to remove the unused `unknown_slot` in AIE2 and AIE2P, which is a relic from AIE1.