### PR TITLE
Add pyyaml to required packages for wheel build

### DIFF
--- a/.github/workflows/amd_aie_releases/pyproject.toml
+++ b/.github/workflows/amd_aie_releases/pyproject.toml
@@ -3,7 +3,8 @@ requires = [
     "setuptools>=42",
     "wheel",
     "ninja",
-    "cmake>=3.12"
+    "cmake>=3.12",
+    "pyyaml>=5.1"
 ]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
libc's new Headergen requires PyYAML version 5.1 or newer in order to generate header files.