### PR TITLE
[AIE2][AIE2P] Fix instruction selection patterns for VMAXDIFF_LT

### DIFF
--- a/llvm/lib/Target/AIE/AIE2InstrPatterns.td
+++ b/llvm/lib/Target/AIE/AIE2InstrPatterns.td
@@ -583,17 +583,17 @@ def : Pat<(int_aie2_vaddsub32 VEC512:$src1, VEC512:$src2, eRS8:$rsel),
 
 // VMAXDIFF_LT
 def : Pat<(int_aie2_vmaxdiff_lt8 VEC512:$src1, VEC512:$src2, 0x0),
-           (VMAX_LT_D8 VEC512:$src1, VEC512:$src2)>;
+           (VMAXDIFF_LT_D8 VEC512:$src1, VEC512:$src2)>;
 def : Pat<(int_aie2_vmaxdiff_lt16 VEC512:$src1, VEC512:$src2, 0x0),
-           (VMAX_LT_D16 VEC512:$src1, VEC512:$src2)>;
+           (VMAXDIFF_LT_D16 VEC512:$src1, VEC512:$src2)>;
 def : Pat<(int_aie2_vmaxdiff_lt32 VEC512:$src1, VEC512:$src2, 0x0),
-           (VMAX_LT_D32 VEC512:$src1, VEC512:$src2)>;
+           (VMAXDIFF_LT_D32 VEC512:$src1, VEC512:$src2)>;
 def : Pat<(int_aie2_vmaxdiff_lt8 VEC512:$src1, VEC512:$src2, 0x1),
-           (VMAX_LT_S8 VEC512:$src1, VEC512:$src2)>;
+           (VMAXDIFF_LT_S8 VEC512:$src1, VEC512:$src2)>;
 def : Pat<(int_aie2_vmaxdiff_lt16 VEC512:$src1, VEC512:$src2, 0x1),
-           (VMAX_LT_S16 VEC512:$src1, VEC512:$src2)>;
+           (VMAXDIFF_LT_S16 VEC512:$src1, VEC512:$src2)>;
 def : Pat<(int_aie2_vmaxdiff_lt32 VEC512:$src1, VEC512:$src2, 0x1),
-           (VMAX_LT_S32 VEC512:$src1, VEC512:$src2)>;
+           (VMAXDIFF_LT_S32 VEC512:$src1, VEC512:$src2)>;
 
 // VADD/VSUB
 def : Pat<(add v64i8:$src1, v64i8:$src2),   (VADD_8  VEC512:$src1, VEC512:$src2)>;

--- a/llvm/lib/Target/AIE/aie2p/AIE2PInstrPatterns.td
+++ b/llvm/lib/Target/AIE/aie2p/AIE2PInstrPatterns.td
@@ -1244,17 +1244,17 @@ def  : Pat<(v32i1 (aie_setne (v16i32 VEC512:$rs1), (v16i32 VEC512:$rs2))),
 
 // VMAXDIFF_LT
 def : Pat<(int_aie2p_vmaxdiff_lt8 VEC512:$src1, VEC512:$src2, 0x0),
-           (VMAX_LT_8_vaddSign0 VEC512:$src1, VEC512:$src2)>;
+           (VMAXDIFF_LT_8_vaddSign0 VEC512:$src1, VEC512:$src2)>;
 def : Pat<(int_aie2p_vmaxdiff_lt16 VEC512:$src1, VEC512:$src2, 0x0),
-           (VMAX_LT_16_vaddSign0 VEC512:$src1, VEC512:$src2)>;
+           (VMAXDIFF_LT_16_vaddSign0 VEC512:$src1, VEC512:$src2)>;
 def : Pat<(int_aie2p_vmaxdiff_lt32 VEC512:$src1, VEC512:$src2, 0x0),
-           (VMAX_LT_32_vaddSign0 VEC512:$src1, VEC512:$src2)>;
+           (VMAXDIFF_LT_32_vaddSign0 VEC512:$src1, VEC512:$src2)>;
 def : Pat<(int_aie2p_vmaxdiff_lt8 VEC512:$src1, VEC512:$src2, 0x1),
-           (VMAX_LT_8_vaddSign1 VEC512:$src1, VEC512:$src2)>;
+           (VMAXDIFF_LT_8_vaddSign1 VEC512:$src1, VEC512:$src2)>;
 def : Pat<(int_aie2p_vmaxdiff_lt16 VEC512:$src1, VEC512:$src2, 0x1),
