### PR TITLE
[AIE] Pass -Wno-missing-template-arg-list-after-template-kw to unbloc…

### DIFF
--- a/clang/lib/Driver/ToolChains/AIE.cpp
+++ b/clang/lib/Driver/ToolChains/AIE.cpp
@@ -200,6 +200,10 @@ void AIEToolChain::addClangTargetOptions(
     CC1Args.push_back("-fno-builtin-memcpy");
     CC1Args.push_back("-fno-builtin-memmove");
   }
+
+  // Temporarily disable the warning to unblock AIE API compilation.
+  // FIXME: remove after all downstream code has been fixed
+  CC1Args.push_back("-Wno-missing-template-arg-list-after-template-kw");
 }
 
 // Avoid using newer dwarf versions, as the simulator doesn't understand newer


### PR DESCRIPTION
…k AIE API compilation

Upstream commit f46d1463b835560d90ad3ac02b63c771e4ebe566 introduced a breaking change for C++ template code. Until all downstream code has been fixed, we pass the option to disable the error.