### PR TITLE
[AIEX] Disable the WindowPipeliner for AIE

### DIFF
--- a/llvm/lib/Target/AIE/AIE2Subtarget.h
+++ b/llvm/lib/Target/AIE/AIE2Subtarget.h
@@ -62,6 +62,9 @@ public:
   bool enableMachinePipeliner() const override {
     return AIEBaseSubtarget::enableMachinePipeliner();
   }
+  bool enableWindowScheduler() const override {
+    return AIEBaseSubtarget::enableWindowScheduler();
+  }
   bool enablePostRAScheduler() const override { return true; }
   bool enablePostRAMachineScheduler() const override { return true; }
   bool forcePostRAScheduling() const override { return true; }

--- a/llvm/lib/Target/AIE/AIEBaseSubtarget.cpp
+++ b/llvm/lib/Target/AIE/AIEBaseSubtarget.cpp
@@ -918,6 +918,12 @@ bool AIEBaseSubtarget::enableMachinePipeliner() const {
   return !ForcePostPipeliner;
 }
 
+bool AIEBaseSubtarget::enableWindowScheduler() const {
+  // This pass triggers an assertion in AIEBundle.h
+  // Disable the pass until the root cause has been fixed.
+  return false;
+}
+
 unsigned AIEBaseSubtarget::getCriticalPathLimitImpl() const {
   return IfConversionCritPathLimit;
 }

--- a/llvm/lib/Target/AIE/AIEBaseSubtarget.h
+++ b/llvm/lib/Target/AIE/AIEBaseSubtarget.h
@@ -91,6 +91,8 @@ public:
   /// the post-RA pipeliner handle the scheduling.
   bool enableMachinePipeliner() const;
 
+  bool enableWindowScheduler() const;
+
   /// Returns the critical path limit that EarlyIfConversion should use
   /// when deciding about a specific conversion - common implementation.
   unsigned getCriticalPathLimitImpl() const;

--- a/llvm/lib/Target/AIE/aie2p/AIE2PSubtarget.h
+++ b/llvm/lib/Target/AIE/aie2p/AIE2PSubtarget.h
@@ -56,6 +56,9 @@ public:
   bool enableMachinePipeliner() const override {
     return AIEBaseSubtarget::enableMachinePipeliner();
   }
+  bool enableWindowScheduler() const override {
+    return AIEBaseSubtarget::enableWindowScheduler();
+  }
   bool enablePostRAScheduler() const override { return true; }
   bool enablePostRAMachineScheduler() const override { return true; }
   bool forcePostRAScheduling() const override { return true; }


### PR DESCRIPTION
The pass is running into an assertion in AIEBundle.h: Assertion failed: !(OccupiedSlots & NewSlots) && "Selected slot already occupied"

Disable the pass until the root cause has been fixed.

Fixes #579 