-           (VMAX_LT_16_vaddSign1 VEC512:$src1, VEC512:$src2)>;
+           (VMAXDIFF_LT_16_vaddSign1 VEC512:$src1, VEC512:$src2)>;
 def : Pat<(int_aie2p_vmaxdiff_lt32 VEC512:$src1, VEC512:$src2, 0x1),
-           (VMAX_LT_32_vaddSign1 VEC512:$src1, VEC512:$src2)>;
+           (VMAXDIFF_LT_32_vaddSign1 VEC512:$src1, VEC512:$src2)>;
 
 // VMAX_LT
 // Note : Non-constant sign is handled in .cpp

--- a/llvm/test/CodeGen/AIE/aie2/GlobalISel/inst-select-vmaxdiff_lt.mir
+++ b/llvm/test/CodeGen/AIE/aie2/GlobalISel/inst-select-vmaxdiff_lt.mir
@@ -16,7 +16,6 @@ regBankSelected: true
 body:             |
   bb.1.entry:
     liveins: $p0, $r0, $x2, $x3
-    ; CHEC
     ; CHECK-LABEL: name: VMAXDIFF_LT8
     ; CHECK: liveins: $p0, $r0, $x2, $x3
     ; CHECK-NEXT: {{  $}}
@@ -49,8 +48,8 @@ body:             |
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:vec512 = COPY $x2
     ; CHECK-NEXT: [[COPY1:%[0-9]+]]:vec512 = COPY $x3
-    ; CHECK-NEXT: [[VMAX_LT_D8_:%[0-9]+]]:vec512, [[VMAX_LT_D8_1:%[0-9]+]]:el = VMAX_LT_D8 [[COPY]], [[COPY1]], implicit $crvaddsign
-    ; CHECK-NEXT: $x0 = COPY [[VMAX_LT_D8_]]
+    ; CHECK-NEXT: [[VMAXDIFF_LT_D8_:%[0-9]+]]:vec512, [[VMAXDIFF_LT_D8_1:%[0-9]+]]:el = VMAXDIFF_LT_D8 [[COPY]], [[COPY1]], implicit $crvaddsign
+    ; CHECK-NEXT: $x0 = COPY [[VMAXDIFF_LT_D8_]]
     ; CHECK-NEXT: PseudoRET implicit $lr, implicit $x0
     %1:vregbank(<64 x s8>) = COPY $x2
     %11:vregbank(<64 x s8>) = COPY $x3
@@ -73,8 +72,8 @@ body:             |
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:vec512 = COPY $x2
     ; CHECK-NEXT: [[COPY1:%[0-9]+]]:vec512 = COPY $x3
-    ; CHECK-NEXT: [[VMAX_LT_S8_:%[0-9]+]]:vec512, [[VMAX_LT_S8_1:%[0-9]+]]:el = VMAX_LT_S8 [[COPY]], [[COPY1]]
-    ; CHECK-NEXT: $x0 = COPY [[VMAX_LT_S8_]]
+    ; CHECK-NEXT: [[VMAXDIFF_LT_S8_:%[0-9]+]]:vec512, [[VMAXDIFF_LT_S8_1:%[0-9]+]]:el = VMAXDIFF_LT_S8 [[COPY]], [[COPY1]]
+    ; CHECK-NEXT: $x0 = COPY [[VMAXDIFF_LT_S8_]]
     ; CHECK-NEXT: PseudoRET implicit $lr, implicit $x0
     %1:vregbank(<64 x s8>) = COPY $x2
     %11:vregbank(<64 x s8>) = COPY $x3
@@ -124,8 +123,8 @@ body:             |
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:vec512 = COPY $x2
     ; CHECK-NEXT: [[COPY1:%[0-9]+]]:vec512 = COPY $x3
-    ; CHECK-NEXT: [[VMAX_LT_D16_:%[0-9]+]]:vec512, [[VMAX_LT_D16_1:%[0-9]+]]:ers8 = VMAX_LT_D16 [[COPY]], [[COPY1]], implicit $crvaddsign
-    ; CHECK-NEXT: $x0 = COPY [[VMAX_LT_D16_]]
+    ; CHECK-NEXT: [[VMAXDIFF_LT_D16_:%[0-9]+]]:vec512, [[VMAXDIFF_LT_D16_1:%[0-9]+]]:ers8 = VMAXDIFF_LT_D16 [[COPY]], [[COPY1]], implicit $crvaddsign
+    ; CHECK-NEXT: $x0 = COPY [[VMAXDIFF_LT_D16_]]
     ; CHECK-NEXT: PseudoRET implicit $lr, implicit $x0
     %1:vregbank(<32 x s16>) = COPY $x2
     %11:vregbank(<32 x s16>) = COPY $x3
