### PR TITLE
Remove bundle alignment through assembler relaxation

### DIFF
--- a/llvm/include/llvm/MC/MCAsmBackend.h
+++ b/llvm/include/llvm/MC/MCAsmBackend.h
@@ -4,9 +4,6 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// Modifications (c) Copyright 2023-2024 Advanced Micro Devices, Inc. or its
-// affiliates
-//
 //===----------------------------------------------------------------------===//
 
 #ifndef LLVM_MC_MCASMBACKEND_H
@@ -64,11 +61,6 @@ public:
   /// emitted into RelaxableFragment and then we can increase its size in a
   /// tricky way for optimization.
   virtual bool allowEnhancedRelaxation() const { return false; }
-
-  /// Relaxation will revisit a relaxed instruction immediately before relaxing
-  /// further instructions. This is useful for padding purposes, where padding
-  /// should not be added based on an offset which is not yet final.
-  virtual bool relaxPerInstruction() const { return false; }
 
   /// lifetime management
   virtual void reset() {}
@@ -164,17 +156,6 @@ public:
   virtual bool mayNeedRelaxation(const MCInst &Inst,
                                  const MCSubtargetInfo &STI) const {
     return false;
-  }
-
-  /// Return the maximum amount that this instruction will stretch when relaxed.
-  /// If it returns zero, it can not be relaxed.
-  /// This method is used to handle AlignByPadding fragments
-  /// \param Inst - The instruction to test.
-  /// \param STI - The MCSubtargetInfo in effect when the instruction was
-  /// encoded.
-  virtual unsigned maxRelaxIncrement(const MCInst &Inst,
-                                     const MCSubtargetInfo &STI) const {
-    return 0;
   }
 
   /// Target specific predicate for whether a given fixup requires the

--- a/llvm/include/llvm/MC/MCAssembler.h
+++ b/llvm/include/llvm/MC/MCAssembler.h
@@ -4,9 +4,6 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// Modifications (c) Copyright 2023-2024 Advanced Micro Devices, Inc. or its
-// affiliates
-//
 //===----------------------------------------------------------------------===//
 
 #ifndef LLVM_MC_MCASSEMBLER_H
@@ -210,9 +207,7 @@ private:
   /// changes as a result of relaxation.
   bool relaxFragment(MCAsmLayout &Layout, MCFragment &F);
   bool relaxInstruction(MCAsmLayout &Layout, MCRelaxableFragment &IF);
-  bool forceRelaxInstruction(MCAsmLayout &Layout, MCRelaxableFragment &IF);
   bool relaxLEB(MCAsmLayout &Layout, MCLEBFragment &IF);
-  bool relaxAlignByPadding(MCAsmLayout &Layout, MCAlignByPaddingFragment &BF);
   bool relaxBoundaryAlign(MCAsmLayout &Layout, MCBoundaryAlignFragment &BF);
   bool relaxDwarfLineAddr(MCAsmLayout &Layout, MCDwarfLineAddrFragment &DF);
   bool relaxDwarfCallFrameFragment(MCAsmLayout &Layout,

--- a/llvm/include/llvm/MC/MCFragment.h
+++ b/llvm/include/llvm/MC/MCFragment.h
@@ -4,9 +4,6 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// Modifications (c) Copyright 2023-2024 Advanced Micro Devices, Inc. or its
-// affiliates
-//
 //===----------------------------------------------------------------------===//
 
 #ifndef LLVM_MC_MCFRAGMENT_H
@@ -55,7 +52,6 @@ public:
     FT_CVInlineLines,
     FT_CVDefRange,
     FT_PseudoProbe,
-    FT_AlignByPadding,
     FT_Dummy
   };
 
@@ -333,21 +329,6 @@ public:
 
   static bool classof(const MCFragment *F) {
     return F->getKind() == MCFragment::FT_Align;
-  }
-};
-
-class MCAlignByPaddingFragment : public MCFragment {
-  /// The alignment to ensure, in bytes.
-  Align Alignment;
-
-public:
-  MCAlignByPaddingFragment(Align Alignment)
-      : MCFragment(FT_AlignByPadding, false), Alignment(Alignment) {}
-
-  Align getAlignment() const { return Alignment; }
-
-  static bool classof(const MCFragment *F) {
-    return F->getKind() == MCFragment::FT_AlignByPadding;
   }
 };
 

