### PR TITLE
[AIEX] Prevent invariant load folding for external constants

### DIFF
--- a/llvm/lib/Target/AIE/AIECombinerHelper.cpp
+++ b/llvm/lib/Target/AIE/AIECombinerHelper.cpp
@@ -3570,6 +3570,10 @@ bool llvm::matchConstLoad(MachineInstr &MI, MachineRegisterInfo &MRI,
   if (!ConstPtr)
     return false;
 
+  // External constants have zero operands (no visible initializer).
+  if (ConstPtr->getNumOperands() == 0)
+    return false;
+
   const Constant *ConstData = dyn_cast<Constant>(ConstPtr->getOperand(0));
   if (!ConstData)
     return false;

--- a/llvm/test/CodeGen/AIE/GlobalISel/combine-invariant-loads.mir
+++ b/llvm/test/CodeGen/AIE/GlobalISel/combine-invariant-loads.mir
@@ -55,6 +55,13 @@
     ret i32 0
   }
 
+  @constinit_external = external constant <{ i32, i32, i32, i32, i32, i32, [10 x i32] }>
+
+  define noundef i32 @cant_combine_external_constant() {
+  entry:
+    ret i32 0
+  }
+
   declare void @llvm.memcpy.p0.p0.i32(ptr noalias nocapture writeonly, ptr noalias nocapture readonly, i32, i1 immarg) #1
 
 ...
@@ -923,5 +930,37 @@ body:             |
     G_MEMCPY %1(p0), %2(p0), %4(s20), 1 :: (store (s8) into `ptr null`, align 4), (dereferenceable invariant load (s8) from @constinit5, align 4)
     $r0 = COPY %0(s32)
     PseudoRET implicit $lr, implicit $r0
+
+...
+
+---
+name:            cant_combine_external_constant
+alignment:       16
+legalized:       false
+regBankSelected: false
+selected:        false
+tracksRegLiveness: true
+
+body:             |
+  bb.1.entry:
+    ; AIE2-FOLD-LABEL: name: cant_combine_external_constant
+    ; AIE2-FOLD: [[GV:%[0-9]+]]:_(p0) = G_GLOBAL_VALUE @constinit_external
+    ; AIE2-FOLD-NEXT: [[LOAD:%[0-9]+]]:_(s8) = G_LOAD [[GV]](p0) :: (dereferenceable invariant load (s8) from @constinit_external)
+    ; AIE2-FOLD-NEXT: PseudoRET implicit $lr, implicit [[LOAD]](s8)
+    ;
+    ; AIE2P-FOLD-LABEL: name: cant_combine_external_constant
+    ; AIE2P-FOLD: [[GV:%[0-9]+]]:_(p0) = G_GLOBAL_VALUE @constinit_external
+    ; AIE2P-FOLD-NEXT: [[LOAD:%[0-9]+]]:_(s8) = G_LOAD [[GV]](p0) :: (dereferenceable invariant load (s8) from @constinit_external)
+    ; AIE2P-FOLD-NEXT: PseudoRET implicit $lr, implicit [[LOAD]](s8)
+    ;
+    ; AIE2P-NOFOLD-LABEL: name: cant_combine_external_constant
+    ; AIE2P-NOFOLD: [[GV:%[0-9]+]]:_(p0) = G_GLOBAL_VALUE @constinit_external
+    ; AIE2P-NOFOLD-NEXT: [[LOAD:%[0-9]+]]:_(s8) = G_LOAD [[GV]](p0) :: (dereferenceable invariant load (s8) from @constinit_external)
+    ; AIE2P-NOFOLD-NEXT: PseudoRET implicit $lr, implicit [[LOAD]](s8)
+    %0:_(s32) = G_CONSTANT i32 0
+    %1:_(p0) = G_CONSTANT i20 0
+    %2:_(p0) = G_GLOBAL_VALUE @constinit_external
+    %6:_(s8) = G_LOAD %2(p0) :: (dereferenceable invariant load (s8) from @constinit_external)
+    PseudoRET implicit $lr, implicit %6
 
 ...


### PR DESCRIPTION
If we have an external constant, we only have the declaration, not the initializer.