@@ -148,8 +147,8 @@ body:             |
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:vec512 = COPY $x2
     ; CHECK-NEXT: [[COPY1:%[0-9]+]]:vec512 = COPY $x3
-    ; CHECK-NEXT: [[VMAX_LT_S16_:%[0-9]+]]:vec512, [[VMAX_LT_S16_1:%[0-9]+]]:ers8 = VMAX_LT_S16 [[COPY]], [[COPY1]]
-    ; CHECK-NEXT: $x0 = COPY [[VMAX_LT_S16_]]
+    ; CHECK-NEXT: [[VMAXDIFF_LT_S16_:%[0-9]+]]:vec512, [[VMAXDIFF_LT_S16_1:%[0-9]+]]:ers8 = VMAXDIFF_LT_S16 [[COPY]], [[COPY1]]
+    ; CHECK-NEXT: $x0 = COPY [[VMAXDIFF_LT_S16_]]
     ; CHECK-NEXT: PseudoRET implicit $lr, implicit $x0
     %1:vregbank(<32 x s16>) = COPY $x2
     %11:vregbank(<32 x s16>) = COPY $x3
@@ -199,8 +198,8 @@ body:             |
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:vec512 = COPY $x2
     ; CHECK-NEXT: [[COPY1:%[0-9]+]]:vec512 = COPY $x3
-    ; CHECK-NEXT: [[VMAX_LT_D32_:%[0-9]+]]:vec512, [[VMAX_LT_D32_1:%[0-9]+]]:ers8 = VMAX_LT_D32 [[COPY]], [[COPY1]], implicit $crvaddsign
-    ; CHECK-NEXT: $x0 = COPY [[VMAX_LT_D32_]]
+    ; CHECK-NEXT: [[VMAXDIFF_LT_D32_:%[0-9]+]]:vec512, [[VMAXDIFF_LT_D32_1:%[0-9]+]]:ers8 = VMAXDIFF_LT_D32 [[COPY]], [[COPY1]], implicit $crvaddsign
+    ; CHECK-NEXT: $x0 = COPY [[VMAXDIFF_LT_D32_]]
     ; CHECK-NEXT: PseudoRET implicit $lr, implicit $x0
     %1:vregbank(<16 x s32>) = COPY $x2
     %11:vregbank(<16 x s32>) = COPY $x3
@@ -223,8 +222,8 @@ body:             |
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:vec512 = COPY $x2
     ; CHECK-NEXT: [[COPY1:%[0-9]+]]:vec512 = COPY $x3
-    ; CHECK-NEXT: [[VMAX_LT_S32_:%[0-9]+]]:vec512, [[VMAX_LT_S32_1:%[0-9]+]]:ers8 = VMAX_LT_S32 [[COPY]], [[COPY1]]
-    ; CHECK-NEXT: $x0 = COPY [[VMAX_LT_S32_]]
+    ; CHECK-NEXT: [[VMAXDIFF_LT_S32_:%[0-9]+]]:vec512, [[VMAXDIFF_LT_S32_1:%[0-9]+]]:ers8 = VMAXDIFF_LT_S32 [[COPY]], [[COPY1]]
+    ; CHECK-NEXT: $x0 = COPY [[VMAXDIFF_LT_S32_]]
     ; CHECK-NEXT: PseudoRET implicit $lr, implicit $x0
     %1:vregbank(<16 x s32>) = COPY $x2
     %11:vregbank(<16 x s32>) = COPY $x3

