### PR TITLE
[AIEX] fix llvm reduce crash

### DIFF
--- a/llvm/lib/Target/AIE/AIEMachineFunctionInfo.cpp
+++ b/llvm/lib/Target/AIE/AIEMachineFunctionInfo.cpp
@@ -30,6 +30,13 @@ void AIEMachineFunctionInfo::initializeBaseYamlFields(
     setVarArgsFrameIndex(*YamlMFI.VarArgsFrameIndex);
 }
 
+MachineFunctionInfo *AIEMachineFunctionInfo::clone(
+    BumpPtrAllocator &Allocator, MachineFunction &DestMF,
+    const DenseMap<MachineBasicBlock *, MachineBasicBlock *> &Src2DstMBB)
+    const {
+  return DestMF.cloneInfo<AIEMachineFunctionInfo>(*this);
+}
+
 namespace llvm {
 AIEMachineFunctionInfo::AIEMachineFunctionInfo(const Function &F,
                                                const TargetSubtargetInfo *STI,

--- a/llvm/lib/Target/AIE/AIEMachineFunctionInfo.h
+++ b/llvm/lib/Target/AIE/AIEMachineFunctionInfo.h
@@ -88,6 +88,11 @@ public:
 
   unsigned getBytesInStackArgArea() const { return BytesInStackArgArea; }
   void setBytesInStackArgArea(unsigned bytes) { BytesInStackArgArea = bytes; }
+
+  MachineFunctionInfo *
+  clone(BumpPtrAllocator &Allocator, MachineFunction &DestMF,
+        const DenseMap<MachineBasicBlock *, MachineBasicBlock *> &Src2DstMBB)
+      const override;
 };
 
 namespace yaml {


### PR DESCRIPTION
This PR fixes a llvm-reduce crash when running llvm-reduce on .mir files. 

Add missing `MachineFunctionInfo::clone` function to `AIEMachineFunctionInfo` (copied from x86)

