### PR TITLE
[AIEX][AIE2P] Improve error handling in decoder methods

### DIFF
--- a/llvm/lib/Target/AIE/Disassembler/AIE2PDisassembler.inc
+++ b/llvm/lib/Target/AIE/Disassembler/AIE2PDisassembler.inc
@@ -37,9 +37,12 @@ TABLEBASEDDECODER(eR)
 static const unsigned eRF2DecoderTable[] = {r24, r25};
 static const unsigned eDNDecoderTable[] = {dn0, dn1, dn2, dn3,
                                            dn4, dn5, dn6, dn7};
-static const unsigned eEloDecoderTable[] = {el1, el3, el5, el7, el9, el11};
-static const unsigned eEhoDecoderTable[] = {eh1, eh3, eh5, eh7, eh9, eh11};
-static const unsigned eBMHHDecoderTable[] = {bmhh0, bmhh1, bmhh2, bmhh3, bmhh4};
+static const unsigned eEloDecoderTable[] = {el1, el3,  el5, el7,
+                                            el9, el11, 0,   0};
+static const unsigned eEhoDecoderTable[] = {eh1, eh3,  eh5, eh7,
+                                            eh9, eh11, 0,   0};
+static const unsigned eBMHHDecoderTable[] = {bmhh0, bmhh1, bmhh2, bmhh3,
+                                             bmhh4, 0,     0,     0};
 static const unsigned eDJDecoderTable[] = {dj0, dj1, dj2, dj3,
                                            dj4, dj5, dj6, dj7};
 TABLEBASEDDECODER(eDJ)
@@ -47,28 +50,35 @@ static const unsigned eLdFifoRegDecoderTable[] = {lf0, lf1};
 static const unsigned eQQsoDecoderTable[] = {q1, q3};
 static const unsigned eDSDecoderTable[] = {d0_3d, d1_3d, d2_3d, d3_3d};
 
-static const unsigned eDMDecoderTable[] = {dm0, dm1, dm2, dm3, dm4};
+static const unsigned eDMDecoderTable[] = {dm0, dm1, dm2, dm3, dm4, 0, 0, 0};
 TABLEBASEDDECODER(eDM)
 static const unsigned eQQseDecoderTable[] = {q0, q2};
-static const unsigned eEheDecoderTable[] = {eh0, eh2, eh4, eh6, eh8, eh10};
+static const unsigned eEheDecoderTable[] = {eh0, eh2,  eh4, eh6,
+                                            eh8, eh10, 0,   0};
 static const unsigned eBMHLDecoderTable[] = {bmhl0, bmhl1, bmhl2, bmhl3, bmhl4};
 static const unsigned eVaddSignDecoderTable[] = {vaddSign0, vaddSign1};
 static const unsigned ePDecoderTable[] = {p0, p1, p2, p3, p4, p5, p6, p7};
 TABLEBASEDDECODER(eP)
 static const unsigned eDNHDecoderTable[] = {dn4, dn5, dn6, dn7};
-static const unsigned eXoDecoderTable[] = {x1, x3, x5, x7, x9, x11};
-static const unsigned eYDecoderTable[] = {llvm::AIE2P::y0, llvm::AIE2P::y1,
-                                          llvm::AIE2P::y2, llvm::AIE2P::y3,
-                                          llvm::AIE2P::y4, llvm::AIE2P::y5};
+static const unsigned eXoDecoderTable[] = {x1, x3, x5, x7, x9, x11, 0, 0};
+static const unsigned eYDecoderTable[] = {llvm::AIE2P::y0,
+                                          llvm::AIE2P::y1,
+                                          llvm::AIE2P::y2,
+                                          llvm::AIE2P::y3,
+                                          llvm::AIE2P::y4,
+                                          llvm::AIE2P::y5,
+                                          0,
+                                          0};
 TABLEBASEDDECODER(eY)
-static const unsigned eWhoDecoderTable[] = {wh1, wh3, wh5, wh7, wh9, wh11};
+static const unsigned eWhoDecoderTable[] = {wh1, wh3,  wh5, wh7,
+                                            wh9, wh11, 0,   0};
 static const unsigned eDCDecoderTable[] = {dc0, dc1, dc2, dc3,
                                            dc4, dc5, dc6, dc7};
 static const unsigned eRS16DecoderTable[] = {r16, r17, r18, r19, r20, r21,
                                              r22, r23, r24, r25, r26, r27,
                                              r28, r29, r30, r31};
 TABLEBASEDDECODER(eRS16)
-static const unsigned eXeDecoderTable[] = {x0, x2, x4, x6, x8, x10};
+static const unsigned eXeDecoderTable[] = {x0, x2, x4, x6, x8, x10, 0, 0};
 static const unsigned eSRSSignDecoderTable[] = {srsSign0, srsSign1};
 static const unsigned eQYsDecoderTable[] = {qy0, qy1};
 TABLEBASEDDECODER(eQYs)
@@ -76,20 +86,27 @@ static const unsigned eDNLDecoderTable[] = {dn0, dn1, dn2, dn3};
 static const unsigned eQEYsDecoderTable[] = {qey0, qey1};
 TABLEBASEDDECODER(eQEYs)
 static const unsigned eBMSLHDecoderTable[] = {bmlh0, bmlh1, bmlh2, bmlh3};
-static const unsigned eWheDecoderTable[] = {wh0, wh2, wh4, wh6, wh8, wh10};
-static const unsigned eCMHDecoderTable[] = {cmh0, cmh1, cmh2, cmh3, cmh4};
+static const unsigned eWheDecoderTable[] = {wh0, wh2,  wh4, wh6,
+                                            wh8, wh10, 0,   0};
+static const unsigned eCMHDecoderTable[] = {cmh0, cmh1, cmh2, cmh3,
+                                            cmh4, 0,    0,    0};
 static const unsigned eBMSLLDecoderTable[] = {bmll0, bmll1, bmll2, bmll3};
-static const unsigned eEleDecoderTable[] = {el0, el2, el4, el6, el8, el10};
+static const unsigned eEleDecoderTable[] = {el0, el2,  el4, el6,
+                                            el8, el10, 0,   0};
 static const unsigned ePSDecoderTable[] = {p0, p1};
 static const unsigned eQXseDecoderTable[] = {qx0, qx2};
 static const unsigned eQEXseDecoderTable[] = {qex0, qex2};
 static const unsigned eDDecoderTable[] = {d0, d1, d2, d3, d4, d5, d6, d7};
-static const unsigned eWloDecoderTable[] = {wl1, wl3, wl5, wl7, wl9, wl11};
+static const unsigned eWloDecoderTable[] = {wl1, wl3,  wl5, wl7,
+                                            wl9, wl11, 0,   0};
 static const unsigned eSDecoderTable[] = {s0, s1, s2, s3};
 TABLEBASEDDECODER(eS)
-static const unsigned eWleDecoderTable[] = {wl0, wl2, wl4, wl6, wl8, wl10};
-static const unsigned eCMLDecoderTable[] = {cml0, cml1, cml2, cml3, cml4};
-static const unsigned eBMLLDecoderTable[] = {bmll0, bmll1, bmll2, bmll3, bmll4};
+static const unsigned eWleDecoderTable[] = {wl0, wl2,  wl4, wl6,
+                                            wl8, wl10, 0,   0};
+static const unsigned eCMLDecoderTable[] = {cml0, cml1, cml2, cml3,
+                                            cml4, 0,    0,    0};
+static const unsigned eBMLLDecoderTable[] = {bmll0, bmll1, bmll2, bmll3,
+                                             bmll4, 0,     0,     0};
 static const unsigned eMDecoderTable[] = {m0, m1, m2, m3, m4, m5, m6, m7};
 TABLEBASEDDECODER(eM)
 static const unsigned eBMSHHDecoderTable[] = {bmhh0, bmhh1, bmhh2, bmhh3};
@@ -97,20 +114,23 @@ static const unsigned eDJLDecoderTable[] = {dj0, dj1, dj2, dj3};
 static const unsigned eDCLDecoderTable[] = {dc0, dc1, dc2, dc3};
 // Decoder Tables for 'Compound' Register Classes.
 static const unsigned mWaDecoderTable[] = {
-    wh0, wl0, wh1, wl1, wh2, wl2, wh3, wl3, wh4,  wl4,  wh5,  wl5,
-    wh6, wl6, wh7, wl7, wh8, wl8, wh9, wl9, wh10, wl10, wh11, wl11};
+    wh0,  wl0,  wh1, wl1, wh2, wl2, wh3, wl3, wh4, wl4,  wh5,
+    wl5,  wh6,  wl6, wh7, wl7, wh8, wl8, wh9, wl9, wh10, wl10,
+    wh11, wl11, 0,   0,   0,   0,   0,   0,   0,   0};
 TABLEBASEDDECODER(mWa)
-static const unsigned mXmDecoderTable[] = {x0, x1, x2, x3, x4,  x5,
-                                           x6, x7, x8, x9, x10, x11};
+static const unsigned mXmDecoderTable[] = {x0, x1, x2,  x3,  x4, x5, x6, x7,
+                                           x8, x9, x10, x11, 0,  0,  0,  0};
 TABLEBASEDDECODER(mXm)
-static const unsigned mCMmDecoderTable[] = {cml0, cmh0, cml1, cmh1, cml2,
-                                            cmh2, cml3, cmh3, cml4, cmh4};
+static const unsigned mCMmDecoderTable[] = {cml0, cmh0, cml1, cmh1, cml2, cmh2,
+                                            cml3, cmh3, cml4, cmh4, 0,    0,
+                                            0,    0,    0,    0};
 TABLEBASEDDECODER(mCMm)
 static const unsigned mQEXsmDecoderTable[] = {qex0, qex1, qex2, qex3};
 TABLEBASEDDECODER(mQEXsm)
 static const unsigned mEsDecoderTable[] = {
-    eh0, el0, eh1, el1, eh2, el2, eh3, el3, eh4,  el4,  eh5,  el5,
-    eh6, el6, eh7, el7, eh8, el8, eh9, el9, eh10, el10, eh11, el11};
+    eh0,  el0,  eh1, el1, eh2, el2, eh3, el3, eh4, el4,  eh5,
+    el5,  eh6,  el6, eh7, el7, eh8, el8, eh9, el9, eh10, el10,
+    eh11, el11, 0,   0,   0,   0,   0,   0,   0,   0};
 static const unsigned mAguSrcDecoderTable[] = {
     r0,  dc0, p0, 0, r1,  dj0, 0, 0, r2,  dn0, 0, 0, r3,  m0, 0, 0,
     r4,  dc1, p1, 0, r5,  dj1, 0, 0, r6,  dn1, 0, 0, r7,  m1, 0, 0,
@@ -119,39 +139,42 @@ static const unsigned mAguSrcDecoderTable[] = {
     r16, dc4, p4, 0, r17, dj4, 0, 0, r18, dn4, 0, 0, r19, m4, 0, 0,
     r20, dc5, p5, 0, r21, dj5, 0, 0, r22, dn5, 0, 0, r23, m5, 0, 0,
     r24, dc6, p6, 0, r25, dj6, 0, 0, r26, dn6, 0, 0, r27, m6, 0, 0,
-    r28, dc7, p7, 0, r29, dj7, 0, 0, r30, dn7, 0, 0, r31, m7};
+    r28, dc7, p7, 0, r29, dj7, 0, 0, r30, dn7, 0, 0, r31, m7, 0, 0};
 TABLEBASEDDECODER(mAguSrc)
 static const unsigned mQXsbDecoderTable[] = {qx0, qx1, qx2, qx3};
-static const unsigned mEhmDecoderTable[] = {eh0, eh1, eh2, eh3, eh4,  eh5,
-                                            eh6, eh7, eh8, eh9, eh10, eh11};
+static const unsigned mEhmDecoderTable[] = {
+    eh0, eh1, eh2, eh3, eh4, eh5, eh6, eh7, eh8, eh9, eh10, eh11, 0, 0, 0, 0};
 TABLEBASEDDECODER(mEhm)
 static const unsigned mLdaSclDecoderTable[] = {
-    m0, eh0,  r0,  p0, dn0, el0,  r1,  lr, dj0, eh1,  r2,  0, dc0, el1,  r3,  0,
-    m1, eh2,  r4,  p1, dn1, el2,  r5,  0,  dj1, eh3,  r6,  0, dc1, el3,  r7,  0,
-    m2, eh4,  r8,  p2, dn2, el4,  r9,  0,  dj2, eh5,  r10, 0, dc2, el5,  r11, 0,
-    m3, eh6,  r12, p3, dn3, el6,  r13, 0,  dj3, eh7,  r14, 0, dc3, el7,  r15, 0,
-    m4, eh8,  r16, p4, dn4, el8,  r17, 0,  dj4, eh9,  r18, 0, dc4, el9,  r19, 0,
-    m5, eh10, r20, p5, dn5, el10, r21, 0,  dj5, eh11, r22, 0, dc5, el11, r23, 0,
-    m6, 0,    r24, p6, dn6, 0,    r25, 0,  dj6, 0,    r26, 0, dc6, 0,    r27, 0,
-    m7, 0,    r28, p7, dn7, 0,    r29, 0,  dj7, 0,    r30, 0, dc7, 0,    r31};
+    m0,  eh0, r0,   p0,   dn0, el0, r1,  lr,   dj0, eh1, r2,  0,    dc0,
+    el1, r3,  0,    m1,   eh2, r4,  p1,  dn1,  el2, r5,  0,   dj1,  eh3,
+    r6,  0,   dc1,  el3,  r7,  0,   m2,  eh4,  r8,  p2,  dn2, el4,  r9,
+    0,   dj2, eh5,  r10,  0,   dc2, el5, r11,  0,   m3,  eh6, r12,  p3,
+    dn3, el6, r13,  0,    dj3, eh7, r14, 0,    dc3, el7, r15, 0,    m4,
+    eh8, r16, p4,   dn4,  el8, r17, 0,   dj4,  eh9, r18, 0,   dc4,  el9,
+    r19, 0,   m5,   eh10, r20, p5,  dn5, el10, r21, 0,   dj5, eh11, r22,
+    0,   dc5, el11, r23,  0,   m6,  0,   r24,  p6,  dn6, 0,   r25,  0,
+    dj6, 0,   r26,  0,    dc6, 0,   r27, 0,    m7,  0,   r28, p7,   dn7,
+    0,   r29, 0,    dj7,  0,   r30, 0,   dc7,  0,   r31, 0};
 TABLEBASEDDECODER(mLdaScl)
 static const unsigned mQQsmDecoderTable[] = {q0, q1, q2, q3};
 TABLEBASEDDECODER(mQQsm)
 static const unsigned mWsDecoderTable[] = {
-    wh0, wl0, wh1, wl1, wh2, wl2, wh3, wl3, wh4,  wl4,  wh5,  wl5,
-    wh6, wl6, wh7, wl7, wh8, wl8, wh9, wl9, wh10, wl10, wh11, wl11};
+    wh0,  wl0,  wh1, wl1, wh2, wl2, wh3, wl3, wh4, wl4,  wh5,
+    wl5,  wh6,  wl6, wh7, wl7, wh8, wl8, wh9, wl9, wh10, wl10,
+    wh11, wl11, 0,   0,   0,   0,   0,   0,   0,   0};
 TABLEBASEDDECODER(mWs)
-static const unsigned mXwDecoderTable[] = {x0, x1, x2, x3, x4,  x5,
-                                           x6, x7, x8, x9, x10, x11};
+static const unsigned mXwDecoderTable[] = {x0, x1, x2,  x3,  x4, x5, x6, x7,
+                                           x8, x9, x10, x11, 0,  0,  0,  0};
 TABLEBASEDDECODER(mXw)
 static const unsigned mAguDstDecoderTable[] = {
     dc0, dj0, dn0, m0, p0, 0, 0, 0, dc1, dj1, dn1, m1, p1, 0, 0, 0,
     dc2, dj2, dn2, m2, p2, 0, 0, 0, dc3, dj3, dn3, m3, p3, 0, 0, 0,
     dc4, dj4, dn4, m4, p4, 0, 0, 0, dc5, dj5, dn5, m5, p5, 0, 0, 0,
-    dc6, dj6, dn6, m6, p6, 0, 0, 0, dc7, dj7, dn7, m7, p7};
+    dc6, dj6, dn6, m6, p6, 0, 0, 0, dc7, dj7, dn7, m7, p7, 0, 0, 0};
 TABLEBASEDDECODER(mAguDst)
-static const unsigned mEXmDecoderTable[] = {ex0, ex1, ex2, ex3, ex4,  ex5,
-                                            ex6, ex7, ex8, ex9, ex10, ex11};
+static const unsigned mEXmDecoderTable[] = {
+    ex0, ex1, ex2, ex3, ex4, ex5, ex6, ex7, ex8, ex9, ex10, ex11, 0, 0, 0, 0};
 TABLEBASEDDECODER(mEXm)
 static const unsigned mQXsaDecoderTable[] = {qx0, qx1, qx2, qx3};
 static const unsigned mDmDecoderTable[] = {
@@ -166,8 +189,9 @@ static const unsigned mShflBMDstDecoderTable[] = {
     bmll2, bmlh2, bmhl2, bmhh2, bmll3, bmlh3, bmhl3, bmhh3};
 TABLEBASEDDECODER(mShflBMDst)
 static const unsigned mBMmDecoderTable[] = {
-    bmll0, bmlh0, bmhl0, bmhh0, bmll1, bmlh1, bmhl1, bmhh1, bmll2, bmlh2,
-    bmhl2, bmhh2, bmll3, bmlh3, bmhl3, bmhh3, bmll4, bmlh4, bmhl4, bmhh4};
+    bmll0, bmlh0, bmhl0, bmhh0, bmll1, bmlh1, bmhl1, bmhh1, bmll2, bmlh2, bmhl2,
+    bmhh2, bmll3, bmlh3, bmhl3, bmhh3, bmll4, bmlh4, bmhl4, bmhh4, 0,     0,
+    0,     0,     0,     0,     0,     0,     0,     0,     0,     0};
 TABLEBASEDDECODER(mBMm)
 static const unsigned mMvBMXDstDecoderTable[] = {
     bmll0, x0,    bmlh0, lfh0,  bmhl0, x1,    bmhh0, 0,     bmll1, x2,    bmlh1,
@@ -307,10 +331,10 @@ static const unsigned mMvSclDstDecoderTable[] = {m0,
                                                  r31,
                                                  srsSign1};
 TABLEBASEDDECODER(mMvSclDst)
-static const unsigned mMcdXSrcDecoderTable[] = {x0, x1, x2, x3, x4,  x5,
-                                                x6, x7, x8, x9, x10, x11};
-static const unsigned mEXnDecoderTable[] = {ex0, ex1, ex2, ex3, ex4,  ex5,
-                                            ex6, ex7, ex8, ex9, ex10, ex11};
+static const unsigned mMcdXSrcDecoderTable[] = {
+    x0, x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, 0, 0, 0, 0};
+static const unsigned mEXnDecoderTable[] = {
+    ex0, ex1, ex2, ex3, ex4, ex5, ex6, ex7, ex8, ex9, ex10, ex11, 0, 0, 0, 0};
 TABLEBASEDDECODER(mEXn)
 static const unsigned mMvSclDstCgDecoderTable[] = {m0,
                                                    r0,
@@ -448,20 +472,21 @@ static const unsigned mSclMSDecoderTable[] = {
     r16, 0, m4, 0, r17, 0, dn4, 0, r18, 0, dj4, 0, r19, p4, dc4, 0,
     r20, 0, m5, 0, r21, 0, dn5, 0, r22, 0, dj5, 0, r23, p5, dc5, 0,
     r24, 0, m6, 0, r25, 0, dn6, 0, r26, 0, dj6, 0, r27, p6, dc6, 0,
-    r28, 0, m7, 0, r29, 0, dn7, 0, r30, 0, dj7, 0, r31, p7, dc7};
+    r28, 0, m7, 0, r29, 0, dn7, 0, r30, 0, dj7, 0, r31, p7, dc7, 0};
 TABLEBASEDDECODER(mSclMS)
-static const unsigned mXnDecoderTable[] = {x0, x1, x2, x3, x4,  x5,
-                                           x6, x7, x8, x9, x10, x11};
+static const unsigned mXnDecoderTable[] = {x0, x1, x2,  x3,  x4, x5, x6, x7,
+                                           x8, x9, x10, x11, 0,  0,  0,  0};
 TABLEBASEDDECODER(mXn)
 static const unsigned mBMSmDecoderTable[] = {
     bmll0, bmlh0, bmhl0, bmhh0, bmll1, bmlh1, bmhl1, bmhh1,
     bmll2, bmlh2, bmhl2, bmhh2, bmll3, bmlh3, bmhl3, bmhh3};
-static const unsigned mXvDecoderTable[] = {x0, x1, x2, x3, x4,  x5,
-                                           x6, x7, x8, x9, x10, x11};
+static const unsigned mXvDecoderTable[] = {x0, x1, x2,  x3,  x4, x5, x6, x7,
+                                           x8, x9, x10, x11, 0,  0,  0,  0};
 TABLEBASEDDECODER(mXv)
 static const unsigned mWbDecoderTable[] = {
-    wh0, wl0, wh1, wl1, wh2, wl2, wh3, wl3, wh4,  wl4,  wh5,  wl5,
-    wh6, wl6, wh7, wl7, wh8, wl8, wh9, wl9, wh10, wl10, wh11, wl11};
+    wh0,  wl0,  wh1, wl1, wh2, wl2, wh3, wl3, wh4, wl4,  wh5,
+    wl5,  wh6,  wl6, wh7, wl7, wh8, wl8, wh9, wl9, wh10, wl10,
+    wh11, wl11, 0,   0,   0,   0,   0,   0,   0,   0};
 TABLEBASEDDECODER(mWb)
 static const unsigned mMvBMXSrcDecoderTable[] = {
     bmll0, x0,    bmlh0, lfh0,  bmhl0, x1,    bmhh0, 0,     bmll1, x2,    bmlh1,
@@ -474,43 +499,45 @@ static const unsigned mAluCgDecoderTable[] = {
     r0,  lc, r1,  0, r2,  0, r3,  0, r4,  0, r5,  0, r6,  0, r7,  0,
     r8,  0,  r9,  0, r10, 0, r11, 0, r12, 0, r13, 0, r14, 0, r15, 0,
     r16, 0,  r17, 0, r18, 0, r19, 0, r20, 0, r21, 0, r22, 0, r23, 0,
-    r24, 0,  r25, 0, r26, 0, r27, 0, r28, 0, r29, 0, r30, 0, r31};
+    r24, 0,  r25, 0, r26, 0, r27, 0, r28, 0, r29, 0, r30, 0, r31, 0};
 TABLEBASEDDECODER(mAluCg)
-static const unsigned mEXwDecoderTable[] = {ex0, ex1, ex2, ex3, ex4,  ex5,
-                                            ex6, ex7, ex8, ex9, ex10, ex11};
+static const unsigned mEXwDecoderTable[] = {
+    ex0, ex1, ex2, ex3, ex4, ex5, ex6, ex7, ex8, ex9, ex10, ex11, 0, 0, 0, 0};
 TABLEBASEDDECODER(mEXw)
-static const unsigned mXsDecoderTable[] = {x0, x1, x2, x3, x4,  x5,
-                                           x6, x7, x8, x9, x10, x11};
+static const unsigned mXsDecoderTable[] = {x0, x1, x2,  x3,  x4, x5, x6, x7,
+                                           x8, x9, x10, x11, 0,  0,  0,  0};
 TABLEBASEDDECODER(mXs)
-static const unsigned mEXsDecoderTable[] = {ex0, ex1, ex2, ex3, ex4,  ex5,
-                                            ex6, ex7, ex8, ex9, ex10, ex11};
+static const unsigned mEXsDecoderTable[] = {
+    ex0, ex1, ex2, ex3, ex4, ex5, ex6, ex7, ex8, ex9, ex10, ex11, 0, 0, 0, 0};
 TABLEBASEDDECODER(mEXs)
-static const unsigned mCMsDecoderTable[] = {cml0, cmh0, cml1, cmh1, cml2,
-                                            cmh2, cml3, cmh3, cml4, cmh4};
+static const unsigned mCMsDecoderTable[] = {cml0, cmh0, cml1, cmh1, cml2, cmh2,
+                                            cml3, cmh3, cml4, cmh4, 0,    0,
+                                            0,    0,    0,    0};
 TABLEBASEDDECODER(mCMs)
 static const unsigned mFifoHLRegDecoderTable[] = {lfh0, lfl0, lfe, sfl,
-                                                  lfh1, lfl1, sfh};
+                                                  lfh1, lfl1, sfh, 0};
 TABLEBASEDDECODER(mFifoHLReg)
 static const unsigned mSRmDecoderTable[] = {
     srCarry,      srF2BFlags, srF2FFlags, srF2IFlags,  srFPCnvFl2Fx,
     srFPCnvFx2Fl, srFPFlags,  srFPNlf,    srFifo_of,   srFifo_uf,
     srMS0,        srSRS_of,   srSS0,      srSparse_of, srUPS_of};
-static const unsigned mElmDecoderTable[] = {el0, el1, el2, el3, el4,  el5,
-                                            el6, el7, el8, el9, el10, el11};
+static const unsigned mElmDecoderTable[] = {
+    el0, el1, el2, el3, el4, el5, el6, el7, el8, el9, el10, el11, 0, 0, 0, 0};
 TABLEBASEDDECODER(mElm)
 static const unsigned mQEXswDecoderTable[] = {qex0, qex1, qex2, qex3};
 TABLEBASEDDECODER(mQEXsw)
 static const unsigned mQQsaDecoderTable[] = {q0, q1, q2, q3};
 TABLEBASEDDECODER(mQQsa)
-static const unsigned mEXvDecoderTable[] = {ex0, ex1, ex2, ex3, ex4,  ex5,
-                                            ex6, ex7, ex8, ex9, ex10, ex11};
+static const unsigned mEXvDecoderTable[] = {
+    ex0, ex1, ex2, ex3, ex4, ex5, ex6, ex7, ex8, ex9, ex10, ex11, 0, 0, 0, 0};
 TABLEBASEDDECODER(mEXv)
-static const unsigned mXaDecoderTable[] = {x0, x1, x2, x3, x4,  x5,
-                                           x6, x7, x8, x9, x10, x11};
+static const unsigned mXaDecoderTable[] = {x0, x1, x2,  x3,  x4, x5, x6, x7,
+                                           x8, x9, x10, x11, 0,  0,  0,  0};
 TABLEBASEDDECODER(mXa)
 static const unsigned mWmDecoderTable[] = {
-    wh0, wl0, wh1, wl1, wh2, wl2, wh3, wl3, wh4,  wl4,  wh5,  wl5,
-    wh6, wl6, wh7, wl7, wh8, wl8, wh9, wl9, wh10, wl10, wh11, wl11};
+    wh0,  wl0,  wh1, wl1, wh2, wl2, wh3, wl3, wh4, wl4,  wh5,
+    wl5,  wh6,  wl6, wh7, wl7, wh8, wl8, wh9, wl9, wh10, wl10,
+    wh11, wl11, 0,   0,   0,   0,   0,   0,   0,   0};
 TABLEBASEDDECODER(mWm)
 static const unsigned mMvSclSrcDecoderTable[] = {m0,
                                                  r0,
@@ -671,22 +698,24 @@ static const unsigned mCRmDecoderTable[] = {crF2BMask,
                                             crSCDEn};
 TABLEBASEDDECODER(mCRm)
 static const unsigned mSclStDecoderTable[] = {
-    m0, eh0,  r0,  p0, dn0, el0,  r1,  lr, dj0, eh1,  r2,  0, dc0, el1,  r3,  0,
-    m1, eh2,  r4,  p1, dn1, el2,  r5,  0,  dj1, eh3,  r6,  0, dc1, el3,  r7,  0,
-    m2, eh4,  r8,  p2, dn2, el4,  r9,  0,  dj2, eh5,  r10, 0, dc2, el5,  r11, 0,
-    m3, eh6,  r12, p3, dn3, el6,  r13, 0,  dj3, eh7,  r14, 0, dc3, el7,  r15, 0,
-    m4, eh8,  r16, p4, dn4, el8,  r17, 0,  dj4, eh9,  r18, 0, dc4, el9,  r19, 0,
-    m5, eh10, r20, p5, dn5, el10, r21, 0,  dj5, eh11, r22, 0, dc5, el11, r23, 0,
-    m6, 0,    r24, p6, dn6, 0,    r25, 0,  dj6, 0,    r26, 0, dc6, 0,    r27, 0,
-    m7, 0,    r28, p7, dn7, 0,    r29, 0,  dj7, 0,    r30, 0, dc7, 0,    r31};
+    m0,  eh0, r0,   p0,   dn0, el0, r1,  lr,   dj0, eh1, r2,  0,    dc0,
+    el1, r3,  0,    m1,   eh2, r4,  p1,  dn1,  el2, r5,  0,   dj1,  eh3,
+    r6,  0,   dc1,  el3,  r7,  0,   m2,  eh4,  r8,  p2,  dn2, el4,  r9,
+    0,   dj2, eh5,  r10,  0,   dc2, el5, r11,  0,   m3,  eh6, r12,  p3,
+    dn3, el6, r13,  0,    dj3, eh7, r14, 0,    dc3, el7, r15, 0,    m4,
+    eh8, r16, p4,   dn4,  el8, r17, 0,   dj4,  eh9, r18, 0,   dc4,  el9,
+    r19, 0,   m5,   eh10, r20, p5,  dn5, el10, r21, 0,   dj5, eh11, r22,
+    0,   dc5, el11, r23,  0,   m6,  0,   r24,  p6,  dn6, 0,   r25,  0,
+    dj6, 0,   r26,  0,    dc6, 0,   r27, 0,    m7,  0,   r28, p7,   dn7,
+    0,   r29, 0,    dj7,  0,   r30, 0,   dc7,  0,   r31, 0};
 TABLEBASEDDECODER(mSclSt)
 static const unsigned mMcdBMSrcDecoderTable[] = {
     bmll0, bmlh0, bmhl0, bmhh0, bmll1, bmlh1, bmhl1, bmhh1, bmll2, bmlh2,
     bmhl2, bmhh2, bmll3, bmlh3, bmhl3, bmhh3, bmll4, bmlh4, bmhl4, bmhh4};
 static const unsigned mQXswDecoderTable[] = {qx0, qx1, qx2, qx3};
 TABLEBASEDDECODER(mQXsw)
-static const unsigned mEXaDecoderTable[] = {ex0, ex1, ex2, ex3, ex4,  ex5,
-                                            ex6, ex7, ex8, ex9, ex10, ex11};
+static const unsigned mEXaDecoderTable[] = {
+    ex0, ex1, ex2, ex3, ex4, ex5, ex6, ex7, ex8, ex9, ex10, ex11, 0, 0, 0, 0};
 TABLEBASEDDECODER(mEXa)
 static const unsigned mQEXsbDecoderTable[] = {qex0, qex1, qex2, qex3};
 static const unsigned mLdaCgDecoderTable[] = {
@@ -697,21 +726,23 @@ static const unsigned mLdaCgDecoderTable[] = {
     r16, 0, m4, 0, r17, 0,  dn4, 0, r18, 0, dj4, 0, r19, p4, dc4, 0,
     r20, 0, m5, 0, r21, 0,  dn5, 0, r22, 0, dj5, 0, r23, p5, dc5, 0,
     r24, 0, m6, 0, r25, 0,  dn6, 0, r26, 0, dj6, 0, r27, p6, dc6, 0,
-    r28, 0, m7, 0, r29, 0,  dn7, 0, r30, 0, dj7, 0, r31, p7, dc7};
+    r28, 0, m7, 0, r29, 0,  dn7, 0, r30, 0, dj7, 0, r31, p7, dc7, 0};
 TABLEBASEDDECODER(mLdaCg)
 static const unsigned mFl2FxSrc_WDecoderTable[] = {
-    wh0, wl0, wh1, wl1, wh2, wl2, wh3, wl3, wh4,  wl4,  wh5,  wl5,
-    wh6, wl6, wh7, wl7, wh8, wl8, wh9, wl9, wh10, wl10, wh11, wl11};
+    wh0,  wl0,  wh1, wl1, wh2, wl2, wh3, wl3, wh4, wl4,  wh5,
+    wl5,  wh6,  wl6, wh7, wl7, wh8, wl8, wh9, wl9, wh10, wl10,
+    wh11, wl11, 0,   0,   0,   0,   0,   0,   0,   0};
 TABLEBASEDDECODER(mFl2FxSrc_W)
-static const unsigned mXbDecoderTable[] = {x0, x1, x2, x3, x4,  x5,
-                                           x6, x7, x8, x9, x10, x11};
+static const unsigned mXbDecoderTable[] = {x0, x1, x2,  x3,  x4, x5, x6, x7,
+                                           x8, x9, x10, x11, 0,  0,  0,  0};
 TABLEBASEDDECODER(mXb)
 static const unsigned mBMsDecoderTable[] = {
-    bmll0, bmlh0, bmhl0, bmhh0, bmll1, bmlh1, bmhl1, bmhh1, bmll2, bmlh2,
-    bmhl2, bmhh2, bmll3, bmlh3, bmhl3, bmhh3, bmll4, bmlh4, bmhl4, bmhh4};
+    bmll0, bmlh0, bmhl0, bmhh0, bmll1, bmlh1, bmhl1, bmhh1, bmll2, bmlh2, bmhl2,
+    bmhh2, bmll3, bmlh3, bmhl3, bmhh3, bmll4, bmlh4, bmhl4, bmhh4, 0,     0,
+    0,     0,     0,     0,     0,     0,     0,     0,     0,     0};
 TABLEBASEDDECODER(mBMs)
-static const unsigned mEXbDecoderTable[] = {ex0, ex1, ex2, ex3, ex4,  ex5,
-                                            ex6, ex7, ex8, ex9, ex10, ex11};
+static const unsigned mEXbDecoderTable[] = {
+    ex0, ex1, ex2, ex3, ex4, ex5, ex6, ex7, ex8, ex9, ex10, ex11, 0, 0, 0, 0};
 
 // Decoder Tables for Singleton Register Classes.
 FIXEDREGDECODER(mR30_fifo_step_e1)

--- a/llvm/lib/Target/AIE/Disassembler/AIE2PGenDecoderMethods.inc
+++ b/llvm/lib/Target/AIE/Disassembler/AIE2PGenDecoderMethods.inc
@@ -15,40 +15,45 @@ static DecodeStatus DecodeDms_lda_2D(MCInst &MI, InsnType &Insn,
                                      uint64_t Address,
                                      const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned dstRegRaw = fieldFromInstruction(Insn, 4, 7);
-  if (dstRegRaw >= std::size(mLdaSclDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dstRegRawNumBits = 7;
+  unsigned dstRegRaw = fieldFromInstruction(Insn, 4, dstRegRawNumBits);
+  static_assert((1 << dstRegRawNumBits) == std::size(mLdaSclDecoderTable));
   Register dstReg = mLdaSclDecoderTable[dstRegRaw];
-  assert(dstReg && "Register not found.");
+  if (!dstReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dstReg));
 
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptr_outRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 3;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePDecoderTable));
   Register ptr_outReg = ePDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned dcRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (dcRegRaw >= std::size(eDCDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dcRegRawNumBits = 3;
+  unsigned dcRegRaw = fieldFromInstruction(Insn, 14, dcRegRawNumBits);
+  static_assert((1 << dcRegRawNumBits) == std::size(eDCDecoderTable));
   Register dcReg = eDCDecoderTable[dcRegRaw];
-  assert(dcReg && "Register not found.");
+  if (!dcReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dcReg));
 
   // --------------------- Ins ------------------------
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptrRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 3;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePDecoderTable));
   Register ptrReg = ePDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (modRegRaw >= std::size(eDDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 3;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 14, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDDecoderTable));
   Register modReg = eDDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -59,40 +64,45 @@ static DecodeStatus DecodeDmv_lda_q_2D(MCInst &MI, InsnType &Insn,
                                        uint64_t Address,
                                        const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned dstRegRaw = fieldFromInstruction(Insn, 9, 2);
-  if (dstRegRaw >= std::size(mQQsaDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dstRegRawNumBits = 2;
+  unsigned dstRegRaw = fieldFromInstruction(Insn, 9, dstRegRawNumBits);
+  static_assert((1 << dstRegRawNumBits) == std::size(mQQsaDecoderTable));
   Register dstReg = mQQsaDecoderTable[dstRegRaw];
-  assert(dstReg && "Register not found.");
+  if (!dstReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dstReg));
 
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptr_outRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 3;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePDecoderTable));
   Register ptr_outReg = ePDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned dcRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (dcRegRaw >= std::size(eDCDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dcRegRawNumBits = 3;
+  unsigned dcRegRaw = fieldFromInstruction(Insn, 14, dcRegRawNumBits);
+  static_assert((1 << dcRegRawNumBits) == std::size(eDCDecoderTable));
   Register dcReg = eDCDecoderTable[dcRegRaw];
-  assert(dcReg && "Register not found.");
+  if (!dcReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dcReg));
 
   // --------------------- Ins ------------------------
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptrRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 3;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePDecoderTable));
   Register ptrReg = ePDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (modRegRaw >= std::size(eDDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 3;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 14, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDDecoderTable));
   Register modReg = eDDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -103,40 +113,45 @@ static DecodeStatus DecodeDmhb_lda_2D(MCInst &MI, InsnType &Insn,
                                       uint64_t Address,
                                       const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned dstRegRaw = fieldFromInstruction(Insn, 6, 5);
-  if (dstRegRaw >= std::size(eRDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dstRegRawNumBits = 5;
+  unsigned dstRegRaw = fieldFromInstruction(Insn, 6, dstRegRawNumBits);
+  static_assert((1 << dstRegRawNumBits) == std::size(eRDecoderTable));
   Register dstReg = eRDecoderTable[dstRegRaw];
-  assert(dstReg && "Register not found.");
+  if (!dstReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dstReg));
 
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptr_outRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 3;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePDecoderTable));
   Register ptr_outReg = ePDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned dcRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (dcRegRaw >= std::size(eDCDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dcRegRawNumBits = 3;
+  unsigned dcRegRaw = fieldFromInstruction(Insn, 14, dcRegRawNumBits);
+  static_assert((1 << dcRegRawNumBits) == std::size(eDCDecoderTable));
   Register dcReg = eDCDecoderTable[dcRegRaw];
-  assert(dcReg && "Register not found.");
+  if (!dcReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dcReg));
 
   // --------------------- Ins ------------------------
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptrRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 3;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePDecoderTable));
   Register ptrReg = ePDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (modRegRaw >= std::size(eDDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 3;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 14, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDDecoderTable));
   Register modReg = eDDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -147,47 +162,53 @@ static DecodeStatus DecodeDms_lda_3D(MCInst &MI, InsnType &Insn,
                                      uint64_t Address,
                                      const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned dstRegRaw = fieldFromInstruction(Insn, 4, 7);
-  if (dstRegRaw >= std::size(mLdaSclDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dstRegRawNumBits = 7;
+  unsigned dstRegRaw = fieldFromInstruction(Insn, 4, dstRegRawNumBits);
+  static_assert((1 << dstRegRawNumBits) == std::size(mLdaSclDecoderTable));
   Register dstReg = mLdaSclDecoderTable[dstRegRaw];
-  assert(dstReg && "Register not found.");
+  if (!dstReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dstReg));
 
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptr_outRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 3;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePDecoderTable));
   Register ptr_outReg = ePDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned dclRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (dclRegRaw >= std::size(eDCLDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dclRegRawNumBits = 2;
+  unsigned dclRegRaw = fieldFromInstruction(Insn, 14, dclRegRawNumBits);
+  static_assert((1 << dclRegRawNumBits) == std::size(eDCLDecoderTable));
   Register dclReg = eDCLDecoderTable[dclRegRaw];
-  assert(dclReg && "Register not found.");
+  if (!dclReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dclReg));
 
-  unsigned dchRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (dchRegRaw >= std::size(eDCHDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dchRegRawNumBits = 2;
+  unsigned dchRegRaw = fieldFromInstruction(Insn, 14, dchRegRawNumBits);
+  static_assert((1 << dchRegRawNumBits) == std::size(eDCHDecoderTable));
   Register dchReg = eDCHDecoderTable[dchRegRaw];
-  assert(dchReg && "Register not found.");
+  if (!dchReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dchReg));
 
   // --------------------- Ins ------------------------
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptrRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 3;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePDecoderTable));
   Register ptrReg = ePDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (modRegRaw >= std::size(eDSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 2;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 14, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDSDecoderTable));
   Register modReg = eDSDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -198,47 +219,53 @@ static DecodeStatus DecodeDmv_lda_q_3D(MCInst &MI, InsnType &Insn,
                                        uint64_t Address,
                                        const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned dstRegRaw = fieldFromInstruction(Insn, 9, 2);
-  if (dstRegRaw >= std::size(mQQsaDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dstRegRawNumBits = 2;
+  unsigned dstRegRaw = fieldFromInstruction(Insn, 9, dstRegRawNumBits);
+  static_assert((1 << dstRegRawNumBits) == std::size(mQQsaDecoderTable));
   Register dstReg = mQQsaDecoderTable[dstRegRaw];
-  assert(dstReg && "Register not found.");
+  if (!dstReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dstReg));
 
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptr_outRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 3;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePDecoderTable));
   Register ptr_outReg = ePDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned dclRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (dclRegRaw >= std::size(eDCLDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dclRegRawNumBits = 2;
+  unsigned dclRegRaw = fieldFromInstruction(Insn, 14, dclRegRawNumBits);
+  static_assert((1 << dclRegRawNumBits) == std::size(eDCLDecoderTable));
   Register dclReg = eDCLDecoderTable[dclRegRaw];
-  assert(dclReg && "Register not found.");
+  if (!dclReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dclReg));
 
-  unsigned dchRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (dchRegRaw >= std::size(eDCHDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dchRegRawNumBits = 2;
+  unsigned dchRegRaw = fieldFromInstruction(Insn, 14, dchRegRawNumBits);
+  static_assert((1 << dchRegRawNumBits) == std::size(eDCHDecoderTable));
   Register dchReg = eDCHDecoderTable[dchRegRaw];
-  assert(dchReg && "Register not found.");
+  if (!dchReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dchReg));
 
   // --------------------- Ins ------------------------
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptrRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 3;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePDecoderTable));
   Register ptrReg = ePDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (modRegRaw >= std::size(eDSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 2;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 14, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDSDecoderTable));
   Register modReg = eDSDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -249,47 +276,53 @@ static DecodeStatus DecodeDmhb_lda_3D(MCInst &MI, InsnType &Insn,
                                       uint64_t Address,
                                       const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned dstRegRaw = fieldFromInstruction(Insn, 6, 5);
-  if (dstRegRaw >= std::size(eRDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dstRegRawNumBits = 5;
+  unsigned dstRegRaw = fieldFromInstruction(Insn, 6, dstRegRawNumBits);
+  static_assert((1 << dstRegRawNumBits) == std::size(eRDecoderTable));
   Register dstReg = eRDecoderTable[dstRegRaw];
-  assert(dstReg && "Register not found.");
+  if (!dstReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dstReg));
 
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptr_outRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 3;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePDecoderTable));
   Register ptr_outReg = ePDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned dclRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (dclRegRaw >= std::size(eDCLDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dclRegRawNumBits = 2;
+  unsigned dclRegRaw = fieldFromInstruction(Insn, 14, dclRegRawNumBits);
+  static_assert((1 << dclRegRawNumBits) == std::size(eDCLDecoderTable));
   Register dclReg = eDCLDecoderTable[dclRegRaw];
-  assert(dclReg && "Register not found.");
+  if (!dclReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dclReg));
 
-  unsigned dchRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (dchRegRaw >= std::size(eDCHDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dchRegRawNumBits = 2;
+  unsigned dchRegRaw = fieldFromInstruction(Insn, 14, dchRegRawNumBits);
+  static_assert((1 << dchRegRawNumBits) == std::size(eDCHDecoderTable));
   Register dchReg = eDCHDecoderTable[dchRegRaw];
-  assert(dchReg && "Register not found.");
+  if (!dchReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dchReg));
 
   // --------------------- Ins ------------------------
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptrRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 3;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePDecoderTable));
   Register ptrReg = ePDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (modRegRaw >= std::size(eDSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 2;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 14, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDSDecoderTable));
   Register modReg = eDSDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -300,40 +333,45 @@ static DecodeStatus DecodeTm_lda_2D(MCInst &MI, InsnType &Insn,
                                     uint64_t Address,
                                     const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned dstRegRaw = fieldFromInstruction(Insn, 6, 5);
-  if (dstRegRaw >= std::size(eRDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dstRegRawNumBits = 5;
+  unsigned dstRegRaw = fieldFromInstruction(Insn, 6, dstRegRawNumBits);
+  static_assert((1 << dstRegRawNumBits) == std::size(eRDecoderTable));
   Register dstReg = eRDecoderTable[dstRegRaw];
-  assert(dstReg && "Register not found.");
+  if (!dstReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dstReg));
 
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptr_outRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 3;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePDecoderTable));
   Register ptr_outReg = ePDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned dcRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (dcRegRaw >= std::size(eDCDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dcRegRawNumBits = 3;
+  unsigned dcRegRaw = fieldFromInstruction(Insn, 14, dcRegRawNumBits);
+  static_assert((1 << dcRegRawNumBits) == std::size(eDCDecoderTable));
   Register dcReg = eDCDecoderTable[dcRegRaw];
-  assert(dcReg && "Register not found.");
+  if (!dcReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dcReg));
 
   // --------------------- Ins ------------------------
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptrRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 3;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePDecoderTable));
   Register ptrReg = ePDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (modRegRaw >= std::size(eDDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 3;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 14, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDDecoderTable));
   Register modReg = eDDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -344,47 +382,53 @@ static DecodeStatus DecodeTm_lda_3D(MCInst &MI, InsnType &Insn,
                                     uint64_t Address,
                                     const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned dstRegRaw = fieldFromInstruction(Insn, 6, 5);
-  if (dstRegRaw >= std::size(eRDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dstRegRawNumBits = 5;
+  unsigned dstRegRaw = fieldFromInstruction(Insn, 6, dstRegRawNumBits);
+  static_assert((1 << dstRegRawNumBits) == std::size(eRDecoderTable));
   Register dstReg = eRDecoderTable[dstRegRaw];
-  assert(dstReg && "Register not found.");
+  if (!dstReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dstReg));
 
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptr_outRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 3;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePDecoderTable));
   Register ptr_outReg = ePDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned dclRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (dclRegRaw >= std::size(eDCLDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dclRegRawNumBits = 2;
+  unsigned dclRegRaw = fieldFromInstruction(Insn, 14, dclRegRawNumBits);
+  static_assert((1 << dclRegRawNumBits) == std::size(eDCLDecoderTable));
   Register dclReg = eDCLDecoderTable[dclRegRaw];
-  assert(dclReg && "Register not found.");
+  if (!dclReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dclReg));
 
-  unsigned dchRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (dchRegRaw >= std::size(eDCHDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dchRegRawNumBits = 2;
+  unsigned dchRegRaw = fieldFromInstruction(Insn, 14, dchRegRawNumBits);
+  static_assert((1 << dchRegRawNumBits) == std::size(eDCHDecoderTable));
   Register dchReg = eDCHDecoderTable[dchRegRaw];
-  assert(dchReg && "Register not found.");
+  if (!dchReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dchReg));
 
   // --------------------- Ins ------------------------
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptrRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 3;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePDecoderTable));
   Register ptrReg = ePDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (modRegRaw >= std::size(eDSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 2;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 14, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDSDecoderTable));
   Register modReg = eDSDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -395,33 +439,37 @@ static DecodeStatus DecodeLda_ptr_inc_2D(MCInst &MI, InsnType &Insn,
                                          uint64_t Address,
                                          const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptr_outRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 3;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePDecoderTable));
   Register ptr_outReg = ePDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned dcRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (dcRegRaw >= std::size(eDCDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dcRegRawNumBits = 3;
+  unsigned dcRegRaw = fieldFromInstruction(Insn, 14, dcRegRawNumBits);
+  static_assert((1 << dcRegRawNumBits) == std::size(eDCDecoderTable));
   Register dcReg = eDCDecoderTable[dcRegRaw];
-  assert(dcReg && "Register not found.");
+  if (!dcReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dcReg));
 
   // --------------------- Ins ------------------------
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptrRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 3;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePDecoderTable));
   Register ptrReg = ePDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (modRegRaw >= std::size(eDDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 3;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 14, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDDecoderTable));
   Register modReg = eDDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -432,40 +480,45 @@ static DecodeStatus DecodeLda_ptr_inc_3D(MCInst &MI, InsnType &Insn,
                                          uint64_t Address,
                                          const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptr_outRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 3;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePDecoderTable));
   Register ptr_outReg = ePDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned dclRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (dclRegRaw >= std::size(eDCLDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dclRegRawNumBits = 2;
+  unsigned dclRegRaw = fieldFromInstruction(Insn, 14, dclRegRawNumBits);
+  static_assert((1 << dclRegRawNumBits) == std::size(eDCLDecoderTable));
   Register dclReg = eDCLDecoderTable[dclRegRaw];
-  assert(dclReg && "Register not found.");
+  if (!dclReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dclReg));
 
-  unsigned dchRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (dchRegRaw >= std::size(eDCHDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dchRegRawNumBits = 2;
+  unsigned dchRegRaw = fieldFromInstruction(Insn, 14, dchRegRawNumBits);
+  static_assert((1 << dchRegRawNumBits) == std::size(eDCHDecoderTable));
   Register dchReg = eDCHDecoderTable[dchRegRaw];
-  assert(dchReg && "Register not found.");
+  if (!dchReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dchReg));
 
   // --------------------- Ins ------------------------
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptrRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 3;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePDecoderTable));
   Register ptrReg = ePDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (modRegRaw >= std::size(eDSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 2;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 14, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDSDecoderTable));
   Register modReg = eDSDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -476,33 +529,37 @@ static DecodeStatus DecodeLdb_or1_2D(MCInst &MI, InsnType &Insn,
                                      uint64_t Address,
                                      const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (ptr_outRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 3;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 14, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePDecoderTable));
   Register ptr_outReg = ePDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned dcRegRaw = fieldFromInstruction(Insn, 11, 3);
-  if (dcRegRaw >= std::size(eDCDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dcRegRawNumBits = 3;
+  unsigned dcRegRaw = fieldFromInstruction(Insn, 11, dcRegRawNumBits);
+  static_assert((1 << dcRegRawNumBits) == std::size(eDCDecoderTable));
   Register dcReg = eDCDecoderTable[dcRegRaw];
-  assert(dcReg && "Register not found.");
+  if (!dcReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dcReg));
 
   // --------------------- Ins ------------------------
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (ptrRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 3;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 14, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePDecoderTable));
   Register ptrReg = ePDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 11, 3);
-  if (modRegRaw >= std::size(eDDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 3;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 11, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDDecoderTable));
   Register modReg = eDDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -513,40 +570,45 @@ static DecodeStatus DecodeLdb_or1_3D(MCInst &MI, InsnType &Insn,
                                      uint64_t Address,
                                      const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (ptr_outRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 3;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 14, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePDecoderTable));
   Register ptr_outReg = ePDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned dclRegRaw = fieldFromInstruction(Insn, 11, 2);
-  if (dclRegRaw >= std::size(eDCLDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dclRegRawNumBits = 2;
+  unsigned dclRegRaw = fieldFromInstruction(Insn, 11, dclRegRawNumBits);
+  static_assert((1 << dclRegRawNumBits) == std::size(eDCLDecoderTable));
   Register dclReg = eDCLDecoderTable[dclRegRaw];
-  assert(dclReg && "Register not found.");
+  if (!dclReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dclReg));
 
-  unsigned dchRegRaw = fieldFromInstruction(Insn, 11, 2);
-  if (dchRegRaw >= std::size(eDCHDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dchRegRawNumBits = 2;
+  unsigned dchRegRaw = fieldFromInstruction(Insn, 11, dchRegRawNumBits);
+  static_assert((1 << dchRegRawNumBits) == std::size(eDCHDecoderTable));
   Register dchReg = eDCHDecoderTable[dchRegRaw];
-  assert(dchReg && "Register not found.");
+  if (!dchReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dchReg));
 
   // --------------------- Ins ------------------------
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (ptrRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 3;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 14, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePDecoderTable));
   Register ptrReg = ePDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 11, 2);
-  if (modRegRaw >= std::size(eDSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 2;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 11, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDSDecoderTable));
   Register modReg = eDSDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -557,33 +619,37 @@ static DecodeStatus DecodeSt_ptr_inc_2D(MCInst &MI, InsnType &Insn,
                                         uint64_t Address,
                                         const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptr_outRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 3;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePDecoderTable));
   Register ptr_outReg = ePDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned dcRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (dcRegRaw >= std::size(eDCDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dcRegRawNumBits = 3;
+  unsigned dcRegRaw = fieldFromInstruction(Insn, 14, dcRegRawNumBits);
+  static_assert((1 << dcRegRawNumBits) == std::size(eDCDecoderTable));
   Register dcReg = eDCDecoderTable[dcRegRaw];
-  assert(dcReg && "Register not found.");
+  if (!dcReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dcReg));
 
   // --------------------- Ins ------------------------
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptrRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 3;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePDecoderTable));
   Register ptrReg = ePDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (modRegRaw >= std::size(eDDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 3;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 14, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDDecoderTable));
   Register modReg = eDDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -594,40 +660,45 @@ static DecodeStatus DecodeSt_ptr_inc_3D(MCInst &MI, InsnType &Insn,
                                         uint64_t Address,
                                         const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptr_outRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 3;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePDecoderTable));
   Register ptr_outReg = ePDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned dclRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (dclRegRaw >= std::size(eDCLDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dclRegRawNumBits = 2;
+  unsigned dclRegRaw = fieldFromInstruction(Insn, 14, dclRegRawNumBits);
+  static_assert((1 << dclRegRawNumBits) == std::size(eDCLDecoderTable));
   Register dclReg = eDCLDecoderTable[dclRegRaw];
-  assert(dclReg && "Register not found.");
+  if (!dclReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dclReg));
 
-  unsigned dchRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (dchRegRaw >= std::size(eDCHDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dchRegRawNumBits = 2;
+  unsigned dchRegRaw = fieldFromInstruction(Insn, 14, dchRegRawNumBits);
+  static_assert((1 << dchRegRawNumBits) == std::size(eDCHDecoderTable));
   Register dchReg = eDCHDecoderTable[dchRegRaw];
-  assert(dchReg && "Register not found.");
+  if (!dchReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dchReg));
 
   // --------------------- Ins ------------------------
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptrRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 3;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePDecoderTable));
   Register ptrReg = ePDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (modRegRaw >= std::size(eDSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 2;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 14, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDSDecoderTable));
   Register modReg = eDSDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -638,40 +709,45 @@ static DecodeStatus DecodeDms_sts_2D(MCInst &MI, InsnType &Insn,
                                      uint64_t Address,
                                      const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptr_outRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 3;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePDecoderTable));
   Register ptr_outReg = ePDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned dcRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (dcRegRaw >= std::size(eDCDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dcRegRawNumBits = 3;
+  unsigned dcRegRaw = fieldFromInstruction(Insn, 14, dcRegRawNumBits);
+  static_assert((1 << dcRegRawNumBits) == std::size(eDCDecoderTable));
   Register dcReg = eDCDecoderTable[dcRegRaw];
-  assert(dcReg && "Register not found.");
+  if (!dcReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dcReg));
 
   // --------------------- Ins ------------------------
-  unsigned srcRegRaw = fieldFromInstruction(Insn, 4, 7);
-  if (srcRegRaw >= std::size(mSclStDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned srcRegRawNumBits = 7;
+  unsigned srcRegRaw = fieldFromInstruction(Insn, 4, srcRegRawNumBits);
+  static_assert((1 << srcRegRawNumBits) == std::size(mSclStDecoderTable));
   Register srcReg = mSclStDecoderTable[srcRegRaw];
-  assert(srcReg && "Register not found.");
+  if (!srcReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(srcReg));
 
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptrRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 3;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePDecoderTable));
   Register ptrReg = ePDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (modRegRaw >= std::size(eDDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 3;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 14, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDDecoderTable));
   Register modReg = eDDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -682,40 +758,45 @@ static DecodeStatus DecodeDmv_sts_q_2D(MCInst &MI, InsnType &Insn,
                                        uint64_t Address,
                                        const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptr_outRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 3;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePDecoderTable));
   Register ptr_outReg = ePDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned dcRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (dcRegRaw >= std::size(eDCDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dcRegRawNumBits = 3;
+  unsigned dcRegRaw = fieldFromInstruction(Insn, 14, dcRegRawNumBits);
+  static_assert((1 << dcRegRawNumBits) == std::size(eDCDecoderTable));
   Register dcReg = eDCDecoderTable[dcRegRaw];
-  assert(dcReg && "Register not found.");
+  if (!dcReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dcReg));
 
   // --------------------- Ins ------------------------
-  unsigned srcRegRaw = fieldFromInstruction(Insn, 9, 2);
-  if (srcRegRaw >= std::size(mQQssDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned srcRegRawNumBits = 2;
+  unsigned srcRegRaw = fieldFromInstruction(Insn, 9, srcRegRawNumBits);
+  static_assert((1 << srcRegRawNumBits) == std::size(mQQssDecoderTable));
   Register srcReg = mQQssDecoderTable[srcRegRaw];
-  assert(srcReg && "Register not found.");
+  if (!srcReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(srcReg));
 
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptrRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 3;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePDecoderTable));
   Register ptrReg = ePDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (modRegRaw >= std::size(eDDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 3;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 14, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDDecoderTable));
   Register modReg = eDDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -726,40 +807,45 @@ static DecodeStatus DecodeDmhb_sts_2D(MCInst &MI, InsnType &Insn,
                                       uint64_t Address,
                                       const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptr_outRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 3;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePDecoderTable));
   Register ptr_outReg = ePDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned dcRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (dcRegRaw >= std::size(eDCDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dcRegRawNumBits = 3;
+  unsigned dcRegRaw = fieldFromInstruction(Insn, 14, dcRegRawNumBits);
+  static_assert((1 << dcRegRawNumBits) == std::size(eDCDecoderTable));
   Register dcReg = eDCDecoderTable[dcRegRaw];
-  assert(dcReg && "Register not found.");
+  if (!dcReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dcReg));
 
   // --------------------- Ins ------------------------
-  unsigned srcRegRaw = fieldFromInstruction(Insn, 6, 5);
-  if (srcRegRaw >= std::size(eRDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned srcRegRawNumBits = 5;
+  unsigned srcRegRaw = fieldFromInstruction(Insn, 6, srcRegRawNumBits);
+  static_assert((1 << srcRegRawNumBits) == std::size(eRDecoderTable));
   Register srcReg = eRDecoderTable[srcRegRaw];
-  assert(srcReg && "Register not found.");
+  if (!srcReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(srcReg));
 
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptrRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 3;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePDecoderTable));
   Register ptrReg = ePDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (modRegRaw >= std::size(eDDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 3;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 14, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDDecoderTable));
   Register modReg = eDDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -770,47 +856,53 @@ static DecodeStatus DecodeDms_sts_3D(MCInst &MI, InsnType &Insn,
                                      uint64_t Address,
                                      const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptr_outRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 3;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePDecoderTable));
   Register ptr_outReg = ePDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned dclRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (dclRegRaw >= std::size(eDCLDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dclRegRawNumBits = 2;
+  unsigned dclRegRaw = fieldFromInstruction(Insn, 14, dclRegRawNumBits);
+  static_assert((1 << dclRegRawNumBits) == std::size(eDCLDecoderTable));
   Register dclReg = eDCLDecoderTable[dclRegRaw];
-  assert(dclReg && "Register not found.");
+  if (!dclReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dclReg));
 
-  unsigned dchRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (dchRegRaw >= std::size(eDCHDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dchRegRawNumBits = 2;
+  unsigned dchRegRaw = fieldFromInstruction(Insn, 14, dchRegRawNumBits);
+  static_assert((1 << dchRegRawNumBits) == std::size(eDCHDecoderTable));
   Register dchReg = eDCHDecoderTable[dchRegRaw];
-  assert(dchReg && "Register not found.");
+  if (!dchReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dchReg));
 
   // --------------------- Ins ------------------------
-  unsigned srcRegRaw = fieldFromInstruction(Insn, 4, 7);
-  if (srcRegRaw >= std::size(mSclStDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned srcRegRawNumBits = 7;
+  unsigned srcRegRaw = fieldFromInstruction(Insn, 4, srcRegRawNumBits);
+  static_assert((1 << srcRegRawNumBits) == std::size(mSclStDecoderTable));
   Register srcReg = mSclStDecoderTable[srcRegRaw];
-  assert(srcReg && "Register not found.");
+  if (!srcReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(srcReg));
 
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptrRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 3;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePDecoderTable));
   Register ptrReg = ePDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (modRegRaw >= std::size(eDSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 2;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 14, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDSDecoderTable));
   Register modReg = eDSDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -821,47 +913,53 @@ static DecodeStatus DecodeDmv_sts_q_3D(MCInst &MI, InsnType &Insn,
                                        uint64_t Address,
                                        const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptr_outRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 3;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePDecoderTable));
   Register ptr_outReg = ePDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned dclRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (dclRegRaw >= std::size(eDCLDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dclRegRawNumBits = 2;
+  unsigned dclRegRaw = fieldFromInstruction(Insn, 14, dclRegRawNumBits);
+  static_assert((1 << dclRegRawNumBits) == std::size(eDCLDecoderTable));
   Register dclReg = eDCLDecoderTable[dclRegRaw];
-  assert(dclReg && "Register not found.");
+  if (!dclReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dclReg));
 
-  unsigned dchRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (dchRegRaw >= std::size(eDCHDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dchRegRawNumBits = 2;
+  unsigned dchRegRaw = fieldFromInstruction(Insn, 14, dchRegRawNumBits);
+  static_assert((1 << dchRegRawNumBits) == std::size(eDCHDecoderTable));
   Register dchReg = eDCHDecoderTable[dchRegRaw];
-  assert(dchReg && "Register not found.");
+  if (!dchReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dchReg));
 
   // --------------------- Ins ------------------------
-  unsigned srcRegRaw = fieldFromInstruction(Insn, 9, 2);
-  if (srcRegRaw >= std::size(mQQssDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned srcRegRawNumBits = 2;
+  unsigned srcRegRaw = fieldFromInstruction(Insn, 9, srcRegRawNumBits);
+  static_assert((1 << srcRegRawNumBits) == std::size(mQQssDecoderTable));
   Register srcReg = mQQssDecoderTable[srcRegRaw];
-  assert(srcReg && "Register not found.");
+  if (!srcReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(srcReg));
 
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptrRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 3;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePDecoderTable));
   Register ptrReg = ePDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (modRegRaw >= std::size(eDSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 2;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 14, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDSDecoderTable));
   Register modReg = eDSDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -872,47 +970,53 @@ static DecodeStatus DecodeDmhb_sts_3D(MCInst &MI, InsnType &Insn,
                                       uint64_t Address,
                                       const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptr_outRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 3;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePDecoderTable));
   Register ptr_outReg = ePDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned dclRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (dclRegRaw >= std::size(eDCLDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dclRegRawNumBits = 2;
+  unsigned dclRegRaw = fieldFromInstruction(Insn, 14, dclRegRawNumBits);
+  static_assert((1 << dclRegRawNumBits) == std::size(eDCLDecoderTable));
   Register dclReg = eDCLDecoderTable[dclRegRaw];
-  assert(dclReg && "Register not found.");
+  if (!dclReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dclReg));
 
-  unsigned dchRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (dchRegRaw >= std::size(eDCHDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dchRegRawNumBits = 2;
+  unsigned dchRegRaw = fieldFromInstruction(Insn, 14, dchRegRawNumBits);
+  static_assert((1 << dchRegRawNumBits) == std::size(eDCHDecoderTable));
   Register dchReg = eDCHDecoderTable[dchRegRaw];
-  assert(dchReg && "Register not found.");
+  if (!dchReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dchReg));
 
   // --------------------- Ins ------------------------
-  unsigned srcRegRaw = fieldFromInstruction(Insn, 6, 5);
-  if (srcRegRaw >= std::size(eRDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned srcRegRawNumBits = 5;
+  unsigned srcRegRaw = fieldFromInstruction(Insn, 6, srcRegRawNumBits);
+  static_assert((1 << srcRegRawNumBits) == std::size(eRDecoderTable));
   Register srcReg = eRDecoderTable[srcRegRaw];
-  assert(srcReg && "Register not found.");
+  if (!srcReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(srcReg));
 
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptrRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 3;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePDecoderTable));
   Register ptrReg = ePDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (modRegRaw >= std::size(eDSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 2;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 14, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDSDecoderTable));
   Register modReg = eDSDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -923,40 +1027,45 @@ static DecodeStatus DecodeTm_sts_2D(MCInst &MI, InsnType &Insn,
                                     uint64_t Address,
                                     const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptr_outRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 3;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePDecoderTable));
   Register ptr_outReg = ePDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned dcRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (dcRegRaw >= std::size(eDCDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dcRegRawNumBits = 3;
+  unsigned dcRegRaw = fieldFromInstruction(Insn, 14, dcRegRawNumBits);
+  static_assert((1 << dcRegRawNumBits) == std::size(eDCDecoderTable));
   Register dcReg = eDCDecoderTable[dcRegRaw];
-  assert(dcReg && "Register not found.");
+  if (!dcReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dcReg));
 
   // --------------------- Ins ------------------------
-  unsigned srcRegRaw = fieldFromInstruction(Insn, 6, 5);
-  if (srcRegRaw >= std::size(eRDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned srcRegRawNumBits = 5;
+  unsigned srcRegRaw = fieldFromInstruction(Insn, 6, srcRegRawNumBits);
+  static_assert((1 << srcRegRawNumBits) == std::size(eRDecoderTable));
   Register srcReg = eRDecoderTable[srcRegRaw];
-  assert(srcReg && "Register not found.");
+  if (!srcReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(srcReg));
 
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptrRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 3;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePDecoderTable));
   Register ptrReg = ePDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (modRegRaw >= std::size(eDDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 3;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 14, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDDecoderTable));
   Register modReg = eDDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -967,47 +1076,53 @@ static DecodeStatus DecodeTm_sts_3D(MCInst &MI, InsnType &Insn,
                                     uint64_t Address,
                                     const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptr_outRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 3;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePDecoderTable));
   Register ptr_outReg = ePDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned dclRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (dclRegRaw >= std::size(eDCLDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dclRegRawNumBits = 2;
+  unsigned dclRegRaw = fieldFromInstruction(Insn, 14, dclRegRawNumBits);
+  static_assert((1 << dclRegRawNumBits) == std::size(eDCLDecoderTable));
   Register dclReg = eDCLDecoderTable[dclRegRaw];
-  assert(dclReg && "Register not found.");
+  if (!dclReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dclReg));
 
-  unsigned dchRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (dchRegRaw >= std::size(eDCHDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dchRegRawNumBits = 2;
+  unsigned dchRegRaw = fieldFromInstruction(Insn, 14, dchRegRawNumBits);
+  static_assert((1 << dchRegRawNumBits) == std::size(eDCHDecoderTable));
   Register dchReg = eDCHDecoderTable[dchRegRaw];
-  assert(dchReg && "Register not found.");
+  if (!dchReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dchReg));
 
   // --------------------- Ins ------------------------
-  unsigned srcRegRaw = fieldFromInstruction(Insn, 6, 5);
-  if (srcRegRaw >= std::size(eRDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned srcRegRawNumBits = 5;
+  unsigned srcRegRaw = fieldFromInstruction(Insn, 6, srcRegRawNumBits);
+  static_assert((1 << srcRegRawNumBits) == std::size(eRDecoderTable));
   Register srcReg = eRDecoderTable[srcRegRaw];
-  assert(srcReg && "Register not found.");
+  if (!srcReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(srcReg));
 
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptrRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 3;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePDecoderTable));
   Register ptrReg = ePDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (modRegRaw >= std::size(eDSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 2;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 14, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDSDecoderTable));
   Register modReg = eDSDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -1018,40 +1133,45 @@ static DecodeStatus DecodeDmv_lda_w_2D(MCInst &MI, InsnType &Insn,
                                        uint64_t Address,
                                        const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned dstRegRaw = fieldFromInstruction(Insn, 6, 5);
-  if (dstRegRaw >= std::size(mWaDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dstRegRawNumBits = 5;
+  unsigned dstRegRaw = fieldFromInstruction(Insn, 6, dstRegRawNumBits);
+  static_assert((1 << dstRegRawNumBits) == std::size(mWaDecoderTable));
   Register dstReg = mWaDecoderTable[dstRegRaw];
-  assert(dstReg && "Register not found.");
+  if (!dstReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dstReg));
 
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptr_outRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 3;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePDecoderTable));
   Register ptr_outReg = ePDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned dcRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (dcRegRaw >= std::size(eDCDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dcRegRawNumBits = 3;
+  unsigned dcRegRaw = fieldFromInstruction(Insn, 14, dcRegRawNumBits);
+  static_assert((1 << dcRegRawNumBits) == std::size(eDCDecoderTable));
   Register dcReg = eDCDecoderTable[dcRegRaw];
-  assert(dcReg && "Register not found.");
+  if (!dcReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dcReg));
 
   // --------------------- Ins ------------------------
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptrRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 3;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePDecoderTable));
   Register ptrReg = ePDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (modRegRaw >= std::size(eDDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 3;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 14, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDDecoderTable));
   Register modReg = eDDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -1062,40 +1182,45 @@ static DecodeStatus DecodeDmw_lda_ups_bf_2D(MCInst &MI, InsnType &Insn,
                                             uint64_t Address,
                                             const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned opRegRaw = fieldFromInstruction(Insn, 6, 5);
-  if (opRegRaw >= std::size(mBMmDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned opRegRawNumBits = 5;
+  unsigned opRegRaw = fieldFromInstruction(Insn, 6, opRegRawNumBits);
+  static_assert((1 << opRegRawNumBits) == std::size(mBMmDecoderTable));
   Register opReg = mBMmDecoderTable[opRegRaw];
-  assert(opReg && "Register not found.");
+  if (!opReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(opReg));
 
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptr_outRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 3;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePDecoderTable));
   Register ptr_outReg = ePDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned dcRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (dcRegRaw >= std::size(eDCDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dcRegRawNumBits = 3;
+  unsigned dcRegRaw = fieldFromInstruction(Insn, 14, dcRegRawNumBits);
+  static_assert((1 << dcRegRawNumBits) == std::size(eDCDecoderTable));
   Register dcReg = eDCDecoderTable[dcRegRaw];
-  assert(dcReg && "Register not found.");
+  if (!dcReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dcReg));
 
   // --------------------- Ins ------------------------
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptrRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 3;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePDecoderTable));
   Register ptrReg = ePDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (modRegRaw >= std::size(eDDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 3;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 14, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDDecoderTable));
   Register modReg = eDDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -1106,40 +1231,45 @@ static DecodeStatus DecodeDmx_lda_ups_bf_2D(MCInst &MI, InsnType &Insn,
                                             uint64_t Address,
                                             const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned opRegRaw = fieldFromInstruction(Insn, 7, 4);
-  if (opRegRaw >= std::size(mCMmDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned opRegRawNumBits = 4;
+  unsigned opRegRaw = fieldFromInstruction(Insn, 7, opRegRawNumBits);
+  static_assert((1 << opRegRawNumBits) == std::size(mCMmDecoderTable));
   Register opReg = mCMmDecoderTable[opRegRaw];
-  assert(opReg && "Register not found.");
+  if (!opReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(opReg));
 
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptr_outRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 3;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePDecoderTable));
   Register ptr_outReg = ePDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned dcRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (dcRegRaw >= std::size(eDCDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dcRegRawNumBits = 3;
+  unsigned dcRegRaw = fieldFromInstruction(Insn, 14, dcRegRawNumBits);
+  static_assert((1 << dcRegRawNumBits) == std::size(eDCDecoderTable));
   Register dcReg = eDCDecoderTable[dcRegRaw];
-  assert(dcReg && "Register not found.");
+  if (!dcReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dcReg));
 
   // --------------------- Ins ------------------------
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptrRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 3;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePDecoderTable));
   Register ptrReg = ePDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (modRegRaw >= std::size(eDDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 3;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 14, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDDecoderTable));
   Register modReg = eDDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -1150,47 +1280,53 @@ static DecodeStatus DecodeDmw_lda_ups_w2b_2D(MCInst &MI, InsnType &Insn,
                                              uint64_t Address,
                                              const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned dstRegRaw = fieldFromInstruction(Insn, 6, 5);
-  if (dstRegRaw >= std::size(mBMmDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dstRegRawNumBits = 5;
+  unsigned dstRegRaw = fieldFromInstruction(Insn, 6, dstRegRawNumBits);
+  static_assert((1 << dstRegRawNumBits) == std::size(mBMmDecoderTable));
   Register dstReg = mBMmDecoderTable[dstRegRaw];
-  assert(dstReg && "Register not found.");
+  if (!dstReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dstReg));
 
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptr_outRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 3;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePDecoderTable));
   Register ptr_outReg = ePDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned dcRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (dcRegRaw >= std::size(eDCDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dcRegRawNumBits = 3;
+  unsigned dcRegRaw = fieldFromInstruction(Insn, 14, dcRegRawNumBits);
+  static_assert((1 << dcRegRawNumBits) == std::size(eDCDecoderTable));
   Register dcReg = eDCDecoderTable[dcRegRaw];
-  assert(dcReg && "Register not found.");
+  if (!dcReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dcReg));
 
   // --------------------- Ins ------------------------
-  unsigned suRegRaw = fieldFromInstruction(Insn, 4, 2);
-  if (suRegRaw >= std::size(eSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned suRegRawNumBits = 2;
+  unsigned suRegRaw = fieldFromInstruction(Insn, 4, suRegRawNumBits);
+  static_assert((1 << suRegRawNumBits) == std::size(eSDecoderTable));
   Register suReg = eSDecoderTable[suRegRaw];
-  assert(suReg && "Register not found.");
+  if (!suReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(suReg));
 
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptrRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 3;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePDecoderTable));
   Register ptrReg = ePDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (modRegRaw >= std::size(eDDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 3;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 14, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDDecoderTable));
   Register modReg = eDDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -1201,47 +1337,53 @@ static DecodeStatus DecodeDmx_lda_ups_x2c_2D(MCInst &MI, InsnType &Insn,
                                              uint64_t Address,
                                              const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned dstRegRaw = fieldFromInstruction(Insn, 7, 4);
-  if (dstRegRaw >= std::size(mCMmDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dstRegRawNumBits = 4;
+  unsigned dstRegRaw = fieldFromInstruction(Insn, 7, dstRegRawNumBits);
+  static_assert((1 << dstRegRawNumBits) == std::size(mCMmDecoderTable));
   Register dstReg = mCMmDecoderTable[dstRegRaw];
-  assert(dstReg && "Register not found.");
+  if (!dstReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dstReg));
 
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptr_outRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 3;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePDecoderTable));
   Register ptr_outReg = ePDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned dcRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (dcRegRaw >= std::size(eDCDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dcRegRawNumBits = 3;
+  unsigned dcRegRaw = fieldFromInstruction(Insn, 14, dcRegRawNumBits);
+  static_assert((1 << dcRegRawNumBits) == std::size(eDCDecoderTable));
   Register dcReg = eDCDecoderTable[dcRegRaw];
-  assert(dcReg && "Register not found.");
+  if (!dcReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dcReg));
 
   // --------------------- Ins ------------------------
-  unsigned suRegRaw = fieldFromInstruction(Insn, 5, 2);
-  if (suRegRaw >= std::size(eSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned suRegRawNumBits = 2;
+  unsigned suRegRaw = fieldFromInstruction(Insn, 5, suRegRawNumBits);
+  static_assert((1 << suRegRawNumBits) == std::size(eSDecoderTable));
   Register suReg = eSDecoderTable[suRegRaw];
-  assert(suReg && "Register not found.");
+  if (!suReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(suReg));
 
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptrRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 3;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePDecoderTable));
   Register ptrReg = ePDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (modRegRaw >= std::size(eDDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 3;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 14, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDDecoderTable));
   Register modReg = eDDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -1252,47 +1394,53 @@ static DecodeStatus DecodeDmw_lda_ups_w2c_2D(MCInst &MI, InsnType &Insn,
                                              uint64_t Address,
                                              const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned dstRegRaw = fieldFromInstruction(Insn, 7, 4);
-  if (dstRegRaw >= std::size(mCMmDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dstRegRawNumBits = 4;
+  unsigned dstRegRaw = fieldFromInstruction(Insn, 7, dstRegRawNumBits);
+  static_assert((1 << dstRegRawNumBits) == std::size(mCMmDecoderTable));
   Register dstReg = mCMmDecoderTable[dstRegRaw];
-  assert(dstReg && "Register not found.");
+  if (!dstReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dstReg));
 
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptr_outRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 3;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePDecoderTable));
   Register ptr_outReg = ePDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned dcRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (dcRegRaw >= std::size(eDCDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dcRegRawNumBits = 3;
+  unsigned dcRegRaw = fieldFromInstruction(Insn, 14, dcRegRawNumBits);
+  static_assert((1 << dcRegRawNumBits) == std::size(eDCDecoderTable));
   Register dcReg = eDCDecoderTable[dcRegRaw];
-  assert(dcReg && "Register not found.");
+  if (!dcReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dcReg));
 
   // --------------------- Ins ------------------------
-  unsigned suRegRaw = fieldFromInstruction(Insn, 5, 2);
-  if (suRegRaw >= std::size(eSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned suRegRawNumBits = 2;
+  unsigned suRegRaw = fieldFromInstruction(Insn, 5, suRegRawNumBits);
+  static_assert((1 << suRegRawNumBits) == std::size(eSDecoderTable));
   Register suReg = eSDecoderTable[suRegRaw];
-  assert(suReg && "Register not found.");
+  if (!suReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(suReg));
 
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptrRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 3;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePDecoderTable));
   Register ptrReg = ePDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (modRegRaw >= std::size(eDDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 3;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 14, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDDecoderTable));
   Register modReg = eDDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -1303,47 +1451,53 @@ static DecodeStatus DecodeDmx_lda_ups_x2d_2D(MCInst &MI, InsnType &Insn,
                                              uint64_t Address,
                                              const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned dstRegRaw = fieldFromInstruction(Insn, 8, 3);
-  if (dstRegRaw >= std::size(eDMDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dstRegRawNumBits = 3;
+  unsigned dstRegRaw = fieldFromInstruction(Insn, 8, dstRegRawNumBits);
+  static_assert((1 << dstRegRawNumBits) == std::size(eDMDecoderTable));
   Register dstReg = eDMDecoderTable[dstRegRaw];
-  assert(dstReg && "Register not found.");
+  if (!dstReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dstReg));
 
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptr_outRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 3;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePDecoderTable));
   Register ptr_outReg = ePDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned dcRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (dcRegRaw >= std::size(eDCDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dcRegRawNumBits = 3;
+  unsigned dcRegRaw = fieldFromInstruction(Insn, 14, dcRegRawNumBits);
+  static_assert((1 << dcRegRawNumBits) == std::size(eDCDecoderTable));
   Register dcReg = eDCDecoderTable[dcRegRaw];
-  assert(dcReg && "Register not found.");
+  if (!dcReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dcReg));
 
   // --------------------- Ins ------------------------
-  unsigned suRegRaw = fieldFromInstruction(Insn, 6, 2);
-  if (suRegRaw >= std::size(eSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned suRegRawNumBits = 2;
+  unsigned suRegRaw = fieldFromInstruction(Insn, 6, suRegRawNumBits);
+  static_assert((1 << suRegRawNumBits) == std::size(eSDecoderTable));
   Register suReg = eSDecoderTable[suRegRaw];
-  assert(suReg && "Register not found.");
+  if (!suReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(suReg));
 
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptrRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 3;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePDecoderTable));
   Register ptrReg = ePDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (modRegRaw >= std::size(eDDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 3;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 14, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDDecoderTable));
   Register modReg = eDDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -1354,40 +1508,45 @@ static DecodeStatus DecodeDmw_lda_w_2D(MCInst &MI, InsnType &Insn,
                                        uint64_t Address,
                                        const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned dstRegRaw = fieldFromInstruction(Insn, 6, 5);
-  if (dstRegRaw >= std::size(mWaDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dstRegRawNumBits = 5;
+  unsigned dstRegRaw = fieldFromInstruction(Insn, 6, dstRegRawNumBits);
+  static_assert((1 << dstRegRawNumBits) == std::size(mWaDecoderTable));
   Register dstReg = mWaDecoderTable[dstRegRaw];
-  assert(dstReg && "Register not found.");
+  if (!dstReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dstReg));
 
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptr_outRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 3;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePDecoderTable));
   Register ptr_outReg = ePDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned dcRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (dcRegRaw >= std::size(eDCDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dcRegRawNumBits = 3;
+  unsigned dcRegRaw = fieldFromInstruction(Insn, 14, dcRegRawNumBits);
+  static_assert((1 << dcRegRawNumBits) == std::size(eDCDecoderTable));
   Register dcReg = eDCDecoderTable[dcRegRaw];
-  assert(dcReg && "Register not found.");
+  if (!dcReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dcReg));
 
   // --------------------- Ins ------------------------
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptrRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 3;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePDecoderTable));
   Register ptrReg = ePDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (modRegRaw >= std::size(eDDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 3;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 14, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDDecoderTable));
   Register modReg = eDDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -1398,40 +1557,45 @@ static DecodeStatus DecodeDmx_lda_bm_2D(MCInst &MI, InsnType &Insn,
                                         uint64_t Address,
                                         const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned dstRegRaw = fieldFromInstruction(Insn, 6, 5);
-  if (dstRegRaw >= std::size(mBMmDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dstRegRawNumBits = 5;
+  unsigned dstRegRaw = fieldFromInstruction(Insn, 6, dstRegRawNumBits);
+  static_assert((1 << dstRegRawNumBits) == std::size(mBMmDecoderTable));
   Register dstReg = mBMmDecoderTable[dstRegRaw];
-  assert(dstReg && "Register not found.");
+  if (!dstReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dstReg));
 
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptr_outRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 3;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePDecoderTable));
   Register ptr_outReg = ePDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned dcRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (dcRegRaw >= std::size(eDCDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dcRegRawNumBits = 3;
+  unsigned dcRegRaw = fieldFromInstruction(Insn, 14, dcRegRawNumBits);
+  static_assert((1 << dcRegRawNumBits) == std::size(eDCDecoderTable));
   Register dcReg = eDCDecoderTable[dcRegRaw];
-  assert(dcReg && "Register not found.");
+  if (!dcReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dcReg));
 
   // --------------------- Ins ------------------------
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptrRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 3;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePDecoderTable));
   Register ptrReg = ePDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (modRegRaw >= std::size(eDDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 3;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 14, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDDecoderTable));
   Register modReg = eDDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -1442,40 +1606,45 @@ static DecodeStatus DecodeDmx_lda_fifohl_2D(MCInst &MI, InsnType &Insn,
                                             uint64_t Address,
                                             const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned dstRegRaw = fieldFromInstruction(Insn, 8, 3);
-  if (dstRegRaw >= std::size(mFifoHLRegDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dstRegRawNumBits = 3;
+  unsigned dstRegRaw = fieldFromInstruction(Insn, 8, dstRegRawNumBits);
+  static_assert((1 << dstRegRawNumBits) == std::size(mFifoHLRegDecoderTable));
   Register dstReg = mFifoHLRegDecoderTable[dstRegRaw];
-  assert(dstReg && "Register not found.");
+  if (!dstReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dstReg));
 
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptr_outRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 3;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePDecoderTable));
   Register ptr_outReg = ePDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned dcRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (dcRegRaw >= std::size(eDCDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dcRegRawNumBits = 3;
+  unsigned dcRegRaw = fieldFromInstruction(Insn, 14, dcRegRawNumBits);
+  static_assert((1 << dcRegRawNumBits) == std::size(eDCDecoderTable));
   Register dcReg = eDCDecoderTable[dcRegRaw];
-  assert(dcReg && "Register not found.");
+  if (!dcReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dcReg));
 
   // --------------------- Ins ------------------------
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptrRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 3;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePDecoderTable));
   Register ptrReg = ePDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (modRegRaw >= std::size(eDDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 3;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 14, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDDecoderTable));
   Register modReg = eDDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -1486,40 +1655,45 @@ static DecodeStatus DecodeDmx_lda_x_2D(MCInst &MI, InsnType &Insn,
                                        uint64_t Address,
                                        const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned dstRegRaw = fieldFromInstruction(Insn, 7, 4);
-  if (dstRegRaw >= std::size(mXaDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dstRegRawNumBits = 4;
+  unsigned dstRegRaw = fieldFromInstruction(Insn, 7, dstRegRawNumBits);
+  static_assert((1 << dstRegRawNumBits) == std::size(mXaDecoderTable));
   Register dstReg = mXaDecoderTable[dstRegRaw];
-  assert(dstReg && "Register not found.");
+  if (!dstReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dstReg));
 
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptr_outRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 3;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePDecoderTable));
   Register ptr_outReg = ePDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned dcRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (dcRegRaw >= std::size(eDCDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dcRegRawNumBits = 3;
+  unsigned dcRegRaw = fieldFromInstruction(Insn, 14, dcRegRawNumBits);
+  static_assert((1 << dcRegRawNumBits) == std::size(eDCDecoderTable));
   Register dcReg = eDCDecoderTable[dcRegRaw];
-  assert(dcReg && "Register not found.");
+  if (!dcReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dcReg));
 
   // --------------------- Ins ------------------------
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptrRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 3;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePDecoderTable));
   Register ptrReg = ePDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (modRegRaw >= std::size(eDDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 3;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 14, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDDecoderTable));
   Register modReg = eDDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -1530,47 +1704,53 @@ static DecodeStatus DecodeDmv_lda_w_3D(MCInst &MI, InsnType &Insn,
                                        uint64_t Address,
                                        const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned dstRegRaw = fieldFromInstruction(Insn, 6, 5);
-  if (dstRegRaw >= std::size(mWaDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dstRegRawNumBits = 5;
+  unsigned dstRegRaw = fieldFromInstruction(Insn, 6, dstRegRawNumBits);
+  static_assert((1 << dstRegRawNumBits) == std::size(mWaDecoderTable));
   Register dstReg = mWaDecoderTable[dstRegRaw];
-  assert(dstReg && "Register not found.");
+  if (!dstReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dstReg));
 
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptr_outRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 3;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePDecoderTable));
   Register ptr_outReg = ePDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned dclRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (dclRegRaw >= std::size(eDCLDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dclRegRawNumBits = 2;
+  unsigned dclRegRaw = fieldFromInstruction(Insn, 14, dclRegRawNumBits);
+  static_assert((1 << dclRegRawNumBits) == std::size(eDCLDecoderTable));
   Register dclReg = eDCLDecoderTable[dclRegRaw];
-  assert(dclReg && "Register not found.");
+  if (!dclReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dclReg));
 
-  unsigned dchRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (dchRegRaw >= std::size(eDCHDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dchRegRawNumBits = 2;
+  unsigned dchRegRaw = fieldFromInstruction(Insn, 14, dchRegRawNumBits);
+  static_assert((1 << dchRegRawNumBits) == std::size(eDCHDecoderTable));
   Register dchReg = eDCHDecoderTable[dchRegRaw];
-  assert(dchReg && "Register not found.");
+  if (!dchReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dchReg));
 
   // --------------------- Ins ------------------------
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptrRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 3;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePDecoderTable));
   Register ptrReg = ePDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (modRegRaw >= std::size(eDSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 2;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 14, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDSDecoderTable));
   Register modReg = eDSDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -1581,47 +1761,53 @@ static DecodeStatus DecodeDmw_lda_ups_bf_3D(MCInst &MI, InsnType &Insn,
                                             uint64_t Address,
                                             const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned opRegRaw = fieldFromInstruction(Insn, 6, 5);
-  if (opRegRaw >= std::size(mBMmDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned opRegRawNumBits = 5;
+  unsigned opRegRaw = fieldFromInstruction(Insn, 6, opRegRawNumBits);
+  static_assert((1 << opRegRawNumBits) == std::size(mBMmDecoderTable));
   Register opReg = mBMmDecoderTable[opRegRaw];
-  assert(opReg && "Register not found.");
+  if (!opReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(opReg));
 
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptr_outRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 3;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePDecoderTable));
   Register ptr_outReg = ePDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned dclRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (dclRegRaw >= std::size(eDCLDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dclRegRawNumBits = 2;
+  unsigned dclRegRaw = fieldFromInstruction(Insn, 14, dclRegRawNumBits);
+  static_assert((1 << dclRegRawNumBits) == std::size(eDCLDecoderTable));
   Register dclReg = eDCLDecoderTable[dclRegRaw];
-  assert(dclReg && "Register not found.");
+  if (!dclReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dclReg));
 
-  unsigned dchRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (dchRegRaw >= std::size(eDCHDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dchRegRawNumBits = 2;
+  unsigned dchRegRaw = fieldFromInstruction(Insn, 14, dchRegRawNumBits);
+  static_assert((1 << dchRegRawNumBits) == std::size(eDCHDecoderTable));
   Register dchReg = eDCHDecoderTable[dchRegRaw];
-  assert(dchReg && "Register not found.");
+  if (!dchReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dchReg));
 
   // --------------------- Ins ------------------------
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptrRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 3;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePDecoderTable));
   Register ptrReg = ePDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (modRegRaw >= std::size(eDSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 2;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 14, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDSDecoderTable));
   Register modReg = eDSDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -1632,47 +1818,53 @@ static DecodeStatus DecodeDmx_lda_ups_bf_3D(MCInst &MI, InsnType &Insn,
                                             uint64_t Address,
                                             const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned opRegRaw = fieldFromInstruction(Insn, 7, 4);
-  if (opRegRaw >= std::size(mCMmDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned opRegRawNumBits = 4;
+  unsigned opRegRaw = fieldFromInstruction(Insn, 7, opRegRawNumBits);
+  static_assert((1 << opRegRawNumBits) == std::size(mCMmDecoderTable));
   Register opReg = mCMmDecoderTable[opRegRaw];
-  assert(opReg && "Register not found.");
+  if (!opReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(opReg));
 
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptr_outRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 3;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePDecoderTable));
   Register ptr_outReg = ePDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned dclRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (dclRegRaw >= std::size(eDCLDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dclRegRawNumBits = 2;
+  unsigned dclRegRaw = fieldFromInstruction(Insn, 14, dclRegRawNumBits);
+  static_assert((1 << dclRegRawNumBits) == std::size(eDCLDecoderTable));
   Register dclReg = eDCLDecoderTable[dclRegRaw];
-  assert(dclReg && "Register not found.");
+  if (!dclReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dclReg));
 
-  unsigned dchRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (dchRegRaw >= std::size(eDCHDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dchRegRawNumBits = 2;
+  unsigned dchRegRaw = fieldFromInstruction(Insn, 14, dchRegRawNumBits);
+  static_assert((1 << dchRegRawNumBits) == std::size(eDCHDecoderTable));
   Register dchReg = eDCHDecoderTable[dchRegRaw];
-  assert(dchReg && "Register not found.");
+  if (!dchReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dchReg));
 
   // --------------------- Ins ------------------------
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptrRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 3;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePDecoderTable));
   Register ptrReg = ePDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (modRegRaw >= std::size(eDSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 2;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 14, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDSDecoderTable));
   Register modReg = eDSDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -1683,54 +1875,61 @@ static DecodeStatus DecodeDmw_lda_ups_w2b_3D(MCInst &MI, InsnType &Insn,
                                              uint64_t Address,
                                              const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned dstRegRaw = fieldFromInstruction(Insn, 6, 5);
-  if (dstRegRaw >= std::size(mBMmDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dstRegRawNumBits = 5;
+  unsigned dstRegRaw = fieldFromInstruction(Insn, 6, dstRegRawNumBits);
+  static_assert((1 << dstRegRawNumBits) == std::size(mBMmDecoderTable));
   Register dstReg = mBMmDecoderTable[dstRegRaw];
-  assert(dstReg && "Register not found.");
+  if (!dstReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dstReg));
 
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptr_outRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 3;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePDecoderTable));
   Register ptr_outReg = ePDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned dclRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (dclRegRaw >= std::size(eDCLDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dclRegRawNumBits = 2;
+  unsigned dclRegRaw = fieldFromInstruction(Insn, 14, dclRegRawNumBits);
+  static_assert((1 << dclRegRawNumBits) == std::size(eDCLDecoderTable));
   Register dclReg = eDCLDecoderTable[dclRegRaw];
-  assert(dclReg && "Register not found.");
+  if (!dclReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dclReg));
 
-  unsigned dchRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (dchRegRaw >= std::size(eDCHDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dchRegRawNumBits = 2;
+  unsigned dchRegRaw = fieldFromInstruction(Insn, 14, dchRegRawNumBits);
+  static_assert((1 << dchRegRawNumBits) == std::size(eDCHDecoderTable));
   Register dchReg = eDCHDecoderTable[dchRegRaw];
-  assert(dchReg && "Register not found.");
+  if (!dchReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dchReg));
 
   // --------------------- Ins ------------------------
-  unsigned suRegRaw = fieldFromInstruction(Insn, 4, 2);
-  if (suRegRaw >= std::size(eSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned suRegRawNumBits = 2;
+  unsigned suRegRaw = fieldFromInstruction(Insn, 4, suRegRawNumBits);
+  static_assert((1 << suRegRawNumBits) == std::size(eSDecoderTable));
   Register suReg = eSDecoderTable[suRegRaw];
-  assert(suReg && "Register not found.");
+  if (!suReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(suReg));
 
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptrRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 3;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePDecoderTable));
   Register ptrReg = ePDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (modRegRaw >= std::size(eDSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 2;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 14, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDSDecoderTable));
   Register modReg = eDSDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -1741,54 +1940,61 @@ static DecodeStatus DecodeDmx_lda_ups_x2c_3D(MCInst &MI, InsnType &Insn,
                                              uint64_t Address,
                                              const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned dstRegRaw = fieldFromInstruction(Insn, 7, 4);
-  if (dstRegRaw >= std::size(mCMmDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dstRegRawNumBits = 4;
+  unsigned dstRegRaw = fieldFromInstruction(Insn, 7, dstRegRawNumBits);
+  static_assert((1 << dstRegRawNumBits) == std::size(mCMmDecoderTable));
   Register dstReg = mCMmDecoderTable[dstRegRaw];
-  assert(dstReg && "Register not found.");
+  if (!dstReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dstReg));
 
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptr_outRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 3;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePDecoderTable));
   Register ptr_outReg = ePDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned dclRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (dclRegRaw >= std::size(eDCLDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dclRegRawNumBits = 2;
+  unsigned dclRegRaw = fieldFromInstruction(Insn, 14, dclRegRawNumBits);
+  static_assert((1 << dclRegRawNumBits) == std::size(eDCLDecoderTable));
   Register dclReg = eDCLDecoderTable[dclRegRaw];
-  assert(dclReg && "Register not found.");
+  if (!dclReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dclReg));
 
-  unsigned dchRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (dchRegRaw >= std::size(eDCHDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dchRegRawNumBits = 2;
+  unsigned dchRegRaw = fieldFromInstruction(Insn, 14, dchRegRawNumBits);
+  static_assert((1 << dchRegRawNumBits) == std::size(eDCHDecoderTable));
   Register dchReg = eDCHDecoderTable[dchRegRaw];
-  assert(dchReg && "Register not found.");
+  if (!dchReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dchReg));
 
   // --------------------- Ins ------------------------
-  unsigned suRegRaw = fieldFromInstruction(Insn, 5, 2);
-  if (suRegRaw >= std::size(eSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned suRegRawNumBits = 2;
+  unsigned suRegRaw = fieldFromInstruction(Insn, 5, suRegRawNumBits);
+  static_assert((1 << suRegRawNumBits) == std::size(eSDecoderTable));
   Register suReg = eSDecoderTable[suRegRaw];
-  assert(suReg && "Register not found.");
+  if (!suReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(suReg));
 
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptrRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 3;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePDecoderTable));
   Register ptrReg = ePDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (modRegRaw >= std::size(eDSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 2;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 14, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDSDecoderTable));
   Register modReg = eDSDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -1799,54 +2005,61 @@ static DecodeStatus DecodeDmw_lda_ups_w2c_3D(MCInst &MI, InsnType &Insn,
                                              uint64_t Address,
                                              const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned dstRegRaw = fieldFromInstruction(Insn, 7, 4);
-  if (dstRegRaw >= std::size(mCMmDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dstRegRawNumBits = 4;
+  unsigned dstRegRaw = fieldFromInstruction(Insn, 7, dstRegRawNumBits);
+  static_assert((1 << dstRegRawNumBits) == std::size(mCMmDecoderTable));
   Register dstReg = mCMmDecoderTable[dstRegRaw];
-  assert(dstReg && "Register not found.");
+  if (!dstReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dstReg));
 
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptr_outRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 3;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePDecoderTable));
   Register ptr_outReg = ePDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned dclRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (dclRegRaw >= std::size(eDCLDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dclRegRawNumBits = 2;
+  unsigned dclRegRaw = fieldFromInstruction(Insn, 14, dclRegRawNumBits);
+  static_assert((1 << dclRegRawNumBits) == std::size(eDCLDecoderTable));
   Register dclReg = eDCLDecoderTable[dclRegRaw];
-  assert(dclReg && "Register not found.");
+  if (!dclReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dclReg));
 
-  unsigned dchRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (dchRegRaw >= std::size(eDCHDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dchRegRawNumBits = 2;
+  unsigned dchRegRaw = fieldFromInstruction(Insn, 14, dchRegRawNumBits);
+  static_assert((1 << dchRegRawNumBits) == std::size(eDCHDecoderTable));
   Register dchReg = eDCHDecoderTable[dchRegRaw];
-  assert(dchReg && "Register not found.");
+  if (!dchReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dchReg));
 
   // --------------------- Ins ------------------------
-  unsigned suRegRaw = fieldFromInstruction(Insn, 5, 2);
-  if (suRegRaw >= std::size(eSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned suRegRawNumBits = 2;
+  unsigned suRegRaw = fieldFromInstruction(Insn, 5, suRegRawNumBits);
+  static_assert((1 << suRegRawNumBits) == std::size(eSDecoderTable));
   Register suReg = eSDecoderTable[suRegRaw];
-  assert(suReg && "Register not found.");
+  if (!suReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(suReg));
 
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptrRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 3;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePDecoderTable));
   Register ptrReg = ePDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (modRegRaw >= std::size(eDSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 2;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 14, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDSDecoderTable));
   Register modReg = eDSDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -1857,54 +2070,61 @@ static DecodeStatus DecodeDmx_lda_ups_x2d_3D(MCInst &MI, InsnType &Insn,
                                              uint64_t Address,
                                              const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned dstRegRaw = fieldFromInstruction(Insn, 8, 3);
-  if (dstRegRaw >= std::size(eDMDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dstRegRawNumBits = 3;
+  unsigned dstRegRaw = fieldFromInstruction(Insn, 8, dstRegRawNumBits);
+  static_assert((1 << dstRegRawNumBits) == std::size(eDMDecoderTable));
   Register dstReg = eDMDecoderTable[dstRegRaw];
-  assert(dstReg && "Register not found.");
+  if (!dstReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dstReg));
 
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptr_outRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 3;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePDecoderTable));
   Register ptr_outReg = ePDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned dclRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (dclRegRaw >= std::size(eDCLDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dclRegRawNumBits = 2;
+  unsigned dclRegRaw = fieldFromInstruction(Insn, 14, dclRegRawNumBits);
+  static_assert((1 << dclRegRawNumBits) == std::size(eDCLDecoderTable));
   Register dclReg = eDCLDecoderTable[dclRegRaw];
-  assert(dclReg && "Register not found.");
+  if (!dclReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dclReg));
 
-  unsigned dchRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (dchRegRaw >= std::size(eDCHDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dchRegRawNumBits = 2;
+  unsigned dchRegRaw = fieldFromInstruction(Insn, 14, dchRegRawNumBits);
+  static_assert((1 << dchRegRawNumBits) == std::size(eDCHDecoderTable));
   Register dchReg = eDCHDecoderTable[dchRegRaw];
-  assert(dchReg && "Register not found.");
+  if (!dchReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dchReg));
 
   // --------------------- Ins ------------------------
-  unsigned suRegRaw = fieldFromInstruction(Insn, 6, 2);
-  if (suRegRaw >= std::size(eSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned suRegRawNumBits = 2;
+  unsigned suRegRaw = fieldFromInstruction(Insn, 6, suRegRawNumBits);
+  static_assert((1 << suRegRawNumBits) == std::size(eSDecoderTable));
   Register suReg = eSDecoderTable[suRegRaw];
-  assert(suReg && "Register not found.");
+  if (!suReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(suReg));
 
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptrRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 3;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePDecoderTable));
   Register ptrReg = ePDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (modRegRaw >= std::size(eDSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 2;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 14, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDSDecoderTable));
   Register modReg = eDSDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -1915,47 +2135,53 @@ static DecodeStatus DecodeDmw_lda_w_3D(MCInst &MI, InsnType &Insn,
                                        uint64_t Address,
                                        const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned dstRegRaw = fieldFromInstruction(Insn, 6, 5);
-  if (dstRegRaw >= std::size(mWaDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dstRegRawNumBits = 5;
+  unsigned dstRegRaw = fieldFromInstruction(Insn, 6, dstRegRawNumBits);
+  static_assert((1 << dstRegRawNumBits) == std::size(mWaDecoderTable));
   Register dstReg = mWaDecoderTable[dstRegRaw];
-  assert(dstReg && "Register not found.");
+  if (!dstReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dstReg));
 
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptr_outRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 3;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePDecoderTable));
   Register ptr_outReg = ePDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned dclRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (dclRegRaw >= std::size(eDCLDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dclRegRawNumBits = 2;
+  unsigned dclRegRaw = fieldFromInstruction(Insn, 14, dclRegRawNumBits);
+  static_assert((1 << dclRegRawNumBits) == std::size(eDCLDecoderTable));
   Register dclReg = eDCLDecoderTable[dclRegRaw];
-  assert(dclReg && "Register not found.");
+  if (!dclReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dclReg));
 
-  unsigned dchRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (dchRegRaw >= std::size(eDCHDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dchRegRawNumBits = 2;
+  unsigned dchRegRaw = fieldFromInstruction(Insn, 14, dchRegRawNumBits);
+  static_assert((1 << dchRegRawNumBits) == std::size(eDCHDecoderTable));
   Register dchReg = eDCHDecoderTable[dchRegRaw];
-  assert(dchReg && "Register not found.");
+  if (!dchReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dchReg));
 
   // --------------------- Ins ------------------------
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptrRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 3;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePDecoderTable));
   Register ptrReg = ePDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (modRegRaw >= std::size(eDSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 2;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 14, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDSDecoderTable));
   Register modReg = eDSDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -1966,47 +2192,53 @@ static DecodeStatus DecodeDmx_lda_bm_3D(MCInst &MI, InsnType &Insn,
                                         uint64_t Address,
                                         const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned dstRegRaw = fieldFromInstruction(Insn, 6, 5);
-  if (dstRegRaw >= std::size(mBMmDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dstRegRawNumBits = 5;
+  unsigned dstRegRaw = fieldFromInstruction(Insn, 6, dstRegRawNumBits);
+  static_assert((1 << dstRegRawNumBits) == std::size(mBMmDecoderTable));
   Register dstReg = mBMmDecoderTable[dstRegRaw];
-  assert(dstReg && "Register not found.");
+  if (!dstReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dstReg));
 
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptr_outRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 3;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePDecoderTable));
   Register ptr_outReg = ePDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned dclRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (dclRegRaw >= std::size(eDCLDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dclRegRawNumBits = 2;
+  unsigned dclRegRaw = fieldFromInstruction(Insn, 14, dclRegRawNumBits);
+  static_assert((1 << dclRegRawNumBits) == std::size(eDCLDecoderTable));
   Register dclReg = eDCLDecoderTable[dclRegRaw];
-  assert(dclReg && "Register not found.");
+  if (!dclReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dclReg));
 
-  unsigned dchRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (dchRegRaw >= std::size(eDCHDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dchRegRawNumBits = 2;
+  unsigned dchRegRaw = fieldFromInstruction(Insn, 14, dchRegRawNumBits);
+  static_assert((1 << dchRegRawNumBits) == std::size(eDCHDecoderTable));
   Register dchReg = eDCHDecoderTable[dchRegRaw];
-  assert(dchReg && "Register not found.");
+  if (!dchReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dchReg));
 
   // --------------------- Ins ------------------------
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptrRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 3;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePDecoderTable));
   Register ptrReg = ePDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (modRegRaw >= std::size(eDSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 2;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 14, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDSDecoderTable));
   Register modReg = eDSDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -2017,47 +2249,53 @@ static DecodeStatus DecodeDmx_lda_fifohl_3D(MCInst &MI, InsnType &Insn,
                                             uint64_t Address,
                                             const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned dstRegRaw = fieldFromInstruction(Insn, 8, 3);
-  if (dstRegRaw >= std::size(mFifoHLRegDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dstRegRawNumBits = 3;
+  unsigned dstRegRaw = fieldFromInstruction(Insn, 8, dstRegRawNumBits);
+  static_assert((1 << dstRegRawNumBits) == std::size(mFifoHLRegDecoderTable));
   Register dstReg = mFifoHLRegDecoderTable[dstRegRaw];
-  assert(dstReg && "Register not found.");
+  if (!dstReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dstReg));
 
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptr_outRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 3;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePDecoderTable));
   Register ptr_outReg = ePDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned dclRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (dclRegRaw >= std::size(eDCLDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dclRegRawNumBits = 2;
+  unsigned dclRegRaw = fieldFromInstruction(Insn, 14, dclRegRawNumBits);
+  static_assert((1 << dclRegRawNumBits) == std::size(eDCLDecoderTable));
   Register dclReg = eDCLDecoderTable[dclRegRaw];
-  assert(dclReg && "Register not found.");
+  if (!dclReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dclReg));
 
-  unsigned dchRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (dchRegRaw >= std::size(eDCHDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dchRegRawNumBits = 2;
+  unsigned dchRegRaw = fieldFromInstruction(Insn, 14, dchRegRawNumBits);
+  static_assert((1 << dchRegRawNumBits) == std::size(eDCHDecoderTable));
   Register dchReg = eDCHDecoderTable[dchRegRaw];
-  assert(dchReg && "Register not found.");
+  if (!dchReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dchReg));
 
   // --------------------- Ins ------------------------
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptrRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 3;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePDecoderTable));
   Register ptrReg = ePDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (modRegRaw >= std::size(eDSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 2;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 14, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDSDecoderTable));
   Register modReg = eDSDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -2068,47 +2306,53 @@ static DecodeStatus DecodeDmx_lda_x_3D(MCInst &MI, InsnType &Insn,
                                        uint64_t Address,
                                        const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned dstRegRaw = fieldFromInstruction(Insn, 7, 4);
-  if (dstRegRaw >= std::size(mXaDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dstRegRawNumBits = 4;
+  unsigned dstRegRaw = fieldFromInstruction(Insn, 7, dstRegRawNumBits);
+  static_assert((1 << dstRegRawNumBits) == std::size(mXaDecoderTable));
   Register dstReg = mXaDecoderTable[dstRegRaw];
-  assert(dstReg && "Register not found.");
+  if (!dstReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dstReg));
 
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptr_outRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 3;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePDecoderTable));
   Register ptr_outReg = ePDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned dclRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (dclRegRaw >= std::size(eDCLDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dclRegRawNumBits = 2;
+  unsigned dclRegRaw = fieldFromInstruction(Insn, 14, dclRegRawNumBits);
+  static_assert((1 << dclRegRawNumBits) == std::size(eDCLDecoderTable));
   Register dclReg = eDCLDecoderTable[dclRegRaw];
-  assert(dclReg && "Register not found.");
+  if (!dclReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dclReg));
 
-  unsigned dchRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (dchRegRaw >= std::size(eDCHDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dchRegRawNumBits = 2;
+  unsigned dchRegRaw = fieldFromInstruction(Insn, 14, dchRegRawNumBits);
+  static_assert((1 << dchRegRawNumBits) == std::size(eDCHDecoderTable));
   Register dchReg = eDCHDecoderTable[dchRegRaw];
-  assert(dchReg && "Register not found.");
+  if (!dchReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dchReg));
 
   // --------------------- Ins ------------------------
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptrRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 3;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePDecoderTable));
   Register ptrReg = ePDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (modRegRaw >= std::size(eDSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 2;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 14, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDSDecoderTable));
   Register modReg = eDSDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -2119,47 +2363,57 @@ static DecodeStatus DecodeVLDA_FILL_512(MCInst &MI, InsnType &Insn,
                                         uint64_t Address,
                                         const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (ptr_outRegRaw >= std::size(ePSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 1;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePSDecoderTable));
   Register ptr_outReg = ePSDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned fifo_reg_outRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (fifo_reg_outRegRaw >= std::size(eLdFifoRegDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned fifo_reg_outRegRawNumBits = 1;
+  unsigned fifo_reg_outRegRaw =
+      fieldFromInstruction(Insn, 17, fifo_reg_outRegRawNumBits);
+  static_assert((1 << fifo_reg_outRegRawNumBits) ==
+                std::size(eLdFifoRegDecoderTable));
   Register fifo_reg_outReg = eLdFifoRegDecoderTable[fifo_reg_outRegRaw];
-  assert(fifo_reg_outReg && "Register not found.");
+  if (!fifo_reg_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(fifo_reg_outReg));
 
-  unsigned pos_outRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (pos_outRegRaw >= std::size(eRF2DecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned pos_outRegRawNumBits = 1;
+  unsigned pos_outRegRaw = fieldFromInstruction(Insn, 17, pos_outRegRawNumBits);
+  static_assert((1 << pos_outRegRawNumBits) == std::size(eRF2DecoderTable));
   Register pos_outReg = eRF2DecoderTable[pos_outRegRaw];
-  assert(pos_outReg && "Register not found.");
+  if (!pos_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(pos_outReg));
 
   // --------------------- Ins ------------------------
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (ptrRegRaw >= std::size(ePSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 1;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePSDecoderTable));
   Register ptrReg = ePSDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned fifo_regRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (fifo_regRegRaw >= std::size(eLdFifoRegDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned fifo_regRegRawNumBits = 1;
+  unsigned fifo_regRegRaw =
+      fieldFromInstruction(Insn, 17, fifo_regRegRawNumBits);
+  static_assert((1 << fifo_regRegRawNumBits) ==
+                std::size(eLdFifoRegDecoderTable));
   Register fifo_regReg = eLdFifoRegDecoderTable[fifo_regRegRaw];
-  assert(fifo_regReg && "Register not found.");
+  if (!fifo_regReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(fifo_regReg));
 
-  unsigned posRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (posRegRaw >= std::size(eRF2DecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned posRegRawNumBits = 1;
+  unsigned posRegRaw = fieldFromInstruction(Insn, 17, posRegRawNumBits);
+  static_assert((1 << posRegRawNumBits) == std::size(eRF2DecoderTable));
   Register posReg = eRF2DecoderTable[posRegRaw];
-  assert(posReg && "Register not found.");
+  if (!posReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(posReg));
 
   return MCDisassembler::Success;
@@ -2170,68 +2424,81 @@ static DecodeStatus
 DecodeDmx_lda_fifo_x__fifo_2d_pop(MCInst &MI, InsnType &Insn, uint64_t Address,
                                   const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned dstRegRaw = fieldFromInstruction(Insn, 7, 4);
-  if (dstRegRaw >= std::size(mXaDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dstRegRawNumBits = 4;
+  unsigned dstRegRaw = fieldFromInstruction(Insn, 7, dstRegRawNumBits);
+  static_assert((1 << dstRegRawNumBits) == std::size(mXaDecoderTable));
   Register dstReg = mXaDecoderTable[dstRegRaw];
-  assert(dstReg && "Register not found.");
+  if (!dstReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dstReg));
 
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (ptr_outRegRaw >= std::size(ePSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 1;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePSDecoderTable));
   Register ptr_outReg = ePSDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned fifo_reg_outRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (fifo_reg_outRegRaw >= std::size(eLdFifoRegDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned fifo_reg_outRegRawNumBits = 1;
+  unsigned fifo_reg_outRegRaw =
+      fieldFromInstruction(Insn, 17, fifo_reg_outRegRawNumBits);
+  static_assert((1 << fifo_reg_outRegRawNumBits) ==
+                std::size(eLdFifoRegDecoderTable));
   Register fifo_reg_outReg = eLdFifoRegDecoderTable[fifo_reg_outRegRaw];
-  assert(fifo_reg_outReg && "Register not found.");
+  if (!fifo_reg_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(fifo_reg_outReg));
 
-  unsigned pos_outRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (pos_outRegRaw >= std::size(eRF2DecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned pos_outRegRawNumBits = 1;
+  unsigned pos_outRegRaw = fieldFromInstruction(Insn, 17, pos_outRegRawNumBits);
+  static_assert((1 << pos_outRegRawNumBits) == std::size(eRF2DecoderTable));
   Register pos_outReg = eRF2DecoderTable[pos_outRegRaw];
-  assert(pos_outReg && "Register not found.");
+  if (!pos_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(pos_outReg));
 
-  unsigned dcRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (dcRegRaw >= std::size(eDCDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dcRegRawNumBits = 3;
+  unsigned dcRegRaw = fieldFromInstruction(Insn, 14, dcRegRawNumBits);
+  static_assert((1 << dcRegRawNumBits) == std::size(eDCDecoderTable));
   Register dcReg = eDCDecoderTable[dcRegRaw];
-  assert(dcReg && "Register not found.");
+  if (!dcReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dcReg));
 
   // --------------------- Ins ------------------------
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (ptrRegRaw >= std::size(ePSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 1;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePSDecoderTable));
   Register ptrReg = ePSDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned fifo_regRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (fifo_regRegRaw >= std::size(eLdFifoRegDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned fifo_regRegRawNumBits = 1;
+  unsigned fifo_regRegRaw =
+      fieldFromInstruction(Insn, 17, fifo_regRegRawNumBits);
+  static_assert((1 << fifo_regRegRawNumBits) ==
+                std::size(eLdFifoRegDecoderTable));
   Register fifo_regReg = eLdFifoRegDecoderTable[fifo_regRegRaw];
-  assert(fifo_regReg && "Register not found.");
+  if (!fifo_regReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(fifo_regReg));
 
-  unsigned posRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (posRegRaw >= std::size(eRF2DecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned posRegRawNumBits = 1;
+  unsigned posRegRaw = fieldFromInstruction(Insn, 17, posRegRawNumBits);
+  static_assert((1 << posRegRawNumBits) == std::size(eRF2DecoderTable));
   Register posReg = eRF2DecoderTable[posRegRaw];
-  assert(posReg && "Register not found.");
+  if (!posReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(posReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (modRegRaw >= std::size(eDDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 3;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 14, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDDecoderTable));
   Register modReg = eDDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -2242,75 +2509,89 @@ static DecodeStatus
 DecodeDmx_lda_fifo_x__fifo_3d_pop(MCInst &MI, InsnType &Insn, uint64_t Address,
                                   const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned dstRegRaw = fieldFromInstruction(Insn, 7, 4);
-  if (dstRegRaw >= std::size(mXaDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dstRegRawNumBits = 4;
+  unsigned dstRegRaw = fieldFromInstruction(Insn, 7, dstRegRawNumBits);
+  static_assert((1 << dstRegRawNumBits) == std::size(mXaDecoderTable));
   Register dstReg = mXaDecoderTable[dstRegRaw];
-  assert(dstReg && "Register not found.");
+  if (!dstReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dstReg));
 
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (ptr_outRegRaw >= std::size(ePSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 1;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePSDecoderTable));
   Register ptr_outReg = ePSDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned fifo_reg_outRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (fifo_reg_outRegRaw >= std::size(eLdFifoRegDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned fifo_reg_outRegRawNumBits = 1;
+  unsigned fifo_reg_outRegRaw =
+      fieldFromInstruction(Insn, 17, fifo_reg_outRegRawNumBits);
+  static_assert((1 << fifo_reg_outRegRawNumBits) ==
+                std::size(eLdFifoRegDecoderTable));
   Register fifo_reg_outReg = eLdFifoRegDecoderTable[fifo_reg_outRegRaw];
-  assert(fifo_reg_outReg && "Register not found.");
+  if (!fifo_reg_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(fifo_reg_outReg));
 
-  unsigned pos_outRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (pos_outRegRaw >= std::size(eRF2DecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned pos_outRegRawNumBits = 1;
+  unsigned pos_outRegRaw = fieldFromInstruction(Insn, 17, pos_outRegRawNumBits);
+  static_assert((1 << pos_outRegRawNumBits) == std::size(eRF2DecoderTable));
   Register pos_outReg = eRF2DecoderTable[pos_outRegRaw];
-  assert(pos_outReg && "Register not found.");
+  if (!pos_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(pos_outReg));
 
-  unsigned dclRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (dclRegRaw >= std::size(eDCLDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dclRegRawNumBits = 2;
+  unsigned dclRegRaw = fieldFromInstruction(Insn, 14, dclRegRawNumBits);
+  static_assert((1 << dclRegRawNumBits) == std::size(eDCLDecoderTable));
   Register dclReg = eDCLDecoderTable[dclRegRaw];
-  assert(dclReg && "Register not found.");
+  if (!dclReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dclReg));
 
-  unsigned dchRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (dchRegRaw >= std::size(eDCHDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dchRegRawNumBits = 2;
+  unsigned dchRegRaw = fieldFromInstruction(Insn, 14, dchRegRawNumBits);
+  static_assert((1 << dchRegRawNumBits) == std::size(eDCHDecoderTable));
   Register dchReg = eDCHDecoderTable[dchRegRaw];
-  assert(dchReg && "Register not found.");
+  if (!dchReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dchReg));
 
   // --------------------- Ins ------------------------
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (ptrRegRaw >= std::size(ePSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 1;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePSDecoderTable));
   Register ptrReg = ePSDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned fifo_regRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (fifo_regRegRaw >= std::size(eLdFifoRegDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned fifo_regRegRawNumBits = 1;
+  unsigned fifo_regRegRaw =
+      fieldFromInstruction(Insn, 17, fifo_regRegRawNumBits);
+  static_assert((1 << fifo_regRegRawNumBits) ==
+                std::size(eLdFifoRegDecoderTable));
   Register fifo_regReg = eLdFifoRegDecoderTable[fifo_regRegRaw];
-  assert(fifo_regReg && "Register not found.");
+  if (!fifo_regReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(fifo_regReg));
 
-  unsigned posRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (posRegRaw >= std::size(eRF2DecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned posRegRawNumBits = 1;
+  unsigned posRegRaw = fieldFromInstruction(Insn, 17, posRegRawNumBits);
+  static_assert((1 << posRegRawNumBits) == std::size(eRF2DecoderTable));
   Register posReg = eRF2DecoderTable[posRegRaw];
-  assert(posReg && "Register not found.");
+  if (!posReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(posReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (modRegRaw >= std::size(eDSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 2;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 14, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDSDecoderTable));
   Register modReg = eDSDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -2321,61 +2602,73 @@ static DecodeStatus
 DecodeVLDA_POP_512_fifo_1d_pop(MCInst &MI, InsnType &Insn, uint64_t Address,
                                const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned dstRegRaw = fieldFromInstruction(Insn, 7, 4);
-  if (dstRegRaw >= std::size(mXaDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dstRegRawNumBits = 4;
+  unsigned dstRegRaw = fieldFromInstruction(Insn, 7, dstRegRawNumBits);
+  static_assert((1 << dstRegRawNumBits) == std::size(mXaDecoderTable));
   Register dstReg = mXaDecoderTable[dstRegRaw];
-  assert(dstReg && "Register not found.");
+  if (!dstReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dstReg));
 
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (ptr_outRegRaw >= std::size(ePSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 1;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePSDecoderTable));
   Register ptr_outReg = ePSDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned fifo_reg_outRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (fifo_reg_outRegRaw >= std::size(eLdFifoRegDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned fifo_reg_outRegRawNumBits = 1;
+  unsigned fifo_reg_outRegRaw =
+      fieldFromInstruction(Insn, 17, fifo_reg_outRegRawNumBits);
+  static_assert((1 << fifo_reg_outRegRawNumBits) ==
+                std::size(eLdFifoRegDecoderTable));
   Register fifo_reg_outReg = eLdFifoRegDecoderTable[fifo_reg_outRegRaw];
-  assert(fifo_reg_outReg && "Register not found.");
+  if (!fifo_reg_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(fifo_reg_outReg));
 
-  unsigned pos_outRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (pos_outRegRaw >= std::size(eRF2DecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned pos_outRegRawNumBits = 1;
+  unsigned pos_outRegRaw = fieldFromInstruction(Insn, 17, pos_outRegRawNumBits);
+  static_assert((1 << pos_outRegRawNumBits) == std::size(eRF2DecoderTable));
   Register pos_outReg = eRF2DecoderTable[pos_outRegRaw];
-  assert(pos_outReg && "Register not found.");
+  if (!pos_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(pos_outReg));
 
   // --------------------- Ins ------------------------
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (ptrRegRaw >= std::size(ePSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 1;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePSDecoderTable));
   Register ptrReg = ePSDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned fifo_regRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (fifo_regRegRaw >= std::size(eLdFifoRegDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned fifo_regRegRawNumBits = 1;
+  unsigned fifo_regRegRaw =
+      fieldFromInstruction(Insn, 17, fifo_regRegRawNumBits);
+  static_assert((1 << fifo_regRegRawNumBits) ==
+                std::size(eLdFifoRegDecoderTable));
   Register fifo_regReg = eLdFifoRegDecoderTable[fifo_regRegRaw];
-  assert(fifo_regReg && "Register not found.");
+  if (!fifo_regReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(fifo_regReg));
 
-  unsigned posRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (posRegRaw >= std::size(eRF2DecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned posRegRawNumBits = 1;
+  unsigned posRegRaw = fieldFromInstruction(Insn, 17, posRegRawNumBits);
+  static_assert((1 << posRegRawNumBits) == std::size(eRF2DecoderTable));
   Register posReg = eRF2DecoderTable[posRegRaw];
-  assert(posReg && "Register not found.");
+  if (!posReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(posReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (modRegRaw >= std::size(eMDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 3;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 14, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eMDecoderTable));
   Register modReg = eMDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -2386,54 +2679,65 @@ static DecodeStatus
 DecodeVLDA_POP_512_normal_pop(MCInst &MI, InsnType &Insn, uint64_t Address,
                               const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned dstRegRaw = fieldFromInstruction(Insn, 7, 4);
-  if (dstRegRaw >= std::size(mXaDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dstRegRawNumBits = 4;
+  unsigned dstRegRaw = fieldFromInstruction(Insn, 7, dstRegRawNumBits);
+  static_assert((1 << dstRegRawNumBits) == std::size(mXaDecoderTable));
   Register dstReg = mXaDecoderTable[dstRegRaw];
-  assert(dstReg && "Register not found.");
+  if (!dstReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dstReg));
 
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (ptr_outRegRaw >= std::size(ePSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 1;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePSDecoderTable));
   Register ptr_outReg = ePSDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned fifo_reg_outRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (fifo_reg_outRegRaw >= std::size(eLdFifoRegDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned fifo_reg_outRegRawNumBits = 1;
+  unsigned fifo_reg_outRegRaw =
+      fieldFromInstruction(Insn, 17, fifo_reg_outRegRawNumBits);
+  static_assert((1 << fifo_reg_outRegRawNumBits) ==
+                std::size(eLdFifoRegDecoderTable));
   Register fifo_reg_outReg = eLdFifoRegDecoderTable[fifo_reg_outRegRaw];
-  assert(fifo_reg_outReg && "Register not found.");
+  if (!fifo_reg_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(fifo_reg_outReg));
 
-  unsigned pos_outRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (pos_outRegRaw >= std::size(eRF2DecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned pos_outRegRawNumBits = 1;
+  unsigned pos_outRegRaw = fieldFromInstruction(Insn, 17, pos_outRegRawNumBits);
+  static_assert((1 << pos_outRegRawNumBits) == std::size(eRF2DecoderTable));
   Register pos_outReg = eRF2DecoderTable[pos_outRegRaw];
-  assert(pos_outReg && "Register not found.");
+  if (!pos_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(pos_outReg));
 
   // --------------------- Ins ------------------------
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (ptrRegRaw >= std::size(ePSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 1;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePSDecoderTable));
   Register ptrReg = ePSDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned fifo_regRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (fifo_regRegRaw >= std::size(eLdFifoRegDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned fifo_regRegRawNumBits = 1;
+  unsigned fifo_regRegRaw =
+      fieldFromInstruction(Insn, 17, fifo_regRegRawNumBits);
+  static_assert((1 << fifo_regRegRawNumBits) ==
+                std::size(eLdFifoRegDecoderTable));
   Register fifo_regReg = eLdFifoRegDecoderTable[fifo_regRegRaw];
-  assert(fifo_regReg && "Register not found.");
+  if (!fifo_regReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(fifo_regReg));
 
-  unsigned posRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (posRegRaw >= std::size(eRF2DecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned posRegRawNumBits = 1;
+  unsigned posRegRaw = fieldFromInstruction(Insn, 17, posRegRawNumBits);
+  static_assert((1 << posRegRawNumBits) == std::size(eRF2DecoderTable));
   Register posReg = eRF2DecoderTable[posRegRaw];
-  assert(posReg && "Register not found.");
+  if (!posReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(posReg));
 
   return MCDisassembler::Success;
@@ -2445,68 +2749,81 @@ DecodeDmx_lda_fifo_ex_ebs16__fifo_2d_pop(MCInst &MI, InsnType &Insn,
                                          uint64_t Address,
                                          const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned dstRegRaw = fieldFromInstruction(Insn, 7, 4);
-  if (dstRegRaw >= std::size(mEXaDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dstRegRawNumBits = 4;
+  unsigned dstRegRaw = fieldFromInstruction(Insn, 7, dstRegRawNumBits);
+  static_assert((1 << dstRegRawNumBits) == std::size(mEXaDecoderTable));
   Register dstReg = mEXaDecoderTable[dstRegRaw];
-  assert(dstReg && "Register not found.");
+  if (!dstReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dstReg));
 
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (ptr_outRegRaw >= std::size(ePSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 1;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePSDecoderTable));
   Register ptr_outReg = ePSDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned fifo_reg_outRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (fifo_reg_outRegRaw >= std::size(eLdFifoRegDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned fifo_reg_outRegRawNumBits = 1;
+  unsigned fifo_reg_outRegRaw =
+      fieldFromInstruction(Insn, 17, fifo_reg_outRegRawNumBits);
+  static_assert((1 << fifo_reg_outRegRawNumBits) ==
+                std::size(eLdFifoRegDecoderTable));
   Register fifo_reg_outReg = eLdFifoRegDecoderTable[fifo_reg_outRegRaw];
-  assert(fifo_reg_outReg && "Register not found.");
+  if (!fifo_reg_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(fifo_reg_outReg));
 
-  unsigned pos_outRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (pos_outRegRaw >= std::size(eRF2DecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned pos_outRegRawNumBits = 1;
+  unsigned pos_outRegRaw = fieldFromInstruction(Insn, 17, pos_outRegRawNumBits);
+  static_assert((1 << pos_outRegRawNumBits) == std::size(eRF2DecoderTable));
   Register pos_outReg = eRF2DecoderTable[pos_outRegRaw];
-  assert(pos_outReg && "Register not found.");
+  if (!pos_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(pos_outReg));
 
-  unsigned dcRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (dcRegRaw >= std::size(eDCDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dcRegRawNumBits = 3;
+  unsigned dcRegRaw = fieldFromInstruction(Insn, 14, dcRegRawNumBits);
+  static_assert((1 << dcRegRawNumBits) == std::size(eDCDecoderTable));
   Register dcReg = eDCDecoderTable[dcRegRaw];
-  assert(dcReg && "Register not found.");
+  if (!dcReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dcReg));
 
   // --------------------- Ins ------------------------
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (ptrRegRaw >= std::size(ePSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 1;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePSDecoderTable));
   Register ptrReg = ePSDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned fifo_regRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (fifo_regRegRaw >= std::size(eLdFifoRegDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned fifo_regRegRawNumBits = 1;
+  unsigned fifo_regRegRaw =
+      fieldFromInstruction(Insn, 17, fifo_regRegRawNumBits);
+  static_assert((1 << fifo_regRegRawNumBits) ==
+                std::size(eLdFifoRegDecoderTable));
   Register fifo_regReg = eLdFifoRegDecoderTable[fifo_regRegRaw];
-  assert(fifo_regReg && "Register not found.");
+  if (!fifo_regReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(fifo_regReg));
 
-  unsigned posRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (posRegRaw >= std::size(eRF2DecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned posRegRawNumBits = 1;
+  unsigned posRegRaw = fieldFromInstruction(Insn, 17, posRegRawNumBits);
+  static_assert((1 << posRegRawNumBits) == std::size(eRF2DecoderTable));
   Register posReg = eRF2DecoderTable[posRegRaw];
-  assert(posReg && "Register not found.");
+  if (!posReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(posReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (modRegRaw >= std::size(eDDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 3;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 14, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDDecoderTable));
   Register modReg = eDDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -2518,75 +2835,89 @@ DecodeDmx_lda_fifo_ex_ebs16__fifo_3d_pop(MCInst &MI, InsnType &Insn,
                                          uint64_t Address,
                                          const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned dstRegRaw = fieldFromInstruction(Insn, 7, 4);
-  if (dstRegRaw >= std::size(mEXaDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dstRegRawNumBits = 4;
+  unsigned dstRegRaw = fieldFromInstruction(Insn, 7, dstRegRawNumBits);
+  static_assert((1 << dstRegRawNumBits) == std::size(mEXaDecoderTable));
   Register dstReg = mEXaDecoderTable[dstRegRaw];
-  assert(dstReg && "Register not found.");
+  if (!dstReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dstReg));
 
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (ptr_outRegRaw >= std::size(ePSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 1;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePSDecoderTable));
   Register ptr_outReg = ePSDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned fifo_reg_outRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (fifo_reg_outRegRaw >= std::size(eLdFifoRegDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned fifo_reg_outRegRawNumBits = 1;
+  unsigned fifo_reg_outRegRaw =
+      fieldFromInstruction(Insn, 17, fifo_reg_outRegRawNumBits);
+  static_assert((1 << fifo_reg_outRegRawNumBits) ==
+                std::size(eLdFifoRegDecoderTable));
   Register fifo_reg_outReg = eLdFifoRegDecoderTable[fifo_reg_outRegRaw];
-  assert(fifo_reg_outReg && "Register not found.");
+  if (!fifo_reg_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(fifo_reg_outReg));
 
-  unsigned pos_outRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (pos_outRegRaw >= std::size(eRF2DecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned pos_outRegRawNumBits = 1;
+  unsigned pos_outRegRaw = fieldFromInstruction(Insn, 17, pos_outRegRawNumBits);
+  static_assert((1 << pos_outRegRawNumBits) == std::size(eRF2DecoderTable));
   Register pos_outReg = eRF2DecoderTable[pos_outRegRaw];
-  assert(pos_outReg && "Register not found.");
+  if (!pos_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(pos_outReg));
 
-  unsigned dclRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (dclRegRaw >= std::size(eDCLDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dclRegRawNumBits = 2;
+  unsigned dclRegRaw = fieldFromInstruction(Insn, 14, dclRegRawNumBits);
+  static_assert((1 << dclRegRawNumBits) == std::size(eDCLDecoderTable));
   Register dclReg = eDCLDecoderTable[dclRegRaw];
-  assert(dclReg && "Register not found.");
+  if (!dclReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dclReg));
 
-  unsigned dchRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (dchRegRaw >= std::size(eDCHDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dchRegRawNumBits = 2;
+  unsigned dchRegRaw = fieldFromInstruction(Insn, 14, dchRegRawNumBits);
+  static_assert((1 << dchRegRawNumBits) == std::size(eDCHDecoderTable));
   Register dchReg = eDCHDecoderTable[dchRegRaw];
-  assert(dchReg && "Register not found.");
+  if (!dchReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dchReg));
 
   // --------------------- Ins ------------------------
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (ptrRegRaw >= std::size(ePSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 1;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePSDecoderTable));
   Register ptrReg = ePSDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned fifo_regRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (fifo_regRegRaw >= std::size(eLdFifoRegDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned fifo_regRegRawNumBits = 1;
+  unsigned fifo_regRegRaw =
+      fieldFromInstruction(Insn, 17, fifo_regRegRawNumBits);
+  static_assert((1 << fifo_regRegRawNumBits) ==
+                std::size(eLdFifoRegDecoderTable));
   Register fifo_regReg = eLdFifoRegDecoderTable[fifo_regRegRaw];
-  assert(fifo_regReg && "Register not found.");
+  if (!fifo_regReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(fifo_regReg));
 
-  unsigned posRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (posRegRaw >= std::size(eRF2DecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned posRegRawNumBits = 1;
+  unsigned posRegRaw = fieldFromInstruction(Insn, 17, posRegRawNumBits);
+  static_assert((1 << posRegRawNumBits) == std::size(eRF2DecoderTable));
   Register posReg = eRF2DecoderTable[posRegRaw];
-  assert(posReg && "Register not found.");
+  if (!posReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(posReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (modRegRaw >= std::size(eDSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 2;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 14, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDSDecoderTable));
   Register modReg = eDSDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -2597,61 +2928,73 @@ static DecodeStatus
 DecodeVLDA_POP_544_fifo_1d_pop(MCInst &MI, InsnType &Insn, uint64_t Address,
                                const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned dstRegRaw = fieldFromInstruction(Insn, 7, 4);
-  if (dstRegRaw >= std::size(mEXaDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dstRegRawNumBits = 4;
+  unsigned dstRegRaw = fieldFromInstruction(Insn, 7, dstRegRawNumBits);
+  static_assert((1 << dstRegRawNumBits) == std::size(mEXaDecoderTable));
   Register dstReg = mEXaDecoderTable[dstRegRaw];
-  assert(dstReg && "Register not found.");
+  if (!dstReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dstReg));
 
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (ptr_outRegRaw >= std::size(ePSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 1;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePSDecoderTable));
   Register ptr_outReg = ePSDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned fifo_reg_outRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (fifo_reg_outRegRaw >= std::size(eLdFifoRegDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned fifo_reg_outRegRawNumBits = 1;
+  unsigned fifo_reg_outRegRaw =
+      fieldFromInstruction(Insn, 17, fifo_reg_outRegRawNumBits);
+  static_assert((1 << fifo_reg_outRegRawNumBits) ==
+                std::size(eLdFifoRegDecoderTable));
   Register fifo_reg_outReg = eLdFifoRegDecoderTable[fifo_reg_outRegRaw];
-  assert(fifo_reg_outReg && "Register not found.");
+  if (!fifo_reg_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(fifo_reg_outReg));
 
-  unsigned pos_outRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (pos_outRegRaw >= std::size(eRF2DecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned pos_outRegRawNumBits = 1;
+  unsigned pos_outRegRaw = fieldFromInstruction(Insn, 17, pos_outRegRawNumBits);
+  static_assert((1 << pos_outRegRawNumBits) == std::size(eRF2DecoderTable));
   Register pos_outReg = eRF2DecoderTable[pos_outRegRaw];
-  assert(pos_outReg && "Register not found.");
+  if (!pos_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(pos_outReg));
 
   // --------------------- Ins ------------------------
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (ptrRegRaw >= std::size(ePSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 1;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePSDecoderTable));
   Register ptrReg = ePSDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned fifo_regRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (fifo_regRegRaw >= std::size(eLdFifoRegDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned fifo_regRegRawNumBits = 1;
+  unsigned fifo_regRegRaw =
+      fieldFromInstruction(Insn, 17, fifo_regRegRawNumBits);
+  static_assert((1 << fifo_regRegRawNumBits) ==
+                std::size(eLdFifoRegDecoderTable));
   Register fifo_regReg = eLdFifoRegDecoderTable[fifo_regRegRaw];
-  assert(fifo_regReg && "Register not found.");
+  if (!fifo_regReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(fifo_regReg));
 
-  unsigned posRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (posRegRaw >= std::size(eRF2DecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned posRegRawNumBits = 1;
+  unsigned posRegRaw = fieldFromInstruction(Insn, 17, posRegRawNumBits);
+  static_assert((1 << posRegRawNumBits) == std::size(eRF2DecoderTable));
   Register posReg = eRF2DecoderTable[posRegRaw];
-  assert(posReg && "Register not found.");
+  if (!posReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(posReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (modRegRaw >= std::size(eMDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 3;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 14, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eMDecoderTable));
   Register modReg = eMDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -2662,54 +3005,65 @@ static DecodeStatus
 DecodeVLDA_POP_544_normal_pop(MCInst &MI, InsnType &Insn, uint64_t Address,
                               const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned dstRegRaw = fieldFromInstruction(Insn, 7, 4);
-  if (dstRegRaw >= std::size(mEXaDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dstRegRawNumBits = 4;
+  unsigned dstRegRaw = fieldFromInstruction(Insn, 7, dstRegRawNumBits);
+  static_assert((1 << dstRegRawNumBits) == std::size(mEXaDecoderTable));
   Register dstReg = mEXaDecoderTable[dstRegRaw];
-  assert(dstReg && "Register not found.");
+  if (!dstReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dstReg));
 
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (ptr_outRegRaw >= std::size(ePSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 1;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePSDecoderTable));
   Register ptr_outReg = ePSDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned fifo_reg_outRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (fifo_reg_outRegRaw >= std::size(eLdFifoRegDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned fifo_reg_outRegRawNumBits = 1;
+  unsigned fifo_reg_outRegRaw =
+      fieldFromInstruction(Insn, 17, fifo_reg_outRegRawNumBits);
+  static_assert((1 << fifo_reg_outRegRawNumBits) ==
+                std::size(eLdFifoRegDecoderTable));
   Register fifo_reg_outReg = eLdFifoRegDecoderTable[fifo_reg_outRegRaw];
-  assert(fifo_reg_outReg && "Register not found.");
+  if (!fifo_reg_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(fifo_reg_outReg));
 
-  unsigned pos_outRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (pos_outRegRaw >= std::size(eRF2DecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned pos_outRegRawNumBits = 1;
+  unsigned pos_outRegRaw = fieldFromInstruction(Insn, 17, pos_outRegRawNumBits);
+  static_assert((1 << pos_outRegRawNumBits) == std::size(eRF2DecoderTable));
   Register pos_outReg = eRF2DecoderTable[pos_outRegRaw];
-  assert(pos_outReg && "Register not found.");
+  if (!pos_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(pos_outReg));
 
   // --------------------- Ins ------------------------
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (ptrRegRaw >= std::size(ePSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 1;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePSDecoderTable));
   Register ptrReg = ePSDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned fifo_regRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (fifo_regRegRaw >= std::size(eLdFifoRegDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned fifo_regRegRawNumBits = 1;
+  unsigned fifo_regRegRaw =
+      fieldFromInstruction(Insn, 17, fifo_regRegRawNumBits);
+  static_assert((1 << fifo_regRegRawNumBits) ==
+                std::size(eLdFifoRegDecoderTable));
   Register fifo_regReg = eLdFifoRegDecoderTable[fifo_regRegRaw];
-  assert(fifo_regReg && "Register not found.");
+  if (!fifo_regReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(fifo_regReg));
 
-  unsigned posRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (posRegRaw >= std::size(eRF2DecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned posRegRawNumBits = 1;
+  unsigned posRegRaw = fieldFromInstruction(Insn, 17, posRegRawNumBits);
+  static_assert((1 << posRegRawNumBits) == std::size(eRF2DecoderTable));
   Register posReg = eRF2DecoderTable[posRegRaw];
-  assert(posReg && "Register not found.");
+  if (!posReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(posReg));
 
   return MCDisassembler::Success;
@@ -2721,68 +3075,81 @@ DecodeDmx_lda_fifo_ex_ebs8__fifo_2d_pop(MCInst &MI, InsnType &Insn,
                                         uint64_t Address,
                                         const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned dstRegRaw = fieldFromInstruction(Insn, 7, 4);
-  if (dstRegRaw >= std::size(mEXaDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dstRegRawNumBits = 4;
+  unsigned dstRegRaw = fieldFromInstruction(Insn, 7, dstRegRawNumBits);
+  static_assert((1 << dstRegRawNumBits) == std::size(mEXaDecoderTable));
   Register dstReg = mEXaDecoderTable[dstRegRaw];
-  assert(dstReg && "Register not found.");
+  if (!dstReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dstReg));
 
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (ptr_outRegRaw >= std::size(ePSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 1;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePSDecoderTable));
   Register ptr_outReg = ePSDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned fifo_reg_outRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (fifo_reg_outRegRaw >= std::size(eLdFifoRegDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned fifo_reg_outRegRawNumBits = 1;
+  unsigned fifo_reg_outRegRaw =
+      fieldFromInstruction(Insn, 17, fifo_reg_outRegRawNumBits);
+  static_assert((1 << fifo_reg_outRegRawNumBits) ==
+                std::size(eLdFifoRegDecoderTable));
   Register fifo_reg_outReg = eLdFifoRegDecoderTable[fifo_reg_outRegRaw];
-  assert(fifo_reg_outReg && "Register not found.");
+  if (!fifo_reg_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(fifo_reg_outReg));
 
-  unsigned pos_outRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (pos_outRegRaw >= std::size(eRF2DecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned pos_outRegRawNumBits = 1;
+  unsigned pos_outRegRaw = fieldFromInstruction(Insn, 17, pos_outRegRawNumBits);
+  static_assert((1 << pos_outRegRawNumBits) == std::size(eRF2DecoderTable));
   Register pos_outReg = eRF2DecoderTable[pos_outRegRaw];
-  assert(pos_outReg && "Register not found.");
+  if (!pos_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(pos_outReg));
 
-  unsigned dcRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (dcRegRaw >= std::size(eDCDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dcRegRawNumBits = 3;
+  unsigned dcRegRaw = fieldFromInstruction(Insn, 14, dcRegRawNumBits);
+  static_assert((1 << dcRegRawNumBits) == std::size(eDCDecoderTable));
   Register dcReg = eDCDecoderTable[dcRegRaw];
-  assert(dcReg && "Register not found.");
+  if (!dcReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dcReg));
 
   // --------------------- Ins ------------------------
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (ptrRegRaw >= std::size(ePSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 1;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePSDecoderTable));
   Register ptrReg = ePSDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned fifo_regRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (fifo_regRegRaw >= std::size(eLdFifoRegDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned fifo_regRegRawNumBits = 1;
+  unsigned fifo_regRegRaw =
+      fieldFromInstruction(Insn, 17, fifo_regRegRawNumBits);
+  static_assert((1 << fifo_regRegRawNumBits) ==
+                std::size(eLdFifoRegDecoderTable));
   Register fifo_regReg = eLdFifoRegDecoderTable[fifo_regRegRaw];
-  assert(fifo_regReg && "Register not found.");
+  if (!fifo_regReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(fifo_regReg));
 
-  unsigned posRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (posRegRaw >= std::size(eRF2DecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned posRegRawNumBits = 1;
+  unsigned posRegRaw = fieldFromInstruction(Insn, 17, posRegRawNumBits);
+  static_assert((1 << posRegRawNumBits) == std::size(eRF2DecoderTable));
   Register posReg = eRF2DecoderTable[posRegRaw];
-  assert(posReg && "Register not found.");
+  if (!posReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(posReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (modRegRaw >= std::size(eDDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 3;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 14, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDDecoderTable));
   Register modReg = eDDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -2794,75 +3161,89 @@ DecodeDmx_lda_fifo_ex_ebs8__fifo_3d_pop(MCInst &MI, InsnType &Insn,
                                         uint64_t Address,
                                         const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned dstRegRaw = fieldFromInstruction(Insn, 7, 4);
-  if (dstRegRaw >= std::size(mEXaDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dstRegRawNumBits = 4;
+  unsigned dstRegRaw = fieldFromInstruction(Insn, 7, dstRegRawNumBits);
+  static_assert((1 << dstRegRawNumBits) == std::size(mEXaDecoderTable));
   Register dstReg = mEXaDecoderTable[dstRegRaw];
-  assert(dstReg && "Register not found.");
+  if (!dstReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dstReg));
 
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (ptr_outRegRaw >= std::size(ePSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 1;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePSDecoderTable));
   Register ptr_outReg = ePSDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned fifo_reg_outRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (fifo_reg_outRegRaw >= std::size(eLdFifoRegDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned fifo_reg_outRegRawNumBits = 1;
+  unsigned fifo_reg_outRegRaw =
+      fieldFromInstruction(Insn, 17, fifo_reg_outRegRawNumBits);
+  static_assert((1 << fifo_reg_outRegRawNumBits) ==
+                std::size(eLdFifoRegDecoderTable));
   Register fifo_reg_outReg = eLdFifoRegDecoderTable[fifo_reg_outRegRaw];
-  assert(fifo_reg_outReg && "Register not found.");
+  if (!fifo_reg_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(fifo_reg_outReg));
 
-  unsigned pos_outRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (pos_outRegRaw >= std::size(eRF2DecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned pos_outRegRawNumBits = 1;
+  unsigned pos_outRegRaw = fieldFromInstruction(Insn, 17, pos_outRegRawNumBits);
+  static_assert((1 << pos_outRegRawNumBits) == std::size(eRF2DecoderTable));
   Register pos_outReg = eRF2DecoderTable[pos_outRegRaw];
-  assert(pos_outReg && "Register not found.");
+  if (!pos_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(pos_outReg));
 
-  unsigned dclRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (dclRegRaw >= std::size(eDCLDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dclRegRawNumBits = 2;
+  unsigned dclRegRaw = fieldFromInstruction(Insn, 14, dclRegRawNumBits);
+  static_assert((1 << dclRegRawNumBits) == std::size(eDCLDecoderTable));
   Register dclReg = eDCLDecoderTable[dclRegRaw];
-  assert(dclReg && "Register not found.");
+  if (!dclReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dclReg));
 
-  unsigned dchRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (dchRegRaw >= std::size(eDCHDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dchRegRawNumBits = 2;
+  unsigned dchRegRaw = fieldFromInstruction(Insn, 14, dchRegRawNumBits);
+  static_assert((1 << dchRegRawNumBits) == std::size(eDCHDecoderTable));
   Register dchReg = eDCHDecoderTable[dchRegRaw];
-  assert(dchReg && "Register not found.");
+  if (!dchReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dchReg));
 
   // --------------------- Ins ------------------------
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (ptrRegRaw >= std::size(ePSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 1;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePSDecoderTable));
   Register ptrReg = ePSDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned fifo_regRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (fifo_regRegRaw >= std::size(eLdFifoRegDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned fifo_regRegRawNumBits = 1;
+  unsigned fifo_regRegRaw =
+      fieldFromInstruction(Insn, 17, fifo_regRegRawNumBits);
+  static_assert((1 << fifo_regRegRawNumBits) ==
+                std::size(eLdFifoRegDecoderTable));
   Register fifo_regReg = eLdFifoRegDecoderTable[fifo_regRegRaw];
-  assert(fifo_regReg && "Register not found.");
+  if (!fifo_regReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(fifo_regReg));
 
-  unsigned posRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (posRegRaw >= std::size(eRF2DecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned posRegRawNumBits = 1;
+  unsigned posRegRaw = fieldFromInstruction(Insn, 17, posRegRawNumBits);
+  static_assert((1 << posRegRawNumBits) == std::size(eRF2DecoderTable));
   Register posReg = eRF2DecoderTable[posRegRaw];
-  assert(posReg && "Register not found.");
+  if (!posReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(posReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (modRegRaw >= std::size(eDSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 2;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 14, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDSDecoderTable));
   Register modReg = eDSDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -2873,61 +3254,73 @@ static DecodeStatus
 DecodeVLDA_POP_576_fifo_1d_pop(MCInst &MI, InsnType &Insn, uint64_t Address,
                                const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned dstRegRaw = fieldFromInstruction(Insn, 7, 4);
-  if (dstRegRaw >= std::size(mEXaDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dstRegRawNumBits = 4;
+  unsigned dstRegRaw = fieldFromInstruction(Insn, 7, dstRegRawNumBits);
+  static_assert((1 << dstRegRawNumBits) == std::size(mEXaDecoderTable));
   Register dstReg = mEXaDecoderTable[dstRegRaw];
-  assert(dstReg && "Register not found.");
+  if (!dstReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dstReg));
 
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (ptr_outRegRaw >= std::size(ePSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 1;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePSDecoderTable));
   Register ptr_outReg = ePSDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned fifo_reg_outRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (fifo_reg_outRegRaw >= std::size(eLdFifoRegDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned fifo_reg_outRegRawNumBits = 1;
+  unsigned fifo_reg_outRegRaw =
+      fieldFromInstruction(Insn, 17, fifo_reg_outRegRawNumBits);
+  static_assert((1 << fifo_reg_outRegRawNumBits) ==
+                std::size(eLdFifoRegDecoderTable));
   Register fifo_reg_outReg = eLdFifoRegDecoderTable[fifo_reg_outRegRaw];
-  assert(fifo_reg_outReg && "Register not found.");
+  if (!fifo_reg_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(fifo_reg_outReg));
 
-  unsigned pos_outRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (pos_outRegRaw >= std::size(eRF2DecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned pos_outRegRawNumBits = 1;
+  unsigned pos_outRegRaw = fieldFromInstruction(Insn, 17, pos_outRegRawNumBits);
+  static_assert((1 << pos_outRegRawNumBits) == std::size(eRF2DecoderTable));
   Register pos_outReg = eRF2DecoderTable[pos_outRegRaw];
-  assert(pos_outReg && "Register not found.");
+  if (!pos_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(pos_outReg));
 
   // --------------------- Ins ------------------------
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (ptrRegRaw >= std::size(ePSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 1;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePSDecoderTable));
   Register ptrReg = ePSDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned fifo_regRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (fifo_regRegRaw >= std::size(eLdFifoRegDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned fifo_regRegRawNumBits = 1;
+  unsigned fifo_regRegRaw =
+      fieldFromInstruction(Insn, 17, fifo_regRegRawNumBits);
+  static_assert((1 << fifo_regRegRawNumBits) ==
+                std::size(eLdFifoRegDecoderTable));
   Register fifo_regReg = eLdFifoRegDecoderTable[fifo_regRegRaw];
-  assert(fifo_regReg && "Register not found.");
+  if (!fifo_regReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(fifo_regReg));
 
-  unsigned posRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (posRegRaw >= std::size(eRF2DecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned posRegRawNumBits = 1;
+  unsigned posRegRaw = fieldFromInstruction(Insn, 17, posRegRawNumBits);
+  static_assert((1 << posRegRawNumBits) == std::size(eRF2DecoderTable));
   Register posReg = eRF2DecoderTable[posRegRaw];
-  assert(posReg && "Register not found.");
+  if (!posReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(posReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (modRegRaw >= std::size(eMDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 3;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 14, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eMDecoderTable));
   Register modReg = eMDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -2938,54 +3331,65 @@ static DecodeStatus
 DecodeVLDA_POP_576_normal_pop(MCInst &MI, InsnType &Insn, uint64_t Address,
                               const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned dstRegRaw = fieldFromInstruction(Insn, 7, 4);
-  if (dstRegRaw >= std::size(mEXaDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dstRegRawNumBits = 4;
+  unsigned dstRegRaw = fieldFromInstruction(Insn, 7, dstRegRawNumBits);
+  static_assert((1 << dstRegRawNumBits) == std::size(mEXaDecoderTable));
   Register dstReg = mEXaDecoderTable[dstRegRaw];
-  assert(dstReg && "Register not found.");
+  if (!dstReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dstReg));
 
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (ptr_outRegRaw >= std::size(ePSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 1;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePSDecoderTable));
   Register ptr_outReg = ePSDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned fifo_reg_outRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (fifo_reg_outRegRaw >= std::size(eLdFifoRegDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned fifo_reg_outRegRawNumBits = 1;
+  unsigned fifo_reg_outRegRaw =
+      fieldFromInstruction(Insn, 17, fifo_reg_outRegRawNumBits);
+  static_assert((1 << fifo_reg_outRegRawNumBits) ==
+                std::size(eLdFifoRegDecoderTable));
   Register fifo_reg_outReg = eLdFifoRegDecoderTable[fifo_reg_outRegRaw];
-  assert(fifo_reg_outReg && "Register not found.");
+  if (!fifo_reg_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(fifo_reg_outReg));
 
-  unsigned pos_outRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (pos_outRegRaw >= std::size(eRF2DecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned pos_outRegRawNumBits = 1;
+  unsigned pos_outRegRaw = fieldFromInstruction(Insn, 17, pos_outRegRawNumBits);
+  static_assert((1 << pos_outRegRawNumBits) == std::size(eRF2DecoderTable));
   Register pos_outReg = eRF2DecoderTable[pos_outRegRaw];
-  assert(pos_outReg && "Register not found.");
+  if (!pos_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(pos_outReg));
 
   // --------------------- Ins ------------------------
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (ptrRegRaw >= std::size(ePSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 1;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePSDecoderTable));
   Register ptrReg = ePSDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned fifo_regRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (fifo_regRegRaw >= std::size(eLdFifoRegDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned fifo_regRegRawNumBits = 1;
+  unsigned fifo_regRegRaw =
+      fieldFromInstruction(Insn, 17, fifo_regRegRawNumBits);
+  static_assert((1 << fifo_regRegRawNumBits) ==
+                std::size(eLdFifoRegDecoderTable));
   Register fifo_regReg = eLdFifoRegDecoderTable[fifo_regRegRaw];
-  assert(fifo_regReg && "Register not found.");
+  if (!fifo_regReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(fifo_regReg));
 
-  unsigned posRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (posRegRaw >= std::size(eRF2DecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned posRegRawNumBits = 1;
+  unsigned posRegRaw = fieldFromInstruction(Insn, 17, posRegRawNumBits);
+  static_assert((1 << posRegRawNumBits) == std::size(eRF2DecoderTable));
   Register posReg = eRF2DecoderTable[posRegRaw];
-  assert(posReg && "Register not found.");
+  if (!posReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(posReg));
 
   return MCDisassembler::Success;
@@ -2996,68 +3400,81 @@ static DecodeStatus
 DecodeDmx_lda_fifo_qx__fifo_2d_pop(MCInst &MI, InsnType &Insn, uint64_t Address,
                                    const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned dstRegRaw = fieldFromInstruction(Insn, 9, 2);
-  if (dstRegRaw >= std::size(mQXsaDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dstRegRawNumBits = 2;
+  unsigned dstRegRaw = fieldFromInstruction(Insn, 9, dstRegRawNumBits);
+  static_assert((1 << dstRegRawNumBits) == std::size(mQXsaDecoderTable));
   Register dstReg = mQXsaDecoderTable[dstRegRaw];
-  assert(dstReg && "Register not found.");
+  if (!dstReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dstReg));
 
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (ptr_outRegRaw >= std::size(ePSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 1;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePSDecoderTable));
   Register ptr_outReg = ePSDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned fifo_reg_outRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (fifo_reg_outRegRaw >= std::size(eLdFifoRegDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned fifo_reg_outRegRawNumBits = 1;
+  unsigned fifo_reg_outRegRaw =
+      fieldFromInstruction(Insn, 17, fifo_reg_outRegRawNumBits);
+  static_assert((1 << fifo_reg_outRegRawNumBits) ==
+                std::size(eLdFifoRegDecoderTable));
   Register fifo_reg_outReg = eLdFifoRegDecoderTable[fifo_reg_outRegRaw];
-  assert(fifo_reg_outReg && "Register not found.");
+  if (!fifo_reg_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(fifo_reg_outReg));
 
-  unsigned pos_outRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (pos_outRegRaw >= std::size(eRF2DecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned pos_outRegRawNumBits = 1;
+  unsigned pos_outRegRaw = fieldFromInstruction(Insn, 17, pos_outRegRawNumBits);
+  static_assert((1 << pos_outRegRawNumBits) == std::size(eRF2DecoderTable));
   Register pos_outReg = eRF2DecoderTable[pos_outRegRaw];
-  assert(pos_outReg && "Register not found.");
+  if (!pos_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(pos_outReg));
 
-  unsigned dcRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (dcRegRaw >= std::size(eDCDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dcRegRawNumBits = 3;
+  unsigned dcRegRaw = fieldFromInstruction(Insn, 14, dcRegRawNumBits);
+  static_assert((1 << dcRegRawNumBits) == std::size(eDCDecoderTable));
   Register dcReg = eDCDecoderTable[dcRegRaw];
-  assert(dcReg && "Register not found.");
+  if (!dcReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dcReg));
 
   // --------------------- Ins ------------------------
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (ptrRegRaw >= std::size(ePSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 1;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePSDecoderTable));
   Register ptrReg = ePSDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned fifo_regRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (fifo_regRegRaw >= std::size(eLdFifoRegDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned fifo_regRegRawNumBits = 1;
+  unsigned fifo_regRegRaw =
+      fieldFromInstruction(Insn, 17, fifo_regRegRawNumBits);
+  static_assert((1 << fifo_regRegRawNumBits) ==
+                std::size(eLdFifoRegDecoderTable));
   Register fifo_regReg = eLdFifoRegDecoderTable[fifo_regRegRaw];
-  assert(fifo_regReg && "Register not found.");
+  if (!fifo_regReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(fifo_regReg));
 
-  unsigned posRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (posRegRaw >= std::size(eRF2DecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned posRegRawNumBits = 1;
+  unsigned posRegRaw = fieldFromInstruction(Insn, 17, posRegRawNumBits);
+  static_assert((1 << posRegRawNumBits) == std::size(eRF2DecoderTable));
   Register posReg = eRF2DecoderTable[posRegRaw];
-  assert(posReg && "Register not found.");
+  if (!posReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(posReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (modRegRaw >= std::size(eDDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 3;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 14, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDDecoderTable));
   Register modReg = eDDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -3068,75 +3485,89 @@ static DecodeStatus
 DecodeDmx_lda_fifo_qx__fifo_3d_pop(MCInst &MI, InsnType &Insn, uint64_t Address,
                                    const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned dstRegRaw = fieldFromInstruction(Insn, 9, 2);
-  if (dstRegRaw >= std::size(mQXsaDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dstRegRawNumBits = 2;
+  unsigned dstRegRaw = fieldFromInstruction(Insn, 9, dstRegRawNumBits);
+  static_assert((1 << dstRegRawNumBits) == std::size(mQXsaDecoderTable));
   Register dstReg = mQXsaDecoderTable[dstRegRaw];
-  assert(dstReg && "Register not found.");
+  if (!dstReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dstReg));
 
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (ptr_outRegRaw >= std::size(ePSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 1;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePSDecoderTable));
   Register ptr_outReg = ePSDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned fifo_reg_outRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (fifo_reg_outRegRaw >= std::size(eLdFifoRegDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned fifo_reg_outRegRawNumBits = 1;
+  unsigned fifo_reg_outRegRaw =
+      fieldFromInstruction(Insn, 17, fifo_reg_outRegRawNumBits);
+  static_assert((1 << fifo_reg_outRegRawNumBits) ==
+                std::size(eLdFifoRegDecoderTable));
   Register fifo_reg_outReg = eLdFifoRegDecoderTable[fifo_reg_outRegRaw];
-  assert(fifo_reg_outReg && "Register not found.");
+  if (!fifo_reg_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(fifo_reg_outReg));
 
-  unsigned pos_outRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (pos_outRegRaw >= std::size(eRF2DecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned pos_outRegRawNumBits = 1;
+  unsigned pos_outRegRaw = fieldFromInstruction(Insn, 17, pos_outRegRawNumBits);
+  static_assert((1 << pos_outRegRawNumBits) == std::size(eRF2DecoderTable));
   Register pos_outReg = eRF2DecoderTable[pos_outRegRaw];
-  assert(pos_outReg && "Register not found.");
+  if (!pos_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(pos_outReg));
 
-  unsigned dclRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (dclRegRaw >= std::size(eDCLDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dclRegRawNumBits = 2;
+  unsigned dclRegRaw = fieldFromInstruction(Insn, 14, dclRegRawNumBits);
+  static_assert((1 << dclRegRawNumBits) == std::size(eDCLDecoderTable));
   Register dclReg = eDCLDecoderTable[dclRegRaw];
-  assert(dclReg && "Register not found.");
+  if (!dclReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dclReg));
 
-  unsigned dchRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (dchRegRaw >= std::size(eDCHDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dchRegRawNumBits = 2;
+  unsigned dchRegRaw = fieldFromInstruction(Insn, 14, dchRegRawNumBits);
+  static_assert((1 << dchRegRawNumBits) == std::size(eDCHDecoderTable));
   Register dchReg = eDCHDecoderTable[dchRegRaw];
-  assert(dchReg && "Register not found.");
+  if (!dchReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dchReg));
 
   // --------------------- Ins ------------------------
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (ptrRegRaw >= std::size(ePSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 1;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePSDecoderTable));
   Register ptrReg = ePSDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned fifo_regRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (fifo_regRegRaw >= std::size(eLdFifoRegDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned fifo_regRegRawNumBits = 1;
+  unsigned fifo_regRegRaw =
+      fieldFromInstruction(Insn, 17, fifo_regRegRawNumBits);
+  static_assert((1 << fifo_regRegRawNumBits) ==
+                std::size(eLdFifoRegDecoderTable));
   Register fifo_regReg = eLdFifoRegDecoderTable[fifo_regRegRaw];
-  assert(fifo_regReg && "Register not found.");
+  if (!fifo_regReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(fifo_regReg));
 
-  unsigned posRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (posRegRaw >= std::size(eRF2DecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned posRegRawNumBits = 1;
+  unsigned posRegRaw = fieldFromInstruction(Insn, 17, posRegRawNumBits);
+  static_assert((1 << posRegRawNumBits) == std::size(eRF2DecoderTable));
   Register posReg = eRF2DecoderTable[posRegRaw];
-  assert(posReg && "Register not found.");
+  if (!posReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(posReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (modRegRaw >= std::size(eDSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 2;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 14, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDSDecoderTable));
   Register modReg = eDSDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -3147,61 +3578,73 @@ static DecodeStatus
 DecodeVLDA_POP_640_fifo_1d_pop(MCInst &MI, InsnType &Insn, uint64_t Address,
                                const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned dstRegRaw = fieldFromInstruction(Insn, 9, 2);
-  if (dstRegRaw >= std::size(mQXsaDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dstRegRawNumBits = 2;
+  unsigned dstRegRaw = fieldFromInstruction(Insn, 9, dstRegRawNumBits);
+  static_assert((1 << dstRegRawNumBits) == std::size(mQXsaDecoderTable));
   Register dstReg = mQXsaDecoderTable[dstRegRaw];
-  assert(dstReg && "Register not found.");
+  if (!dstReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dstReg));
 
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (ptr_outRegRaw >= std::size(ePSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 1;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePSDecoderTable));
   Register ptr_outReg = ePSDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned fifo_reg_outRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (fifo_reg_outRegRaw >= std::size(eLdFifoRegDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned fifo_reg_outRegRawNumBits = 1;
+  unsigned fifo_reg_outRegRaw =
+      fieldFromInstruction(Insn, 17, fifo_reg_outRegRawNumBits);
+  static_assert((1 << fifo_reg_outRegRawNumBits) ==
+                std::size(eLdFifoRegDecoderTable));
   Register fifo_reg_outReg = eLdFifoRegDecoderTable[fifo_reg_outRegRaw];
-  assert(fifo_reg_outReg && "Register not found.");
+  if (!fifo_reg_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(fifo_reg_outReg));
 
-  unsigned pos_outRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (pos_outRegRaw >= std::size(eRF2DecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned pos_outRegRawNumBits = 1;
+  unsigned pos_outRegRaw = fieldFromInstruction(Insn, 17, pos_outRegRawNumBits);
+  static_assert((1 << pos_outRegRawNumBits) == std::size(eRF2DecoderTable));
   Register pos_outReg = eRF2DecoderTable[pos_outRegRaw];
-  assert(pos_outReg && "Register not found.");
+  if (!pos_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(pos_outReg));
 
   // --------------------- Ins ------------------------
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (ptrRegRaw >= std::size(ePSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 1;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePSDecoderTable));
   Register ptrReg = ePSDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned fifo_regRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (fifo_regRegRaw >= std::size(eLdFifoRegDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned fifo_regRegRawNumBits = 1;
+  unsigned fifo_regRegRaw =
+      fieldFromInstruction(Insn, 17, fifo_regRegRawNumBits);
+  static_assert((1 << fifo_regRegRawNumBits) ==
+                std::size(eLdFifoRegDecoderTable));
   Register fifo_regReg = eLdFifoRegDecoderTable[fifo_regRegRaw];
-  assert(fifo_regReg && "Register not found.");
+  if (!fifo_regReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(fifo_regReg));
 
-  unsigned posRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (posRegRaw >= std::size(eRF2DecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned posRegRawNumBits = 1;
+  unsigned posRegRaw = fieldFromInstruction(Insn, 17, posRegRawNumBits);
+  static_assert((1 << posRegRawNumBits) == std::size(eRF2DecoderTable));
   Register posReg = eRF2DecoderTable[posRegRaw];
-  assert(posReg && "Register not found.");
+  if (!posReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(posReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (modRegRaw >= std::size(eMDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 3;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 14, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eMDecoderTable));
   Register modReg = eMDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -3212,54 +3655,65 @@ static DecodeStatus
 DecodeVLDA_POP_640_normal_pop(MCInst &MI, InsnType &Insn, uint64_t Address,
                               const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned dstRegRaw = fieldFromInstruction(Insn, 9, 2);
-  if (dstRegRaw >= std::size(mQXsaDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dstRegRawNumBits = 2;
+  unsigned dstRegRaw = fieldFromInstruction(Insn, 9, dstRegRawNumBits);
+  static_assert((1 << dstRegRawNumBits) == std::size(mQXsaDecoderTable));
   Register dstReg = mQXsaDecoderTable[dstRegRaw];
-  assert(dstReg && "Register not found.");
+  if (!dstReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dstReg));
 
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (ptr_outRegRaw >= std::size(ePSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 1;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePSDecoderTable));
   Register ptr_outReg = ePSDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned fifo_reg_outRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (fifo_reg_outRegRaw >= std::size(eLdFifoRegDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned fifo_reg_outRegRawNumBits = 1;
+  unsigned fifo_reg_outRegRaw =
+      fieldFromInstruction(Insn, 17, fifo_reg_outRegRawNumBits);
+  static_assert((1 << fifo_reg_outRegRawNumBits) ==
+                std::size(eLdFifoRegDecoderTable));
   Register fifo_reg_outReg = eLdFifoRegDecoderTable[fifo_reg_outRegRaw];
-  assert(fifo_reg_outReg && "Register not found.");
+  if (!fifo_reg_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(fifo_reg_outReg));
 
-  unsigned pos_outRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (pos_outRegRaw >= std::size(eRF2DecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned pos_outRegRawNumBits = 1;
+  unsigned pos_outRegRaw = fieldFromInstruction(Insn, 17, pos_outRegRawNumBits);
+  static_assert((1 << pos_outRegRawNumBits) == std::size(eRF2DecoderTable));
   Register pos_outReg = eRF2DecoderTable[pos_outRegRaw];
-  assert(pos_outReg && "Register not found.");
+  if (!pos_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(pos_outReg));
 
   // --------------------- Ins ------------------------
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (ptrRegRaw >= std::size(ePSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 1;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePSDecoderTable));
   Register ptrReg = ePSDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned fifo_regRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (fifo_regRegRaw >= std::size(eLdFifoRegDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned fifo_regRegRawNumBits = 1;
+  unsigned fifo_regRegRaw =
+      fieldFromInstruction(Insn, 17, fifo_regRegRawNumBits);
+  static_assert((1 << fifo_regRegRawNumBits) ==
+                std::size(eLdFifoRegDecoderTable));
   Register fifo_regReg = eLdFifoRegDecoderTable[fifo_regRegRaw];
-  assert(fifo_regReg && "Register not found.");
+  if (!fifo_regReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(fifo_regReg));
 
-  unsigned posRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (posRegRaw >= std::size(eRF2DecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned posRegRawNumBits = 1;
+  unsigned posRegRaw = fieldFromInstruction(Insn, 17, posRegRawNumBits);
+  static_assert((1 << posRegRawNumBits) == std::size(eRF2DecoderTable));
   Register posReg = eRF2DecoderTable[posRegRaw];
-  assert(posReg && "Register not found.");
+  if (!posReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(posReg));
 
   return MCDisassembler::Success;
@@ -3271,68 +3725,81 @@ DecodeDmx_lda_fifo_qex_ebs16__fifo_2d_pop(MCInst &MI, InsnType &Insn,
                                           uint64_t Address,
                                           const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned dstRegRaw = fieldFromInstruction(Insn, 9, 2);
-  if (dstRegRaw >= std::size(mQEXsaDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dstRegRawNumBits = 2;
+  unsigned dstRegRaw = fieldFromInstruction(Insn, 9, dstRegRawNumBits);
+  static_assert((1 << dstRegRawNumBits) == std::size(mQEXsaDecoderTable));
   Register dstReg = mQEXsaDecoderTable[dstRegRaw];
-  assert(dstReg && "Register not found.");
+  if (!dstReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dstReg));
 
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (ptr_outRegRaw >= std::size(ePSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 1;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePSDecoderTable));
   Register ptr_outReg = ePSDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned fifo_reg_outRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (fifo_reg_outRegRaw >= std::size(eLdFifoRegDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned fifo_reg_outRegRawNumBits = 1;
+  unsigned fifo_reg_outRegRaw =
+      fieldFromInstruction(Insn, 17, fifo_reg_outRegRawNumBits);
+  static_assert((1 << fifo_reg_outRegRawNumBits) ==
+                std::size(eLdFifoRegDecoderTable));
   Register fifo_reg_outReg = eLdFifoRegDecoderTable[fifo_reg_outRegRaw];
-  assert(fifo_reg_outReg && "Register not found.");
+  if (!fifo_reg_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(fifo_reg_outReg));
 
-  unsigned pos_outRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (pos_outRegRaw >= std::size(eRF2DecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned pos_outRegRawNumBits = 1;
+  unsigned pos_outRegRaw = fieldFromInstruction(Insn, 17, pos_outRegRawNumBits);
+  static_assert((1 << pos_outRegRawNumBits) == std::size(eRF2DecoderTable));
   Register pos_outReg = eRF2DecoderTable[pos_outRegRaw];
-  assert(pos_outReg && "Register not found.");
+  if (!pos_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(pos_outReg));
 
-  unsigned dcRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (dcRegRaw >= std::size(eDCDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dcRegRawNumBits = 3;
+  unsigned dcRegRaw = fieldFromInstruction(Insn, 14, dcRegRawNumBits);
+  static_assert((1 << dcRegRawNumBits) == std::size(eDCDecoderTable));
   Register dcReg = eDCDecoderTable[dcRegRaw];
-  assert(dcReg && "Register not found.");
+  if (!dcReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dcReg));
 
   // --------------------- Ins ------------------------
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (ptrRegRaw >= std::size(ePSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 1;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePSDecoderTable));
   Register ptrReg = ePSDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned fifo_regRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (fifo_regRegRaw >= std::size(eLdFifoRegDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned fifo_regRegRawNumBits = 1;
+  unsigned fifo_regRegRaw =
+      fieldFromInstruction(Insn, 17, fifo_regRegRawNumBits);
+  static_assert((1 << fifo_regRegRawNumBits) ==
+                std::size(eLdFifoRegDecoderTable));
   Register fifo_regReg = eLdFifoRegDecoderTable[fifo_regRegRaw];
-  assert(fifo_regReg && "Register not found.");
+  if (!fifo_regReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(fifo_regReg));
 
-  unsigned posRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (posRegRaw >= std::size(eRF2DecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned posRegRawNumBits = 1;
+  unsigned posRegRaw = fieldFromInstruction(Insn, 17, posRegRawNumBits);
+  static_assert((1 << posRegRawNumBits) == std::size(eRF2DecoderTable));
   Register posReg = eRF2DecoderTable[posRegRaw];
-  assert(posReg && "Register not found.");
+  if (!posReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(posReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (modRegRaw >= std::size(eDDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 3;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 14, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDDecoderTable));
   Register modReg = eDDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -3344,75 +3811,89 @@ DecodeDmx_lda_fifo_qex_ebs16__fifo_3d_pop(MCInst &MI, InsnType &Insn,
                                           uint64_t Address,
                                           const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned dstRegRaw = fieldFromInstruction(Insn, 9, 2);
-  if (dstRegRaw >= std::size(mQEXsaDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dstRegRawNumBits = 2;
+  unsigned dstRegRaw = fieldFromInstruction(Insn, 9, dstRegRawNumBits);
+  static_assert((1 << dstRegRawNumBits) == std::size(mQEXsaDecoderTable));
   Register dstReg = mQEXsaDecoderTable[dstRegRaw];
-  assert(dstReg && "Register not found.");
+  if (!dstReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dstReg));
 
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (ptr_outRegRaw >= std::size(ePSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 1;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePSDecoderTable));
   Register ptr_outReg = ePSDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned fifo_reg_outRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (fifo_reg_outRegRaw >= std::size(eLdFifoRegDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned fifo_reg_outRegRawNumBits = 1;
+  unsigned fifo_reg_outRegRaw =
+      fieldFromInstruction(Insn, 17, fifo_reg_outRegRawNumBits);
+  static_assert((1 << fifo_reg_outRegRawNumBits) ==
+                std::size(eLdFifoRegDecoderTable));
   Register fifo_reg_outReg = eLdFifoRegDecoderTable[fifo_reg_outRegRaw];
-  assert(fifo_reg_outReg && "Register not found.");
+  if (!fifo_reg_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(fifo_reg_outReg));
 
-  unsigned pos_outRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (pos_outRegRaw >= std::size(eRF2DecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned pos_outRegRawNumBits = 1;
+  unsigned pos_outRegRaw = fieldFromInstruction(Insn, 17, pos_outRegRawNumBits);
+  static_assert((1 << pos_outRegRawNumBits) == std::size(eRF2DecoderTable));
   Register pos_outReg = eRF2DecoderTable[pos_outRegRaw];
-  assert(pos_outReg && "Register not found.");
+  if (!pos_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(pos_outReg));
 
-  unsigned dclRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (dclRegRaw >= std::size(eDCLDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dclRegRawNumBits = 2;
+  unsigned dclRegRaw = fieldFromInstruction(Insn, 14, dclRegRawNumBits);
+  static_assert((1 << dclRegRawNumBits) == std::size(eDCLDecoderTable));
   Register dclReg = eDCLDecoderTable[dclRegRaw];
-  assert(dclReg && "Register not found.");
+  if (!dclReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dclReg));
 
-  unsigned dchRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (dchRegRaw >= std::size(eDCHDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dchRegRawNumBits = 2;
+  unsigned dchRegRaw = fieldFromInstruction(Insn, 14, dchRegRawNumBits);
+  static_assert((1 << dchRegRawNumBits) == std::size(eDCHDecoderTable));
   Register dchReg = eDCHDecoderTable[dchRegRaw];
-  assert(dchReg && "Register not found.");
+  if (!dchReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dchReg));
 
   // --------------------- Ins ------------------------
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (ptrRegRaw >= std::size(ePSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 1;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePSDecoderTable));
   Register ptrReg = ePSDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned fifo_regRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (fifo_regRegRaw >= std::size(eLdFifoRegDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned fifo_regRegRawNumBits = 1;
+  unsigned fifo_regRegRaw =
+      fieldFromInstruction(Insn, 17, fifo_regRegRawNumBits);
+  static_assert((1 << fifo_regRegRawNumBits) ==
+                std::size(eLdFifoRegDecoderTable));
   Register fifo_regReg = eLdFifoRegDecoderTable[fifo_regRegRaw];
-  assert(fifo_regReg && "Register not found.");
+  if (!fifo_regReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(fifo_regReg));
 
-  unsigned posRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (posRegRaw >= std::size(eRF2DecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned posRegRawNumBits = 1;
+  unsigned posRegRaw = fieldFromInstruction(Insn, 17, posRegRawNumBits);
+  static_assert((1 << posRegRawNumBits) == std::size(eRF2DecoderTable));
   Register posReg = eRF2DecoderTable[posRegRaw];
-  assert(posReg && "Register not found.");
+  if (!posReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(posReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (modRegRaw >= std::size(eDSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 2;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 14, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDSDecoderTable));
   Register modReg = eDSDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -3423,61 +3904,73 @@ static DecodeStatus
 DecodeVLDA_POP_704_fifo_1d_pop(MCInst &MI, InsnType &Insn, uint64_t Address,
                                const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned dstRegRaw = fieldFromInstruction(Insn, 9, 2);
-  if (dstRegRaw >= std::size(mQEXsaDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dstRegRawNumBits = 2;
+  unsigned dstRegRaw = fieldFromInstruction(Insn, 9, dstRegRawNumBits);
+  static_assert((1 << dstRegRawNumBits) == std::size(mQEXsaDecoderTable));
   Register dstReg = mQEXsaDecoderTable[dstRegRaw];
-  assert(dstReg && "Register not found.");
+  if (!dstReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dstReg));
 
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (ptr_outRegRaw >= std::size(ePSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 1;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePSDecoderTable));
   Register ptr_outReg = ePSDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned fifo_reg_outRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (fifo_reg_outRegRaw >= std::size(eLdFifoRegDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned fifo_reg_outRegRawNumBits = 1;
+  unsigned fifo_reg_outRegRaw =
+      fieldFromInstruction(Insn, 17, fifo_reg_outRegRawNumBits);
+  static_assert((1 << fifo_reg_outRegRawNumBits) ==
+                std::size(eLdFifoRegDecoderTable));
   Register fifo_reg_outReg = eLdFifoRegDecoderTable[fifo_reg_outRegRaw];
-  assert(fifo_reg_outReg && "Register not found.");
+  if (!fifo_reg_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(fifo_reg_outReg));
 
-  unsigned pos_outRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (pos_outRegRaw >= std::size(eRF2DecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned pos_outRegRawNumBits = 1;
+  unsigned pos_outRegRaw = fieldFromInstruction(Insn, 17, pos_outRegRawNumBits);
+  static_assert((1 << pos_outRegRawNumBits) == std::size(eRF2DecoderTable));
   Register pos_outReg = eRF2DecoderTable[pos_outRegRaw];
-  assert(pos_outReg && "Register not found.");
+  if (!pos_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(pos_outReg));
 
   // --------------------- Ins ------------------------
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (ptrRegRaw >= std::size(ePSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 1;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePSDecoderTable));
   Register ptrReg = ePSDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned fifo_regRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (fifo_regRegRaw >= std::size(eLdFifoRegDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned fifo_regRegRawNumBits = 1;
+  unsigned fifo_regRegRaw =
+      fieldFromInstruction(Insn, 17, fifo_regRegRawNumBits);
+  static_assert((1 << fifo_regRegRawNumBits) ==
+                std::size(eLdFifoRegDecoderTable));
   Register fifo_regReg = eLdFifoRegDecoderTable[fifo_regRegRaw];
-  assert(fifo_regReg && "Register not found.");
+  if (!fifo_regReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(fifo_regReg));
 
-  unsigned posRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (posRegRaw >= std::size(eRF2DecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned posRegRawNumBits = 1;
+  unsigned posRegRaw = fieldFromInstruction(Insn, 17, posRegRawNumBits);
+  static_assert((1 << posRegRawNumBits) == std::size(eRF2DecoderTable));
   Register posReg = eRF2DecoderTable[posRegRaw];
-  assert(posReg && "Register not found.");
+  if (!posReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(posReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (modRegRaw >= std::size(eMDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 3;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 14, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eMDecoderTable));
   Register modReg = eMDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -3488,54 +3981,65 @@ static DecodeStatus
 DecodeVLDA_POP_704_normal_pop(MCInst &MI, InsnType &Insn, uint64_t Address,
                               const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned dstRegRaw = fieldFromInstruction(Insn, 9, 2);
-  if (dstRegRaw >= std::size(mQEXsaDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dstRegRawNumBits = 2;
+  unsigned dstRegRaw = fieldFromInstruction(Insn, 9, dstRegRawNumBits);
+  static_assert((1 << dstRegRawNumBits) == std::size(mQEXsaDecoderTable));
   Register dstReg = mQEXsaDecoderTable[dstRegRaw];
-  assert(dstReg && "Register not found.");
+  if (!dstReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dstReg));
 
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (ptr_outRegRaw >= std::size(ePSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 1;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePSDecoderTable));
   Register ptr_outReg = ePSDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned fifo_reg_outRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (fifo_reg_outRegRaw >= std::size(eLdFifoRegDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned fifo_reg_outRegRawNumBits = 1;
+  unsigned fifo_reg_outRegRaw =
+      fieldFromInstruction(Insn, 17, fifo_reg_outRegRawNumBits);
+  static_assert((1 << fifo_reg_outRegRawNumBits) ==
+                std::size(eLdFifoRegDecoderTable));
   Register fifo_reg_outReg = eLdFifoRegDecoderTable[fifo_reg_outRegRaw];
-  assert(fifo_reg_outReg && "Register not found.");
+  if (!fifo_reg_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(fifo_reg_outReg));
 
-  unsigned pos_outRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (pos_outRegRaw >= std::size(eRF2DecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned pos_outRegRawNumBits = 1;
+  unsigned pos_outRegRaw = fieldFromInstruction(Insn, 17, pos_outRegRawNumBits);
+  static_assert((1 << pos_outRegRawNumBits) == std::size(eRF2DecoderTable));
   Register pos_outReg = eRF2DecoderTable[pos_outRegRaw];
-  assert(pos_outReg && "Register not found.");
+  if (!pos_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(pos_outReg));
 
   // --------------------- Ins ------------------------
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (ptrRegRaw >= std::size(ePSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 1;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePSDecoderTable));
   Register ptrReg = ePSDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned fifo_regRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (fifo_regRegRaw >= std::size(eLdFifoRegDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned fifo_regRegRawNumBits = 1;
+  unsigned fifo_regRegRaw =
+      fieldFromInstruction(Insn, 17, fifo_regRegRawNumBits);
+  static_assert((1 << fifo_regRegRawNumBits) ==
+                std::size(eLdFifoRegDecoderTable));
   Register fifo_regReg = eLdFifoRegDecoderTable[fifo_regRegRaw];
-  assert(fifo_regReg && "Register not found.");
+  if (!fifo_regReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(fifo_regReg));
 
-  unsigned posRegRaw = fieldFromInstruction(Insn, 17, 1);
-  if (posRegRaw >= std::size(eRF2DecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned posRegRawNumBits = 1;
+  unsigned posRegRaw = fieldFromInstruction(Insn, 17, posRegRawNumBits);
+  static_assert((1 << posRegRawNumBits) == std::size(eRF2DecoderTable));
   Register posReg = eRF2DecoderTable[posRegRaw];
-  assert(posReg && "Register not found.");
+  if (!posReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(posReg));
 
   return MCDisassembler::Success;
@@ -3546,40 +4050,45 @@ static DecodeStatus DecodeDmv_ldb_2D(MCInst &MI, InsnType &Insn,
                                      uint64_t Address,
                                      const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned dstRegRaw = fieldFromInstruction(Insn, 3, 5);
-  if (dstRegRaw >= std::size(mWbDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dstRegRawNumBits = 5;
+  unsigned dstRegRaw = fieldFromInstruction(Insn, 3, dstRegRawNumBits);
+  static_assert((1 << dstRegRawNumBits) == std::size(mWbDecoderTable));
   Register dstReg = mWbDecoderTable[dstRegRaw];
-  assert(dstReg && "Register not found.");
+  if (!dstReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dstReg));
 
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (ptr_outRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 3;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 14, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePDecoderTable));
   Register ptr_outReg = ePDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned dcRegRaw = fieldFromInstruction(Insn, 11, 3);
-  if (dcRegRaw >= std::size(eDCDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dcRegRawNumBits = 3;
+  unsigned dcRegRaw = fieldFromInstruction(Insn, 11, dcRegRawNumBits);
+  static_assert((1 << dcRegRawNumBits) == std::size(eDCDecoderTable));
   Register dcReg = eDCDecoderTable[dcRegRaw];
-  assert(dcReg && "Register not found.");
+  if (!dcReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dcReg));
 
   // --------------------- Ins ------------------------
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (ptrRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 3;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 14, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePDecoderTable));
   Register ptrReg = ePDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 11, 3);
-  if (modRegRaw >= std::size(eDDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 3;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 11, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDDecoderTable));
   Register modReg = eDDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -3590,40 +4099,45 @@ static DecodeStatus DecodeDmw_ldb_unpack_2D(MCInst &MI, InsnType &Insn,
                                             uint64_t Address,
                                             const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned dstRegRaw = fieldFromInstruction(Insn, 4, 4);
-  if (dstRegRaw >= std::size(mXbDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dstRegRawNumBits = 4;
+  unsigned dstRegRaw = fieldFromInstruction(Insn, 4, dstRegRawNumBits);
+  static_assert((1 << dstRegRawNumBits) == std::size(mXbDecoderTable));
   Register dstReg = mXbDecoderTable[dstRegRaw];
-  assert(dstReg && "Register not found.");
+  if (!dstReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dstReg));
 
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (ptr_outRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 3;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 14, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePDecoderTable));
   Register ptr_outReg = ePDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned dcRegRaw = fieldFromInstruction(Insn, 11, 3);
-  if (dcRegRaw >= std::size(eDCDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dcRegRawNumBits = 3;
+  unsigned dcRegRaw = fieldFromInstruction(Insn, 11, dcRegRawNumBits);
+  static_assert((1 << dcRegRawNumBits) == std::size(eDCDecoderTable));
   Register dcReg = eDCDecoderTable[dcRegRaw];
-  assert(dcReg && "Register not found.");
+  if (!dcReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dcReg));
 
   // --------------------- Ins ------------------------
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (ptrRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 3;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 14, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePDecoderTable));
   Register ptrReg = ePDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 11, 3);
-  if (modRegRaw >= std::size(eDDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 3;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 11, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDDecoderTable));
   Register modReg = eDDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -3634,40 +4148,45 @@ static DecodeStatus DecodeDmx_ldb_unpack_2D(MCInst &MI, InsnType &Insn,
                                             uint64_t Address,
                                             const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned dstRegRaw = fieldFromInstruction(Insn, 5, 3);
-  if (dstRegRaw >= std::size(eYDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dstRegRawNumBits = 3;
+  unsigned dstRegRaw = fieldFromInstruction(Insn, 5, dstRegRawNumBits);
+  static_assert((1 << dstRegRawNumBits) == std::size(eYDecoderTable));
   Register dstReg = eYDecoderTable[dstRegRaw];
-  assert(dstReg && "Register not found.");
+  if (!dstReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dstReg));
 
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (ptr_outRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 3;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 14, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePDecoderTable));
   Register ptr_outReg = ePDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned dcRegRaw = fieldFromInstruction(Insn, 11, 3);
-  if (dcRegRaw >= std::size(eDCDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dcRegRawNumBits = 3;
+  unsigned dcRegRaw = fieldFromInstruction(Insn, 11, dcRegRawNumBits);
+  static_assert((1 << dcRegRawNumBits) == std::size(eDCDecoderTable));
   Register dcReg = eDCDecoderTable[dcRegRaw];
-  assert(dcReg && "Register not found.");
+  if (!dcReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dcReg));
 
   // --------------------- Ins ------------------------
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (ptrRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 3;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 14, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePDecoderTable));
   Register ptrReg = ePDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 11, 3);
-  if (modRegRaw >= std::size(eDDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 3;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 11, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDDecoderTable));
   Register modReg = eDDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -3678,40 +4197,45 @@ static DecodeStatus DecodeDmw_ldb_2D(MCInst &MI, InsnType &Insn,
                                      uint64_t Address,
                                      const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned dstRegRaw = fieldFromInstruction(Insn, 3, 5);
-  if (dstRegRaw >= std::size(mWbDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dstRegRawNumBits = 5;
+  unsigned dstRegRaw = fieldFromInstruction(Insn, 3, dstRegRawNumBits);
+  static_assert((1 << dstRegRawNumBits) == std::size(mWbDecoderTable));
   Register dstReg = mWbDecoderTable[dstRegRaw];
-  assert(dstReg && "Register not found.");
+  if (!dstReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dstReg));
 
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (ptr_outRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 3;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 14, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePDecoderTable));
   Register ptr_outReg = ePDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned dcRegRaw = fieldFromInstruction(Insn, 11, 3);
-  if (dcRegRaw >= std::size(eDCDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dcRegRawNumBits = 3;
+  unsigned dcRegRaw = fieldFromInstruction(Insn, 11, dcRegRawNumBits);
+  static_assert((1 << dcRegRawNumBits) == std::size(eDCDecoderTable));
   Register dcReg = eDCDecoderTable[dcRegRaw];
-  assert(dcReg && "Register not found.");
+  if (!dcReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dcReg));
 
   // --------------------- Ins ------------------------
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (ptrRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 3;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 14, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePDecoderTable));
   Register ptrReg = ePDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 11, 3);
-  if (modRegRaw >= std::size(eDDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 3;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 11, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDDecoderTable));
   Register modReg = eDDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -3722,40 +4246,45 @@ static DecodeStatus DecodeDmx_ldb_x_2D(MCInst &MI, InsnType &Insn,
                                        uint64_t Address,
                                        const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned dstRegRaw = fieldFromInstruction(Insn, 4, 4);
-  if (dstRegRaw >= std::size(mXbDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dstRegRawNumBits = 4;
+  unsigned dstRegRaw = fieldFromInstruction(Insn, 4, dstRegRawNumBits);
+  static_assert((1 << dstRegRawNumBits) == std::size(mXbDecoderTable));
   Register dstReg = mXbDecoderTable[dstRegRaw];
-  assert(dstReg && "Register not found.");
+  if (!dstReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dstReg));
 
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (ptr_outRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 3;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 14, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePDecoderTable));
   Register ptr_outReg = ePDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned dcRegRaw = fieldFromInstruction(Insn, 11, 3);
-  if (dcRegRaw >= std::size(eDCDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dcRegRawNumBits = 3;
+  unsigned dcRegRaw = fieldFromInstruction(Insn, 11, dcRegRawNumBits);
+  static_assert((1 << dcRegRawNumBits) == std::size(eDCDecoderTable));
   Register dcReg = eDCDecoderTable[dcRegRaw];
-  assert(dcReg && "Register not found.");
+  if (!dcReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dcReg));
 
   // --------------------- Ins ------------------------
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (ptrRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 3;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 14, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePDecoderTable));
   Register ptrReg = ePDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 11, 3);
-  if (modRegRaw >= std::size(eDDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 3;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 11, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDDecoderTable));
   Register modReg = eDDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -3766,47 +4295,53 @@ static DecodeStatus DecodeDmv_ldb_3D(MCInst &MI, InsnType &Insn,
                                      uint64_t Address,
                                      const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned dstRegRaw = fieldFromInstruction(Insn, 3, 5);
-  if (dstRegRaw >= std::size(mWbDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dstRegRawNumBits = 5;
+  unsigned dstRegRaw = fieldFromInstruction(Insn, 3, dstRegRawNumBits);
+  static_assert((1 << dstRegRawNumBits) == std::size(mWbDecoderTable));
   Register dstReg = mWbDecoderTable[dstRegRaw];
-  assert(dstReg && "Register not found.");
+  if (!dstReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dstReg));
 
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (ptr_outRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 3;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 14, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePDecoderTable));
   Register ptr_outReg = ePDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned dclRegRaw = fieldFromInstruction(Insn, 11, 2);
-  if (dclRegRaw >= std::size(eDCLDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dclRegRawNumBits = 2;
+  unsigned dclRegRaw = fieldFromInstruction(Insn, 11, dclRegRawNumBits);
+  static_assert((1 << dclRegRawNumBits) == std::size(eDCLDecoderTable));
   Register dclReg = eDCLDecoderTable[dclRegRaw];
-  assert(dclReg && "Register not found.");
+  if (!dclReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dclReg));
 
-  unsigned dchRegRaw = fieldFromInstruction(Insn, 11, 2);
-  if (dchRegRaw >= std::size(eDCHDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dchRegRawNumBits = 2;
+  unsigned dchRegRaw = fieldFromInstruction(Insn, 11, dchRegRawNumBits);
+  static_assert((1 << dchRegRawNumBits) == std::size(eDCHDecoderTable));
   Register dchReg = eDCHDecoderTable[dchRegRaw];
-  assert(dchReg && "Register not found.");
+  if (!dchReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dchReg));
 
   // --------------------- Ins ------------------------
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (ptrRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 3;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 14, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePDecoderTable));
   Register ptrReg = ePDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 11, 2);
-  if (modRegRaw >= std::size(eDSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 2;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 11, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDSDecoderTable));
   Register modReg = eDSDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -3817,47 +4352,53 @@ static DecodeStatus DecodeDmw_ldb_unpack_3D(MCInst &MI, InsnType &Insn,
                                             uint64_t Address,
                                             const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned dstRegRaw = fieldFromInstruction(Insn, 4, 4);
-  if (dstRegRaw >= std::size(mXbDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dstRegRawNumBits = 4;
+  unsigned dstRegRaw = fieldFromInstruction(Insn, 4, dstRegRawNumBits);
+  static_assert((1 << dstRegRawNumBits) == std::size(mXbDecoderTable));
   Register dstReg = mXbDecoderTable[dstRegRaw];
-  assert(dstReg && "Register not found.");
+  if (!dstReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dstReg));
 
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (ptr_outRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 3;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 14, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePDecoderTable));
   Register ptr_outReg = ePDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned dclRegRaw = fieldFromInstruction(Insn, 11, 2);
-  if (dclRegRaw >= std::size(eDCLDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dclRegRawNumBits = 2;
+  unsigned dclRegRaw = fieldFromInstruction(Insn, 11, dclRegRawNumBits);
+  static_assert((1 << dclRegRawNumBits) == std::size(eDCLDecoderTable));
   Register dclReg = eDCLDecoderTable[dclRegRaw];
-  assert(dclReg && "Register not found.");
+  if (!dclReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dclReg));
 
-  unsigned dchRegRaw = fieldFromInstruction(Insn, 11, 2);
-  if (dchRegRaw >= std::size(eDCHDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dchRegRawNumBits = 2;
+  unsigned dchRegRaw = fieldFromInstruction(Insn, 11, dchRegRawNumBits);
+  static_assert((1 << dchRegRawNumBits) == std::size(eDCHDecoderTable));
   Register dchReg = eDCHDecoderTable[dchRegRaw];
-  assert(dchReg && "Register not found.");
+  if (!dchReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dchReg));
 
   // --------------------- Ins ------------------------
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (ptrRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 3;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 14, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePDecoderTable));
   Register ptrReg = ePDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 11, 2);
-  if (modRegRaw >= std::size(eDSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 2;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 11, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDSDecoderTable));
   Register modReg = eDSDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -3868,47 +4409,53 @@ static DecodeStatus DecodeDmx_ldb_unpack_3D(MCInst &MI, InsnType &Insn,
                                             uint64_t Address,
                                             const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned dstRegRaw = fieldFromInstruction(Insn, 5, 3);
-  if (dstRegRaw >= std::size(eYDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dstRegRawNumBits = 3;
+  unsigned dstRegRaw = fieldFromInstruction(Insn, 5, dstRegRawNumBits);
+  static_assert((1 << dstRegRawNumBits) == std::size(eYDecoderTable));
   Register dstReg = eYDecoderTable[dstRegRaw];
-  assert(dstReg && "Register not found.");
+  if (!dstReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dstReg));
 
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (ptr_outRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 3;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 14, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePDecoderTable));
   Register ptr_outReg = ePDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned dclRegRaw = fieldFromInstruction(Insn, 11, 2);
-  if (dclRegRaw >= std::size(eDCLDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dclRegRawNumBits = 2;
+  unsigned dclRegRaw = fieldFromInstruction(Insn, 11, dclRegRawNumBits);
+  static_assert((1 << dclRegRawNumBits) == std::size(eDCLDecoderTable));
   Register dclReg = eDCLDecoderTable[dclRegRaw];
-  assert(dclReg && "Register not found.");
+  if (!dclReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dclReg));
 
-  unsigned dchRegRaw = fieldFromInstruction(Insn, 11, 2);
-  if (dchRegRaw >= std::size(eDCHDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dchRegRawNumBits = 2;
+  unsigned dchRegRaw = fieldFromInstruction(Insn, 11, dchRegRawNumBits);
+  static_assert((1 << dchRegRawNumBits) == std::size(eDCHDecoderTable));
   Register dchReg = eDCHDecoderTable[dchRegRaw];
-  assert(dchReg && "Register not found.");
+  if (!dchReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dchReg));
 
   // --------------------- Ins ------------------------
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (ptrRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 3;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 14, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePDecoderTable));
   Register ptrReg = ePDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 11, 2);
-  if (modRegRaw >= std::size(eDSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 2;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 11, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDSDecoderTable));
   Register modReg = eDSDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -3919,47 +4466,53 @@ static DecodeStatus DecodeDmw_ldb_3D(MCInst &MI, InsnType &Insn,
                                      uint64_t Address,
                                      const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned dstRegRaw = fieldFromInstruction(Insn, 3, 5);
-  if (dstRegRaw >= std::size(mWbDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dstRegRawNumBits = 5;
+  unsigned dstRegRaw = fieldFromInstruction(Insn, 3, dstRegRawNumBits);
+  static_assert((1 << dstRegRawNumBits) == std::size(mWbDecoderTable));
   Register dstReg = mWbDecoderTable[dstRegRaw];
-  assert(dstReg && "Register not found.");
+  if (!dstReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dstReg));
 
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (ptr_outRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 3;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 14, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePDecoderTable));
   Register ptr_outReg = ePDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned dclRegRaw = fieldFromInstruction(Insn, 11, 2);
-  if (dclRegRaw >= std::size(eDCLDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dclRegRawNumBits = 2;
+  unsigned dclRegRaw = fieldFromInstruction(Insn, 11, dclRegRawNumBits);
+  static_assert((1 << dclRegRawNumBits) == std::size(eDCLDecoderTable));
   Register dclReg = eDCLDecoderTable[dclRegRaw];
-  assert(dclReg && "Register not found.");
+  if (!dclReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dclReg));
 
-  unsigned dchRegRaw = fieldFromInstruction(Insn, 11, 2);
-  if (dchRegRaw >= std::size(eDCHDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dchRegRawNumBits = 2;
+  unsigned dchRegRaw = fieldFromInstruction(Insn, 11, dchRegRawNumBits);
+  static_assert((1 << dchRegRawNumBits) == std::size(eDCHDecoderTable));
   Register dchReg = eDCHDecoderTable[dchRegRaw];
-  assert(dchReg && "Register not found.");
+  if (!dchReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dchReg));
 
   // --------------------- Ins ------------------------
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (ptrRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 3;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 14, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePDecoderTable));
   Register ptrReg = ePDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 11, 2);
-  if (modRegRaw >= std::size(eDSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 2;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 11, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDSDecoderTable));
   Register modReg = eDSDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -3970,47 +4523,53 @@ static DecodeStatus DecodeDmx_ldb_x_3D(MCInst &MI, InsnType &Insn,
                                        uint64_t Address,
                                        const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned dstRegRaw = fieldFromInstruction(Insn, 4, 4);
-  if (dstRegRaw >= std::size(mXbDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dstRegRawNumBits = 4;
+  unsigned dstRegRaw = fieldFromInstruction(Insn, 4, dstRegRawNumBits);
+  static_assert((1 << dstRegRawNumBits) == std::size(mXbDecoderTable));
   Register dstReg = mXbDecoderTable[dstRegRaw];
-  assert(dstReg && "Register not found.");
+  if (!dstReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dstReg));
 
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (ptr_outRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 3;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 14, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePDecoderTable));
   Register ptr_outReg = ePDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned dclRegRaw = fieldFromInstruction(Insn, 11, 2);
-  if (dclRegRaw >= std::size(eDCLDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dclRegRawNumBits = 2;
+  unsigned dclRegRaw = fieldFromInstruction(Insn, 11, dclRegRawNumBits);
+  static_assert((1 << dclRegRawNumBits) == std::size(eDCLDecoderTable));
   Register dclReg = eDCLDecoderTable[dclRegRaw];
-  assert(dclReg && "Register not found.");
+  if (!dclReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dclReg));
 
-  unsigned dchRegRaw = fieldFromInstruction(Insn, 11, 2);
-  if (dchRegRaw >= std::size(eDCHDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dchRegRawNumBits = 2;
+  unsigned dchRegRaw = fieldFromInstruction(Insn, 11, dchRegRawNumBits);
+  static_assert((1 << dchRegRawNumBits) == std::size(eDCHDecoderTable));
   Register dchReg = eDCHDecoderTable[dchRegRaw];
-  assert(dchReg && "Register not found.");
+  if (!dchReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dchReg));
 
   // --------------------- Ins ------------------------
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (ptrRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 3;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 14, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePDecoderTable));
   Register ptrReg = ePDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 11, 2);
-  if (modRegRaw >= std::size(eDSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 2;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 11, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDSDecoderTable));
   Register modReg = eDSDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -4021,25 +4580,30 @@ static DecodeStatus DecodeVLDB_FILLX_512(MCInst &MI, InsnType &Insn,
                                          uint64_t Address,
                                          const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (ptr_outRegRaw >= std::size(ePSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 1;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 14, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePSDecoderTable));
   Register ptr_outReg = ePSDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned fifo_reg_outRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (fifo_reg_outRegRaw >= std::size(eLdFifoRegDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned fifo_reg_outRegRawNumBits = 1;
+  unsigned fifo_reg_outRegRaw =
+      fieldFromInstruction(Insn, 14, fifo_reg_outRegRawNumBits);
+  static_assert((1 << fifo_reg_outRegRawNumBits) ==
+                std::size(eLdFifoRegDecoderTable));
   Register fifo_reg_outReg = eLdFifoRegDecoderTable[fifo_reg_outRegRaw];
-  assert(fifo_reg_outReg && "Register not found.");
+  if (!fifo_reg_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(fifo_reg_outReg));
 
-  unsigned pos_outRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (pos_outRegRaw >= std::size(eRF2DecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned pos_outRegRawNumBits = 1;
+  unsigned pos_outRegRaw = fieldFromInstruction(Insn, 14, pos_outRegRawNumBits);
+  static_assert((1 << pos_outRegRawNumBits) == std::size(eRF2DecoderTable));
   Register pos_outReg = eRF2DecoderTable[pos_outRegRaw];
-  assert(pos_outReg && "Register not found.");
+  if (!pos_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(pos_outReg));
 
   // --------------------- Ins ------------------------
@@ -4055,25 +4619,30 @@ static DecodeStatus DecodeVLDB_FILLX_512(MCInst &MI, InsnType &Insn,
   unsigned conf_e7Reg = conf_e7RC.getRegister(0);
   MI.addOperand(MCOperand::createReg(conf_e7Reg));
 
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (ptrRegRaw >= std::size(ePSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 1;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 14, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePSDecoderTable));
   Register ptrReg = ePSDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned fifo_regRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (fifo_regRegRaw >= std::size(eLdFifoRegDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned fifo_regRegRawNumBits = 1;
+  unsigned fifo_regRegRaw =
+      fieldFromInstruction(Insn, 14, fifo_regRegRawNumBits);
+  static_assert((1 << fifo_regRegRawNumBits) ==
+                std::size(eLdFifoRegDecoderTable));
   Register fifo_regReg = eLdFifoRegDecoderTable[fifo_regRegRaw];
-  assert(fifo_regReg && "Register not found.");
+  if (!fifo_regReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(fifo_regReg));
 
-  unsigned posRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (posRegRaw >= std::size(eRF2DecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned posRegRawNumBits = 1;
+  unsigned posRegRaw = fieldFromInstruction(Insn, 14, posRegRawNumBits);
+  static_assert((1 << posRegRawNumBits) == std::size(eRF2DecoderTable));
   Register posReg = eRF2DecoderTable[posRegRaw];
-  assert(posReg && "Register not found.");
+  if (!posReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(posReg));
 
   return MCDisassembler::Success;
@@ -4084,47 +4653,57 @@ static DecodeStatus DecodeVLDB_FILL_512(MCInst &MI, InsnType &Insn,
                                         uint64_t Address,
                                         const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (ptr_outRegRaw >= std::size(ePSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 1;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 14, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePSDecoderTable));
   Register ptr_outReg = ePSDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned fifo_reg_outRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (fifo_reg_outRegRaw >= std::size(eLdFifoRegDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned fifo_reg_outRegRawNumBits = 1;
+  unsigned fifo_reg_outRegRaw =
+      fieldFromInstruction(Insn, 14, fifo_reg_outRegRawNumBits);
+  static_assert((1 << fifo_reg_outRegRawNumBits) ==
+                std::size(eLdFifoRegDecoderTable));
   Register fifo_reg_outReg = eLdFifoRegDecoderTable[fifo_reg_outRegRaw];
-  assert(fifo_reg_outReg && "Register not found.");
+  if (!fifo_reg_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(fifo_reg_outReg));
 
-  unsigned pos_outRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (pos_outRegRaw >= std::size(eRF2DecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned pos_outRegRawNumBits = 1;
+  unsigned pos_outRegRaw = fieldFromInstruction(Insn, 14, pos_outRegRawNumBits);
+  static_assert((1 << pos_outRegRawNumBits) == std::size(eRF2DecoderTable));
   Register pos_outReg = eRF2DecoderTable[pos_outRegRaw];
-  assert(pos_outReg && "Register not found.");
+  if (!pos_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(pos_outReg));
 
   // --------------------- Ins ------------------------
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (ptrRegRaw >= std::size(ePSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 1;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 14, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePSDecoderTable));
   Register ptrReg = ePSDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned fifo_regRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (fifo_regRegRaw >= std::size(eLdFifoRegDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned fifo_regRegRawNumBits = 1;
+  unsigned fifo_regRegRaw =
+      fieldFromInstruction(Insn, 14, fifo_regRegRawNumBits);
+  static_assert((1 << fifo_regRegRawNumBits) ==
+                std::size(eLdFifoRegDecoderTable));
   Register fifo_regReg = eLdFifoRegDecoderTable[fifo_regRegRaw];
-  assert(fifo_regReg && "Register not found.");
+  if (!fifo_regReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(fifo_regReg));
 
-  unsigned posRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (posRegRaw >= std::size(eRF2DecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned posRegRawNumBits = 1;
+  unsigned posRegRaw = fieldFromInstruction(Insn, 14, posRegRawNumBits);
+  static_assert((1 << posRegRawNumBits) == std::size(eRF2DecoderTable));
   Register posReg = eRF2DecoderTable[posRegRaw];
-  assert(posReg && "Register not found.");
+  if (!posReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(posReg));
 
   return MCDisassembler::Success;
@@ -4135,32 +4714,38 @@ static DecodeStatus DecodeVLDB_POPX_512(MCInst &MI, InsnType &Insn,
                                         uint64_t Address,
                                         const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned dstRegRaw = fieldFromInstruction(Insn, 4, 4);
-  if (dstRegRaw >= std::size(mXbDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dstRegRawNumBits = 4;
+  unsigned dstRegRaw = fieldFromInstruction(Insn, 4, dstRegRawNumBits);
+  static_assert((1 << dstRegRawNumBits) == std::size(mXbDecoderTable));
   Register dstReg = mXbDecoderTable[dstRegRaw];
-  assert(dstReg && "Register not found.");
+  if (!dstReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dstReg));
 
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (ptr_outRegRaw >= std::size(ePSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 1;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 14, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePSDecoderTable));
   Register ptr_outReg = ePSDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned fifo_reg_outRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (fifo_reg_outRegRaw >= std::size(eLdFifoRegDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned fifo_reg_outRegRawNumBits = 1;
+  unsigned fifo_reg_outRegRaw =
+      fieldFromInstruction(Insn, 14, fifo_reg_outRegRawNumBits);
+  static_assert((1 << fifo_reg_outRegRawNumBits) ==
+                std::size(eLdFifoRegDecoderTable));
   Register fifo_reg_outReg = eLdFifoRegDecoderTable[fifo_reg_outRegRaw];
-  assert(fifo_reg_outReg && "Register not found.");
+  if (!fifo_reg_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(fifo_reg_outReg));
 
-  unsigned pos_outRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (pos_outRegRaw >= std::size(eRF2DecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned pos_outRegRawNumBits = 1;
+  unsigned pos_outRegRaw = fieldFromInstruction(Insn, 14, pos_outRegRawNumBits);
+  static_assert((1 << pos_outRegRawNumBits) == std::size(eRF2DecoderTable));
   Register pos_outReg = eRF2DecoderTable[pos_outRegRaw];
-  assert(pos_outReg && "Register not found.");
+  if (!pos_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(pos_outReg));
 
   // --------------------- Ins ------------------------
@@ -4176,25 +4761,30 @@ static DecodeStatus DecodeVLDB_POPX_512(MCInst &MI, InsnType &Insn,
   unsigned conf_e7Reg = conf_e7RC.getRegister(0);
   MI.addOperand(MCOperand::createReg(conf_e7Reg));
 
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (ptrRegRaw >= std::size(ePSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 1;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 14, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePSDecoderTable));
   Register ptrReg = ePSDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned fifo_regRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (fifo_regRegRaw >= std::size(eLdFifoRegDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned fifo_regRegRawNumBits = 1;
+  unsigned fifo_regRegRaw =
+      fieldFromInstruction(Insn, 14, fifo_regRegRawNumBits);
+  static_assert((1 << fifo_regRegRawNumBits) ==
+                std::size(eLdFifoRegDecoderTable));
   Register fifo_regReg = eLdFifoRegDecoderTable[fifo_regRegRaw];
-  assert(fifo_regReg && "Register not found.");
+  if (!fifo_regReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(fifo_regReg));
 
-  unsigned posRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (posRegRaw >= std::size(eRF2DecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned posRegRawNumBits = 1;
+  unsigned posRegRaw = fieldFromInstruction(Insn, 14, posRegRawNumBits);
+  static_assert((1 << posRegRawNumBits) == std::size(eRF2DecoderTable));
   Register posReg = eRF2DecoderTable[posRegRaw];
-  assert(posReg && "Register not found.");
+  if (!posReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(posReg));
 
   return MCDisassembler::Success;
@@ -4205,68 +4795,81 @@ static DecodeStatus
 DecodeDmx_ldb_fifo_x__fifo_2d_pop(MCInst &MI, InsnType &Insn, uint64_t Address,
                                   const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned dstRegRaw = fieldFromInstruction(Insn, 4, 4);
-  if (dstRegRaw >= std::size(mXbDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dstRegRawNumBits = 4;
+  unsigned dstRegRaw = fieldFromInstruction(Insn, 4, dstRegRawNumBits);
+  static_assert((1 << dstRegRawNumBits) == std::size(mXbDecoderTable));
   Register dstReg = mXbDecoderTable[dstRegRaw];
-  assert(dstReg && "Register not found.");
+  if (!dstReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dstReg));
 
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (ptr_outRegRaw >= std::size(ePSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 1;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 14, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePSDecoderTable));
   Register ptr_outReg = ePSDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned fifo_reg_outRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (fifo_reg_outRegRaw >= std::size(eLdFifoRegDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned fifo_reg_outRegRawNumBits = 1;
+  unsigned fifo_reg_outRegRaw =
+      fieldFromInstruction(Insn, 14, fifo_reg_outRegRawNumBits);
+  static_assert((1 << fifo_reg_outRegRawNumBits) ==
+                std::size(eLdFifoRegDecoderTable));
   Register fifo_reg_outReg = eLdFifoRegDecoderTable[fifo_reg_outRegRaw];
-  assert(fifo_reg_outReg && "Register not found.");
+  if (!fifo_reg_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(fifo_reg_outReg));
 
-  unsigned pos_outRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (pos_outRegRaw >= std::size(eRF2DecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned pos_outRegRawNumBits = 1;
+  unsigned pos_outRegRaw = fieldFromInstruction(Insn, 14, pos_outRegRawNumBits);
+  static_assert((1 << pos_outRegRawNumBits) == std::size(eRF2DecoderTable));
   Register pos_outReg = eRF2DecoderTable[pos_outRegRaw];
-  assert(pos_outReg && "Register not found.");
+  if (!pos_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(pos_outReg));
 
-  unsigned dcRegRaw = fieldFromInstruction(Insn, 11, 3);
-  if (dcRegRaw >= std::size(eDCDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dcRegRawNumBits = 3;
+  unsigned dcRegRaw = fieldFromInstruction(Insn, 11, dcRegRawNumBits);
+  static_assert((1 << dcRegRawNumBits) == std::size(eDCDecoderTable));
   Register dcReg = eDCDecoderTable[dcRegRaw];
-  assert(dcReg && "Register not found.");
+  if (!dcReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dcReg));
 
   // --------------------- Ins ------------------------
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (ptrRegRaw >= std::size(ePSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 1;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 14, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePSDecoderTable));
   Register ptrReg = ePSDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned fifo_regRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (fifo_regRegRaw >= std::size(eLdFifoRegDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned fifo_regRegRawNumBits = 1;
+  unsigned fifo_regRegRaw =
+      fieldFromInstruction(Insn, 14, fifo_regRegRawNumBits);
+  static_assert((1 << fifo_regRegRawNumBits) ==
+                std::size(eLdFifoRegDecoderTable));
   Register fifo_regReg = eLdFifoRegDecoderTable[fifo_regRegRaw];
-  assert(fifo_regReg && "Register not found.");
+  if (!fifo_regReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(fifo_regReg));
 
-  unsigned posRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (posRegRaw >= std::size(eRF2DecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned posRegRawNumBits = 1;
+  unsigned posRegRaw = fieldFromInstruction(Insn, 14, posRegRawNumBits);
+  static_assert((1 << posRegRawNumBits) == std::size(eRF2DecoderTable));
   Register posReg = eRF2DecoderTable[posRegRaw];
-  assert(posReg && "Register not found.");
+  if (!posReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(posReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 11, 3);
-  if (modRegRaw >= std::size(eDDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 3;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 11, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDDecoderTable));
   Register modReg = eDDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -4277,75 +4880,89 @@ static DecodeStatus
 DecodeDmx_ldb_fifo_x__fifo_3d_pop(MCInst &MI, InsnType &Insn, uint64_t Address,
                                   const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned dstRegRaw = fieldFromInstruction(Insn, 4, 4);
-  if (dstRegRaw >= std::size(mXbDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dstRegRawNumBits = 4;
+  unsigned dstRegRaw = fieldFromInstruction(Insn, 4, dstRegRawNumBits);
+  static_assert((1 << dstRegRawNumBits) == std::size(mXbDecoderTable));
   Register dstReg = mXbDecoderTable[dstRegRaw];
-  assert(dstReg && "Register not found.");
+  if (!dstReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dstReg));
 
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (ptr_outRegRaw >= std::size(ePSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 1;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 14, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePSDecoderTable));
   Register ptr_outReg = ePSDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned fifo_reg_outRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (fifo_reg_outRegRaw >= std::size(eLdFifoRegDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned fifo_reg_outRegRawNumBits = 1;
+  unsigned fifo_reg_outRegRaw =
+      fieldFromInstruction(Insn, 14, fifo_reg_outRegRawNumBits);
+  static_assert((1 << fifo_reg_outRegRawNumBits) ==
+                std::size(eLdFifoRegDecoderTable));
   Register fifo_reg_outReg = eLdFifoRegDecoderTable[fifo_reg_outRegRaw];
-  assert(fifo_reg_outReg && "Register not found.");
+  if (!fifo_reg_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(fifo_reg_outReg));
 
-  unsigned pos_outRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (pos_outRegRaw >= std::size(eRF2DecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned pos_outRegRawNumBits = 1;
+  unsigned pos_outRegRaw = fieldFromInstruction(Insn, 14, pos_outRegRawNumBits);
+  static_assert((1 << pos_outRegRawNumBits) == std::size(eRF2DecoderTable));
   Register pos_outReg = eRF2DecoderTable[pos_outRegRaw];
-  assert(pos_outReg && "Register not found.");
+  if (!pos_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(pos_outReg));
 
-  unsigned dclRegRaw = fieldFromInstruction(Insn, 11, 2);
-  if (dclRegRaw >= std::size(eDCLDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dclRegRawNumBits = 2;
+  unsigned dclRegRaw = fieldFromInstruction(Insn, 11, dclRegRawNumBits);
+  static_assert((1 << dclRegRawNumBits) == std::size(eDCLDecoderTable));
   Register dclReg = eDCLDecoderTable[dclRegRaw];
-  assert(dclReg && "Register not found.");
+  if (!dclReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dclReg));
 
-  unsigned dchRegRaw = fieldFromInstruction(Insn, 11, 2);
-  if (dchRegRaw >= std::size(eDCHDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dchRegRawNumBits = 2;
+  unsigned dchRegRaw = fieldFromInstruction(Insn, 11, dchRegRawNumBits);
+  static_assert((1 << dchRegRawNumBits) == std::size(eDCHDecoderTable));
   Register dchReg = eDCHDecoderTable[dchRegRaw];
-  assert(dchReg && "Register not found.");
+  if (!dchReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dchReg));
 
   // --------------------- Ins ------------------------
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (ptrRegRaw >= std::size(ePSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 1;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 14, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePSDecoderTable));
   Register ptrReg = ePSDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned fifo_regRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (fifo_regRegRaw >= std::size(eLdFifoRegDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned fifo_regRegRawNumBits = 1;
+  unsigned fifo_regRegRaw =
+      fieldFromInstruction(Insn, 14, fifo_regRegRawNumBits);
+  static_assert((1 << fifo_regRegRawNumBits) ==
+                std::size(eLdFifoRegDecoderTable));
   Register fifo_regReg = eLdFifoRegDecoderTable[fifo_regRegRaw];
-  assert(fifo_regReg && "Register not found.");
+  if (!fifo_regReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(fifo_regReg));
 
-  unsigned posRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (posRegRaw >= std::size(eRF2DecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned posRegRawNumBits = 1;
+  unsigned posRegRaw = fieldFromInstruction(Insn, 14, posRegRawNumBits);
+  static_assert((1 << posRegRawNumBits) == std::size(eRF2DecoderTable));
   Register posReg = eRF2DecoderTable[posRegRaw];
-  assert(posReg && "Register not found.");
+  if (!posReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(posReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 11, 2);
-  if (modRegRaw >= std::size(eDSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 2;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 11, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDSDecoderTable));
   Register modReg = eDSDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -4356,61 +4973,73 @@ static DecodeStatus
 DecodeVLDB_POP_512_fifo_1d_pop(MCInst &MI, InsnType &Insn, uint64_t Address,
                                const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned dstRegRaw = fieldFromInstruction(Insn, 4, 4);
-  if (dstRegRaw >= std::size(mXbDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dstRegRawNumBits = 4;
+  unsigned dstRegRaw = fieldFromInstruction(Insn, 4, dstRegRawNumBits);
+  static_assert((1 << dstRegRawNumBits) == std::size(mXbDecoderTable));
   Register dstReg = mXbDecoderTable[dstRegRaw];
-  assert(dstReg && "Register not found.");
+  if (!dstReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dstReg));
 
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (ptr_outRegRaw >= std::size(ePSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 1;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 14, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePSDecoderTable));
   Register ptr_outReg = ePSDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned fifo_reg_outRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (fifo_reg_outRegRaw >= std::size(eLdFifoRegDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned fifo_reg_outRegRawNumBits = 1;
+  unsigned fifo_reg_outRegRaw =
+      fieldFromInstruction(Insn, 14, fifo_reg_outRegRawNumBits);
+  static_assert((1 << fifo_reg_outRegRawNumBits) ==
+                std::size(eLdFifoRegDecoderTable));
   Register fifo_reg_outReg = eLdFifoRegDecoderTable[fifo_reg_outRegRaw];
-  assert(fifo_reg_outReg && "Register not found.");
+  if (!fifo_reg_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(fifo_reg_outReg));
 
-  unsigned pos_outRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (pos_outRegRaw >= std::size(eRF2DecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned pos_outRegRawNumBits = 1;
+  unsigned pos_outRegRaw = fieldFromInstruction(Insn, 14, pos_outRegRawNumBits);
+  static_assert((1 << pos_outRegRawNumBits) == std::size(eRF2DecoderTable));
   Register pos_outReg = eRF2DecoderTable[pos_outRegRaw];
-  assert(pos_outReg && "Register not found.");
+  if (!pos_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(pos_outReg));
 
   // --------------------- Ins ------------------------
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (ptrRegRaw >= std::size(ePSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 1;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 14, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePSDecoderTable));
   Register ptrReg = ePSDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned fifo_regRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (fifo_regRegRaw >= std::size(eLdFifoRegDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned fifo_regRegRawNumBits = 1;
+  unsigned fifo_regRegRaw =
+      fieldFromInstruction(Insn, 14, fifo_regRegRawNumBits);
+  static_assert((1 << fifo_regRegRawNumBits) ==
+                std::size(eLdFifoRegDecoderTable));
   Register fifo_regReg = eLdFifoRegDecoderTable[fifo_regRegRaw];
-  assert(fifo_regReg && "Register not found.");
+  if (!fifo_regReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(fifo_regReg));
 
-  unsigned posRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (posRegRaw >= std::size(eRF2DecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned posRegRawNumBits = 1;
+  unsigned posRegRaw = fieldFromInstruction(Insn, 14, posRegRawNumBits);
+  static_assert((1 << posRegRawNumBits) == std::size(eRF2DecoderTable));
   Register posReg = eRF2DecoderTable[posRegRaw];
-  assert(posReg && "Register not found.");
+  if (!posReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(posReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 11, 3);
-  if (modRegRaw >= std::size(eMDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 3;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 11, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eMDecoderTable));
   Register modReg = eMDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -4421,54 +5050,65 @@ static DecodeStatus
 DecodeVLDB_POP_512_normal_pop(MCInst &MI, InsnType &Insn, uint64_t Address,
                               const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned dstRegRaw = fieldFromInstruction(Insn, 4, 4);
-  if (dstRegRaw >= std::size(mXbDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dstRegRawNumBits = 4;
+  unsigned dstRegRaw = fieldFromInstruction(Insn, 4, dstRegRawNumBits);
+  static_assert((1 << dstRegRawNumBits) == std::size(mXbDecoderTable));
   Register dstReg = mXbDecoderTable[dstRegRaw];
-  assert(dstReg && "Register not found.");
+  if (!dstReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dstReg));
 
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (ptr_outRegRaw >= std::size(ePSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 1;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 14, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePSDecoderTable));
   Register ptr_outReg = ePSDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned fifo_reg_outRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (fifo_reg_outRegRaw >= std::size(eLdFifoRegDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned fifo_reg_outRegRawNumBits = 1;
+  unsigned fifo_reg_outRegRaw =
+      fieldFromInstruction(Insn, 14, fifo_reg_outRegRawNumBits);
+  static_assert((1 << fifo_reg_outRegRawNumBits) ==
+                std::size(eLdFifoRegDecoderTable));
   Register fifo_reg_outReg = eLdFifoRegDecoderTable[fifo_reg_outRegRaw];
-  assert(fifo_reg_outReg && "Register not found.");
+  if (!fifo_reg_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(fifo_reg_outReg));
 
-  unsigned pos_outRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (pos_outRegRaw >= std::size(eRF2DecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned pos_outRegRawNumBits = 1;
+  unsigned pos_outRegRaw = fieldFromInstruction(Insn, 14, pos_outRegRawNumBits);
+  static_assert((1 << pos_outRegRawNumBits) == std::size(eRF2DecoderTable));
   Register pos_outReg = eRF2DecoderTable[pos_outRegRaw];
-  assert(pos_outReg && "Register not found.");
+  if (!pos_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(pos_outReg));
 
   // --------------------- Ins ------------------------
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (ptrRegRaw >= std::size(ePSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 1;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 14, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePSDecoderTable));
   Register ptrReg = ePSDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned fifo_regRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (fifo_regRegRaw >= std::size(eLdFifoRegDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned fifo_regRegRawNumBits = 1;
+  unsigned fifo_regRegRaw =
+      fieldFromInstruction(Insn, 14, fifo_regRegRawNumBits);
+  static_assert((1 << fifo_regRegRawNumBits) ==
+                std::size(eLdFifoRegDecoderTable));
   Register fifo_regReg = eLdFifoRegDecoderTable[fifo_regRegRaw];
-  assert(fifo_regReg && "Register not found.");
+  if (!fifo_regReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(fifo_regReg));
 
-  unsigned posRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (posRegRaw >= std::size(eRF2DecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned posRegRawNumBits = 1;
+  unsigned posRegRaw = fieldFromInstruction(Insn, 14, posRegRawNumBits);
+  static_assert((1 << posRegRawNumBits) == std::size(eRF2DecoderTable));
   Register posReg = eRF2DecoderTable[posRegRaw];
-  assert(posReg && "Register not found.");
+  if (!posReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(posReg));
 
   return MCDisassembler::Success;
@@ -4480,68 +5120,81 @@ DecodeDmx_ldb_fifo_ex_ebs16__fifo_2d_pop(MCInst &MI, InsnType &Insn,
                                          uint64_t Address,
                                          const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned dstRegRaw = fieldFromInstruction(Insn, 4, 4);
-  if (dstRegRaw >= std::size(mEXbDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dstRegRawNumBits = 4;
+  unsigned dstRegRaw = fieldFromInstruction(Insn, 4, dstRegRawNumBits);
+  static_assert((1 << dstRegRawNumBits) == std::size(mEXbDecoderTable));
   Register dstReg = mEXbDecoderTable[dstRegRaw];
-  assert(dstReg && "Register not found.");
+  if (!dstReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dstReg));
 
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (ptr_outRegRaw >= std::size(ePSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 1;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 14, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePSDecoderTable));
   Register ptr_outReg = ePSDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned fifo_reg_outRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (fifo_reg_outRegRaw >= std::size(eLdFifoRegDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned fifo_reg_outRegRawNumBits = 1;
+  unsigned fifo_reg_outRegRaw =
+      fieldFromInstruction(Insn, 14, fifo_reg_outRegRawNumBits);
+  static_assert((1 << fifo_reg_outRegRawNumBits) ==
+                std::size(eLdFifoRegDecoderTable));
   Register fifo_reg_outReg = eLdFifoRegDecoderTable[fifo_reg_outRegRaw];
-  assert(fifo_reg_outReg && "Register not found.");
+  if (!fifo_reg_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(fifo_reg_outReg));
 
-  unsigned pos_outRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (pos_outRegRaw >= std::size(eRF2DecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned pos_outRegRawNumBits = 1;
+  unsigned pos_outRegRaw = fieldFromInstruction(Insn, 14, pos_outRegRawNumBits);
+  static_assert((1 << pos_outRegRawNumBits) == std::size(eRF2DecoderTable));
   Register pos_outReg = eRF2DecoderTable[pos_outRegRaw];
-  assert(pos_outReg && "Register not found.");
+  if (!pos_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(pos_outReg));
 
-  unsigned dcRegRaw = fieldFromInstruction(Insn, 11, 3);
-  if (dcRegRaw >= std::size(eDCDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dcRegRawNumBits = 3;
+  unsigned dcRegRaw = fieldFromInstruction(Insn, 11, dcRegRawNumBits);
+  static_assert((1 << dcRegRawNumBits) == std::size(eDCDecoderTable));
   Register dcReg = eDCDecoderTable[dcRegRaw];
-  assert(dcReg && "Register not found.");
+  if (!dcReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dcReg));
 
   // --------------------- Ins ------------------------
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (ptrRegRaw >= std::size(ePSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 1;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 14, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePSDecoderTable));
   Register ptrReg = ePSDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned fifo_regRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (fifo_regRegRaw >= std::size(eLdFifoRegDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned fifo_regRegRawNumBits = 1;
+  unsigned fifo_regRegRaw =
+      fieldFromInstruction(Insn, 14, fifo_regRegRawNumBits);
+  static_assert((1 << fifo_regRegRawNumBits) ==
+                std::size(eLdFifoRegDecoderTable));
   Register fifo_regReg = eLdFifoRegDecoderTable[fifo_regRegRaw];
-  assert(fifo_regReg && "Register not found.");
+  if (!fifo_regReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(fifo_regReg));
 
-  unsigned posRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (posRegRaw >= std::size(eRF2DecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned posRegRawNumBits = 1;
+  unsigned posRegRaw = fieldFromInstruction(Insn, 14, posRegRawNumBits);
+  static_assert((1 << posRegRawNumBits) == std::size(eRF2DecoderTable));
   Register posReg = eRF2DecoderTable[posRegRaw];
-  assert(posReg && "Register not found.");
+  if (!posReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(posReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 11, 3);
-  if (modRegRaw >= std::size(eDDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 3;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 11, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDDecoderTable));
   Register modReg = eDDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -4553,75 +5206,89 @@ DecodeDmx_ldb_fifo_ex_ebs16__fifo_3d_pop(MCInst &MI, InsnType &Insn,
                                          uint64_t Address,
                                          const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned dstRegRaw = fieldFromInstruction(Insn, 4, 4);
-  if (dstRegRaw >= std::size(mEXbDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dstRegRawNumBits = 4;
+  unsigned dstRegRaw = fieldFromInstruction(Insn, 4, dstRegRawNumBits);
+  static_assert((1 << dstRegRawNumBits) == std::size(mEXbDecoderTable));
   Register dstReg = mEXbDecoderTable[dstRegRaw];
-  assert(dstReg && "Register not found.");
+  if (!dstReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dstReg));
 
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (ptr_outRegRaw >= std::size(ePSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 1;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 14, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePSDecoderTable));
   Register ptr_outReg = ePSDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned fifo_reg_outRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (fifo_reg_outRegRaw >= std::size(eLdFifoRegDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned fifo_reg_outRegRawNumBits = 1;
+  unsigned fifo_reg_outRegRaw =
+      fieldFromInstruction(Insn, 14, fifo_reg_outRegRawNumBits);
+  static_assert((1 << fifo_reg_outRegRawNumBits) ==
+                std::size(eLdFifoRegDecoderTable));
   Register fifo_reg_outReg = eLdFifoRegDecoderTable[fifo_reg_outRegRaw];
-  assert(fifo_reg_outReg && "Register not found.");
+  if (!fifo_reg_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(fifo_reg_outReg));
 
-  unsigned pos_outRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (pos_outRegRaw >= std::size(eRF2DecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned pos_outRegRawNumBits = 1;
+  unsigned pos_outRegRaw = fieldFromInstruction(Insn, 14, pos_outRegRawNumBits);
+  static_assert((1 << pos_outRegRawNumBits) == std::size(eRF2DecoderTable));
   Register pos_outReg = eRF2DecoderTable[pos_outRegRaw];
-  assert(pos_outReg && "Register not found.");
+  if (!pos_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(pos_outReg));
 
-  unsigned dclRegRaw = fieldFromInstruction(Insn, 11, 2);
-  if (dclRegRaw >= std::size(eDCLDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dclRegRawNumBits = 2;
+  unsigned dclRegRaw = fieldFromInstruction(Insn, 11, dclRegRawNumBits);
+  static_assert((1 << dclRegRawNumBits) == std::size(eDCLDecoderTable));
   Register dclReg = eDCLDecoderTable[dclRegRaw];
-  assert(dclReg && "Register not found.");
+  if (!dclReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dclReg));
 
-  unsigned dchRegRaw = fieldFromInstruction(Insn, 11, 2);
-  if (dchRegRaw >= std::size(eDCHDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dchRegRawNumBits = 2;
+  unsigned dchRegRaw = fieldFromInstruction(Insn, 11, dchRegRawNumBits);
+  static_assert((1 << dchRegRawNumBits) == std::size(eDCHDecoderTable));
   Register dchReg = eDCHDecoderTable[dchRegRaw];
-  assert(dchReg && "Register not found.");
+  if (!dchReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dchReg));
 
   // --------------------- Ins ------------------------
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (ptrRegRaw >= std::size(ePSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 1;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 14, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePSDecoderTable));
   Register ptrReg = ePSDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned fifo_regRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (fifo_regRegRaw >= std::size(eLdFifoRegDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned fifo_regRegRawNumBits = 1;
+  unsigned fifo_regRegRaw =
+      fieldFromInstruction(Insn, 14, fifo_regRegRawNumBits);
+  static_assert((1 << fifo_regRegRawNumBits) ==
+                std::size(eLdFifoRegDecoderTable));
   Register fifo_regReg = eLdFifoRegDecoderTable[fifo_regRegRaw];
-  assert(fifo_regReg && "Register not found.");
+  if (!fifo_regReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(fifo_regReg));
 
-  unsigned posRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (posRegRaw >= std::size(eRF2DecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned posRegRawNumBits = 1;
+  unsigned posRegRaw = fieldFromInstruction(Insn, 14, posRegRawNumBits);
+  static_assert((1 << posRegRawNumBits) == std::size(eRF2DecoderTable));
   Register posReg = eRF2DecoderTable[posRegRaw];
-  assert(posReg && "Register not found.");
+  if (!posReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(posReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 11, 2);
-  if (modRegRaw >= std::size(eDSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 2;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 11, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDSDecoderTable));
   Register modReg = eDSDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -4632,61 +5299,73 @@ static DecodeStatus
 DecodeVLDB_POP_544_fifo_1d_pop(MCInst &MI, InsnType &Insn, uint64_t Address,
                                const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned dstRegRaw = fieldFromInstruction(Insn, 4, 4);
-  if (dstRegRaw >= std::size(mEXbDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dstRegRawNumBits = 4;
+  unsigned dstRegRaw = fieldFromInstruction(Insn, 4, dstRegRawNumBits);
+  static_assert((1 << dstRegRawNumBits) == std::size(mEXbDecoderTable));
   Register dstReg = mEXbDecoderTable[dstRegRaw];
-  assert(dstReg && "Register not found.");
+  if (!dstReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dstReg));
 
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (ptr_outRegRaw >= std::size(ePSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 1;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 14, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePSDecoderTable));
   Register ptr_outReg = ePSDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned fifo_reg_outRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (fifo_reg_outRegRaw >= std::size(eLdFifoRegDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned fifo_reg_outRegRawNumBits = 1;
+  unsigned fifo_reg_outRegRaw =
+      fieldFromInstruction(Insn, 14, fifo_reg_outRegRawNumBits);
+  static_assert((1 << fifo_reg_outRegRawNumBits) ==
+                std::size(eLdFifoRegDecoderTable));
   Register fifo_reg_outReg = eLdFifoRegDecoderTable[fifo_reg_outRegRaw];
-  assert(fifo_reg_outReg && "Register not found.");
+  if (!fifo_reg_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(fifo_reg_outReg));
 
-  unsigned pos_outRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (pos_outRegRaw >= std::size(eRF2DecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned pos_outRegRawNumBits = 1;
+  unsigned pos_outRegRaw = fieldFromInstruction(Insn, 14, pos_outRegRawNumBits);
+  static_assert((1 << pos_outRegRawNumBits) == std::size(eRF2DecoderTable));
   Register pos_outReg = eRF2DecoderTable[pos_outRegRaw];
-  assert(pos_outReg && "Register not found.");
+  if (!pos_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(pos_outReg));
 
   // --------------------- Ins ------------------------
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (ptrRegRaw >= std::size(ePSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 1;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 14, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePSDecoderTable));
   Register ptrReg = ePSDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned fifo_regRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (fifo_regRegRaw >= std::size(eLdFifoRegDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned fifo_regRegRawNumBits = 1;
+  unsigned fifo_regRegRaw =
+      fieldFromInstruction(Insn, 14, fifo_regRegRawNumBits);
+  static_assert((1 << fifo_regRegRawNumBits) ==
+                std::size(eLdFifoRegDecoderTable));
   Register fifo_regReg = eLdFifoRegDecoderTable[fifo_regRegRaw];
-  assert(fifo_regReg && "Register not found.");
+  if (!fifo_regReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(fifo_regReg));
 
-  unsigned posRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (posRegRaw >= std::size(eRF2DecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned posRegRawNumBits = 1;
+  unsigned posRegRaw = fieldFromInstruction(Insn, 14, posRegRawNumBits);
+  static_assert((1 << posRegRawNumBits) == std::size(eRF2DecoderTable));
   Register posReg = eRF2DecoderTable[posRegRaw];
-  assert(posReg && "Register not found.");
+  if (!posReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(posReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 11, 3);
-  if (modRegRaw >= std::size(eMDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 3;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 11, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eMDecoderTable));
   Register modReg = eMDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -4697,54 +5376,65 @@ static DecodeStatus
 DecodeVLDB_POP_544_normal_pop(MCInst &MI, InsnType &Insn, uint64_t Address,
                               const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned dstRegRaw = fieldFromInstruction(Insn, 4, 4);
-  if (dstRegRaw >= std::size(mEXbDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dstRegRawNumBits = 4;
+  unsigned dstRegRaw = fieldFromInstruction(Insn, 4, dstRegRawNumBits);
+  static_assert((1 << dstRegRawNumBits) == std::size(mEXbDecoderTable));
   Register dstReg = mEXbDecoderTable[dstRegRaw];
-  assert(dstReg && "Register not found.");
+  if (!dstReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dstReg));
 
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (ptr_outRegRaw >= std::size(ePSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 1;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 14, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePSDecoderTable));
   Register ptr_outReg = ePSDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned fifo_reg_outRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (fifo_reg_outRegRaw >= std::size(eLdFifoRegDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned fifo_reg_outRegRawNumBits = 1;
+  unsigned fifo_reg_outRegRaw =
+      fieldFromInstruction(Insn, 14, fifo_reg_outRegRawNumBits);
+  static_assert((1 << fifo_reg_outRegRawNumBits) ==
+                std::size(eLdFifoRegDecoderTable));
   Register fifo_reg_outReg = eLdFifoRegDecoderTable[fifo_reg_outRegRaw];
-  assert(fifo_reg_outReg && "Register not found.");
+  if (!fifo_reg_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(fifo_reg_outReg));
 
-  unsigned pos_outRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (pos_outRegRaw >= std::size(eRF2DecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned pos_outRegRawNumBits = 1;
+  unsigned pos_outRegRaw = fieldFromInstruction(Insn, 14, pos_outRegRawNumBits);
+  static_assert((1 << pos_outRegRawNumBits) == std::size(eRF2DecoderTable));
   Register pos_outReg = eRF2DecoderTable[pos_outRegRaw];
-  assert(pos_outReg && "Register not found.");
+  if (!pos_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(pos_outReg));
 
   // --------------------- Ins ------------------------
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (ptrRegRaw >= std::size(ePSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 1;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 14, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePSDecoderTable));
   Register ptrReg = ePSDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned fifo_regRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (fifo_regRegRaw >= std::size(eLdFifoRegDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned fifo_regRegRawNumBits = 1;
+  unsigned fifo_regRegRaw =
+      fieldFromInstruction(Insn, 14, fifo_regRegRawNumBits);
+  static_assert((1 << fifo_regRegRawNumBits) ==
+                std::size(eLdFifoRegDecoderTable));
   Register fifo_regReg = eLdFifoRegDecoderTable[fifo_regRegRaw];
-  assert(fifo_regReg && "Register not found.");
+  if (!fifo_regReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(fifo_regReg));
 
-  unsigned posRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (posRegRaw >= std::size(eRF2DecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned posRegRawNumBits = 1;
+  unsigned posRegRaw = fieldFromInstruction(Insn, 14, posRegRawNumBits);
+  static_assert((1 << posRegRawNumBits) == std::size(eRF2DecoderTable));
   Register posReg = eRF2DecoderTable[posRegRaw];
-  assert(posReg && "Register not found.");
+  if (!posReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(posReg));
 
   return MCDisassembler::Success;
@@ -4756,68 +5446,81 @@ DecodeDmx_ldb_fifo_ex_ebs8__fifo_2d_pop(MCInst &MI, InsnType &Insn,
                                         uint64_t Address,
                                         const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned dstRegRaw = fieldFromInstruction(Insn, 4, 4);
-  if (dstRegRaw >= std::size(mEXbDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dstRegRawNumBits = 4;
+  unsigned dstRegRaw = fieldFromInstruction(Insn, 4, dstRegRawNumBits);
+  static_assert((1 << dstRegRawNumBits) == std::size(mEXbDecoderTable));
   Register dstReg = mEXbDecoderTable[dstRegRaw];
-  assert(dstReg && "Register not found.");
+  if (!dstReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dstReg));
 
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (ptr_outRegRaw >= std::size(ePSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 1;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 14, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePSDecoderTable));
   Register ptr_outReg = ePSDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned fifo_reg_outRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (fifo_reg_outRegRaw >= std::size(eLdFifoRegDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned fifo_reg_outRegRawNumBits = 1;
+  unsigned fifo_reg_outRegRaw =
+      fieldFromInstruction(Insn, 14, fifo_reg_outRegRawNumBits);
+  static_assert((1 << fifo_reg_outRegRawNumBits) ==
+                std::size(eLdFifoRegDecoderTable));
   Register fifo_reg_outReg = eLdFifoRegDecoderTable[fifo_reg_outRegRaw];
-  assert(fifo_reg_outReg && "Register not found.");
+  if (!fifo_reg_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(fifo_reg_outReg));
 
-  unsigned pos_outRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (pos_outRegRaw >= std::size(eRF2DecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned pos_outRegRawNumBits = 1;
+  unsigned pos_outRegRaw = fieldFromInstruction(Insn, 14, pos_outRegRawNumBits);
+  static_assert((1 << pos_outRegRawNumBits) == std::size(eRF2DecoderTable));
   Register pos_outReg = eRF2DecoderTable[pos_outRegRaw];
-  assert(pos_outReg && "Register not found.");
+  if (!pos_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(pos_outReg));
 
-  unsigned dcRegRaw = fieldFromInstruction(Insn, 11, 3);
-  if (dcRegRaw >= std::size(eDCDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dcRegRawNumBits = 3;
+  unsigned dcRegRaw = fieldFromInstruction(Insn, 11, dcRegRawNumBits);
+  static_assert((1 << dcRegRawNumBits) == std::size(eDCDecoderTable));
   Register dcReg = eDCDecoderTable[dcRegRaw];
-  assert(dcReg && "Register not found.");
+  if (!dcReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dcReg));
 
   // --------------------- Ins ------------------------
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (ptrRegRaw >= std::size(ePSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 1;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 14, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePSDecoderTable));
   Register ptrReg = ePSDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned fifo_regRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (fifo_regRegRaw >= std::size(eLdFifoRegDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned fifo_regRegRawNumBits = 1;
+  unsigned fifo_regRegRaw =
+      fieldFromInstruction(Insn, 14, fifo_regRegRawNumBits);
+  static_assert((1 << fifo_regRegRawNumBits) ==
+                std::size(eLdFifoRegDecoderTable));
   Register fifo_regReg = eLdFifoRegDecoderTable[fifo_regRegRaw];
-  assert(fifo_regReg && "Register not found.");
+  if (!fifo_regReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(fifo_regReg));
 
-  unsigned posRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (posRegRaw >= std::size(eRF2DecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned posRegRawNumBits = 1;
+  unsigned posRegRaw = fieldFromInstruction(Insn, 14, posRegRawNumBits);
+  static_assert((1 << posRegRawNumBits) == std::size(eRF2DecoderTable));
   Register posReg = eRF2DecoderTable[posRegRaw];
-  assert(posReg && "Register not found.");
+  if (!posReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(posReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 11, 3);
-  if (modRegRaw >= std::size(eDDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 3;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 11, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDDecoderTable));
   Register modReg = eDDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -4829,75 +5532,89 @@ DecodeDmx_ldb_fifo_ex_ebs8__fifo_3d_pop(MCInst &MI, InsnType &Insn,
                                         uint64_t Address,
                                         const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned dstRegRaw = fieldFromInstruction(Insn, 4, 4);
-  if (dstRegRaw >= std::size(mEXbDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dstRegRawNumBits = 4;
+  unsigned dstRegRaw = fieldFromInstruction(Insn, 4, dstRegRawNumBits);
+  static_assert((1 << dstRegRawNumBits) == std::size(mEXbDecoderTable));
   Register dstReg = mEXbDecoderTable[dstRegRaw];
-  assert(dstReg && "Register not found.");
+  if (!dstReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dstReg));
 
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (ptr_outRegRaw >= std::size(ePSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 1;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 14, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePSDecoderTable));
   Register ptr_outReg = ePSDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned fifo_reg_outRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (fifo_reg_outRegRaw >= std::size(eLdFifoRegDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned fifo_reg_outRegRawNumBits = 1;
+  unsigned fifo_reg_outRegRaw =
+      fieldFromInstruction(Insn, 14, fifo_reg_outRegRawNumBits);
+  static_assert((1 << fifo_reg_outRegRawNumBits) ==
+                std::size(eLdFifoRegDecoderTable));
   Register fifo_reg_outReg = eLdFifoRegDecoderTable[fifo_reg_outRegRaw];
-  assert(fifo_reg_outReg && "Register not found.");
+  if (!fifo_reg_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(fifo_reg_outReg));
 
-  unsigned pos_outRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (pos_outRegRaw >= std::size(eRF2DecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned pos_outRegRawNumBits = 1;
+  unsigned pos_outRegRaw = fieldFromInstruction(Insn, 14, pos_outRegRawNumBits);
+  static_assert((1 << pos_outRegRawNumBits) == std::size(eRF2DecoderTable));
   Register pos_outReg = eRF2DecoderTable[pos_outRegRaw];
-  assert(pos_outReg && "Register not found.");
+  if (!pos_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(pos_outReg));
 
-  unsigned dclRegRaw = fieldFromInstruction(Insn, 11, 2);
-  if (dclRegRaw >= std::size(eDCLDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dclRegRawNumBits = 2;
+  unsigned dclRegRaw = fieldFromInstruction(Insn, 11, dclRegRawNumBits);
+  static_assert((1 << dclRegRawNumBits) == std::size(eDCLDecoderTable));
   Register dclReg = eDCLDecoderTable[dclRegRaw];
-  assert(dclReg && "Register not found.");
+  if (!dclReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dclReg));
 
-  unsigned dchRegRaw = fieldFromInstruction(Insn, 11, 2);
-  if (dchRegRaw >= std::size(eDCHDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dchRegRawNumBits = 2;
+  unsigned dchRegRaw = fieldFromInstruction(Insn, 11, dchRegRawNumBits);
+  static_assert((1 << dchRegRawNumBits) == std::size(eDCHDecoderTable));
   Register dchReg = eDCHDecoderTable[dchRegRaw];
-  assert(dchReg && "Register not found.");
+  if (!dchReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dchReg));
 
   // --------------------- Ins ------------------------
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (ptrRegRaw >= std::size(ePSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 1;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 14, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePSDecoderTable));
   Register ptrReg = ePSDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned fifo_regRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (fifo_regRegRaw >= std::size(eLdFifoRegDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned fifo_regRegRawNumBits = 1;
+  unsigned fifo_regRegRaw =
+      fieldFromInstruction(Insn, 14, fifo_regRegRawNumBits);
+  static_assert((1 << fifo_regRegRawNumBits) ==
+                std::size(eLdFifoRegDecoderTable));
   Register fifo_regReg = eLdFifoRegDecoderTable[fifo_regRegRaw];
-  assert(fifo_regReg && "Register not found.");
+  if (!fifo_regReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(fifo_regReg));
 
-  unsigned posRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (posRegRaw >= std::size(eRF2DecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned posRegRawNumBits = 1;
+  unsigned posRegRaw = fieldFromInstruction(Insn, 14, posRegRawNumBits);
+  static_assert((1 << posRegRawNumBits) == std::size(eRF2DecoderTable));
   Register posReg = eRF2DecoderTable[posRegRaw];
-  assert(posReg && "Register not found.");
+  if (!posReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(posReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 11, 2);
-  if (modRegRaw >= std::size(eDSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 2;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 11, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDSDecoderTable));
   Register modReg = eDSDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -4908,61 +5625,73 @@ static DecodeStatus
 DecodeVLDB_POP_576_fifo_1d_pop(MCInst &MI, InsnType &Insn, uint64_t Address,
                                const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned dstRegRaw = fieldFromInstruction(Insn, 4, 4);
-  if (dstRegRaw >= std::size(mEXbDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dstRegRawNumBits = 4;
+  unsigned dstRegRaw = fieldFromInstruction(Insn, 4, dstRegRawNumBits);
+  static_assert((1 << dstRegRawNumBits) == std::size(mEXbDecoderTable));
   Register dstReg = mEXbDecoderTable[dstRegRaw];
-  assert(dstReg && "Register not found.");
+  if (!dstReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dstReg));
 
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (ptr_outRegRaw >= std::size(ePSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 1;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 14, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePSDecoderTable));
   Register ptr_outReg = ePSDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned fifo_reg_outRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (fifo_reg_outRegRaw >= std::size(eLdFifoRegDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned fifo_reg_outRegRawNumBits = 1;
+  unsigned fifo_reg_outRegRaw =
+      fieldFromInstruction(Insn, 14, fifo_reg_outRegRawNumBits);
+  static_assert((1 << fifo_reg_outRegRawNumBits) ==
+                std::size(eLdFifoRegDecoderTable));
   Register fifo_reg_outReg = eLdFifoRegDecoderTable[fifo_reg_outRegRaw];
-  assert(fifo_reg_outReg && "Register not found.");
+  if (!fifo_reg_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(fifo_reg_outReg));
 
-  unsigned pos_outRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (pos_outRegRaw >= std::size(eRF2DecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned pos_outRegRawNumBits = 1;
+  unsigned pos_outRegRaw = fieldFromInstruction(Insn, 14, pos_outRegRawNumBits);
+  static_assert((1 << pos_outRegRawNumBits) == std::size(eRF2DecoderTable));
   Register pos_outReg = eRF2DecoderTable[pos_outRegRaw];
-  assert(pos_outReg && "Register not found.");
+  if (!pos_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(pos_outReg));
 
   // --------------------- Ins ------------------------
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (ptrRegRaw >= std::size(ePSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 1;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 14, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePSDecoderTable));
   Register ptrReg = ePSDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned fifo_regRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (fifo_regRegRaw >= std::size(eLdFifoRegDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned fifo_regRegRawNumBits = 1;
+  unsigned fifo_regRegRaw =
+      fieldFromInstruction(Insn, 14, fifo_regRegRawNumBits);
+  static_assert((1 << fifo_regRegRawNumBits) ==
+                std::size(eLdFifoRegDecoderTable));
   Register fifo_regReg = eLdFifoRegDecoderTable[fifo_regRegRaw];
-  assert(fifo_regReg && "Register not found.");
+  if (!fifo_regReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(fifo_regReg));
 
-  unsigned posRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (posRegRaw >= std::size(eRF2DecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned posRegRawNumBits = 1;
+  unsigned posRegRaw = fieldFromInstruction(Insn, 14, posRegRawNumBits);
+  static_assert((1 << posRegRawNumBits) == std::size(eRF2DecoderTable));
   Register posReg = eRF2DecoderTable[posRegRaw];
-  assert(posReg && "Register not found.");
+  if (!posReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(posReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 11, 3);
-  if (modRegRaw >= std::size(eMDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 3;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 11, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eMDecoderTable));
   Register modReg = eMDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -4973,54 +5702,65 @@ static DecodeStatus
 DecodeVLDB_POP_576_normal_pop(MCInst &MI, InsnType &Insn, uint64_t Address,
                               const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned dstRegRaw = fieldFromInstruction(Insn, 4, 4);
-  if (dstRegRaw >= std::size(mEXbDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dstRegRawNumBits = 4;
+  unsigned dstRegRaw = fieldFromInstruction(Insn, 4, dstRegRawNumBits);
+  static_assert((1 << dstRegRawNumBits) == std::size(mEXbDecoderTable));
   Register dstReg = mEXbDecoderTable[dstRegRaw];
-  assert(dstReg && "Register not found.");
+  if (!dstReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dstReg));
 
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (ptr_outRegRaw >= std::size(ePSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 1;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 14, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePSDecoderTable));
   Register ptr_outReg = ePSDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned fifo_reg_outRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (fifo_reg_outRegRaw >= std::size(eLdFifoRegDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned fifo_reg_outRegRawNumBits = 1;
+  unsigned fifo_reg_outRegRaw =
+      fieldFromInstruction(Insn, 14, fifo_reg_outRegRawNumBits);
+  static_assert((1 << fifo_reg_outRegRawNumBits) ==
+                std::size(eLdFifoRegDecoderTable));
   Register fifo_reg_outReg = eLdFifoRegDecoderTable[fifo_reg_outRegRaw];
-  assert(fifo_reg_outReg && "Register not found.");
+  if (!fifo_reg_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(fifo_reg_outReg));
 
-  unsigned pos_outRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (pos_outRegRaw >= std::size(eRF2DecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned pos_outRegRawNumBits = 1;
+  unsigned pos_outRegRaw = fieldFromInstruction(Insn, 14, pos_outRegRawNumBits);
+  static_assert((1 << pos_outRegRawNumBits) == std::size(eRF2DecoderTable));
   Register pos_outReg = eRF2DecoderTable[pos_outRegRaw];
-  assert(pos_outReg && "Register not found.");
+  if (!pos_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(pos_outReg));
 
   // --------------------- Ins ------------------------
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (ptrRegRaw >= std::size(ePSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 1;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 14, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePSDecoderTable));
   Register ptrReg = ePSDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned fifo_regRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (fifo_regRegRaw >= std::size(eLdFifoRegDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned fifo_regRegRawNumBits = 1;
+  unsigned fifo_regRegRaw =
+      fieldFromInstruction(Insn, 14, fifo_regRegRawNumBits);
+  static_assert((1 << fifo_regRegRawNumBits) ==
+                std::size(eLdFifoRegDecoderTable));
   Register fifo_regReg = eLdFifoRegDecoderTable[fifo_regRegRaw];
-  assert(fifo_regReg && "Register not found.");
+  if (!fifo_regReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(fifo_regReg));
 
-  unsigned posRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (posRegRaw >= std::size(eRF2DecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned posRegRawNumBits = 1;
+  unsigned posRegRaw = fieldFromInstruction(Insn, 14, posRegRawNumBits);
+  static_assert((1 << posRegRawNumBits) == std::size(eRF2DecoderTable));
   Register posReg = eRF2DecoderTable[posRegRaw];
-  assert(posReg && "Register not found.");
+  if (!posReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(posReg));
 
   return MCDisassembler::Success;
@@ -5031,68 +5771,81 @@ static DecodeStatus
 DecodeDmx_ldb_fifo_qx__fifo_2d_pop(MCInst &MI, InsnType &Insn, uint64_t Address,
                                    const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned dstRegRaw = fieldFromInstruction(Insn, 6, 2);
-  if (dstRegRaw >= std::size(mQXsbDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dstRegRawNumBits = 2;
+  unsigned dstRegRaw = fieldFromInstruction(Insn, 6, dstRegRawNumBits);
+  static_assert((1 << dstRegRawNumBits) == std::size(mQXsbDecoderTable));
   Register dstReg = mQXsbDecoderTable[dstRegRaw];
-  assert(dstReg && "Register not found.");
+  if (!dstReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dstReg));
 
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (ptr_outRegRaw >= std::size(ePSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 1;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 14, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePSDecoderTable));
   Register ptr_outReg = ePSDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned fifo_reg_outRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (fifo_reg_outRegRaw >= std::size(eLdFifoRegDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned fifo_reg_outRegRawNumBits = 1;
+  unsigned fifo_reg_outRegRaw =
+      fieldFromInstruction(Insn, 14, fifo_reg_outRegRawNumBits);
+  static_assert((1 << fifo_reg_outRegRawNumBits) ==
+                std::size(eLdFifoRegDecoderTable));
   Register fifo_reg_outReg = eLdFifoRegDecoderTable[fifo_reg_outRegRaw];
-  assert(fifo_reg_outReg && "Register not found.");
+  if (!fifo_reg_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(fifo_reg_outReg));
 
-  unsigned pos_outRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (pos_outRegRaw >= std::size(eRF2DecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned pos_outRegRawNumBits = 1;
+  unsigned pos_outRegRaw = fieldFromInstruction(Insn, 14, pos_outRegRawNumBits);
+  static_assert((1 << pos_outRegRawNumBits) == std::size(eRF2DecoderTable));
   Register pos_outReg = eRF2DecoderTable[pos_outRegRaw];
-  assert(pos_outReg && "Register not found.");
+  if (!pos_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(pos_outReg));
 
-  unsigned dcRegRaw = fieldFromInstruction(Insn, 11, 3);
-  if (dcRegRaw >= std::size(eDCDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dcRegRawNumBits = 3;
+  unsigned dcRegRaw = fieldFromInstruction(Insn, 11, dcRegRawNumBits);
+  static_assert((1 << dcRegRawNumBits) == std::size(eDCDecoderTable));
   Register dcReg = eDCDecoderTable[dcRegRaw];
-  assert(dcReg && "Register not found.");
+  if (!dcReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dcReg));
 
   // --------------------- Ins ------------------------
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (ptrRegRaw >= std::size(ePSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 1;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 14, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePSDecoderTable));
   Register ptrReg = ePSDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned fifo_regRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (fifo_regRegRaw >= std::size(eLdFifoRegDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned fifo_regRegRawNumBits = 1;
+  unsigned fifo_regRegRaw =
+      fieldFromInstruction(Insn, 14, fifo_regRegRawNumBits);
+  static_assert((1 << fifo_regRegRawNumBits) ==
+                std::size(eLdFifoRegDecoderTable));
   Register fifo_regReg = eLdFifoRegDecoderTable[fifo_regRegRaw];
-  assert(fifo_regReg && "Register not found.");
+  if (!fifo_regReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(fifo_regReg));
 
-  unsigned posRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (posRegRaw >= std::size(eRF2DecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned posRegRawNumBits = 1;
+  unsigned posRegRaw = fieldFromInstruction(Insn, 14, posRegRawNumBits);
+  static_assert((1 << posRegRawNumBits) == std::size(eRF2DecoderTable));
   Register posReg = eRF2DecoderTable[posRegRaw];
-  assert(posReg && "Register not found.");
+  if (!posReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(posReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 11, 3);
-  if (modRegRaw >= std::size(eDDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 3;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 11, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDDecoderTable));
   Register modReg = eDDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -5103,75 +5856,89 @@ static DecodeStatus
 DecodeDmx_ldb_fifo_qx__fifo_3d_pop(MCInst &MI, InsnType &Insn, uint64_t Address,
                                    const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned dstRegRaw = fieldFromInstruction(Insn, 6, 2);
-  if (dstRegRaw >= std::size(mQXsbDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dstRegRawNumBits = 2;
+  unsigned dstRegRaw = fieldFromInstruction(Insn, 6, dstRegRawNumBits);
+  static_assert((1 << dstRegRawNumBits) == std::size(mQXsbDecoderTable));
   Register dstReg = mQXsbDecoderTable[dstRegRaw];
-  assert(dstReg && "Register not found.");
+  if (!dstReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dstReg));
 
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (ptr_outRegRaw >= std::size(ePSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 1;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 14, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePSDecoderTable));
   Register ptr_outReg = ePSDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned fifo_reg_outRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (fifo_reg_outRegRaw >= std::size(eLdFifoRegDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned fifo_reg_outRegRawNumBits = 1;
+  unsigned fifo_reg_outRegRaw =
+      fieldFromInstruction(Insn, 14, fifo_reg_outRegRawNumBits);
+  static_assert((1 << fifo_reg_outRegRawNumBits) ==
+                std::size(eLdFifoRegDecoderTable));
   Register fifo_reg_outReg = eLdFifoRegDecoderTable[fifo_reg_outRegRaw];
-  assert(fifo_reg_outReg && "Register not found.");
+  if (!fifo_reg_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(fifo_reg_outReg));
 
-  unsigned pos_outRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (pos_outRegRaw >= std::size(eRF2DecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned pos_outRegRawNumBits = 1;
+  unsigned pos_outRegRaw = fieldFromInstruction(Insn, 14, pos_outRegRawNumBits);
+  static_assert((1 << pos_outRegRawNumBits) == std::size(eRF2DecoderTable));
   Register pos_outReg = eRF2DecoderTable[pos_outRegRaw];
-  assert(pos_outReg && "Register not found.");
+  if (!pos_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(pos_outReg));
 
-  unsigned dclRegRaw = fieldFromInstruction(Insn, 11, 2);
-  if (dclRegRaw >= std::size(eDCLDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dclRegRawNumBits = 2;
+  unsigned dclRegRaw = fieldFromInstruction(Insn, 11, dclRegRawNumBits);
+  static_assert((1 << dclRegRawNumBits) == std::size(eDCLDecoderTable));
   Register dclReg = eDCLDecoderTable[dclRegRaw];
-  assert(dclReg && "Register not found.");
+  if (!dclReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dclReg));
 
-  unsigned dchRegRaw = fieldFromInstruction(Insn, 11, 2);
-  if (dchRegRaw >= std::size(eDCHDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dchRegRawNumBits = 2;
+  unsigned dchRegRaw = fieldFromInstruction(Insn, 11, dchRegRawNumBits);
+  static_assert((1 << dchRegRawNumBits) == std::size(eDCHDecoderTable));
   Register dchReg = eDCHDecoderTable[dchRegRaw];
-  assert(dchReg && "Register not found.");
+  if (!dchReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dchReg));
 
   // --------------------- Ins ------------------------
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (ptrRegRaw >= std::size(ePSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 1;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 14, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePSDecoderTable));
   Register ptrReg = ePSDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned fifo_regRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (fifo_regRegRaw >= std::size(eLdFifoRegDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned fifo_regRegRawNumBits = 1;
+  unsigned fifo_regRegRaw =
+      fieldFromInstruction(Insn, 14, fifo_regRegRawNumBits);
+  static_assert((1 << fifo_regRegRawNumBits) ==
+                std::size(eLdFifoRegDecoderTable));
   Register fifo_regReg = eLdFifoRegDecoderTable[fifo_regRegRaw];
-  assert(fifo_regReg && "Register not found.");
+  if (!fifo_regReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(fifo_regReg));
 
-  unsigned posRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (posRegRaw >= std::size(eRF2DecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned posRegRawNumBits = 1;
+  unsigned posRegRaw = fieldFromInstruction(Insn, 14, posRegRawNumBits);
+  static_assert((1 << posRegRawNumBits) == std::size(eRF2DecoderTable));
   Register posReg = eRF2DecoderTable[posRegRaw];
-  assert(posReg && "Register not found.");
+  if (!posReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(posReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 11, 2);
-  if (modRegRaw >= std::size(eDSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 2;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 11, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDSDecoderTable));
   Register modReg = eDSDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -5182,61 +5949,73 @@ static DecodeStatus
 DecodeVLDB_POP_640_fifo_1d_pop(MCInst &MI, InsnType &Insn, uint64_t Address,
                                const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned dstRegRaw = fieldFromInstruction(Insn, 6, 2);
-  if (dstRegRaw >= std::size(mQXsbDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dstRegRawNumBits = 2;
+  unsigned dstRegRaw = fieldFromInstruction(Insn, 6, dstRegRawNumBits);
+  static_assert((1 << dstRegRawNumBits) == std::size(mQXsbDecoderTable));
   Register dstReg = mQXsbDecoderTable[dstRegRaw];
-  assert(dstReg && "Register not found.");
+  if (!dstReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dstReg));
 
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (ptr_outRegRaw >= std::size(ePSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 1;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 14, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePSDecoderTable));
   Register ptr_outReg = ePSDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned fifo_reg_outRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (fifo_reg_outRegRaw >= std::size(eLdFifoRegDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned fifo_reg_outRegRawNumBits = 1;
+  unsigned fifo_reg_outRegRaw =
+      fieldFromInstruction(Insn, 14, fifo_reg_outRegRawNumBits);
+  static_assert((1 << fifo_reg_outRegRawNumBits) ==
+                std::size(eLdFifoRegDecoderTable));
   Register fifo_reg_outReg = eLdFifoRegDecoderTable[fifo_reg_outRegRaw];
-  assert(fifo_reg_outReg && "Register not found.");
+  if (!fifo_reg_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(fifo_reg_outReg));
 
-  unsigned pos_outRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (pos_outRegRaw >= std::size(eRF2DecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned pos_outRegRawNumBits = 1;
+  unsigned pos_outRegRaw = fieldFromInstruction(Insn, 14, pos_outRegRawNumBits);
+  static_assert((1 << pos_outRegRawNumBits) == std::size(eRF2DecoderTable));
   Register pos_outReg = eRF2DecoderTable[pos_outRegRaw];
-  assert(pos_outReg && "Register not found.");
+  if (!pos_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(pos_outReg));
 
   // --------------------- Ins ------------------------
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (ptrRegRaw >= std::size(ePSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 1;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 14, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePSDecoderTable));
   Register ptrReg = ePSDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned fifo_regRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (fifo_regRegRaw >= std::size(eLdFifoRegDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned fifo_regRegRawNumBits = 1;
+  unsigned fifo_regRegRaw =
+      fieldFromInstruction(Insn, 14, fifo_regRegRawNumBits);
+  static_assert((1 << fifo_regRegRawNumBits) ==
+                std::size(eLdFifoRegDecoderTable));
   Register fifo_regReg = eLdFifoRegDecoderTable[fifo_regRegRaw];
-  assert(fifo_regReg && "Register not found.");
+  if (!fifo_regReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(fifo_regReg));
 
-  unsigned posRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (posRegRaw >= std::size(eRF2DecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned posRegRawNumBits = 1;
+  unsigned posRegRaw = fieldFromInstruction(Insn, 14, posRegRawNumBits);
+  static_assert((1 << posRegRawNumBits) == std::size(eRF2DecoderTable));
   Register posReg = eRF2DecoderTable[posRegRaw];
-  assert(posReg && "Register not found.");
+  if (!posReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(posReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 11, 3);
-  if (modRegRaw >= std::size(eMDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 3;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 11, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eMDecoderTable));
   Register modReg = eMDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -5247,54 +6026,65 @@ static DecodeStatus
 DecodeVLDB_POP_640_normal_pop(MCInst &MI, InsnType &Insn, uint64_t Address,
                               const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned dstRegRaw = fieldFromInstruction(Insn, 6, 2);
-  if (dstRegRaw >= std::size(mQXsbDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dstRegRawNumBits = 2;
+  unsigned dstRegRaw = fieldFromInstruction(Insn, 6, dstRegRawNumBits);
+  static_assert((1 << dstRegRawNumBits) == std::size(mQXsbDecoderTable));
   Register dstReg = mQXsbDecoderTable[dstRegRaw];
-  assert(dstReg && "Register not found.");
+  if (!dstReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dstReg));
 
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (ptr_outRegRaw >= std::size(ePSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 1;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 14, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePSDecoderTable));
   Register ptr_outReg = ePSDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned fifo_reg_outRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (fifo_reg_outRegRaw >= std::size(eLdFifoRegDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned fifo_reg_outRegRawNumBits = 1;
+  unsigned fifo_reg_outRegRaw =
+      fieldFromInstruction(Insn, 14, fifo_reg_outRegRawNumBits);
+  static_assert((1 << fifo_reg_outRegRawNumBits) ==
+                std::size(eLdFifoRegDecoderTable));
   Register fifo_reg_outReg = eLdFifoRegDecoderTable[fifo_reg_outRegRaw];
-  assert(fifo_reg_outReg && "Register not found.");
+  if (!fifo_reg_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(fifo_reg_outReg));
 
-  unsigned pos_outRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (pos_outRegRaw >= std::size(eRF2DecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned pos_outRegRawNumBits = 1;
+  unsigned pos_outRegRaw = fieldFromInstruction(Insn, 14, pos_outRegRawNumBits);
+  static_assert((1 << pos_outRegRawNumBits) == std::size(eRF2DecoderTable));
   Register pos_outReg = eRF2DecoderTable[pos_outRegRaw];
-  assert(pos_outReg && "Register not found.");
+  if (!pos_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(pos_outReg));
 
   // --------------------- Ins ------------------------
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (ptrRegRaw >= std::size(ePSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 1;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 14, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePSDecoderTable));
   Register ptrReg = ePSDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned fifo_regRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (fifo_regRegRaw >= std::size(eLdFifoRegDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned fifo_regRegRawNumBits = 1;
+  unsigned fifo_regRegRaw =
+      fieldFromInstruction(Insn, 14, fifo_regRegRawNumBits);
+  static_assert((1 << fifo_regRegRawNumBits) ==
+                std::size(eLdFifoRegDecoderTable));
   Register fifo_regReg = eLdFifoRegDecoderTable[fifo_regRegRaw];
-  assert(fifo_regReg && "Register not found.");
+  if (!fifo_regReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(fifo_regReg));
 
-  unsigned posRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (posRegRaw >= std::size(eRF2DecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned posRegRawNumBits = 1;
+  unsigned posRegRaw = fieldFromInstruction(Insn, 14, posRegRawNumBits);
+  static_assert((1 << posRegRawNumBits) == std::size(eRF2DecoderTable));
   Register posReg = eRF2DecoderTable[posRegRaw];
-  assert(posReg && "Register not found.");
+  if (!posReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(posReg));
 
   return MCDisassembler::Success;
@@ -5306,68 +6096,81 @@ DecodeDmx_ldb_fifo_qex_ebs16__fifo_2d_pop(MCInst &MI, InsnType &Insn,
                                           uint64_t Address,
                                           const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned dstRegRaw = fieldFromInstruction(Insn, 6, 2);
-  if (dstRegRaw >= std::size(mQEXsbDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dstRegRawNumBits = 2;
+  unsigned dstRegRaw = fieldFromInstruction(Insn, 6, dstRegRawNumBits);
+  static_assert((1 << dstRegRawNumBits) == std::size(mQEXsbDecoderTable));
   Register dstReg = mQEXsbDecoderTable[dstRegRaw];
-  assert(dstReg && "Register not found.");
+  if (!dstReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dstReg));
 
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (ptr_outRegRaw >= std::size(ePSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 1;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 14, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePSDecoderTable));
   Register ptr_outReg = ePSDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned fifo_reg_outRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (fifo_reg_outRegRaw >= std::size(eLdFifoRegDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned fifo_reg_outRegRawNumBits = 1;
+  unsigned fifo_reg_outRegRaw =
+      fieldFromInstruction(Insn, 14, fifo_reg_outRegRawNumBits);
+  static_assert((1 << fifo_reg_outRegRawNumBits) ==
+                std::size(eLdFifoRegDecoderTable));
   Register fifo_reg_outReg = eLdFifoRegDecoderTable[fifo_reg_outRegRaw];
-  assert(fifo_reg_outReg && "Register not found.");
+  if (!fifo_reg_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(fifo_reg_outReg));
 
-  unsigned pos_outRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (pos_outRegRaw >= std::size(eRF2DecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned pos_outRegRawNumBits = 1;
+  unsigned pos_outRegRaw = fieldFromInstruction(Insn, 14, pos_outRegRawNumBits);
+  static_assert((1 << pos_outRegRawNumBits) == std::size(eRF2DecoderTable));
   Register pos_outReg = eRF2DecoderTable[pos_outRegRaw];
-  assert(pos_outReg && "Register not found.");
+  if (!pos_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(pos_outReg));
 
-  unsigned dcRegRaw = fieldFromInstruction(Insn, 11, 3);
-  if (dcRegRaw >= std::size(eDCDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dcRegRawNumBits = 3;
+  unsigned dcRegRaw = fieldFromInstruction(Insn, 11, dcRegRawNumBits);
+  static_assert((1 << dcRegRawNumBits) == std::size(eDCDecoderTable));
   Register dcReg = eDCDecoderTable[dcRegRaw];
-  assert(dcReg && "Register not found.");
+  if (!dcReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dcReg));
 
   // --------------------- Ins ------------------------
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (ptrRegRaw >= std::size(ePSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 1;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 14, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePSDecoderTable));
   Register ptrReg = ePSDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned fifo_regRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (fifo_regRegRaw >= std::size(eLdFifoRegDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned fifo_regRegRawNumBits = 1;
+  unsigned fifo_regRegRaw =
+      fieldFromInstruction(Insn, 14, fifo_regRegRawNumBits);
+  static_assert((1 << fifo_regRegRawNumBits) ==
+                std::size(eLdFifoRegDecoderTable));
   Register fifo_regReg = eLdFifoRegDecoderTable[fifo_regRegRaw];
-  assert(fifo_regReg && "Register not found.");
+  if (!fifo_regReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(fifo_regReg));
 
-  unsigned posRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (posRegRaw >= std::size(eRF2DecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned posRegRawNumBits = 1;
+  unsigned posRegRaw = fieldFromInstruction(Insn, 14, posRegRawNumBits);
+  static_assert((1 << posRegRawNumBits) == std::size(eRF2DecoderTable));
   Register posReg = eRF2DecoderTable[posRegRaw];
-  assert(posReg && "Register not found.");
+  if (!posReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(posReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 11, 3);
-  if (modRegRaw >= std::size(eDDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 3;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 11, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDDecoderTable));
   Register modReg = eDDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -5379,75 +6182,89 @@ DecodeDmx_ldb_fifo_qex_ebs16__fifo_3d_pop(MCInst &MI, InsnType &Insn,
                                           uint64_t Address,
                                           const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned dstRegRaw = fieldFromInstruction(Insn, 6, 2);
-  if (dstRegRaw >= std::size(mQEXsbDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dstRegRawNumBits = 2;
+  unsigned dstRegRaw = fieldFromInstruction(Insn, 6, dstRegRawNumBits);
+  static_assert((1 << dstRegRawNumBits) == std::size(mQEXsbDecoderTable));
   Register dstReg = mQEXsbDecoderTable[dstRegRaw];
-  assert(dstReg && "Register not found.");
+  if (!dstReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dstReg));
 
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (ptr_outRegRaw >= std::size(ePSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 1;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 14, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePSDecoderTable));
   Register ptr_outReg = ePSDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned fifo_reg_outRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (fifo_reg_outRegRaw >= std::size(eLdFifoRegDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned fifo_reg_outRegRawNumBits = 1;
+  unsigned fifo_reg_outRegRaw =
+      fieldFromInstruction(Insn, 14, fifo_reg_outRegRawNumBits);
+  static_assert((1 << fifo_reg_outRegRawNumBits) ==
+                std::size(eLdFifoRegDecoderTable));
   Register fifo_reg_outReg = eLdFifoRegDecoderTable[fifo_reg_outRegRaw];
-  assert(fifo_reg_outReg && "Register not found.");
+  if (!fifo_reg_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(fifo_reg_outReg));
 
-  unsigned pos_outRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (pos_outRegRaw >= std::size(eRF2DecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned pos_outRegRawNumBits = 1;
+  unsigned pos_outRegRaw = fieldFromInstruction(Insn, 14, pos_outRegRawNumBits);
+  static_assert((1 << pos_outRegRawNumBits) == std::size(eRF2DecoderTable));
   Register pos_outReg = eRF2DecoderTable[pos_outRegRaw];
-  assert(pos_outReg && "Register not found.");
+  if (!pos_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(pos_outReg));
 
-  unsigned dclRegRaw = fieldFromInstruction(Insn, 11, 2);
-  if (dclRegRaw >= std::size(eDCLDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dclRegRawNumBits = 2;
+  unsigned dclRegRaw = fieldFromInstruction(Insn, 11, dclRegRawNumBits);
+  static_assert((1 << dclRegRawNumBits) == std::size(eDCLDecoderTable));
   Register dclReg = eDCLDecoderTable[dclRegRaw];
-  assert(dclReg && "Register not found.");
+  if (!dclReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dclReg));
 
-  unsigned dchRegRaw = fieldFromInstruction(Insn, 11, 2);
-  if (dchRegRaw >= std::size(eDCHDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dchRegRawNumBits = 2;
+  unsigned dchRegRaw = fieldFromInstruction(Insn, 11, dchRegRawNumBits);
+  static_assert((1 << dchRegRawNumBits) == std::size(eDCHDecoderTable));
   Register dchReg = eDCHDecoderTable[dchRegRaw];
-  assert(dchReg && "Register not found.");
+  if (!dchReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dchReg));
 
   // --------------------- Ins ------------------------
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (ptrRegRaw >= std::size(ePSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 1;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 14, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePSDecoderTable));
   Register ptrReg = ePSDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned fifo_regRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (fifo_regRegRaw >= std::size(eLdFifoRegDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned fifo_regRegRawNumBits = 1;
+  unsigned fifo_regRegRaw =
+      fieldFromInstruction(Insn, 14, fifo_regRegRawNumBits);
+  static_assert((1 << fifo_regRegRawNumBits) ==
+                std::size(eLdFifoRegDecoderTable));
   Register fifo_regReg = eLdFifoRegDecoderTable[fifo_regRegRaw];
-  assert(fifo_regReg && "Register not found.");
+  if (!fifo_regReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(fifo_regReg));
 
-  unsigned posRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (posRegRaw >= std::size(eRF2DecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned posRegRawNumBits = 1;
+  unsigned posRegRaw = fieldFromInstruction(Insn, 14, posRegRawNumBits);
+  static_assert((1 << posRegRawNumBits) == std::size(eRF2DecoderTable));
   Register posReg = eRF2DecoderTable[posRegRaw];
-  assert(posReg && "Register not found.");
+  if (!posReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(posReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 11, 2);
-  if (modRegRaw >= std::size(eDSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 2;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 11, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDSDecoderTable));
   Register modReg = eDSDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -5458,61 +6275,73 @@ static DecodeStatus
 DecodeVLDB_POP_704_fifo_1d_pop(MCInst &MI, InsnType &Insn, uint64_t Address,
                                const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned dstRegRaw = fieldFromInstruction(Insn, 6, 2);
-  if (dstRegRaw >= std::size(mQEXsbDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dstRegRawNumBits = 2;
+  unsigned dstRegRaw = fieldFromInstruction(Insn, 6, dstRegRawNumBits);
+  static_assert((1 << dstRegRawNumBits) == std::size(mQEXsbDecoderTable));
   Register dstReg = mQEXsbDecoderTable[dstRegRaw];
-  assert(dstReg && "Register not found.");
+  if (!dstReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dstReg));
 
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (ptr_outRegRaw >= std::size(ePSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 1;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 14, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePSDecoderTable));
   Register ptr_outReg = ePSDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned fifo_reg_outRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (fifo_reg_outRegRaw >= std::size(eLdFifoRegDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned fifo_reg_outRegRawNumBits = 1;
+  unsigned fifo_reg_outRegRaw =
+      fieldFromInstruction(Insn, 14, fifo_reg_outRegRawNumBits);
+  static_assert((1 << fifo_reg_outRegRawNumBits) ==
+                std::size(eLdFifoRegDecoderTable));
   Register fifo_reg_outReg = eLdFifoRegDecoderTable[fifo_reg_outRegRaw];
-  assert(fifo_reg_outReg && "Register not found.");
+  if (!fifo_reg_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(fifo_reg_outReg));
 
-  unsigned pos_outRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (pos_outRegRaw >= std::size(eRF2DecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned pos_outRegRawNumBits = 1;
+  unsigned pos_outRegRaw = fieldFromInstruction(Insn, 14, pos_outRegRawNumBits);
+  static_assert((1 << pos_outRegRawNumBits) == std::size(eRF2DecoderTable));
   Register pos_outReg = eRF2DecoderTable[pos_outRegRaw];
-  assert(pos_outReg && "Register not found.");
+  if (!pos_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(pos_outReg));
 
   // --------------------- Ins ------------------------
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (ptrRegRaw >= std::size(ePSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 1;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 14, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePSDecoderTable));
   Register ptrReg = ePSDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned fifo_regRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (fifo_regRegRaw >= std::size(eLdFifoRegDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned fifo_regRegRawNumBits = 1;
+  unsigned fifo_regRegRaw =
+      fieldFromInstruction(Insn, 14, fifo_regRegRawNumBits);
+  static_assert((1 << fifo_regRegRawNumBits) ==
+                std::size(eLdFifoRegDecoderTable));
   Register fifo_regReg = eLdFifoRegDecoderTable[fifo_regRegRaw];
-  assert(fifo_regReg && "Register not found.");
+  if (!fifo_regReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(fifo_regReg));
 
-  unsigned posRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (posRegRaw >= std::size(eRF2DecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned posRegRawNumBits = 1;
+  unsigned posRegRaw = fieldFromInstruction(Insn, 14, posRegRawNumBits);
+  static_assert((1 << posRegRawNumBits) == std::size(eRF2DecoderTable));
   Register posReg = eRF2DecoderTable[posRegRaw];
-  assert(posReg && "Register not found.");
+  if (!posReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(posReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 11, 3);
-  if (modRegRaw >= std::size(eMDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 3;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 11, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eMDecoderTable));
   Register modReg = eMDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -5523,54 +6352,65 @@ static DecodeStatus
 DecodeVLDB_POP_704_normal_pop(MCInst &MI, InsnType &Insn, uint64_t Address,
                               const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned dstRegRaw = fieldFromInstruction(Insn, 6, 2);
-  if (dstRegRaw >= std::size(mQEXsbDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dstRegRawNumBits = 2;
+  unsigned dstRegRaw = fieldFromInstruction(Insn, 6, dstRegRawNumBits);
+  static_assert((1 << dstRegRawNumBits) == std::size(mQEXsbDecoderTable));
   Register dstReg = mQEXsbDecoderTable[dstRegRaw];
-  assert(dstReg && "Register not found.");
+  if (!dstReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dstReg));
 
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (ptr_outRegRaw >= std::size(ePSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 1;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 14, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePSDecoderTable));
   Register ptr_outReg = ePSDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned fifo_reg_outRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (fifo_reg_outRegRaw >= std::size(eLdFifoRegDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned fifo_reg_outRegRawNumBits = 1;
+  unsigned fifo_reg_outRegRaw =
+      fieldFromInstruction(Insn, 14, fifo_reg_outRegRawNumBits);
+  static_assert((1 << fifo_reg_outRegRawNumBits) ==
+                std::size(eLdFifoRegDecoderTable));
   Register fifo_reg_outReg = eLdFifoRegDecoderTable[fifo_reg_outRegRaw];
-  assert(fifo_reg_outReg && "Register not found.");
+  if (!fifo_reg_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(fifo_reg_outReg));
 
-  unsigned pos_outRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (pos_outRegRaw >= std::size(eRF2DecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned pos_outRegRawNumBits = 1;
+  unsigned pos_outRegRaw = fieldFromInstruction(Insn, 14, pos_outRegRawNumBits);
+  static_assert((1 << pos_outRegRawNumBits) == std::size(eRF2DecoderTable));
   Register pos_outReg = eRF2DecoderTable[pos_outRegRaw];
-  assert(pos_outReg && "Register not found.");
+  if (!pos_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(pos_outReg));
 
   // --------------------- Ins ------------------------
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (ptrRegRaw >= std::size(ePSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 1;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 14, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePSDecoderTable));
   Register ptrReg = ePSDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned fifo_regRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (fifo_regRegRaw >= std::size(eLdFifoRegDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned fifo_regRegRawNumBits = 1;
+  unsigned fifo_regRegRaw =
+      fieldFromInstruction(Insn, 14, fifo_regRegRawNumBits);
+  static_assert((1 << fifo_regRegRawNumBits) ==
+                std::size(eLdFifoRegDecoderTable));
   Register fifo_regReg = eLdFifoRegDecoderTable[fifo_regRegRaw];
-  assert(fifo_regReg && "Register not found.");
+  if (!fifo_regReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(fifo_regReg));
 
-  unsigned posRegRaw = fieldFromInstruction(Insn, 14, 1);
-  if (posRegRaw >= std::size(eRF2DecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned posRegRawNumBits = 1;
+  unsigned posRegRaw = fieldFromInstruction(Insn, 14, posRegRawNumBits);
+  static_assert((1 << posRegRawNumBits) == std::size(eRF2DecoderTable));
   Register posReg = eRF2DecoderTable[posRegRaw];
-  assert(posReg && "Register not found.");
+  if (!posReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(posReg));
 
   return MCDisassembler::Success;
@@ -5581,40 +6421,45 @@ static DecodeStatus DecodeDmv_sts_w_2D(MCInst &MI, InsnType &Insn,
                                        uint64_t Address,
                                        const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptr_outRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 3;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePDecoderTable));
   Register ptr_outReg = ePDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned dcRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (dcRegRaw >= std::size(eDCDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dcRegRawNumBits = 3;
+  unsigned dcRegRaw = fieldFromInstruction(Insn, 14, dcRegRawNumBits);
+  static_assert((1 << dcRegRawNumBits) == std::size(eDCDecoderTable));
   Register dcReg = eDCDecoderTable[dcRegRaw];
-  assert(dcReg && "Register not found.");
+  if (!dcReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dcReg));
 
   // --------------------- Ins ------------------------
-  unsigned srcRegRaw = fieldFromInstruction(Insn, 6, 5);
-  if (srcRegRaw >= std::size(mWsDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned srcRegRawNumBits = 5;
+  unsigned srcRegRaw = fieldFromInstruction(Insn, 6, srcRegRawNumBits);
+  static_assert((1 << srcRegRawNumBits) == std::size(mWsDecoderTable));
   Register srcReg = mWsDecoderTable[srcRegRaw];
-  assert(srcReg && "Register not found.");
+  if (!srcReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(srcReg));
 
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptrRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 3;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePDecoderTable));
   Register ptrReg = ePDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (modRegRaw >= std::size(eDDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 3;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 14, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDDecoderTable));
   Register modReg = eDDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -5625,40 +6470,45 @@ static DecodeStatus DecodeDmw_sts_srs_bf_2D(MCInst &MI, InsnType &Insn,
                                             uint64_t Address,
                                             const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptr_outRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 3;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePDecoderTable));
   Register ptr_outReg = ePDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned dcRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (dcRegRaw >= std::size(eDCDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dcRegRawNumBits = 3;
+  unsigned dcRegRaw = fieldFromInstruction(Insn, 14, dcRegRawNumBits);
+  static_assert((1 << dcRegRawNumBits) == std::size(eDCDecoderTable));
   Register dcReg = eDCDecoderTable[dcRegRaw];
-  assert(dcReg && "Register not found.");
+  if (!dcReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dcReg));
 
   // --------------------- Ins ------------------------
-  unsigned srcRegRaw = fieldFromInstruction(Insn, 6, 5);
-  if (srcRegRaw >= std::size(mBMsDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned srcRegRawNumBits = 5;
+  unsigned srcRegRaw = fieldFromInstruction(Insn, 6, srcRegRawNumBits);
+  static_assert((1 << srcRegRawNumBits) == std::size(mBMsDecoderTable));
   Register srcReg = mBMsDecoderTable[srcRegRaw];
-  assert(srcReg && "Register not found.");
+  if (!srcReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(srcReg));
 
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptrRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 3;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePDecoderTable));
   Register ptrReg = ePDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (modRegRaw >= std::size(eDDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 3;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 14, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDDecoderTable));
   Register modReg = eDDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -5669,40 +6519,45 @@ static DecodeStatus DecodeDmx_sts_srs_bf_2D(MCInst &MI, InsnType &Insn,
                                             uint64_t Address,
                                             const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptr_outRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 3;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePDecoderTable));
   Register ptr_outReg = ePDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned dcRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (dcRegRaw >= std::size(eDCDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dcRegRawNumBits = 3;
+  unsigned dcRegRaw = fieldFromInstruction(Insn, 14, dcRegRawNumBits);
+  static_assert((1 << dcRegRawNumBits) == std::size(eDCDecoderTable));
   Register dcReg = eDCDecoderTable[dcRegRaw];
-  assert(dcReg && "Register not found.");
+  if (!dcReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dcReg));
 
   // --------------------- Ins ------------------------
-  unsigned srcRegRaw = fieldFromInstruction(Insn, 7, 4);
-  if (srcRegRaw >= std::size(mCMsDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned srcRegRawNumBits = 4;
+  unsigned srcRegRaw = fieldFromInstruction(Insn, 7, srcRegRawNumBits);
+  static_assert((1 << srcRegRawNumBits) == std::size(mCMsDecoderTable));
   Register srcReg = mCMsDecoderTable[srcRegRaw];
-  assert(srcReg && "Register not found.");
+  if (!srcReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(srcReg));
 
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptrRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 3;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePDecoderTable));
   Register ptrReg = ePDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (modRegRaw >= std::size(eDDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 3;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 14, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDDecoderTable));
   Register modReg = eDDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -5713,40 +6568,45 @@ static DecodeStatus DecodeDmw_sts_pack_2D(MCInst &MI, InsnType &Insn,
                                           uint64_t Address,
                                           const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptr_outRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 3;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePDecoderTable));
   Register ptr_outReg = ePDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned dcRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (dcRegRaw >= std::size(eDCDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dcRegRawNumBits = 3;
+  unsigned dcRegRaw = fieldFromInstruction(Insn, 14, dcRegRawNumBits);
+  static_assert((1 << dcRegRawNumBits) == std::size(eDCDecoderTable));
   Register dcReg = eDCDecoderTable[dcRegRaw];
-  assert(dcReg && "Register not found.");
+  if (!dcReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dcReg));
 
   // --------------------- Ins ------------------------
-  unsigned srcRegRaw = fieldFromInstruction(Insn, 7, 4);
-  if (srcRegRaw >= std::size(mXsDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned srcRegRawNumBits = 4;
+  unsigned srcRegRaw = fieldFromInstruction(Insn, 7, srcRegRawNumBits);
+  static_assert((1 << srcRegRawNumBits) == std::size(mXsDecoderTable));
   Register srcReg = mXsDecoderTable[srcRegRaw];
-  assert(srcReg && "Register not found.");
+  if (!srcReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(srcReg));
 
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptrRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 3;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePDecoderTable));
   Register ptrReg = ePDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (modRegRaw >= std::size(eDDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 3;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 14, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDDecoderTable));
   Register modReg = eDDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -5757,40 +6617,45 @@ static DecodeStatus DecodeDmx_sts_pack_2D(MCInst &MI, InsnType &Insn,
                                           uint64_t Address,
                                           const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptr_outRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 3;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePDecoderTable));
   Register ptr_outReg = ePDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned dcRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (dcRegRaw >= std::size(eDCDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dcRegRawNumBits = 3;
+  unsigned dcRegRaw = fieldFromInstruction(Insn, 14, dcRegRawNumBits);
+  static_assert((1 << dcRegRawNumBits) == std::size(eDCDecoderTable));
   Register dcReg = eDCDecoderTable[dcRegRaw];
-  assert(dcReg && "Register not found.");
+  if (!dcReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dcReg));
 
   // --------------------- Ins ------------------------
-  unsigned srcRegRaw = fieldFromInstruction(Insn, 8, 3);
-  if (srcRegRaw >= std::size(eYDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned srcRegRawNumBits = 3;
+  unsigned srcRegRaw = fieldFromInstruction(Insn, 8, srcRegRawNumBits);
+  static_assert((1 << srcRegRawNumBits) == std::size(eYDecoderTable));
   Register srcReg = eYDecoderTable[srcRegRaw];
-  assert(srcReg && "Register not found.");
+  if (!srcReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(srcReg));
 
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptrRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 3;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePDecoderTable));
   Register ptrReg = ePDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (modRegRaw >= std::size(eDDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 3;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 14, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDDecoderTable));
   Register modReg = eDDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -5801,47 +6666,53 @@ static DecodeStatus DecodeDm_sts_srs_cm_2D(MCInst &MI, InsnType &Insn,
                                            uint64_t Address,
                                            const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptr_outRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 3;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePDecoderTable));
   Register ptr_outReg = ePDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned dcRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (dcRegRaw >= std::size(eDCDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dcRegRawNumBits = 3;
+  unsigned dcRegRaw = fieldFromInstruction(Insn, 14, dcRegRawNumBits);
+  static_assert((1 << dcRegRawNumBits) == std::size(eDCDecoderTable));
   Register dcReg = eDCDecoderTable[dcRegRaw];
-  assert(dcReg && "Register not found.");
+  if (!dcReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dcReg));
 
   // --------------------- Ins ------------------------
-  unsigned srcRegRaw = fieldFromInstruction(Insn, 7, 4);
-  if (srcRegRaw >= std::size(mCMsDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned srcRegRawNumBits = 4;
+  unsigned srcRegRaw = fieldFromInstruction(Insn, 7, srcRegRawNumBits);
+  static_assert((1 << srcRegRawNumBits) == std::size(mCMsDecoderTable));
   Register srcReg = mCMsDecoderTable[srcRegRaw];
-  assert(srcReg && "Register not found.");
+  if (!srcReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(srcReg));
 
-  unsigned suRegRaw = fieldFromInstruction(Insn, 4, 2);
-  if (suRegRaw >= std::size(eSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned suRegRawNumBits = 2;
+  unsigned suRegRaw = fieldFromInstruction(Insn, 4, suRegRawNumBits);
+  static_assert((1 << suRegRawNumBits) == std::size(eSDecoderTable));
   Register suReg = eSDecoderTable[suRegRaw];
-  assert(suReg && "Register not found.");
+  if (!suReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(suReg));
 
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptrRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 3;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePDecoderTable));
   Register ptrReg = ePDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (modRegRaw >= std::size(eDDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 3;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 14, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDDecoderTable));
   Register modReg = eDDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -5852,47 +6723,53 @@ static DecodeStatus DecodeDmw_sts_srs_bm_2D(MCInst &MI, InsnType &Insn,
                                             uint64_t Address,
                                             const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptr_outRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 3;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePDecoderTable));
   Register ptr_outReg = ePDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned dcRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (dcRegRaw >= std::size(eDCDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dcRegRawNumBits = 3;
+  unsigned dcRegRaw = fieldFromInstruction(Insn, 14, dcRegRawNumBits);
+  static_assert((1 << dcRegRawNumBits) == std::size(eDCDecoderTable));
   Register dcReg = eDCDecoderTable[dcRegRaw];
-  assert(dcReg && "Register not found.");
+  if (!dcReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dcReg));
 
   // --------------------- Ins ------------------------
-  unsigned srcRegRaw = fieldFromInstruction(Insn, 6, 5);
-  if (srcRegRaw >= std::size(mBMsDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned srcRegRawNumBits = 5;
+  unsigned srcRegRaw = fieldFromInstruction(Insn, 6, srcRegRawNumBits);
+  static_assert((1 << srcRegRawNumBits) == std::size(mBMsDecoderTable));
   Register srcReg = mBMsDecoderTable[srcRegRaw];
-  assert(srcReg && "Register not found.");
+  if (!srcReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(srcReg));
 
-  unsigned suRegRaw = fieldFromInstruction(Insn, 4, 2);
-  if (suRegRaw >= std::size(eSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned suRegRawNumBits = 2;
+  unsigned suRegRaw = fieldFromInstruction(Insn, 4, suRegRawNumBits);
+  static_assert((1 << suRegRawNumBits) == std::size(eSDecoderTable));
   Register suReg = eSDecoderTable[suRegRaw];
-  assert(suReg && "Register not found.");
+  if (!suReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(suReg));
 
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptrRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 3;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePDecoderTable));
   Register ptrReg = ePDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (modRegRaw >= std::size(eDDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 3;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 14, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDDecoderTable));
   Register modReg = eDDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -5903,47 +6780,53 @@ static DecodeStatus DecodeDmx_sts_srs_dm_2D(MCInst &MI, InsnType &Insn,
                                             uint64_t Address,
                                             const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptr_outRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 3;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePDecoderTable));
   Register ptr_outReg = ePDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned dcRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (dcRegRaw >= std::size(eDCDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dcRegRawNumBits = 3;
+  unsigned dcRegRaw = fieldFromInstruction(Insn, 14, dcRegRawNumBits);
+  static_assert((1 << dcRegRawNumBits) == std::size(eDCDecoderTable));
   Register dcReg = eDCDecoderTable[dcRegRaw];
-  assert(dcReg && "Register not found.");
+  if (!dcReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dcReg));
 
   // --------------------- Ins ------------------------
-  unsigned srcRegRaw = fieldFromInstruction(Insn, 8, 3);
-  if (srcRegRaw >= std::size(eDMDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned srcRegRawNumBits = 3;
+  unsigned srcRegRaw = fieldFromInstruction(Insn, 8, srcRegRawNumBits);
+  static_assert((1 << srcRegRawNumBits) == std::size(eDMDecoderTable));
   Register srcReg = eDMDecoderTable[srcRegRaw];
-  assert(srcReg && "Register not found.");
+  if (!srcReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(srcReg));
 
-  unsigned suRegRaw = fieldFromInstruction(Insn, 4, 2);
-  if (suRegRaw >= std::size(eSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned suRegRawNumBits = 2;
+  unsigned suRegRaw = fieldFromInstruction(Insn, 4, suRegRawNumBits);
+  static_assert((1 << suRegRawNumBits) == std::size(eSDecoderTable));
   Register suReg = eSDecoderTable[suRegRaw];
-  assert(suReg && "Register not found.");
+  if (!suReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(suReg));
 
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptrRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 3;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePDecoderTable));
   Register ptrReg = ePDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (modRegRaw >= std::size(eDDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 3;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 14, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDDecoderTable));
   Register modReg = eDDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -5954,40 +6837,45 @@ static DecodeStatus DecodeDmw_sts_w_2D(MCInst &MI, InsnType &Insn,
                                        uint64_t Address,
                                        const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptr_outRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 3;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePDecoderTable));
   Register ptr_outReg = ePDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned dcRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (dcRegRaw >= std::size(eDCDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dcRegRawNumBits = 3;
+  unsigned dcRegRaw = fieldFromInstruction(Insn, 14, dcRegRawNumBits);
+  static_assert((1 << dcRegRawNumBits) == std::size(eDCDecoderTable));
   Register dcReg = eDCDecoderTable[dcRegRaw];
-  assert(dcReg && "Register not found.");
+  if (!dcReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dcReg));
 
   // --------------------- Ins ------------------------
-  unsigned srcRegRaw = fieldFromInstruction(Insn, 6, 5);
-  if (srcRegRaw >= std::size(mWsDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned srcRegRawNumBits = 5;
+  unsigned srcRegRaw = fieldFromInstruction(Insn, 6, srcRegRawNumBits);
+  static_assert((1 << srcRegRawNumBits) == std::size(mWsDecoderTable));
   Register srcReg = mWsDecoderTable[srcRegRaw];
-  assert(srcReg && "Register not found.");
+  if (!srcReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(srcReg));
 
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptrRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 3;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePDecoderTable));
   Register ptrReg = ePDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (modRegRaw >= std::size(eDDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 3;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 14, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDDecoderTable));
   Register modReg = eDDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -5998,40 +6886,45 @@ static DecodeStatus DecodeDmx_sts_bm_2D(MCInst &MI, InsnType &Insn,
                                         uint64_t Address,
                                         const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptr_outRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 3;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePDecoderTable));
   Register ptr_outReg = ePDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned dcRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (dcRegRaw >= std::size(eDCDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dcRegRawNumBits = 3;
+  unsigned dcRegRaw = fieldFromInstruction(Insn, 14, dcRegRawNumBits);
+  static_assert((1 << dcRegRawNumBits) == std::size(eDCDecoderTable));
   Register dcReg = eDCDecoderTable[dcRegRaw];
-  assert(dcReg && "Register not found.");
+  if (!dcReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dcReg));
 
   // --------------------- Ins ------------------------
-  unsigned srcRegRaw = fieldFromInstruction(Insn, 6, 5);
-  if (srcRegRaw >= std::size(mBMsDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned srcRegRawNumBits = 5;
+  unsigned srcRegRaw = fieldFromInstruction(Insn, 6, srcRegRawNumBits);
+  static_assert((1 << srcRegRawNumBits) == std::size(mBMsDecoderTable));
   Register srcReg = mBMsDecoderTable[srcRegRaw];
-  assert(srcReg && "Register not found.");
+  if (!srcReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(srcReg));
 
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptrRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 3;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePDecoderTable));
   Register ptrReg = ePDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (modRegRaw >= std::size(eDDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 3;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 14, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDDecoderTable));
   Register modReg = eDDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -6042,40 +6935,45 @@ static DecodeStatus DecodeDmx_sts_fifohl_2D(MCInst &MI, InsnType &Insn,
                                             uint64_t Address,
                                             const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptr_outRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 3;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePDecoderTable));
   Register ptr_outReg = ePDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned dcRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (dcRegRaw >= std::size(eDCDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dcRegRawNumBits = 3;
+  unsigned dcRegRaw = fieldFromInstruction(Insn, 14, dcRegRawNumBits);
+  static_assert((1 << dcRegRawNumBits) == std::size(eDCDecoderTable));
   Register dcReg = eDCDecoderTable[dcRegRaw];
-  assert(dcReg && "Register not found.");
+  if (!dcReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dcReg));
 
   // --------------------- Ins ------------------------
-  unsigned srcRegRaw = fieldFromInstruction(Insn, 8, 3);
-  if (srcRegRaw >= std::size(mFifoHLRegDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned srcRegRawNumBits = 3;
+  unsigned srcRegRaw = fieldFromInstruction(Insn, 8, srcRegRawNumBits);
+  static_assert((1 << srcRegRawNumBits) == std::size(mFifoHLRegDecoderTable));
   Register srcReg = mFifoHLRegDecoderTable[srcRegRaw];
-  assert(srcReg && "Register not found.");
+  if (!srcReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(srcReg));
 
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptrRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 3;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePDecoderTable));
   Register ptrReg = ePDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (modRegRaw >= std::size(eDDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 3;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 14, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDDecoderTable));
   Register modReg = eDDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -6086,40 +6984,45 @@ static DecodeStatus DecodeDmx_sts_x_2D(MCInst &MI, InsnType &Insn,
                                        uint64_t Address,
                                        const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptr_outRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 3;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePDecoderTable));
   Register ptr_outReg = ePDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned dcRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (dcRegRaw >= std::size(eDCDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dcRegRawNumBits = 3;
+  unsigned dcRegRaw = fieldFromInstruction(Insn, 14, dcRegRawNumBits);
+  static_assert((1 << dcRegRawNumBits) == std::size(eDCDecoderTable));
   Register dcReg = eDCDecoderTable[dcRegRaw];
-  assert(dcReg && "Register not found.");
+  if (!dcReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dcReg));
 
   // --------------------- Ins ------------------------
-  unsigned srcRegRaw = fieldFromInstruction(Insn, 7, 4);
-  if (srcRegRaw >= std::size(mXsDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned srcRegRawNumBits = 4;
+  unsigned srcRegRaw = fieldFromInstruction(Insn, 7, srcRegRawNumBits);
+  static_assert((1 << srcRegRawNumBits) == std::size(mXsDecoderTable));
   Register srcReg = mXsDecoderTable[srcRegRaw];
-  assert(srcReg && "Register not found.");
+  if (!srcReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(srcReg));
 
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptrRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 3;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePDecoderTable));
   Register ptrReg = ePDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (modRegRaw >= std::size(eDDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 3;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 14, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDDecoderTable));
   Register modReg = eDDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -6130,47 +7033,53 @@ static DecodeStatus DecodeDmv_sts_w_3D(MCInst &MI, InsnType &Insn,
                                        uint64_t Address,
                                        const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptr_outRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 3;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePDecoderTable));
   Register ptr_outReg = ePDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned dclRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (dclRegRaw >= std::size(eDCLDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dclRegRawNumBits = 2;
+  unsigned dclRegRaw = fieldFromInstruction(Insn, 14, dclRegRawNumBits);
+  static_assert((1 << dclRegRawNumBits) == std::size(eDCLDecoderTable));
   Register dclReg = eDCLDecoderTable[dclRegRaw];
-  assert(dclReg && "Register not found.");
+  if (!dclReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dclReg));
 
-  unsigned dchRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (dchRegRaw >= std::size(eDCHDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dchRegRawNumBits = 2;
+  unsigned dchRegRaw = fieldFromInstruction(Insn, 14, dchRegRawNumBits);
+  static_assert((1 << dchRegRawNumBits) == std::size(eDCHDecoderTable));
   Register dchReg = eDCHDecoderTable[dchRegRaw];
-  assert(dchReg && "Register not found.");
+  if (!dchReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dchReg));
 
   // --------------------- Ins ------------------------
-  unsigned srcRegRaw = fieldFromInstruction(Insn, 6, 5);
-  if (srcRegRaw >= std::size(mWsDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned srcRegRawNumBits = 5;
+  unsigned srcRegRaw = fieldFromInstruction(Insn, 6, srcRegRawNumBits);
+  static_assert((1 << srcRegRawNumBits) == std::size(mWsDecoderTable));
   Register srcReg = mWsDecoderTable[srcRegRaw];
-  assert(srcReg && "Register not found.");
+  if (!srcReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(srcReg));
 
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptrRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 3;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePDecoderTable));
   Register ptrReg = ePDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (modRegRaw >= std::size(eDSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 2;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 14, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDSDecoderTable));
   Register modReg = eDSDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -6181,47 +7090,53 @@ static DecodeStatus DecodeDmw_sts_srs_bf_3D(MCInst &MI, InsnType &Insn,
                                             uint64_t Address,
                                             const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptr_outRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 3;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePDecoderTable));
   Register ptr_outReg = ePDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned dclRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (dclRegRaw >= std::size(eDCLDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dclRegRawNumBits = 2;
+  unsigned dclRegRaw = fieldFromInstruction(Insn, 14, dclRegRawNumBits);
+  static_assert((1 << dclRegRawNumBits) == std::size(eDCLDecoderTable));
   Register dclReg = eDCLDecoderTable[dclRegRaw];
-  assert(dclReg && "Register not found.");
+  if (!dclReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dclReg));
 
-  unsigned dchRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (dchRegRaw >= std::size(eDCHDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dchRegRawNumBits = 2;
+  unsigned dchRegRaw = fieldFromInstruction(Insn, 14, dchRegRawNumBits);
+  static_assert((1 << dchRegRawNumBits) == std::size(eDCHDecoderTable));
   Register dchReg = eDCHDecoderTable[dchRegRaw];
-  assert(dchReg && "Register not found.");
+  if (!dchReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dchReg));
 
   // --------------------- Ins ------------------------
-  unsigned srcRegRaw = fieldFromInstruction(Insn, 6, 5);
-  if (srcRegRaw >= std::size(mBMsDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned srcRegRawNumBits = 5;
+  unsigned srcRegRaw = fieldFromInstruction(Insn, 6, srcRegRawNumBits);
+  static_assert((1 << srcRegRawNumBits) == std::size(mBMsDecoderTable));
   Register srcReg = mBMsDecoderTable[srcRegRaw];
-  assert(srcReg && "Register not found.");
+  if (!srcReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(srcReg));
 
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptrRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 3;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePDecoderTable));
   Register ptrReg = ePDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (modRegRaw >= std::size(eDSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 2;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 14, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDSDecoderTable));
   Register modReg = eDSDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -6232,47 +7147,53 @@ static DecodeStatus DecodeDmx_sts_srs_bf_3D(MCInst &MI, InsnType &Insn,
                                             uint64_t Address,
                                             const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptr_outRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 3;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePDecoderTable));
   Register ptr_outReg = ePDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned dclRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (dclRegRaw >= std::size(eDCLDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dclRegRawNumBits = 2;
+  unsigned dclRegRaw = fieldFromInstruction(Insn, 14, dclRegRawNumBits);
+  static_assert((1 << dclRegRawNumBits) == std::size(eDCLDecoderTable));
   Register dclReg = eDCLDecoderTable[dclRegRaw];
-  assert(dclReg && "Register not found.");
+  if (!dclReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dclReg));
 
-  unsigned dchRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (dchRegRaw >= std::size(eDCHDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dchRegRawNumBits = 2;
+  unsigned dchRegRaw = fieldFromInstruction(Insn, 14, dchRegRawNumBits);
+  static_assert((1 << dchRegRawNumBits) == std::size(eDCHDecoderTable));
   Register dchReg = eDCHDecoderTable[dchRegRaw];
-  assert(dchReg && "Register not found.");
+  if (!dchReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dchReg));
 
   // --------------------- Ins ------------------------
-  unsigned srcRegRaw = fieldFromInstruction(Insn, 7, 4);
-  if (srcRegRaw >= std::size(mCMsDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned srcRegRawNumBits = 4;
+  unsigned srcRegRaw = fieldFromInstruction(Insn, 7, srcRegRawNumBits);
+  static_assert((1 << srcRegRawNumBits) == std::size(mCMsDecoderTable));
   Register srcReg = mCMsDecoderTable[srcRegRaw];
-  assert(srcReg && "Register not found.");
+  if (!srcReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(srcReg));
 
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptrRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 3;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePDecoderTable));
   Register ptrReg = ePDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (modRegRaw >= std::size(eDSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 2;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 14, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDSDecoderTable));
   Register modReg = eDSDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -6283,47 +7204,53 @@ static DecodeStatus DecodeDmw_sts_pack_3D(MCInst &MI, InsnType &Insn,
                                           uint64_t Address,
                                           const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptr_outRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 3;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePDecoderTable));
   Register ptr_outReg = ePDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned dclRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (dclRegRaw >= std::size(eDCLDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dclRegRawNumBits = 2;
+  unsigned dclRegRaw = fieldFromInstruction(Insn, 14, dclRegRawNumBits);
+  static_assert((1 << dclRegRawNumBits) == std::size(eDCLDecoderTable));
   Register dclReg = eDCLDecoderTable[dclRegRaw];
-  assert(dclReg && "Register not found.");
+  if (!dclReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dclReg));
 
-  unsigned dchRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (dchRegRaw >= std::size(eDCHDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dchRegRawNumBits = 2;
+  unsigned dchRegRaw = fieldFromInstruction(Insn, 14, dchRegRawNumBits);
+  static_assert((1 << dchRegRawNumBits) == std::size(eDCHDecoderTable));
   Register dchReg = eDCHDecoderTable[dchRegRaw];
-  assert(dchReg && "Register not found.");
+  if (!dchReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dchReg));
 
   // --------------------- Ins ------------------------
-  unsigned srcRegRaw = fieldFromInstruction(Insn, 7, 4);
-  if (srcRegRaw >= std::size(mXsDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned srcRegRawNumBits = 4;
+  unsigned srcRegRaw = fieldFromInstruction(Insn, 7, srcRegRawNumBits);
+  static_assert((1 << srcRegRawNumBits) == std::size(mXsDecoderTable));
   Register srcReg = mXsDecoderTable[srcRegRaw];
-  assert(srcReg && "Register not found.");
+  if (!srcReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(srcReg));
 
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptrRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 3;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePDecoderTable));
   Register ptrReg = ePDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (modRegRaw >= std::size(eDSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 2;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 14, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDSDecoderTable));
   Register modReg = eDSDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -6334,47 +7261,53 @@ static DecodeStatus DecodeDmx_sts_pack_3D(MCInst &MI, InsnType &Insn,
                                           uint64_t Address,
                                           const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptr_outRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 3;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePDecoderTable));
   Register ptr_outReg = ePDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned dclRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (dclRegRaw >= std::size(eDCLDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dclRegRawNumBits = 2;
+  unsigned dclRegRaw = fieldFromInstruction(Insn, 14, dclRegRawNumBits);
+  static_assert((1 << dclRegRawNumBits) == std::size(eDCLDecoderTable));
   Register dclReg = eDCLDecoderTable[dclRegRaw];
-  assert(dclReg && "Register not found.");
+  if (!dclReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dclReg));
 
-  unsigned dchRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (dchRegRaw >= std::size(eDCHDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dchRegRawNumBits = 2;
+  unsigned dchRegRaw = fieldFromInstruction(Insn, 14, dchRegRawNumBits);
+  static_assert((1 << dchRegRawNumBits) == std::size(eDCHDecoderTable));
   Register dchReg = eDCHDecoderTable[dchRegRaw];
-  assert(dchReg && "Register not found.");
+  if (!dchReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dchReg));
 
   // --------------------- Ins ------------------------
-  unsigned srcRegRaw = fieldFromInstruction(Insn, 8, 3);
-  if (srcRegRaw >= std::size(eYDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned srcRegRawNumBits = 3;
+  unsigned srcRegRaw = fieldFromInstruction(Insn, 8, srcRegRawNumBits);
+  static_assert((1 << srcRegRawNumBits) == std::size(eYDecoderTable));
   Register srcReg = eYDecoderTable[srcRegRaw];
-  assert(srcReg && "Register not found.");
+  if (!srcReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(srcReg));
 
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptrRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 3;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePDecoderTable));
   Register ptrReg = ePDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (modRegRaw >= std::size(eDSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 2;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 14, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDSDecoderTable));
   Register modReg = eDSDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -6385,54 +7318,61 @@ static DecodeStatus DecodeDm_sts_srs_cm_3D(MCInst &MI, InsnType &Insn,
                                            uint64_t Address,
                                            const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptr_outRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 3;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePDecoderTable));
   Register ptr_outReg = ePDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned dclRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (dclRegRaw >= std::size(eDCLDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dclRegRawNumBits = 2;
+  unsigned dclRegRaw = fieldFromInstruction(Insn, 14, dclRegRawNumBits);
+  static_assert((1 << dclRegRawNumBits) == std::size(eDCLDecoderTable));
   Register dclReg = eDCLDecoderTable[dclRegRaw];
-  assert(dclReg && "Register not found.");
+  if (!dclReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dclReg));
 
-  unsigned dchRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (dchRegRaw >= std::size(eDCHDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dchRegRawNumBits = 2;
+  unsigned dchRegRaw = fieldFromInstruction(Insn, 14, dchRegRawNumBits);
+  static_assert((1 << dchRegRawNumBits) == std::size(eDCHDecoderTable));
   Register dchReg = eDCHDecoderTable[dchRegRaw];
-  assert(dchReg && "Register not found.");
+  if (!dchReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dchReg));
 
   // --------------------- Ins ------------------------
-  unsigned srcRegRaw = fieldFromInstruction(Insn, 7, 4);
-  if (srcRegRaw >= std::size(mCMsDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned srcRegRawNumBits = 4;
+  unsigned srcRegRaw = fieldFromInstruction(Insn, 7, srcRegRawNumBits);
+  static_assert((1 << srcRegRawNumBits) == std::size(mCMsDecoderTable));
   Register srcReg = mCMsDecoderTable[srcRegRaw];
-  assert(srcReg && "Register not found.");
+  if (!srcReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(srcReg));
 
-  unsigned suRegRaw = fieldFromInstruction(Insn, 4, 2);
-  if (suRegRaw >= std::size(eSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned suRegRawNumBits = 2;
+  unsigned suRegRaw = fieldFromInstruction(Insn, 4, suRegRawNumBits);
+  static_assert((1 << suRegRawNumBits) == std::size(eSDecoderTable));
   Register suReg = eSDecoderTable[suRegRaw];
-  assert(suReg && "Register not found.");
+  if (!suReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(suReg));
 
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptrRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 3;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePDecoderTable));
   Register ptrReg = ePDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (modRegRaw >= std::size(eDSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 2;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 14, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDSDecoderTable));
   Register modReg = eDSDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -6443,54 +7383,61 @@ static DecodeStatus DecodeDmw_sts_srs_bm_3D(MCInst &MI, InsnType &Insn,
                                             uint64_t Address,
                                             const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptr_outRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 3;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePDecoderTable));
   Register ptr_outReg = ePDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned dclRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (dclRegRaw >= std::size(eDCLDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dclRegRawNumBits = 2;
+  unsigned dclRegRaw = fieldFromInstruction(Insn, 14, dclRegRawNumBits);
+  static_assert((1 << dclRegRawNumBits) == std::size(eDCLDecoderTable));
   Register dclReg = eDCLDecoderTable[dclRegRaw];
-  assert(dclReg && "Register not found.");
+  if (!dclReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dclReg));
 
-  unsigned dchRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (dchRegRaw >= std::size(eDCHDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dchRegRawNumBits = 2;
+  unsigned dchRegRaw = fieldFromInstruction(Insn, 14, dchRegRawNumBits);
+  static_assert((1 << dchRegRawNumBits) == std::size(eDCHDecoderTable));
   Register dchReg = eDCHDecoderTable[dchRegRaw];
-  assert(dchReg && "Register not found.");
+  if (!dchReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dchReg));
 
   // --------------------- Ins ------------------------
-  unsigned srcRegRaw = fieldFromInstruction(Insn, 6, 5);
-  if (srcRegRaw >= std::size(mBMsDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned srcRegRawNumBits = 5;
+  unsigned srcRegRaw = fieldFromInstruction(Insn, 6, srcRegRawNumBits);
+  static_assert((1 << srcRegRawNumBits) == std::size(mBMsDecoderTable));
   Register srcReg = mBMsDecoderTable[srcRegRaw];
-  assert(srcReg && "Register not found.");
+  if (!srcReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(srcReg));
 
-  unsigned suRegRaw = fieldFromInstruction(Insn, 4, 2);
-  if (suRegRaw >= std::size(eSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned suRegRawNumBits = 2;
+  unsigned suRegRaw = fieldFromInstruction(Insn, 4, suRegRawNumBits);
+  static_assert((1 << suRegRawNumBits) == std::size(eSDecoderTable));
   Register suReg = eSDecoderTable[suRegRaw];
-  assert(suReg && "Register not found.");
+  if (!suReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(suReg));
 
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptrRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 3;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePDecoderTable));
   Register ptrReg = ePDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (modRegRaw >= std::size(eDSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 2;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 14, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDSDecoderTable));
   Register modReg = eDSDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -6501,54 +7448,61 @@ static DecodeStatus DecodeDmx_sts_srs_dm_3D(MCInst &MI, InsnType &Insn,
                                             uint64_t Address,
                                             const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptr_outRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 3;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePDecoderTable));
   Register ptr_outReg = ePDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned dclRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (dclRegRaw >= std::size(eDCLDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dclRegRawNumBits = 2;
+  unsigned dclRegRaw = fieldFromInstruction(Insn, 14, dclRegRawNumBits);
+  static_assert((1 << dclRegRawNumBits) == std::size(eDCLDecoderTable));
   Register dclReg = eDCLDecoderTable[dclRegRaw];
-  assert(dclReg && "Register not found.");
+  if (!dclReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dclReg));
 
-  unsigned dchRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (dchRegRaw >= std::size(eDCHDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dchRegRawNumBits = 2;
+  unsigned dchRegRaw = fieldFromInstruction(Insn, 14, dchRegRawNumBits);
+  static_assert((1 << dchRegRawNumBits) == std::size(eDCHDecoderTable));
   Register dchReg = eDCHDecoderTable[dchRegRaw];
-  assert(dchReg && "Register not found.");
+  if (!dchReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dchReg));
 
   // --------------------- Ins ------------------------
-  unsigned srcRegRaw = fieldFromInstruction(Insn, 8, 3);
-  if (srcRegRaw >= std::size(eDMDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned srcRegRawNumBits = 3;
+  unsigned srcRegRaw = fieldFromInstruction(Insn, 8, srcRegRawNumBits);
+  static_assert((1 << srcRegRawNumBits) == std::size(eDMDecoderTable));
   Register srcReg = eDMDecoderTable[srcRegRaw];
-  assert(srcReg && "Register not found.");
+  if (!srcReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(srcReg));
 
-  unsigned suRegRaw = fieldFromInstruction(Insn, 4, 2);
-  if (suRegRaw >= std::size(eSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned suRegRawNumBits = 2;
+  unsigned suRegRaw = fieldFromInstruction(Insn, 4, suRegRawNumBits);
+  static_assert((1 << suRegRawNumBits) == std::size(eSDecoderTable));
   Register suReg = eSDecoderTable[suRegRaw];
-  assert(suReg && "Register not found.");
+  if (!suReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(suReg));
 
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptrRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 3;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePDecoderTable));
   Register ptrReg = ePDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (modRegRaw >= std::size(eDSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 2;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 14, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDSDecoderTable));
   Register modReg = eDSDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -6559,47 +7513,53 @@ static DecodeStatus DecodeDmw_sts_w_3D(MCInst &MI, InsnType &Insn,
                                        uint64_t Address,
                                        const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptr_outRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 3;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePDecoderTable));
   Register ptr_outReg = ePDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned dclRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (dclRegRaw >= std::size(eDCLDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dclRegRawNumBits = 2;
+  unsigned dclRegRaw = fieldFromInstruction(Insn, 14, dclRegRawNumBits);
+  static_assert((1 << dclRegRawNumBits) == std::size(eDCLDecoderTable));
   Register dclReg = eDCLDecoderTable[dclRegRaw];
-  assert(dclReg && "Register not found.");
+  if (!dclReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dclReg));
 
-  unsigned dchRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (dchRegRaw >= std::size(eDCHDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dchRegRawNumBits = 2;
+  unsigned dchRegRaw = fieldFromInstruction(Insn, 14, dchRegRawNumBits);
+  static_assert((1 << dchRegRawNumBits) == std::size(eDCHDecoderTable));
   Register dchReg = eDCHDecoderTable[dchRegRaw];
-  assert(dchReg && "Register not found.");
+  if (!dchReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dchReg));
 
   // --------------------- Ins ------------------------
-  unsigned srcRegRaw = fieldFromInstruction(Insn, 6, 5);
-  if (srcRegRaw >= std::size(mWsDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned srcRegRawNumBits = 5;
+  unsigned srcRegRaw = fieldFromInstruction(Insn, 6, srcRegRawNumBits);
+  static_assert((1 << srcRegRawNumBits) == std::size(mWsDecoderTable));
   Register srcReg = mWsDecoderTable[srcRegRaw];
-  assert(srcReg && "Register not found.");
+  if (!srcReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(srcReg));
 
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptrRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 3;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePDecoderTable));
   Register ptrReg = ePDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (modRegRaw >= std::size(eDSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 2;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 14, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDSDecoderTable));
   Register modReg = eDSDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -6610,47 +7570,53 @@ static DecodeStatus DecodeDmx_sts_bm_3D(MCInst &MI, InsnType &Insn,
                                         uint64_t Address,
                                         const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptr_outRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 3;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePDecoderTable));
   Register ptr_outReg = ePDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned dclRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (dclRegRaw >= std::size(eDCLDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dclRegRawNumBits = 2;
+  unsigned dclRegRaw = fieldFromInstruction(Insn, 14, dclRegRawNumBits);
+  static_assert((1 << dclRegRawNumBits) == std::size(eDCLDecoderTable));
   Register dclReg = eDCLDecoderTable[dclRegRaw];
-  assert(dclReg && "Register not found.");
+  if (!dclReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dclReg));
 
-  unsigned dchRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (dchRegRaw >= std::size(eDCHDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dchRegRawNumBits = 2;
+  unsigned dchRegRaw = fieldFromInstruction(Insn, 14, dchRegRawNumBits);
+  static_assert((1 << dchRegRawNumBits) == std::size(eDCHDecoderTable));
   Register dchReg = eDCHDecoderTable[dchRegRaw];
-  assert(dchReg && "Register not found.");
+  if (!dchReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dchReg));
 
   // --------------------- Ins ------------------------
-  unsigned srcRegRaw = fieldFromInstruction(Insn, 6, 5);
-  if (srcRegRaw >= std::size(mBMsDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned srcRegRawNumBits = 5;
+  unsigned srcRegRaw = fieldFromInstruction(Insn, 6, srcRegRawNumBits);
+  static_assert((1 << srcRegRawNumBits) == std::size(mBMsDecoderTable));
   Register srcReg = mBMsDecoderTable[srcRegRaw];
-  assert(srcReg && "Register not found.");
+  if (!srcReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(srcReg));
 
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptrRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 3;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePDecoderTable));
   Register ptrReg = ePDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (modRegRaw >= std::size(eDSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 2;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 14, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDSDecoderTable));
   Register modReg = eDSDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -6661,47 +7627,53 @@ static DecodeStatus DecodeDmx_sts_fifohl_3D(MCInst &MI, InsnType &Insn,
                                             uint64_t Address,
                                             const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptr_outRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 3;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePDecoderTable));
   Register ptr_outReg = ePDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned dclRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (dclRegRaw >= std::size(eDCLDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dclRegRawNumBits = 2;
+  unsigned dclRegRaw = fieldFromInstruction(Insn, 14, dclRegRawNumBits);
+  static_assert((1 << dclRegRawNumBits) == std::size(eDCLDecoderTable));
   Register dclReg = eDCLDecoderTable[dclRegRaw];
-  assert(dclReg && "Register not found.");
+  if (!dclReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dclReg));
 
-  unsigned dchRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (dchRegRaw >= std::size(eDCHDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dchRegRawNumBits = 2;
+  unsigned dchRegRaw = fieldFromInstruction(Insn, 14, dchRegRawNumBits);
+  static_assert((1 << dchRegRawNumBits) == std::size(eDCHDecoderTable));
   Register dchReg = eDCHDecoderTable[dchRegRaw];
-  assert(dchReg && "Register not found.");
+  if (!dchReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dchReg));
 
   // --------------------- Ins ------------------------
-  unsigned srcRegRaw = fieldFromInstruction(Insn, 8, 3);
-  if (srcRegRaw >= std::size(mFifoHLRegDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned srcRegRawNumBits = 3;
+  unsigned srcRegRaw = fieldFromInstruction(Insn, 8, srcRegRawNumBits);
+  static_assert((1 << srcRegRawNumBits) == std::size(mFifoHLRegDecoderTable));
   Register srcReg = mFifoHLRegDecoderTable[srcRegRaw];
-  assert(srcReg && "Register not found.");
+  if (!srcReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(srcReg));
 
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptrRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 3;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePDecoderTable));
   Register ptrReg = ePDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (modRegRaw >= std::size(eDSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 2;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 14, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDSDecoderTable));
   Register modReg = eDSDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -6712,47 +7684,53 @@ static DecodeStatus DecodeDmx_sts_x_3D(MCInst &MI, InsnType &Insn,
                                        uint64_t Address,
                                        const MCDisassembler *Decoder) {
   // ------------------- Outs ------------------------
-  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptr_outRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptr_outRegRawNumBits = 3;
+  unsigned ptr_outRegRaw = fieldFromInstruction(Insn, 17, ptr_outRegRawNumBits);
+  static_assert((1 << ptr_outRegRawNumBits) == std::size(ePDecoderTable));
   Register ptr_outReg = ePDecoderTable[ptr_outRegRaw];
-  assert(ptr_outReg && "Register not found.");
+  if (!ptr_outReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptr_outReg));
 
-  unsigned dclRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (dclRegRaw >= std::size(eDCLDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dclRegRawNumBits = 2;
+  unsigned dclRegRaw = fieldFromInstruction(Insn, 14, dclRegRawNumBits);
+  static_assert((1 << dclRegRawNumBits) == std::size(eDCLDecoderTable));
   Register dclReg = eDCLDecoderTable[dclRegRaw];
-  assert(dclReg && "Register not found.");
+  if (!dclReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dclReg));
 
-  unsigned dchRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (dchRegRaw >= std::size(eDCHDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dchRegRawNumBits = 2;
+  unsigned dchRegRaw = fieldFromInstruction(Insn, 14, dchRegRawNumBits);
+  static_assert((1 << dchRegRawNumBits) == std::size(eDCHDecoderTable));
   Register dchReg = eDCHDecoderTable[dchRegRaw];
-  assert(dchReg && "Register not found.");
+  if (!dchReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dchReg));
 
   // --------------------- Ins ------------------------
-  unsigned srcRegRaw = fieldFromInstruction(Insn, 7, 4);
-  if (srcRegRaw >= std::size(mXsDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned srcRegRawNumBits = 4;
+  unsigned srcRegRaw = fieldFromInstruction(Insn, 7, srcRegRawNumBits);
+  static_assert((1 << srcRegRawNumBits) == std::size(mXsDecoderTable));
   Register srcReg = mXsDecoderTable[srcRegRaw];
-  assert(srcReg && "Register not found.");
+  if (!srcReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(srcReg));
 
-  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, 3);
-  if (ptrRegRaw >= std::size(ePDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned ptrRegRawNumBits = 3;
+  unsigned ptrRegRaw = fieldFromInstruction(Insn, 17, ptrRegRawNumBits);
+  static_assert((1 << ptrRegRawNumBits) == std::size(ePDecoderTable));
   Register ptrReg = ePDecoderTable[ptrRegRaw];
-  assert(ptrReg && "Register not found.");
+  if (!ptrReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(ptrReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (modRegRaw >= std::size(eDSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 2;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 14, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDSDecoderTable));
   Register modReg = eDSDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -6782,11 +7760,12 @@ DecodeDmx_sts_fifo_bare_x__fifo_2d_flush(MCInst &MI, InsnType &Insn,
   unsigned avail_outReg = avail_outRC.getRegister(0);
   MI.addOperand(MCOperand::createReg(avail_outReg));
 
-  unsigned dcRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (dcRegRaw >= std::size(eDCDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dcRegRawNumBits = 3;
+  unsigned dcRegRaw = fieldFromInstruction(Insn, 14, dcRegRawNumBits);
+  static_assert((1 << dcRegRawNumBits) == std::size(eDCDecoderTable));
   Register dcReg = eDCDecoderTable[dcRegRaw];
-  assert(dcReg && "Register not found.");
+  if (!dcReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dcReg));
 
   // --------------------- Ins ------------------------
@@ -6808,11 +7787,12 @@ DecodeDmx_sts_fifo_bare_x__fifo_2d_flush(MCInst &MI, InsnType &Insn,
   unsigned availReg = availRC.getRegister(0);
   MI.addOperand(MCOperand::createReg(availReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (modRegRaw >= std::size(eDDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 3;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 14, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDDecoderTable));
   Register modReg = eDDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -6842,18 +7822,20 @@ DecodeDmx_sts_fifo_bare_x__fifo_3d_flush(MCInst &MI, InsnType &Insn,
   unsigned avail_outReg = avail_outRC.getRegister(0);
   MI.addOperand(MCOperand::createReg(avail_outReg));
 
-  unsigned dclRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (dclRegRaw >= std::size(eDCLDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dclRegRawNumBits = 2;
+  unsigned dclRegRaw = fieldFromInstruction(Insn, 14, dclRegRawNumBits);
+  static_assert((1 << dclRegRawNumBits) == std::size(eDCLDecoderTable));
   Register dclReg = eDCLDecoderTable[dclRegRaw];
-  assert(dclReg && "Register not found.");
+  if (!dclReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dclReg));
 
-  unsigned dchRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (dchRegRaw >= std::size(eDCHDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dchRegRawNumBits = 2;
+  unsigned dchRegRaw = fieldFromInstruction(Insn, 14, dchRegRawNumBits);
+  static_assert((1 << dchRegRawNumBits) == std::size(eDCHDecoderTable));
   Register dchReg = eDCHDecoderTable[dchRegRaw];
-  assert(dchReg && "Register not found.");
+  if (!dchReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dchReg));
 
   // --------------------- Ins ------------------------
@@ -6875,11 +7857,12 @@ DecodeDmx_sts_fifo_bare_x__fifo_3d_flush(MCInst &MI, InsnType &Insn,
   unsigned availReg = availRC.getRegister(0);
   MI.addOperand(MCOperand::createReg(availReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (modRegRaw >= std::size(eDSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 2;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 14, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDSDecoderTable));
   Register modReg = eDSDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -6909,11 +7892,12 @@ DecodeDmx_sts_fifo_conv_x__fifo_2d_flush(MCInst &MI, InsnType &Insn,
   unsigned avail_outReg = avail_outRC.getRegister(0);
   MI.addOperand(MCOperand::createReg(avail_outReg));
 
-  unsigned dcRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (dcRegRaw >= std::size(eDCDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dcRegRawNumBits = 3;
+  unsigned dcRegRaw = fieldFromInstruction(Insn, 14, dcRegRawNumBits);
+  static_assert((1 << dcRegRawNumBits) == std::size(eDCDecoderTable));
   Register dcReg = eDCDecoderTable[dcRegRaw];
-  assert(dcReg && "Register not found.");
+  if (!dcReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dcReg));
 
   // --------------------- Ins ------------------------
@@ -6935,11 +7919,12 @@ DecodeDmx_sts_fifo_conv_x__fifo_2d_flush(MCInst &MI, InsnType &Insn,
   unsigned availReg = availRC.getRegister(0);
   MI.addOperand(MCOperand::createReg(availReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 14, 3);
-  if (modRegRaw >= std::size(eDDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 3;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 14, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDDecoderTable));
   Register modReg = eDDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;
@@ -6969,18 +7954,20 @@ DecodeDmx_sts_fifo_conv_x__fifo_3d_flush(MCInst &MI, InsnType &Insn,
   unsigned avail_outReg = avail_outRC.getRegister(0);
   MI.addOperand(MCOperand::createReg(avail_outReg));
 
-  unsigned dclRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (dclRegRaw >= std::size(eDCLDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dclRegRawNumBits = 2;
+  unsigned dclRegRaw = fieldFromInstruction(Insn, 14, dclRegRawNumBits);
+  static_assert((1 << dclRegRawNumBits) == std::size(eDCLDecoderTable));
   Register dclReg = eDCLDecoderTable[dclRegRaw];
-  assert(dclReg && "Register not found.");
+  if (!dclReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dclReg));
 
-  unsigned dchRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (dchRegRaw >= std::size(eDCHDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned dchRegRawNumBits = 2;
+  unsigned dchRegRaw = fieldFromInstruction(Insn, 14, dchRegRawNumBits);
+  static_assert((1 << dchRegRawNumBits) == std::size(eDCHDecoderTable));
   Register dchReg = eDCHDecoderTable[dchRegRaw];
-  assert(dchReg && "Register not found.");
+  if (!dchReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(dchReg));
 
   // --------------------- Ins ------------------------
@@ -7002,11 +7989,12 @@ DecodeDmx_sts_fifo_conv_x__fifo_3d_flush(MCInst &MI, InsnType &Insn,
   unsigned availReg = availRC.getRegister(0);
   MI.addOperand(MCOperand::createReg(availReg));
 
-  unsigned modRegRaw = fieldFromInstruction(Insn, 14, 2);
-  if (modRegRaw >= std::size(eDSDecoderTable))
-    return MCDisassembler::Fail;
+  const unsigned modRegRawNumBits = 2;
+  unsigned modRegRaw = fieldFromInstruction(Insn, 14, modRegRawNumBits);
+  static_assert((1 << modRegRawNumBits) == std::size(eDSDecoderTable));
   Register modReg = eDSDecoderTable[modRegRaw];
-  assert(modReg && "Register not found.");
+  if (!modReg)
+    return MCDisassembler::Fail;
   MI.addOperand(MCOperand::createReg(modReg));
 
   return MCDisassembler::Success;

--- a/llvm/lib/Target/AIE/Disassembler/AIEDisassemblerPP.h
+++ b/llvm/lib/Target/AIE/Disassembler/AIEDisassemblerPP.h
@@ -23,7 +23,8 @@
       return MCDisassembler::Fail;                                             \
     unsigned Reg = TableClassName##DecoderTable[RegNo];                        \
     LLVM_DEBUG(dbgs() << "RegEnc=" << RegNo << " Reg=" << Reg << "\n");        \
-    assert(Reg && "Register not found!");                                      \
+    if (!Reg)                                                                  \
+      return MCDisassembler::Fail;                                             \
     Inst.addOperand(MCOperand::createReg(Reg));                                \
     return MCDisassembler::Success;                                            \
   }


### PR DESCRIPTION
This PR changes two things:
- Some decoder tables have "holes" (zeros). If someone tries to decode an incorrect object file and the lookup table returns such a zero, the decoder method asserts. I updated them to fail properly.
- I updated the out-of-bound checks for the lookup tables. Since we know the number of bits that are read in the decoder methods we can check the bounds at compile time. A few decoder tables with non-power-of-two table sizes needed to be padded with zeroes to make this work. The previously introduced check catches these cases and fails properly as it did before these changes.