--- a/llvm/test/CodeGen/AIE/aie2/vmaxdiff_lt.ll
+++ b/llvm/test/CodeGen/AIE/aie2/vmaxdiff_lt.ll
@@ -33,7 +33,7 @@ define <64 x i8> @test_vmaxdiff_lt_v64uint8_sign0(<64 x i8>  %a, <64 x i8>  %b, 
 ; CHECK-LABEL: test_vmaxdiff_lt_v64uint8_sign0:
 ; CHECK:       // %bb.0: // %entry
 ; CHECK-NEXT:    nopb ; nopa ; nops ; ret lr ; nopm ; nopv
-; CHECK-NEXT:    vmax_lt.d8 x0, r25:r24, x2, x4 // Delay Slot 5
+; CHECK-NEXT:    vmaxdiff_lt.d8 x0, r25:r24, x2, x4 // Delay Slot 5
 ; CHECK-NEXT:    nop // Delay Slot 4
 ; CHECK-NEXT:    st r24, [p0, #0] // Delay Slot 3
 ; CHECK-NEXT:    st r25, [p0, #4] // Delay Slot 2
@@ -50,7 +50,7 @@ define <64 x i8> @test_vmaxdiff_lt_v64uint8_sign1(<64 x i8>  %a, <64 x i8>  %b, 
 ; CHECK-LABEL: test_vmaxdiff_lt_v64uint8_sign1:
 ; CHECK:       // %bb.0: // %entry
 ; CHECK-NEXT:    nopb ; nopa ; nops ; ret lr ; nopm ; nopv
-; CHECK-NEXT:    vmax_lt.s8 x0, r25:r24, x2, x4 // Delay Slot 5
+; CHECK-NEXT:    vmaxdiff_lt.s8 x0, r25:r24, x2, x4 // Delay Slot 5
 ; CHECK-NEXT:    nop // Delay Slot 4
 ; CHECK-NEXT:    st r24, [p0, #0] // Delay Slot 3
 ; CHECK-NEXT:    st r25, [p0, #4] // Delay Slot 2
@@ -89,7 +89,7 @@ define <32 x i16> @test_vmaxdiff_lt_v32uint16_sign0(<32 x i16>  %a, <32 x i16>  
 ; CHECK:       // %bb.0: // %entry
 ; CHECK-NEXT:    nopa ; nopb ; ret lr ; nopm ; nops
 ; CHECK-NEXT:    nop // Delay Slot 5
-; CHECK-NEXT:    vmax_lt.d16 x0, r16, x2, x4 // Delay Slot 4
+; CHECK-NEXT:    vmaxdiff_lt.d16 x0, r16, x2, x4 // Delay Slot 4
 ; CHECK-NEXT:    or r0, r16, r16 // Delay Slot 3
 ; CHECK-NEXT:    st r16, [p0, #0] // Delay Slot 2
 ; CHECK-NEXT:    mov r16, r0 // Delay Slot 1
@@ -106,7 +106,7 @@ define <32 x i16> @test_vmaxdiff_lt_v32uint16_sign1(<32 x i16>  %a, <32 x i16>  
 ; CHECK:       // %bb.0: // %entry
 ; CHECK-NEXT:    nopa ; nopb ; ret lr ; nopm ; nops
 ; CHECK-NEXT:    nop // Delay Slot 5
-; CHECK-NEXT:    vmax_lt.s16 x0, r16, x2, x4 // Delay Slot 4
+; CHECK-NEXT:    vmaxdiff_lt.s16 x0, r16, x2, x4 // Delay Slot 4
 ; CHECK-NEXT:    or r0, r16, r16 // Delay Slot 3
 ; CHECK-NEXT:    st r16, [p0, #0] // Delay Slot 2
 ; CHECK-NEXT:    mov r16, r0 // Delay Slot 1
@@ -144,7 +144,7 @@ define <16 x i32> @test_vmaxdiff_lt_v16int32_sign0(<16 x i32>  %a, <16 x i32> %b
 ; CHECK:       // %bb.0: // %entry
 ; CHECK-NEXT:    nopa ; nopb ; ret lr ; nopm ; nops
 ; CHECK-NEXT:    nop // Delay Slot 5
-; CHECK-NEXT:    vmax_lt.d32 x0, r16, x2, x2 // Delay Slot 4
+; CHECK-NEXT:    vmaxdiff_lt.d32 x0, r16, x2, x2 // Delay Slot 4
 ; CHECK-NEXT:    or r0, r16, r16 // Delay Slot 3
 ; CHECK-NEXT:    st r16, [p0, #0] // Delay Slot 2
 ; CHECK-NEXT:    mov r16, r0 // Delay Slot 1
@@ -161,7 +161,7 @@ define <16 x i32> @test_vmaxdiff_lt_v16int32_sign1(<16 x i32>  %a, <16 x i32>  %
 ; CHECK:       // %bb.0: // %entry
 ; CHECK-NEXT:    nopa ; nopb ; ret lr ; nopm ; nops
 ; CHECK-NEXT:    nop // Delay Slot 5
-; CHECK-NEXT:    vmax_lt.s32 x0, r16, x2, x4 // Delay Slot 4
+; CHECK-NEXT:    vmaxdiff_lt.s32 x0, r16, x2, x4 // Delay Slot 4
 ; CHECK-NEXT:    or r0, r16, r16 // Delay Slot 3
 ; CHECK-NEXT:    st r16, [p0, #0] // Delay Slot 2
 ; CHECK-NEXT:    mov r16, r0 // Delay Slot 1

--- a/llvm/test/CodeGen/AIE/aie2p/GlobalIsel/inst-select-vmaxdiff_lt.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/GlobalIsel/inst-select-vmaxdiff_lt.mir
@@ -48,8 +48,8 @@ body:             |
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:vec512 = COPY $x2
     ; CHECK-NEXT: [[COPY1:%[0-9]+]]:vec512 = COPY $x3
-    ; CHECK-NEXT: [[VMAX_LT_8_vaddSign0_:%[0-9]+]]:vec512, [[VMAX_LT_8_vaddSign0_1:%[0-9]+]]:ml8m = VMAX_LT_8_vaddSign0 [[COPY]], [[COPY1]], implicit $vaddsign0
-    ; CHECK-NEXT: $x0 = COPY [[VMAX_LT_8_vaddSign0_]]
+    ; CHECK-NEXT: [[VMAXDIFF_LT_8_vaddSign0_:%[0-9]+]]:vec512, [[VMAXDIFF_LT_8_vaddSign0_1:%[0-9]+]]:ml8m = VMAXDIFF_LT_8_vaddSign0 [[COPY]], [[COPY1]], implicit $vaddsign0
+    ; CHECK-NEXT: $x0 = COPY [[VMAXDIFF_LT_8_vaddSign0_]]
     ; CHECK-NEXT: PseudoRET implicit $lr, implicit $x0
     %1:vregbank(<64 x s8>) = COPY $x2
     %11:vregbank(<64 x s8>) = COPY $x3
@@ -72,8 +72,8 @@ body:             |
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:vec512 = COPY $x2
     ; CHECK-NEXT: [[COPY1:%[0-9]+]]:vec512 = COPY $x3
-    ; CHECK-NEXT: [[VMAX_LT_8_vaddSign1_:%[0-9]+]]:vec512, [[VMAX_LT_8_vaddSign1_1:%[0-9]+]]:ml8m = VMAX_LT_8_vaddSign1 [[COPY]], [[COPY1]], implicit $vaddsign1
-    ; CHECK-NEXT: $x0 = COPY [[VMAX_LT_8_vaddSign1_]]
+    ; CHECK-NEXT: [[VMAXDIFF_LT_8_vaddSign1_:%[0-9]+]]:vec512, [[VMAXDIFF_LT_8_vaddSign1_1:%[0-9]+]]:ml8m = VMAXDIFF_LT_8_vaddSign1 [[COPY]], [[COPY1]], implicit $vaddsign1
+    ; CHECK-NEXT: $x0 = COPY [[VMAXDIFF_LT_8_vaddSign1_]]
     ; CHECK-NEXT: PseudoRET implicit $lr, implicit $x0
     %1:vregbank(<64 x s8>) = COPY $x2
     %11:vregbank(<64 x s8>) = COPY $x3
@@ -123,8 +123,8 @@ body:             |
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:vec512 = COPY $x2
     ; CHECK-NEXT: [[COPY1:%[0-9]+]]:vec512 = COPY $x3
-    ; CHECK-NEXT: [[VMAX_LT_16_vaddSign0_:%[0-9]+]]:vec512, [[VMAX_LT_16_vaddSign0_1:%[0-9]+]]:mr16_vcompare = VMAX_LT_16_vaddSign0 [[COPY]], [[COPY1]], implicit $vaddsign0
-    ; CHECK-NEXT: $x0 = COPY [[VMAX_LT_16_vaddSign0_]]
+    ; CHECK-NEXT: [[VMAXDIFF_LT_16_vaddSign0_:%[0-9]+]]:vec512, [[VMAXDIFF_LT_16_vaddSign0_1:%[0-9]+]]:mr16_vcompare = VMAXDIFF_LT_16_vaddSign0 [[COPY]], [[COPY1]], implicit $vaddsign0
+    ; CHECK-NEXT: $x0 = COPY [[VMAXDIFF_LT_16_vaddSign0_]]
     ; CHECK-NEXT: PseudoRET implicit $lr, implicit $x0
     %1:vregbank(<32 x s16>) = COPY $x2
     %11:vregbank(<32 x s16>) = COPY $x3
@@ -147,8 +147,8 @@ body:             |
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:vec512 = COPY $x2
     ; CHECK-NEXT: [[COPY1:%[0-9]+]]:vec512 = COPY $x3
-    ; CHECK-NEXT: [[VMAX_LT_16_vaddSign1_:%[0-9]+]]:vec512, [[VMAX_LT_16_vaddSign1_1:%[0-9]+]]:mr16_vcompare = VMAX_LT_16_vaddSign1 [[COPY]], [[COPY1]], implicit $vaddsign1
-    ; CHECK-NEXT: $x0 = COPY [[VMAX_LT_16_vaddSign1_]]
+    ; CHECK-NEXT: [[VMAXDIFF_LT_16_vaddSign1_:%[0-9]+]]:vec512, [[VMAXDIFF_LT_16_vaddSign1_1:%[0-9]+]]:mr16_vcompare = VMAXDIFF_LT_16_vaddSign1 [[COPY]], [[COPY1]], implicit $vaddsign1
+    ; CHECK-NEXT: $x0 = COPY [[VMAXDIFF_LT_16_vaddSign1_]]
     ; CHECK-NEXT: PseudoRET implicit $lr, implicit $x0
     %1:vregbank(<32 x s16>) = COPY $x2
     %11:vregbank(<32 x s16>) = COPY $x3
@@ -198,8 +198,8 @@ body:             |
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:vec512 = COPY $x2
     ; CHECK-NEXT: [[COPY1:%[0-9]+]]:vec512 = COPY $x3
-    ; CHECK-NEXT: [[VMAX_LT_32_vaddSign0_:%[0-9]+]]:vec512, [[VMAX_LT_32_vaddSign0_1:%[0-9]+]]:mr16_vcompare = VMAX_LT_32_vaddSign0 [[COPY]], [[COPY1]], implicit $vaddsign0
-    ; CHECK-NEXT: $x0 = COPY [[VMAX_LT_32_vaddSign0_]]
+    ; CHECK-NEXT: [[VMAXDIFF_LT_32_vaddSign0_:%[0-9]+]]:vec512, [[VMAXDIFF_LT_32_vaddSign0_1:%[0-9]+]]:mr16_vcompare = VMAXDIFF_LT_32_vaddSign0 [[COPY]], [[COPY1]], implicit $vaddsign0
+    ; CHECK-NEXT: $x0 = COPY [[VMAXDIFF_LT_32_vaddSign0_]]
     ; CHECK-NEXT: PseudoRET implicit $lr, implicit $x0
     %1:vregbank(<16 x s32>) = COPY $x2
     %11:vregbank(<16 x s32>) = COPY $x3
@@ -222,8 +222,8 @@ body:             |
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:vec512 = COPY $x2
     ; CHECK-NEXT: [[COPY1:%[0-9]+]]:vec512 = COPY $x3
-    ; CHECK-NEXT: [[VMAX_LT_32_vaddSign1_:%[0-9]+]]:vec512, [[VMAX_LT_32_vaddSign1_1:%[0-9]+]]:mr16_vcompare = VMAX_LT_32_vaddSign1 [[COPY]], [[COPY1]], implicit $vaddsign1
-    ; CHECK-NEXT: $x0 = COPY [[VMAX_LT_32_vaddSign1_]]
+    ; CHECK-NEXT: [[VMAXDIFF_LT_32_vaddSign1_:%[0-9]+]]:vec512, [[VMAXDIFF_LT_32_vaddSign1_1:%[0-9]+]]:mr16_vcompare = VMAXDIFF_LT_32_vaddSign1 [[COPY]], [[COPY1]], implicit $vaddsign1
+    ; CHECK-NEXT: $x0 = COPY [[VMAXDIFF_LT_32_vaddSign1_]]
     ; CHECK-NEXT: PseudoRET implicit $lr, implicit $x0
     %1:vregbank(<16 x s32>) = COPY $x2
     %11:vregbank(<16 x s32>) = COPY $x3


### PR DESCRIPTION
The patterns were wrongly copy&pasted from VMAX_LT. 
Fixes https://github.com/Xilinx/llvm-aie/issues/642