### PR TITLE
Changes to fix the tracking of new line counter in the Asm Printer

### DIFF
--- a/mlir/lib/IR/AsmPrinter.cpp
+++ b/mlir/lib/IR/AsmPrinter.cpp
@@ -2363,13 +2363,19 @@ void AsmPrinter::Impl::printAttributeImpl(Attribute attr,
       for (size_t i = 0; i < separator.size() - 2; ++i) {
         separatorBracket.push_back(' ');
       }
+      ++newLine.curLine; // Increment new line counter
       os << separatorBracket;
     }
+    auto dictAttrValue = dictAttr.getValue();
+    if (breakOnNewLine)
+      newLine.curLine +=
+          ((std::distance(dictAttrValue.begin(), dictAttrValue.end())) - 1);
     interleave(
-        dictAttr.getValue(),
-        [&](NamedAttribute attr) { printNamedAttribute(attr); }, separator);
+        dictAttrValue, [&](NamedAttribute attr) { printNamedAttribute(attr); },
+        separator);
     if (breakOnNewLine) {
       separatorBracket.pop_back_n(2);
+      ++newLine.curLine;
       os << separatorBracket;
     }
     os << '}';
@@ -2422,14 +2428,19 @@ void AsmPrinter::Impl::printAttributeImpl(Attribute attr,
       for (size_t i = 0; i < separator.size() - 2; ++i) {
         separatorBracket.push_back(' ');
       }
+      ++newLine.curLine;
       os << separatorBracket;
+      auto arrayAttrValue = arrayAttr.getValue();
+      newLine.curLine +=
+          ((std::distance(arrayAttrValue.begin(), arrayAttrValue.end())) - 1);
       interleave(
-          arrayAttr.getValue(),
+          arrayAttrValue,
           [&](Attribute attr) {
             printAttribute(attr, AttrTypeElision::May, separator);
           },
           separator);
       separatorBracket.pop_back_n(2);
+      ++newLine.curLine;
       os << separatorBracket;
     } else {
       interleaveComma(arrayAttr.getValue(), [&](Attribute attr) {
@@ -2843,9 +2854,10 @@ void AsmPrinter::Impl::printOptionalAttrDict(ArrayRef<NamedAttribute> attrs,
     os << " {";
 
     SmallString<16> separator = StringRef(", ");
+    auto filteredAttrCount =
+        std::distance(filteredAttrs.begin(), filteredAttrs.end());
     if (printerFlags.getNewlineAfterAttrLimit() &&
-        std::distance(filteredAttrs.begin(), filteredAttrs.end()) >
-            *printerFlags.getNewlineAfterAttrLimit()) {
+        filteredAttrCount > *printerFlags.getNewlineAfterAttrLimit()) {
 
       // Increase indent to match the visually match the "{ " below.
       // currentIndent += 2;
@@ -2857,8 +2869,11 @@ void AsmPrinter::Impl::printOptionalAttrDict(ArrayRef<NamedAttribute> attrs,
         separator.push_back(' ');
 
       // Already put the first attribute on its own line.
-      os << "\n";
+      os << newLine;
       os.indent(currentIndent);
+
+      // Increment the new line counter by the number of attributes minus one.
+      newLine.curLine += (filteredAttrCount - 1);
     }
 
     // Otherwise, print them all out in braces.

--- a/mlir/lib/IR/AsmPrinter.cpp
+++ b/mlir/lib/IR/AsmPrinter.cpp
@@ -2369,7 +2369,7 @@ void AsmPrinter::Impl::printAttributeImpl(Attribute attr,
     auto dictAttrValue = dictAttr.getValue();
     if (breakOnNewLine)
       newLine.curLine +=
-          ((std::distance(dictAttrValue.begin(), dictAttrValue.end())) - 1);
+          ((std::distance(dictAttrValue.begin(), dictAttrValue.end()))-1);
     interleave(
         dictAttrValue, [&](NamedAttribute attr) { printNamedAttribute(attr); },
         separator);
@@ -2432,7 +2432,7 @@ void AsmPrinter::Impl::printAttributeImpl(Attribute attr,
       os << separatorBracket;
       auto arrayAttrValue = arrayAttr.getValue();
       newLine.curLine +=
-          ((std::distance(arrayAttrValue.begin(), arrayAttrValue.end())) - 1);
+          ((std::distance(arrayAttrValue.begin(), arrayAttrValue.end()))-1);
       interleave(
           arrayAttrValue,
           [&](Attribute attr) {

--- a/mlir/test/IR/mlir-op-to-location-map.mlir
+++ b/mlir/test/IR/mlir-op-to-location-map.mlir
@@ -1,0 +1,21 @@
+// RUN: mlir-opt -allow-unregistered-dialect %s -snapshot-op-locations='filename=%t print-debuginfo' -mlir-print-debuginfo -mlir-newline-after-attr=2 | FileCheck %s
+
+// CHECK:module {
+// CHECK-NEXT:  func.func @myfunc() -> i32 attributes {
+// CHECK-NEXT:    attr1 = "foo",
+// CHECK-NEXT:    attr2 = 42 : i32,
+// CHECK-NEXT:    attr3 = true} {
+// CHECK-NEXT:    %0 = "myop"() : () -> i32 loc(#loc2)
+// CHECK-NEXT:    return %0 : i32 loc(#loc3)
+// CHECK-NEXT:  } loc(#loc1)
+// CHECK-NEXT:} loc(#loc)
+// CHECK-NEXT:#loc = loc("{{.*}}":1:0)
+// CHECK-NEXT:#loc1 = loc("{{.*}}":2:2)
+// CHECK-NEXT:#loc2 = loc("{{.*}}":6:4)
+// CHECK-NEXT:#loc3 = loc("{{.*}}":7:4)
+
+func.func @myfunc() -> i32
+attributes { attr1 = "foo", attr2 = 42 : i32, attr3 = true } {
+%0 = "myop"() : () -> i32
+return %0 : i32
+}


### PR DESCRIPTION
The new line counter was not incremented when print flag `newlineAfterAttribute` is enabled. 
This PR provides a fix for it.