--- a/llvm/lib/MC/MCAssembler.cpp
+++ b/llvm/lib/MC/MCAssembler.cpp
@@ -4,9 +4,6 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// Modifications (c) Copyright 2023-2024 Advanced Micro Devices, Inc. or its
-// affiliates
-//
 //===----------------------------------------------------------------------===//
 
 #include "llvm/MC/MCAssembler.h"
@@ -339,9 +336,6 @@ uint64_t MCAssembler::computeFragmentSize(const MCAsmLayout &Layout,
   case MCFragment::FT_SymbolId:
     return 4;
 
-  case MCFragment::FT_AlignByPadding: {
-    return 0;
-  }
   case MCFragment::FT_Align: {
     const MCAlignFragment &AF = cast<MCAlignFragment>(F);
     unsigned Offset = Layout.getFragmentOffset(&AF);
@@ -622,9 +616,6 @@ static void writeFragment(raw_ostream &OS, const MCAssembler &Asm,
     }
     break;
   }
-  case MCFragment::FT_AlignByPadding:
-    // nothing to do
-    break;
 
   case MCFragment::FT_Data:
     ++stats::EmittedDataFragments;
@@ -1047,11 +1038,6 @@ bool MCAssembler::relaxInstruction(MCAsmLayout &Layout,
   if (!fragmentNeedsRelaxation(&F, Layout))
     return false;
 
-  return forceRelaxInstruction(Layout, F);
-}
-
-bool MCAssembler::forceRelaxInstruction(MCAsmLayout &Layout,
-                                   MCRelaxableFragment &F) {
   ++stats::RelaxedInstructions;
 
   // FIXME-PERF: We could immediately lower out instructions if we can tell
@@ -1145,41 +1131,6 @@ static bool needPadding(uint64_t StartAddr, uint64_t Size,
                         Align BoundaryAlignment) {
   return mayCrossBoundary(StartAddr, Size, BoundaryAlignment) ||
          isAgainstBoundary(StartAddr, Size, BoundaryAlignment);
-}
-
-bool MCAssembler::relaxAlignByPadding(MCAsmLayout &Layout,
-                                      MCAlignByPaddingFragment &BF) {
-  uint64_t AlignedOffset = Layout.getFragmentOffset(&BF);
-  Align Alignment(BF.getAlignment());
-  uint64_t BytesNeeded = offsetToAlignment(AlignedOffset, Alignment);
-  if (BytesNeeded == 0)
-    return false;
-
-  // Any instruction that can be relaxed sits in an FT_Relaxable fragment
-  SmallVector<MCRelaxableFragment *> RelaxableFragments;
-  for (MCFragment &F : *BF.getParent()) {
-    if (auto *RF = dyn_cast<MCRelaxableFragment>(&F)) {
-      RelaxableFragments.push_back(RF);
-    }
-  }
-  // Walk backwards, finding appropriate instructions to pad.
-  for (MCRelaxableFragment *RF : llvm::reverse(RelaxableFragments)) {
-    // If relaxing this instruction might contribute to our BytesNeeded,
-    // then try it. We should not overshoot, so never stretch more than the
-    // number of bytes we need.
-    unsigned Extra = getBackend().maxRelaxIncrement(RF->getInst(),
-                                                    *RF->getSubtargetInfo());
-    if (Extra > 0 && Extra <= BytesNeeded) {
-      forceRelaxInstruction(Layout, *RF);
-      // This is a rather conservative approach that will likely result in re-entering this
-      // function.  It's possible that there is some O(N^2) runtime here, but N is probably
-      // always small, since we won't look very far to find an instruction that we can
-      // pad.
-      Layout.invalidateFragmentsFrom(RF);
-      return true;
-    }
-  }
-  return false;
 }
 
 bool MCAssembler::relaxBoundaryAlign(MCAsmLayout &Layout,
@@ -1302,8 +1253,6 @@ bool MCAssembler::relaxFragment(MCAsmLayout &Layout, MCFragment &F) {
                                        cast<MCDwarfCallFrameFragment>(F));
   case MCFragment::FT_LEB:
     return relaxLEB(Layout, cast<MCLEBFragment>(F));
-  case MCFragment::FT_AlignByPadding:
-    return relaxAlignByPadding(Layout, cast<MCAlignByPaddingFragment>(F));
   case MCFragment::FT_BoundaryAlign:
     return relaxBoundaryAlign(Layout, cast<MCBoundaryAlignFragment>(F));
   case MCFragment::FT_CVInlineLines:

--- a/llvm/lib/MC/MCFragment.cpp
+++ b/llvm/lib/MC/MCFragment.cpp
@@ -4,9 +4,6 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// Modifications (c) Copyright 2023-2024 Advanced Micro Devices, Inc. or its
-// affiliates
-//
 //===----------------------------------------------------------------------===//
 
 #include "llvm/MC/MCFragment.h"
@@ -168,9 +165,6 @@ void MCFragment::destroy() {
     case FT_Align:
       cast<MCAlignFragment>(this)->~MCAlignFragment();
       return;
-    case FT_AlignByPadding:
-      delete cast<MCAlignByPaddingFragment>(this);
-      return;
     case FT_Data:
       cast<MCDataFragment>(this)->~MCDataFragment();
       return;
@@ -243,7 +237,6 @@ LLVM_DUMP_METHOD void MCFragment::dump() const {
   OS << "<";
   switch (getKind()) {
   case MCFragment::FT_Align: OS << "MCAlignFragment"; break;
-  case MCFragment::FT_AlignByPadding: OS << "MCAlignByPaddingFragment"; break;
   case MCFragment::FT_Data:  OS << "MCDataFragment"; break;
   case MCFragment::FT_CompactEncodedInst:
     OS << "MCCompactEncodedInstFragment"; break;
@@ -281,12 +274,6 @@ LLVM_DUMP_METHOD void MCFragment::dump() const {
     OS << " Alignment:" << AF->getAlignment().value()
        << " Value:" << AF->getValue() << " ValueSize:" << AF->getValueSize()
        << " MaxBytesToEmit:" << AF->getMaxBytesToEmit() << ">";
-    break;
-  }
-  case MCFragment::FT_AlignByPadding: {
-    const auto *AF = cast<MCAlignByPaddingFragment>(this);
-    OS << "\n       ";
-    OS << " Alignment:" << AF->getAlignment().value() << ">";
     break;
   }
   case MCFragment::FT_Data:  {

--- a/llvm/lib/Target/AIE/MCTargetDesc/AIE1AsmBackend.cpp
+++ b/llvm/lib/Target/AIE/MCTargetDesc/AIE1AsmBackend.cpp
@@ -13,66 +13,6 @@
 
 using namespace llvm;
 
-bool AIE1AsmBackend::isCall(unsigned Opcode) const {
-  switch (Opcode) {
-  default:
-    break;
-  case AIE::JAL:
-    return true;
-  }
-  return false;
-}
-
-bool AIE1AsmBackend::isDelaySlotInstr(unsigned Opcode) const {
-  switch (Opcode) {
-  default:
-    break;
-  case AIE::JAL:
-  case AIE::J:
-  case AIE::BNEZ:
-    return true;
-  }
-  return false;
-}
-
-void AIE1AsmBackend::relaxInstruction(MCInst &Inst,
-                                      const MCSubtargetInfo &STI) const {
-  switch (Inst.getOpcode()) {
-  default:
-    llvm_unreachable("Opcode not expected!");
-  case AIE::JAL:
-    Inst.setOpcode(AIE::JAL64);
-    return;
-  case AIE::NOP:
-    Inst.setOpcode(AIE::NOP32);
-    return;
-  case AIE::NOP32:
-    Inst.setOpcode(AIE::NOP64);
-    return;
-  case AIE::NOP64:
-    Inst.setOpcode(AIE::NOP96);
-    return;
-  case AIE::NOP96:
-    Inst.setOpcode(AIE::NOP128);
-    return;
-  }
-}
-
-unsigned AIE1AsmBackend::maxRelaxIncrement(const MCInst &Inst,
-                                           const MCSubtargetInfo &STI) const {
-  switch (Inst.getOpcode()) {
-  default:
-    break;
-  case AIE::NOP:
-    return 2;
-  case AIE::NOP32:
-  case AIE::NOP64:
-  case AIE::NOP96:
-    return 4;
-  }
-  return 0;
-}
-
 bool AIE1AsmBackend::writeNopData(raw_ostream &OS, uint64_t Count,
                                   const MCSubtargetInfo *STI) const {
   unsigned MinNopLen = 2;

--- a/llvm/lib/Target/AIE/MCTargetDesc/AIE1AsmBackend.h
+++ b/llvm/lib/Target/AIE/MCTargetDesc/AIE1AsmBackend.h
@@ -31,18 +31,8 @@ public:
     return AIE::NumTargetFixupKinds;
   }
 
-  void relaxInstruction(MCInst &Inst,
-                        const MCSubtargetInfo &STI) const override;
-
-  unsigned maxRelaxIncrement(const MCInst &Inst,
-                             const MCSubtargetInfo &STI) const override;
-
   bool writeNopData(raw_ostream &OS, uint64_t Count,
                     const MCSubtargetInfo *STI) const override;
-
-  bool isCall(unsigned Opcode) const override;
-
-  bool isDelaySlotInstr(unsigned Opcode) const override;
 };
 } // namespace llvm
 

--- a/llvm/lib/Target/AIE/MCTargetDesc/AIE2AsmBackend.cpp
+++ b/llvm/lib/Target/AIE/MCTargetDesc/AIE2AsmBackend.cpp
@@ -10,47 +10,8 @@
 
 #include "AIE2AsmBackend.h"
 #include "llvm/MC/MCObjectStreamer.h"
-#include "llvm/Support/ErrorHandling.h"
 
 using namespace llvm;
-
-bool AIE2AsmBackend::isCall(unsigned Opcode) const {
-  switch (Opcode) {
-  default:
-    break;
-  case AIE2::JL:
-  case AIE2::JL_IND:
-    return true;
-  }
-  return false;
-}
-
-bool AIE2AsmBackend::isDelaySlotInstr(unsigned Opcode) const {
-  switch (Opcode) {
-  default:
-    break;
-  case AIE2::JL:
-  case AIE2::JL_IND:
-  case AIE2::J_jump_imm:
-  case AIE2::J_jump_ind:
-  case AIE2::JNZ:
-  case AIE2::JZ:
-  case AIE2::RET:
-  case AIE2::JNZD:
-    return true;
-  }
-  return false;
-}
-
-void AIE2AsmBackend::relaxInstruction(MCInst &Inst,
-                                      const MCSubtargetInfo &STI) const {
-  llvm_unreachable("relaxInstruction call not expected in AIE2");
-}
-
-unsigned AIE2AsmBackend::maxRelaxIncrement(const MCInst &Inst,
-                                           const MCSubtargetInfo &STI) const {
-  return 0;
-}
 
 bool AIE2AsmBackend::writeNopData(raw_ostream &OS, uint64_t Count,
                                   const MCSubtargetInfo *STI) const {

--- a/llvm/lib/Target/AIE/MCTargetDesc/AIE2AsmBackend.h
+++ b/llvm/lib/Target/AIE/MCTargetDesc/AIE2AsmBackend.h
@@ -30,18 +30,8 @@ public:
     return AIE2::NumTargetFixupKinds;
   }
 
-  unsigned maxRelaxIncrement(const MCInst &Inst,
-                             const MCSubtargetInfo &STI) const override;
-
-  void relaxInstruction(MCInst &Inst,
-                        const MCSubtargetInfo &STI) const override;
-
   bool writeNopData(raw_ostream &OS, uint64_t Count,
                     const MCSubtargetInfo *STI) const override;
-
-  bool isCall(unsigned Opcode) const override;
-
-  bool isDelaySlotInstr(unsigned Opcode) const override;
 };
 } // namespace llvm
 

--- a/llvm/lib/Target/AIE/MCTargetDesc/AIEBaseAsmBackend.cpp
+++ b/llvm/lib/Target/AIE/MCTargetDesc/AIEBaseAsmBackend.cpp
@@ -15,69 +15,6 @@
 
 using namespace llvm;
 
-bool AIEBaseAsmBackend::hasDelaySlotInstr(const MCInst &Inst, bool &IsCall,
-                                          const Triple &TT) const {
-
-  unsigned Opcode = Inst.getOpcode();
-
-  // If it is a plain instruction having delay slot.
-  if (isDelaySlotInstr(Opcode)) {
-    IsCall = isCall(Opcode);
-    return true;
-  }
-
-  // AIE1 does not support bundling delay slot instructions.
-  if (TT.isAIE1())
-    return false;
-
-  // If it is a bundle having a delay slot instr.
-  for (const MCOperand &Op : Inst) {
-    if (!Op.isInst())
-      continue;
-    const unsigned SubOpcode = Op.getInst()->getOpcode();
-    if (isDelaySlotInstr(SubOpcode)) {
-      IsCall = isCall(SubOpcode);
-      return true;
-    }
-  }
-
-  return false;
-}
-
-void AIEBaseAsmBackend::emitInstructionEnd(MCObjectStreamer &OS,
-                                           const MCInst &Inst) {
-  bool IsCall = false;
-  const Triple &TT = STI.getTargetTriple();
-  if (hasDelaySlotInstr(Inst, IsCall, TT)) {
-    if (DelaySlot > 0)
-      llvm_unreachable("Cannot have branch in branch delay slot!\n");
-
-    // AIE branches have 5 delay slots.
-    DelaySlot = 5;
-    NeedsAlign = IsCall;
-    return;
-  }
-
-  // Count down and insert an alignment directive after the last delay slot.
-  // The goal is to force the instruction after the last delay slot (i.e. the
-  // target of a RET instruction) to be 16-byte aligned.
-  // This is required by the architecture.
-  // However, we can't simply insert NOOPs since that would change the
-  // scheduling of the branch.
-  if (DelaySlot > 0) {
-    if (NeedsAlign && DelaySlot == 1)
-      OS.insert(new MCAlignByPaddingFragment(Align(16)));
-    DelaySlot--;
-  }
-}
-
-// Actually 'canBeRelaxed'. Returning true here will insert it in a relaxable
-// fragment, which will be picked up by the return address alignment padding
-bool AIEBaseAsmBackend::mayNeedRelaxation(const MCInst &Inst,
-                                          const MCSubtargetInfo &STI) const {
-  return maxRelaxIncrement(Inst, STI) > 0;
-}
-
 static uint64_t adjustFixupValue(const MCFixup &Fixup, uint64_t Value,
                                  MCContext &Ctx) {
   unsigned Kind = Fixup.getKind();

--- a/llvm/lib/Target/AIE/MCTargetDesc/AIEBaseAsmBackend.cpp
+++ b/llvm/lib/Target/AIE/MCTargetDesc/AIEBaseAsmBackend.cpp
@@ -10,42 +10,10 @@
 
 #include "AIEBaseAsmBackend.h"
 #include "llvm/MC/MCAssembler.h"
-#include "llvm/MC/MCELFStreamer.h"
-#include "llvm/MC/MCCodeEmitter.h"
 #include "llvm/MC/MCObjectStreamer.h"
-#include "llvm/MC/MCStreamer.h"
 #include "llvm/MC/MCSubtargetInfo.h"
 
 using namespace llvm;
-
-namespace {
-class AIEELFStreamer : public MCELFStreamer {
-public:
-  AIEELFStreamer(MCContext &Context, std::unique_ptr<MCAsmBackend> TAB,
-                 std::unique_ptr<MCObjectWriter> OW,
-                 std::unique_ptr<MCCodeEmitter> Emitter)
-      : MCELFStreamer(Context, std::move(TAB), std::move(OW),
-                      std::move(Emitter)) {}
-
-  void emitInstruction(const MCInst &Inst, const MCSubtargetInfo &STI) override;
-};
-} // end anonymous namespace
-
-void AIEELFStreamer::emitInstruction(const MCInst &Inst,
-                                     const MCSubtargetInfo &STI) {
-  auto &Backend = static_cast<AIEBaseAsmBackend &>(getAssembler().getBackend());
-  // Backend.emitInstructionBegin(S, Inst, STI);
-  this->MCObjectStreamer::emitInstruction(Inst, STI);
-  Backend.emitInstructionEnd(*this, Inst);
-}
-
-MCStreamer *llvm::createAIEELFStreamer(const Triple &T, MCContext &Context,
-                                       std::unique_ptr<MCAsmBackend> &&MAB,
-                                       std::unique_ptr<MCObjectWriter> &&MOW,
-                                       std::unique_ptr<MCCodeEmitter> &&MCE) {
-  return new AIEELFStreamer(Context, std::move(MAB), std::move(MOW),
-                             std::move(MCE));
-}
 
 bool AIEBaseAsmBackend::hasDelaySlotInstr(const MCInst &Inst, bool &IsCall,
                                           const Triple &TT) const {

--- a/llvm/lib/Target/AIE/MCTargetDesc/AIEBaseAsmBackend.h
+++ b/llvm/lib/Target/AIE/MCTargetDesc/AIEBaseAsmBackend.h
@@ -29,15 +29,6 @@ protected:
   uint8_t OSABI;
   const MCTargetOptions &TargetOptions;
   AIEABI::ABI TargetABI = AIEABI::ABI_VITIS;
-  /// DelaySlot and NeedsAlign are set in conjunction.
-  /// Delayslot counts down from the delay slot holder, and will assert that
-  /// delay slots don't contain other delay slot holders.
-  /// NeedsAlign is encoding an alignment request for the end of the last
-  /// delay slot, effectively saying whether the delay slot holder was a call
-  /// instruction, which needs alignment of the return address. Note that the
-  /// alignment of branch targets is done separately at the start of each block
-  int DelaySlot = 0;
-  bool NeedsAlign = false;
 
 public:
   AIEBaseAsmBackend(const MCSubtargetInfo &STI, uint8_t OSABI,
@@ -55,8 +46,6 @@ public:
 
   std::unique_ptr<MCObjectTargetWriter>
   createObjectTargetWriter() const override;
-
-  void emitInstructionEnd(MCObjectStreamer &OS, const MCInst &Inst) override;
 
   bool fixupNeedsRelaxation(const MCFixup &Fixup, uint64_t Value,
                             const MCRelaxableFragment *DF,
@@ -84,30 +73,11 @@ public:
     return Dummy;
   }
 
-  bool mayNeedRelaxation(const MCInst &Inst,
-                         const MCSubtargetInfo &STI) const override;
-
-  void relaxInstruction(MCInst &Inst,
-                        const MCSubtargetInfo &STI) const override = 0;
-
-  bool relaxPerInstruction() const override { return true; }
-  unsigned maxRelaxIncrement(const MCInst &Inst,
-                             const MCSubtargetInfo &STI) const override = 0;
-
   bool writeNopData(raw_ostream &OS, uint64_t Count,
                     const MCSubtargetInfo *STI) const override = 0;
 
   const MCTargetOptions &getTargetOptions() const { return TargetOptions; }
   AIEABI::ABI getTargetABI() const { return TargetABI; }
-
-  virtual bool isCall(unsigned Opcode) const = 0;
-  virtual bool isDelaySlotInstr(unsigned Opcode) const = 0;
-
-  /// Check if the given MCInst has a delay slot instruction, either as itself
-  /// or as a sub-instruction in a bundle; @param IsCallInstr Set to **true** if
-  /// the instruction with the delay slots is a call.
-  bool hasDelaySlotInstr(const MCInst &Inst, bool &IsCallInstr,
-                         const Triple &TargetTriple) const;
 };
 } // namespace llvm
 

--- a/llvm/lib/Target/AIE/MCTargetDesc/AIEBaseAsmBackend.h
+++ b/llvm/lib/Target/AIE/MCTargetDesc/AIEBaseAsmBackend.h
@@ -16,7 +16,6 @@
 #include "Utils/AIEBaseInfo.h"
 #include "llvm/ADT/bit.h"
 #include "llvm/MC/MCAsmBackend.h"
-#include "llvm/MC/MCSubtargetInfo.h"
 
 namespace llvm {
 class MCAssembler;
@@ -57,7 +56,7 @@ public:
   std::unique_ptr<MCObjectTargetWriter>
   createObjectTargetWriter() const override;
 
-  void emitInstructionEnd(MCObjectStreamer &OS, const MCInst &Inst);
+  void emitInstructionEnd(MCObjectStreamer &OS, const MCInst &Inst) override;
 
   bool fixupNeedsRelaxation(const MCFixup &Fixup, uint64_t Value,
                             const MCRelaxableFragment *DF,

--- a/llvm/lib/Target/AIE/MCTargetDesc/AIEMCTargetDesc.cpp
+++ b/llvm/lib/Target/AIE/MCTargetDesc/AIEMCTargetDesc.cpp
@@ -171,9 +171,6 @@ extern "C" LLVM_EXTERNAL_VISIBILITY void LLVMInitializeAIETargetMC() {
                                                  createAIEObjectTargetStreamer);
     // Support for ASM output files
     TargetRegistry::RegisterAsmTargetStreamer(*T, createTargetAsmStreamer);
-
-    // Register the ELF streamer
-    TargetRegistry::RegisterELFStreamer(*T, createAIEELFStreamer);
   }
   // Register the MC instruction info.
   TargetRegistry::RegisterMCInstrInfo(getTheAIETarget(), createAIEMCInstrInfo);

--- a/llvm/lib/Target/AIE/MCTargetDesc/AIEMCTargetDesc.h
+++ b/llvm/lib/Target/AIE/MCTargetDesc/AIEMCTargetDesc.h
@@ -42,10 +42,6 @@ MCCodeEmitter *createAIEMCCodeEmitter(const MCInstrInfo &MCII,
 std::unique_ptr<MCObjectTargetWriter>
 createAIEELFObjectWriter(uint8_t OSABI, Triple TargetTriple);
 
-MCStreamer *createAIEELFStreamer(const Triple &T, MCContext &Context,
-                                 std::unique_ptr<MCAsmBackend> &&MAB,
-                                 std::unique_ptr<MCObjectWriter> &&MOW,
-                                 std::unique_ptr<MCCodeEmitter> &&MCE);
 } // end namespace llvm
 
 // Defines symbolic names for AIE registers.  This defines a mapping from

--- a/llvm/lib/Target/AIE/MCTargetDesc/aie2p/AIE2PAsmBackend.cpp
+++ b/llvm/lib/Target/AIE/MCTargetDesc/aie2p/AIE2PAsmBackend.cpp
@@ -10,39 +10,8 @@
 
 #include "AIE2PAsmBackend.h"
 #include "llvm/MC/MCObjectStreamer.h"
-#include "llvm/Support/ErrorHandling.h"
 
 using namespace llvm;
-
-bool AIE2PAsmBackend::isCall(unsigned Opcode) const {
-  switch (Opcode) {
-  // TODO Add Call Opcode e.g. JL
-  default:
-    break;
-  }
-  return false;
-}
-
-bool AIE2PAsmBackend::isDelaySlotInstr(unsigned Opcode) const {
-  switch (Opcode) {
-  default:
-    break;
-  // TODO Add other opcode e.g. JL, JZ, etc.
-  case AIE2P::RET:
-    return true;
-  }
-  return false;
-}
-
-void AIE2PAsmBackend::relaxInstruction(MCInst &Inst,
-                                       const MCSubtargetInfo &STI) const {
-  llvm_unreachable("relaxInstruction call not expected in AIE2P");
-}
-
-unsigned AIE2PAsmBackend::maxRelaxIncrement(const MCInst &Inst,
-                                            const MCSubtargetInfo &STI) const {
-  return 0;
-}
 
 bool AIE2PAsmBackend::writeNopData(raw_ostream &OS, uint64_t Count,
                                    const MCSubtargetInfo *STI) const {

--- a/llvm/lib/Target/AIE/MCTargetDesc/aie2p/AIE2PAsmBackend.h
+++ b/llvm/lib/Target/AIE/MCTargetDesc/aie2p/AIE2PAsmBackend.h
@@ -30,18 +30,8 @@ public:
     return AIE2P::NumTargetFixupKinds;
   }
 
-  unsigned maxRelaxIncrement(const MCInst &Inst,
-                             const MCSubtargetInfo &STI) const override;
-
-  void relaxInstruction(MCInst &Inst,
-                        const MCSubtargetInfo &STI) const override;
-
   bool writeNopData(raw_ostream &OS, uint64_t Count,
                     const MCSubtargetInfo *STI) const override;
-
-  bool isCall(unsigned Opcode) const override;
-
-  bool isDelaySlotInstr(unsigned Opcode) const override;
 };
 } // namespace llvm
 

--- a/llvm/test/CodeGen/AIE/aie1/BinaryOutput/JAL.mir
+++ b/llvm/test/CodeGen/AIE/aie1/BinaryOutput/JAL.mir
@@ -8,6 +8,9 @@
 # RUN: llc -O2 --march=aie %s --start-after=post-RA-sched --filetype=obj -o %t
 # RUN: llvm-objdump --triple=aie -dr %t | FileCheck %s
 
+# FIXME: Use the AIEMachineAlignment pass for AIE1 to align jump return addresses
+# XFAIL: *
+
 # CHECK: 0: 0b 08 20 a0 {{(nop;?)*}}jal #128
 # CHECK: 10: 41 a0 jal cb5
 # CHECK: 26: 01 01 ret lr


### PR DESCRIPTION
AIE2/AIE2p already use a dedicated AIEMachineAlignment pass to compute the correct alignment for all special AIE alignment requirements.
This change removes the return address alignment handling through assembler relaxation that was only used by AIE1.
Note that this is a breaking change for correct AIE1 code generation, and the CodeGen/AIE/aie1/BinaryOutput/JAL.mir test has been marked XFAIL.