### PR TITLE
Martien.ghissue 641

### DIFF
--- a/llvm/lib/Target/AIE/AIE2TargetTransformInfo.cpp
+++ b/llvm/lib/Target/AIE/AIE2TargetTransformInfo.cpp
@@ -31,6 +31,14 @@ instCombineDemandedBits(InstCombiner &IC, IntrinsicInst &II, unsigned numBits) {
   return std::nullopt;
 }
 
+bool AIE2TTICommon::isAllowedInZOL(Instruction &I) {
+  // FMul is legalized to a VMUL for bfloat16 in other targets
+  if (I.getOpcode() == Instruction::FMul) {
+    return false;
+  }
+  return AIETTICommon::isAllowedInZOL(I);
+}
+
 std::optional<Instruction *>
 AIE2TTIImpl::instCombineIntrinsic(InstCombiner &IC, IntrinsicInst &II) const {
   Intrinsic::ID IID = II.getIntrinsicID();

--- a/llvm/lib/Target/AIE/AIE2TargetTransformInfo.h
+++ b/llvm/lib/Target/AIE/AIE2TargetTransformInfo.h
@@ -24,11 +24,17 @@
 #include "llvm/Transforms/Utils/ScalarEvolutionExpander.h"
 
 namespace llvm {
+
+class AIE2TTICommon : public AIETTICommon {
+private:
+  bool isAllowedInZOL(llvm::Instruction &Instr) override;
+};
+
 class AIE2TTIImpl : public AIEBaseTTIImpl<AIE2TTIImpl> {
   typedef AIEBaseTTIImpl<AIE2TTIImpl> BaseT;
   typedef TargetTransformInfo TTI;
   friend BaseT;
-  AIETTICommon Common;
+  AIE2TTICommon Common;
 
 public:
   explicit AIE2TTIImpl(const AIE2TargetMachine *TM, const Function &F)

--- a/llvm/test/CodeGen/AIE/aie2/hardware-loops/issue-641.ll
+++ b/llvm/test/CodeGen/AIE/aie2/hardware-loops/issue-641.ll
@@ -1,0 +1,34 @@
+; This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+; See https://llvm.org/LICENSE.txt for license information.
+; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+;
+; (c) Copyright 2025 Advanced Micro Devices, Inc. or its affiliates
+; RUN: llc -O2 -mtriple=aie2 -stop-after=irtranslator %s -o - | FileCheck %s
+; CHECK: llvm.set.loop.iterations
+; CHECK: llvm.loop.decrement
+
+define dso_local void @_Z3sqrPK8bfloat16PS_i(ptr noalias nocapture readonly %in, ptr noalias nocapture writeonly %out, i32 noundef %N) {
+entry:
+  tail call void @llvm.aie2.event(i32 0)
+  %cmp9 = icmp sgt i32 %N, 0
+  br i1 %cmp9, label %for.body, label %for.cond.cleanup
+
+for.body:                                         ; preds = %entry, %for.body
+  %i.010 = phi i32 [ %inc, %for.body ], [ 0, %entry ]
+  %0 = trunc i32 %i.010 to i20
+  %arrayidx = getelementptr inbounds bfloat, ptr %in, i20 %0
+  %1 = load bfloat, ptr %arrayidx, align 2
+  %unpromotion = fmul bfloat %1, %1
+  %arrayidx3 = getelementptr inbounds bfloat, ptr %out, i20 %0
+  store bfloat %unpromotion, ptr %arrayidx3, align 2
+  %inc = add nuw nsw i32 %i.010, 1
+  %exitcond.not = icmp eq i32 %inc, %N
+  br i1 %exitcond.not, label %for.cond.cleanup, label %for.body
+
+for.cond.cleanup:                                 ; preds = %for.body, %entry
+  tail call void @llvm.aie2.event(i32 1)
+  ret void
+}
+
+declare void @llvm.aie2.event(i32)
+

--- a/llvm/test/CodeGen/AIE/aie2/hardware-loops/issue-641.ll
+++ b/llvm/test/CodeGen/AIE/aie2/hardware-loops/issue-641.ll
@@ -4,8 +4,8 @@
 ;
 ; (c) Copyright 2025 Advanced Micro Devices, Inc. or its affiliates
 ; RUN: llc -O2 -mtriple=aie2 -stop-after=irtranslator %s -o - | FileCheck %s
-; CHECK: llvm.set.loop.iterations
-; CHECK: llvm.loop.decrement
+; CHECK-NOT: llvm.set.loop.iterations
+; CHECK-NOT: llvm.loop.decrement
 
 define dso_local void @_Z3sqrPK8bfloat16PS_i(ptr noalias nocapture readonly %in, ptr noalias nocapture writeonly %out, i32 noundef %N) {
 entry:


### PR DESCRIPTION
issue-641 had a runtime library call in a hardware loop, which very likely caused the output data mismatch. This PR fixes that error. 
The problem is that the TargetTransformInfo is a redundant coding with the legalizer in this respect, and that it is shared between AIE2 and AIE2P, whereas the two legalizers diverged on legalizing a scalar fmul.