### PR TITLE
ci: Run check-mlir on PRs

### DIFF
--- a/.github/workflows/llvm-project-tests.yml
+++ b/.github/workflows/llvm-project-tests.yml
@@ -88,6 +88,7 @@ jobs:
       # lldb.  Using this setup-python action to make 3.10 the default
       # python fixes this.
       - name: Setup Python
+        if: inputs.projects != 'mlir'
         uses: actions/setup-python@v5
         with:
           python-version: ${{ inputs.python_version }}
@@ -100,6 +101,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 250
+      - name: Install requirements.txt
+        if: inputs.projects == 'mlir'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y python3-dev python3-pip
+          pip install -r mlir/python/requirements.txt
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@v1
         with:

--- a/.github/workflows/mlir-tests.yml
+++ b/.github/workflows/mlir-tests.yml
@@ -1,0 +1,28 @@
+name: MLIR Tests
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+  pull_request:
+  # Only builds on push populate the ccache that can be used by PRs
+  push:
+    branches: [ main, feature/fused-ops ]
+
+concurrency:
+  # Skip intermediate builds: always.
+  # Cancel intermediate builds: only if it is a pull request build.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
+jobs:
+  check_mlir:
+    name: Test mlir
+    uses: ./.github/workflows/llvm-project-tests.yml
+    with:
+      build_target: check-mlir
+      projects: mlir
+      cache-key: amd-mlir
+      extra_cmake_args: -DMLIR_ENABLE_BINDINGS_PYTHON=ON
+      os_list: '["ubuntu-22.04"]'


### PR DESCRIPTION
Run the `check-mlir` target on PRs to verify that our MLIR changes are good.
Needs some modifications in the CI setup to ensure that cmake can find python and pybind for the MLIR python bindings. `actions/setup-python` unfortunately doesn't bring the required python dev headers/libs.