### PR TITLE
[AIE2P] Add alternative calling convention for library calls

### DIFF
--- a/llvm/include/llvm/IR/CallingConv.h
+++ b/llvm/include/llvm/IR/CallingConv.h
@@ -270,6 +270,9 @@ namespace CallingConv {
     /// Preserve X1-X15, X19-X29, SP, Z0-Z31, P0-P15.
     AArch64_SME_ABI_Support_Routines_PreserveMost_From_X1 = 111,
 
+    /// Preserve vector registers.
+    AIE_PreserveAll_Vec = 112,
+
     /// The highest possible ID. Must be some 2^k - 1.
     MaxID = 1023
   };

--- a/llvm/lib/Target/AIE/AIEBaseISelLowering.cpp
+++ b/llvm/lib/Target/AIE/AIEBaseISelLowering.cpp
@@ -19,6 +19,7 @@
 #include "MCTargetDesc/AIEMCTargetDesc.h"
 #include "MCTargetDesc/aie2p/AIE2PMCTargetDesc.h"
 #include "MCTargetDesc/aie2ps/AIE2PSMCTargetDesc.h"
+#include "llvm/IR/RuntimeLibcalls.h"
 #include "llvm/MC/MCRegister.h"
 using namespace llvm;
 
@@ -28,6 +29,11 @@ static cl::opt<bool>
     AllowVecRegMemOps("aie-vect-reg-mem-ops", cl::init(true), cl::Hidden,
                       cl::desc("Allow the usage of vector registers when "
                                "lowering mem[cpy|set|mov]."));
+
+cl::opt<bool>
+    VecCCLibcalls("aie-libcalls-preserve-vectors", cl::init(true), cl::Hidden,
+                  cl::desc("Assume all vector registers are callee-saved by "
+                           "builtin library functions."));
 
 AIEBaseTargetLowering::AIEBaseTargetLowering(const TargetMachine &TM,
                                              const AIEBaseSubtarget &STI)

--- a/llvm/lib/Target/AIE/aie2p/AIE2PCallingConv.td
+++ b/llvm/lib/Target/AIE/aie2p/AIE2PCallingConv.td
@@ -219,5 +219,12 @@ def CC_AIE2P : CallingConv<[
 def CSR_AIE2P
     : CalleeSavedRegs<(add lr, r8, r9, r10, r11, r12, r13, r14, r15, p6, p7)>;
 
+def CSR_AIE2P_Vec
+    : CalleeSavedRegs<(add lr, r8, r9, r10, r11, r12, r13, r14, r15, p6, p7,
+          wl0, wl2, wl4, wl6, wl8, wl10, wl1, wl3, wl5, wl7, wl9, wl11, wh0,
+          wh2, wh4, wh6, wh8, wh10, wh1, wh3, wh5, wh7, wh9, wh11, bmll0, bmll1,
+          bmll2, bmll3, bmll4, bmhl0, bmhl1, bmhl2, bmhl3, bmhl4, bmlh0, bmlh1,
+          bmlh2, bmlh3, bmlh4, bmhh0, bmhh1, bmhh2, bmhh3, bmhh4)>;
+
 // Needed for implementation of AIERegisterInfo::getNoPreservedMask()
 def CSR_NoRegs : CalleeSavedRegs<(add)>;

--- a/llvm/lib/Target/AIE/aie2p/AIE2PISelLowering.cpp
+++ b/llvm/lib/Target/AIE/aie2p/AIE2PISelLowering.cpp
@@ -17,14 +17,37 @@
 #include "MCTargetDesc/aie2p/AIE2PMCTargetDesc.h"
 #include "llvm/CodeGen/TargetLowering.h"
 #include "llvm/IR/IntrinsicsAIE2P.h"
+#include "llvm/IR/RuntimeLibcalls.h"
 
 using namespace llvm;
 
 #define DEBUG_TYPE "aie-lower"
 
+extern cl::opt<bool> VecCCLibcalls;
+
 AIE2PTargetLowering::AIE2PTargetLowering(const TargetMachine &TM,
                                          const AIEBaseSubtarget &STI)
     : AIEBaseTargetLowering(TM, STI) {
+
+  if (VecCCLibcalls) {
+    setLibcallCallingConv(RTLIB::SINTTOFP_I32_F32,
+                          CallingConv::AIE_PreserveAll_Vec);
+    setLibcallCallingConv(RTLIB::SINTTOFP_I32_F64,
+                          CallingConv::AIE_PreserveAll_Vec);
+    setLibcallCallingConv(RTLIB::SINTTOFP_I64_F32,
+                          CallingConv::AIE_PreserveAll_Vec);
+    setLibcallCallingConv(RTLIB::SINTTOFP_I64_F64,
+                          CallingConv::AIE_PreserveAll_Vec);
+    setLibcallCallingConv(RTLIB::SDIV_I32, CallingConv::AIE_PreserveAll_Vec);
+    setLibcallCallingConv(RTLIB::SDIV_I64, CallingConv::AIE_PreserveAll_Vec);
+    setLibcallCallingConv(RTLIB::UDIV_I32, CallingConv::AIE_PreserveAll_Vec);
+    setLibcallCallingConv(RTLIB::UDIV_I64, CallingConv::AIE_PreserveAll_Vec);
+    setLibcallCallingConv(RTLIB::SREM_I32, CallingConv::AIE_PreserveAll_Vec);
+    setLibcallCallingConv(RTLIB::SREM_I64, CallingConv::AIE_PreserveAll_Vec);
+    setLibcallCallingConv(RTLIB::UREM_I32, CallingConv::AIE_PreserveAll_Vec);
+    setLibcallCallingConv(RTLIB::UREM_I64, CallingConv::AIE_PreserveAll_Vec);
+  }
+
   const TargetRegisterInfo *TRI = Subtarget.getRegisterInfo();
 
   // We already define in .td which types are legal for each register class.

--- a/llvm/lib/Target/AIE/aie2p/AIE2PRegisterInfo.cpp
+++ b/llvm/lib/Target/AIE/aie2p/AIE2PRegisterInfo.cpp
@@ -25,6 +25,7 @@
 #include "llvm/CodeGen/RegisterScavenging.h"
 #include "llvm/CodeGen/TargetFrameLowering.h"
 #include "llvm/CodeGen/TargetRegisterInfo.h"
+#include "llvm/IR/CallingConv.h"
 #include "llvm/Support/ErrorHandling.h"
 
 #define GET_REGINFO_TARGET_DESC
@@ -283,8 +284,13 @@ AIE2PRegisterInfo::getPointerRegClass(const MachineFunction &MF,
 
 const uint32_t *
 AIE2PRegisterInfo::getCallPreservedMask(const MachineFunction &MF,
-                                        CallingConv::ID /*CC*/) const {
-  return CSR_AIE2P_RegMask;
+                                        CallingConv::ID CC) const {
+  switch (CC) {
+  case CallingConv::AIE_PreserveAll_Vec:
+    return CSR_AIE2P_Vec_RegMask;
+  default:
+    return CSR_AIE2P_RegMask;
+  }
 }
 
 bool AIE2PRegisterInfo::isTypeLegalForClass(const TargetRegisterClass &RC,

--- a/llvm/lib/Target/AIE/aie2ps/AIE2PSCallingConv.td
+++ b/llvm/lib/Target/AIE/aie2ps/AIE2PSCallingConv.td
@@ -225,5 +225,14 @@ def CC_AIE2PS : CallingConv<[
 def CSR_AIE2PS
     : CalleeSavedRegs<(add lr, r8, r9, r10, r11, r12, r13, r14, r15, p6, p7)>;
 
+def CSR_AIE2PS_Vec
+    : CalleeSavedRegs<(add lr, r8, r9, r10, r11, r12, r13, r14, r15, p6, p7,
+          wl0, wl2, wl4, wl6, wl8, wl10, wl1, wl3, wl5, wl7, wl9, wl11,
+          wh0, wh2, wh4, wh6, wh8, wh10, wh1, wh3, wh5, wh7, wh9, wh11,
+          bmll0, bmll1, bmll2, bmll3, bmll4, bmll5, bmll6, bmll7,
+          bmhl0, bmhl1, bmhl2, bmhl3, bmhl4, bmhl5, bmhl6, bmhl7,
+          bmlh0, bmlh1, bmlh2, bmlh3, bmlh4, bmlh5, bmlh6, bmlh7,
+          bmhh0, bmhh1, bmhh2, bmhh3, bmhh4, bmhh5, bmhh6, bmhh7)>;
+
 // Needed for implementation of AIERegisterInfo::getNoPreservedMask()
 def CSR_NoRegs : CalleeSavedRegs<(add)>;

--- a/llvm/lib/Target/AIE/aie2ps/AIE2PSISelLowering.cpp
+++ b/llvm/lib/Target/AIE/aie2ps/AIE2PSISelLowering.cpp
@@ -16,14 +16,38 @@
 #include "AIEBaseSubtarget.h"
 #include "MCTargetDesc/aie2ps/AIE2PSMCTargetDesc.h"
 #include "llvm/IR/IntrinsicsAIE2PS.h"
+#include "llvm/IR/RuntimeLibcalls.h"
 
 using namespace llvm;
 
 #define DEBUG_TYPE "aie-lower"
 
+// Shared with AIE2PISelLowering.cpp
+extern cl::opt<bool> VecCCLibcalls;
+
 AIE2PSTargetLowering::AIE2PSTargetLowering(const TargetMachine &TM,
                                            const AIEBaseSubtarget &STI)
     : AIEBaseTargetLowering(TM, STI) {
+
+  if (VecCCLibcalls) {
+    setLibcallCallingConv(RTLIB::SINTTOFP_I32_F32,
+                          CallingConv::AIE_PreserveAll_Vec);
+    setLibcallCallingConv(RTLIB::SINTTOFP_I32_F64,
+                          CallingConv::AIE_PreserveAll_Vec);
+    setLibcallCallingConv(RTLIB::SINTTOFP_I64_F32,
+                          CallingConv::AIE_PreserveAll_Vec);
+    setLibcallCallingConv(RTLIB::SINTTOFP_I64_F64,
+                          CallingConv::AIE_PreserveAll_Vec);
+    setLibcallCallingConv(RTLIB::SDIV_I32, CallingConv::AIE_PreserveAll_Vec);
+    setLibcallCallingConv(RTLIB::SDIV_I64, CallingConv::AIE_PreserveAll_Vec);
+    setLibcallCallingConv(RTLIB::UDIV_I32, CallingConv::AIE_PreserveAll_Vec);
+    setLibcallCallingConv(RTLIB::UDIV_I64, CallingConv::AIE_PreserveAll_Vec);
+    setLibcallCallingConv(RTLIB::SREM_I32, CallingConv::AIE_PreserveAll_Vec);
+    setLibcallCallingConv(RTLIB::SREM_I64, CallingConv::AIE_PreserveAll_Vec);
+    setLibcallCallingConv(RTLIB::UREM_I32, CallingConv::AIE_PreserveAll_Vec);
+    setLibcallCallingConv(RTLIB::UREM_I64, CallingConv::AIE_PreserveAll_Vec);
+  }
+
   const TargetRegisterInfo *TRI = Subtarget.getRegisterInfo();
 
   // We already define in .td which types are legal for each register class.

--- a/llvm/lib/Target/AIE/aie2ps/AIE2PSRegisterInfo.cpp
+++ b/llvm/lib/Target/AIE/aie2ps/AIE2PSRegisterInfo.cpp
@@ -25,6 +25,7 @@
 #include "llvm/CodeGen/RegisterScavenging.h"
 #include "llvm/CodeGen/TargetFrameLowering.h"
 #include "llvm/CodeGen/TargetRegisterInfo.h"
+#include "llvm/IR/CallingConv.h"
 #include "llvm/Support/ErrorHandling.h"
 
 #define GET_REGINFO_TARGET_DESC
@@ -539,8 +540,13 @@ bool AIE2PSRegisterInfo::isTypeLegalForClass(const TargetRegisterClass &RC,
 
 const uint32_t *
 AIE2PSRegisterInfo::getCallPreservedMask(const MachineFunction &MF,
-                                         CallingConv::ID /*CC*/) const {
-  return CSR_AIE2PS_RegMask;
+                                         CallingConv::ID CC) const {
+  switch (CC) {
+  case CallingConv::AIE_PreserveAll_Vec:
+    return CSR_AIE2PS_Vec_RegMask;
+  default:
+    return CSR_AIE2PS_RegMask;
+  }
 }
 
 const TargetRegisterClass *

--- a/llvm/test/CodeGen/AIE/GlobalISel/legalize-sdiv.mir
+++ b/llvm/test/CodeGen/AIE/GlobalISel/legalize-sdiv.mir
@@ -6,8 +6,8 @@
 # (c) Copyright 2023-2026 Advanced Micro Devices, Inc. or its affiliates
 # RUN: llc -mtriple aie -run-pass=legalizer %s -verify-machineinstrs -o - | FileCheck -DVER=1 %s
 # RUN: llc -mtriple aie2 -run-pass=legalizer %s -verify-machineinstrs -o - | FileCheck -DVER=2 %s
-# RUN: llc -mtriple aie2p -run-pass=legalizer %s -verify-machineinstrs -o - | FileCheck -DVER=2p %s
-# RUN: llc -mtriple aie2ps -run-pass=legalizer %s -verify-machineinstrs -o - | FileCheck -DVER=2ps %s
+# RUN: llc -mtriple aie2p -run-pass=legalizer %s -verify-machineinstrs -o - | FileCheck -DVER=2p_vec %s
+# RUN: llc -mtriple aie2ps -run-pass=legalizer %s -verify-machineinstrs -o - | FileCheck -DVER=2ps_vec %s
 
 ---
 name: sdiv_s32

--- a/llvm/test/CodeGen/AIE/GlobalISel/legalize-sdivrem.mir
+++ b/llvm/test/CodeGen/AIE/GlobalISel/legalize-sdivrem.mir
@@ -6,8 +6,8 @@
 # (c) Copyright 2023-2026 Advanced Micro Devices, Inc. or its affiliates
 # RUN: llc -mtriple aie -run-pass=legalizer %s -verify-machineinstrs -o - | FileCheck -DVER=1 %s
 # RUN: llc -mtriple aie2 -run-pass=legalizer %s -verify-machineinstrs -o - | FileCheck -DVER=2 %s
-# RUN: llc -mtriple aie2p -run-pass=legalizer %s -verify-machineinstrs -o - | FileCheck -DVER=2p %s
-# RUN: llc -mtriple aie2ps -run-pass=legalizer %s -verify-machineinstrs -o - | FileCheck -DVER=2ps %s
+# RUN: llc -mtriple aie2p -run-pass=legalizer %s -verify-machineinstrs -o - | FileCheck -DVER=2p_vec %s
+# RUN: llc -mtriple aie2ps -run-pass=legalizer %s -verify-machineinstrs -o - | FileCheck -DVER=2ps_vec %s
 
 ---
 name: sdivrem_s32

--- a/llvm/test/CodeGen/AIE/GlobalISel/legalize-sitofp.mir
+++ b/llvm/test/CodeGen/AIE/GlobalISel/legalize-sitofp.mir
@@ -4,9 +4,10 @@
 #
 # (c) Copyright 2023-2026 Advanced Micro Devices, Inc. or its affiliates
 # RUN: llc -mtriple aie2 -run-pass=legalizer %s -verify-machineinstrs -o - | FileCheck -DVER=2 --check-prefix=COMMON --check-prefix=AIE2 %s
-# RUN: llc -mtriple aie2p -run-pass=legalizer %s -verify-machineinstrs -o - | FileCheck -DVER=2p --check-prefix=COMMON --check-prefix=AIE2P %s
-# RUN: llc -mtriple aie2ps -run-pass=legalizer %s -verify-machineinstrs -o - | FileCheck -DVER=2ps --check-prefix=COMMON --check-prefix=AIE2PS %s
+# RUN: llc -mtriple aie2p -run-pass=legalizer %s -verify-machineinstrs -o - | FileCheck -DVER=2p_vec --check-prefix=COMMON --check-prefix=AIE2P %s
+# RUN: llc -mtriple aie2ps -run-pass=legalizer %s -verify-machineinstrs -o - | FileCheck -DVER=2ps_vec --check-prefix=COMMON --check-prefix=AIE2PS %s
 
+---
 ---
 name: test_sitofp_s32_to_s32
 body: |

--- a/llvm/test/CodeGen/AIE/GlobalISel/legalize-srem.mir
+++ b/llvm/test/CodeGen/AIE/GlobalISel/legalize-srem.mir
@@ -6,8 +6,8 @@
 # (c) Copyright 2023-2026 Advanced Micro Devices, Inc. or its affiliates
 # RUN: llc -mtriple aie -run-pass=legalizer %s -verify-machineinstrs -o - | FileCheck -DVER=1 %s
 # RUN: llc -mtriple aie2 -run-pass=legalizer %s -verify-machineinstrs -o - | FileCheck -DVER=2 %s
-# RUN: llc -mtriple aie2p -run-pass=legalizer %s -verify-machineinstrs -o - | FileCheck -DVER=2p %s
-# RUN: llc -mtriple aie2ps -run-pass=legalizer %s -verify-machineinstrs -o - | FileCheck -DVER=2ps %s
+# RUN: llc -mtriple aie2p -run-pass=legalizer %s -verify-machineinstrs -o - | FileCheck -DVER=2p_vec %s
+# RUN: llc -mtriple aie2ps -run-pass=legalizer %s -verify-machineinstrs -o - | FileCheck -DVER=2ps_vec %s
 
 ---
 name: srem_s32

--- a/llvm/test/CodeGen/AIE/GlobalISel/legalize-udiv.mir
+++ b/llvm/test/CodeGen/AIE/GlobalISel/legalize-udiv.mir
@@ -6,8 +6,8 @@
 # (c) Copyright 2023-2026 Advanced Micro Devices, Inc. or its affiliates
 # RUN: llc -mtriple aie -run-pass=legalizer %s -verify-machineinstrs -o - | FileCheck -DVER=1 %s
 # RUN: llc -mtriple aie2 -run-pass=legalizer %s -verify-machineinstrs -o - | FileCheck -DVER=2 %s
-# RUN: llc -mtriple aie2p -run-pass=legalizer %s -verify-machineinstrs -o - | FileCheck -DVER=2p %s
-# RUN: llc -mtriple aie2ps -run-pass=legalizer %s -verify-machineinstrs -o - | FileCheck -DVER=2ps %s
+# RUN: llc -mtriple aie2p -run-pass=legalizer %s -verify-machineinstrs -o - | FileCheck -DVER=2p_vec %s
+# RUN: llc -mtriple aie2ps -run-pass=legalizer %s -verify-machineinstrs -o - | FileCheck -DVER=2ps_vec %s
 
 ---
 name: udiv_s32

--- a/llvm/test/CodeGen/AIE/GlobalISel/legalize-udivrem.mir
+++ b/llvm/test/CodeGen/AIE/GlobalISel/legalize-udivrem.mir
@@ -6,8 +6,8 @@
 # (c) Copyright 2023-2026 Advanced Micro Devices, Inc. or its affiliates
 # RUN: llc -mtriple aie -run-pass=legalizer %s -verify-machineinstrs -o - | FileCheck -DVER=1 %s
 # RUN: llc -mtriple aie2 -run-pass=legalizer %s -verify-machineinstrs -o - | FileCheck -DVER=2 %s
-# RUN: llc -mtriple aie2p -run-pass=legalizer %s -verify-machineinstrs -o - | FileCheck -DVER=2p %s
-# RUN: llc -mtriple aie2ps -run-pass=legalizer %s -verify-machineinstrs -o - | FileCheck -DVER=2ps %s
+# RUN: llc -mtriple aie2p -run-pass=legalizer %s -verify-machineinstrs -o - | FileCheck -DVER=2p_vec %s
+# RUN: llc -mtriple aie2ps -run-pass=legalizer %s -verify-machineinstrs -o - | FileCheck -DVER=2ps_vec %s
 
 ---
 name: udivrem_s32

--- a/llvm/test/CodeGen/AIE/GlobalISel/legalize-urem.mir
+++ b/llvm/test/CodeGen/AIE/GlobalISel/legalize-urem.mir
@@ -6,8 +6,8 @@
 # (c) Copyright 2023-2026 Advanced Micro Devices, Inc. or its affiliates
 # RUN: llc -mtriple aie -run-pass=legalizer %s -verify-machineinstrs -o - | FileCheck -DVER=1 %s
 # RUN: llc -mtriple aie2 -run-pass=legalizer %s -verify-machineinstrs -o - | FileCheck -DVER=2 %s
-# RUN: llc -mtriple aie2p -run-pass=legalizer %s -verify-machineinstrs -o - | FileCheck -DVER=2p %s
-# RUN: llc -mtriple aie2ps -run-pass=legalizer %s -verify-machineinstrs -o - | FileCheck -DVER=2ps %s
+# RUN: llc -mtriple aie2p -run-pass=legalizer %s -verify-machineinstrs -o - | FileCheck -DVER=2p_vec %s
+# RUN: llc -mtriple aie2ps -run-pass=legalizer %s -verify-machineinstrs -o - | FileCheck -DVER=2ps_vec %s
 
 ---
 name: urem_s32

--- a/llvm/test/CodeGen/AIE/aie2p/vscl2vec.ll
+++ b/llvm/test/CodeGen/AIE/aie2p/vscl2vec.ll
@@ -520,24 +520,24 @@ entry:
 define dso_local noundef <16 x float> @_Z13test_upd_elemDv16_fif(<16 x float> noundef %v, i32 noundef %idx, float noundef %b) local_unnamed_addr  {
 ; CHECK-LABEL: _Z13test_upd_elemDv16_fif:
 ; CHECK:       // %bb.0: // %entry
-; CHECK-NEXT:    nopa ; jl #__floatsisf
-; CHECK-NEXT:    paddxm [sp], #128 // Delay Slot 5
-; CHECK-NEXT:    st r8, [sp, #-60] // 4-byte Folded Spill Delay Slot 4
+; CHECK-NEXT:    nopa ; nopb ; jl #__floatsisf
+; CHECK-NEXT:    nop // Delay Slot 5
+; CHECK-NEXT:    paddxm [sp], #64 // Delay Slot 4
 ; CHECK-NEXT:    st lr, [sp, #-64] // 4-byte Folded Spill Delay Slot 3
-; CHECK-NEXT:    vst x2, [sp, #-128] // 64-byte Folded Spill Delay Slot 2
+; CHECK-NEXT:    st r8, [sp, #-60] // 4-byte Folded Spill Delay Slot 2
 ; CHECK-NEXT:    mov r8, r0 // Delay Slot 1
-; CHECK-NEXT:    lda lr, [sp, #-64]; nopxm // 4-byte Folded Reload
+; CHECK-NEXT:    lda lr, [sp, #-64]; nopb ; nopxm // 4-byte Folded Reload
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
-; CHECK-NEXT:    vlda x0, [sp, #-128] // 64-byte Folded Reload
+; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    lda r8, [sp, #-60] // 4-byte Folded Reload
 ; CHECK-NEXT:    ret lr
 ; CHECK-NEXT:    nop // Delay Slot 5
 ; CHECK-NEXT:    mov r29, r8 // Delay Slot 4
-; CHECK-NEXT:    paddxm [sp], #-128 // Delay Slot 3
-; CHECK-NEXT:    vinsert.32 x0, x0, r29, r0 // Delay Slot 2
+; CHECK-NEXT:    paddxm [sp], #-64 // Delay Slot 3
+; CHECK-NEXT:    vinsert.32 x0, x2, r29, r0 // Delay Slot 2
 ; CHECK-NEXT:    nop // Delay Slot 1
 entry:
   %0 = bitcast float %b to i32

--- a/llvm/test/CodeGen/AIE/aie2ps/schedule/postpipeliner/avgpool2d_bf16.ll
+++ b/llvm/test/CodeGen/AIE/aie2ps/schedule/postpipeliner/avgpool2d_bf16.ll
@@ -29,125 +29,119 @@ declare <16 x i32> @llvm.aie2ps.vshuffle(<16 x i32>, <16 x i32>, i32) #1
 define weak_odr dso_local void @_Z9avgpool2dILh1E8bfloat16Qsr5mllib5utilsE11is_one_of_vIT0_ahS0_7float16EEvPS1_S3_R25avgpool2d_internal_paramsIS1_E(ptr noalias %ifm_ptr, ptr noalias %ofm_ptr, ptr nonnull align 64 dereferenceable(64) %avgpool2d_params) local_unnamed_addr #2 comdat {
 ; CHECK-LABEL: _Z9avgpool2dILh1E8bfloat16Qsr5mllib5utilsE11is_one_of_vIT0_ahS0_7float16EEvPS1_S3_R25avgpool2d_internal_paramsIS1_E:
 ; CHECK:       // %bb.0: // %entry
-; CHECK-NEXT:    lda.u8 r0, [p2, #0]; nopb ; nopx ; mov m0, #46
-; CHECK-NEXT:    mova m0, #-42; paddb [p2], m0
-; CHECK-NEXT:    lda.s16 r2, [p2], m0
-; CHECK-NEXT:    paddxm [sp], #128
+; CHECK-NEXT:    paddxm [sp], #64
 ; CHECK-NEXT:    st r10, [sp, #-52] // 4-byte Folded Spill
-; CHECK-NEXT:    st p6, [sp, #-44] // 4-byte Folded Spill
-; CHECK-NEXT:    st p7, [sp, #-40] // 4-byte Folded Spill
-; CHECK-NEXT:    st r8, [sp, #-60] // 4-byte Folded Spill
+; CHECK-NEXT:    lda.u8 r0, [p2, #0]; st p6, [sp, #-44]; mov m0, #46 // 4-byte Folded Spill
+; CHECK-NEXT:    mova m0, #-42; paddb [p2], m0; st p7, [sp, #-40] // 4-byte Folded Spill
+; CHECK-NEXT:    lda.s16 r2, [p2], m0; st r8, [sp, #-60] // 4-byte Folded Spill
 ; CHECK-NEXT:    st lr, [sp, #-64] // 4-byte Folded Spill
-; CHECK-NEXT:    st r9, [sp, #-56]; vbcst.16 x0, r2 // 4-byte Folded Spill
-; CHECK-NEXT:    st r12, [sp, #-48] // 4-byte Folded Spill
-; CHECK-NEXT:    vst x0, [sp, #-128]; jl #__floatsisf // 64-byte Folded Spill
+; CHECK-NEXT:    st r9, [sp, #-56] // 4-byte Folded Spill
+; CHECK-NEXT:    st r12, [sp, #-48]; jl #__floatsisf // 4-byte Folded Spill
 ; CHECK-NEXT:    nop // Delay Slot 5
 ; CHECK-NEXT:    nop // Delay Slot 4
-; CHECK-NEXT:    nop // Delay Slot 3
-; CHECK-NEXT:    movs p6, p0; movxm r8, #50332476 // Delay Slot 2
+; CHECK-NEXT:    movxm r8, #50332476 // Delay Slot 3
+; CHECK-NEXT:    movs p6, p0; vbcst.16 x0, r2 // Delay Slot 2
 ; CHECK-NEXT:    mova r10, #1; movs p7, p1; add r1, r0, #-2; mov r9, p2 // Delay Slot 1
-; CHECK-NEXT:    vlda x9, [sp, #-128]; nopx // 64-byte Folded Reload
-; CHECK-NEXT:    nop
-; CHECK-NEXT:    vinsert.32 x0, x0, #0, r0
-; CHECK-NEXT:    vmov bmll0, x0
+; CHECK-NEXT:    nopa ; nopb ; nopx ; vinsert.32 x2, x0, #0, r0
+; CHECK-NEXT:    vmov bmll0, x2
 ; CHECK-NEXT:    mova m0, #24; mov p0, r9
-; CHECK-NEXT:    lda.u16 r26, [p0], m0; vconv.bf16.fp32 wl0, bmll0
+; CHECK-NEXT:    lda.u16 r26, [p0], m0; vconv.bf16.fp32 wl2, bmll0
 ; CHECK-NEXT:    lda.s16 r22, [p0], #12
 ; CHECK-NEXT:    lda.s8 r2, [p0], #1; movxm r12, #50331708
-; CHECK-NEXT:    lda.s8 r4, [p0], #-8; vmul.f cml0, x9, x0, r12
+; CHECK-NEXT:    lda.s8 r4, [p0], #-8; vmul.f cml0, x0, x2, r12
 ; CHECK-NEXT:    lda.s8 r6, [p0], #1
 ; CHECK-NEXT:    lda.s8 r16, [p0], #1
-; CHECK-NEXT:    lda.s8 r18, [p0], #1; vldb x2, [p6], #64
-; CHECK-NEXT:    lda.s8 r20, [p0], #1; vldb x4, [p6], #64
-; CHECK-NEXT:    lda.s8 r24, [p0], #1; vldb x6, [p6], #64
-; CHECK-NEXT:    lda.s8 r28, [p0], #1; vldb x8, [p6], #64; mov m1, r22
-; CHECK-NEXT:    vlda x5, [p6], m1; vconv.bf16.fp32 x0, cml0; movxm ls, #.LBB0_1
-; CHECK-NEXT:    vlda x8, [p6], #64; mov m0, #-9
+; CHECK-NEXT:    lda.s8 r18, [p0], #1; vldb x4, [p6], #64
+; CHECK-NEXT:    lda.s8 r20, [p0], #1; vldb x6, [p6], #64
+; CHECK-NEXT:    lda.s8 r24, [p0], #1; vldb x8, [p6], #64
+; CHECK-NEXT:    lda.s8 r28, [p0], #1; vldb x10, [p6], #64; mov m1, r22
+; CHECK-NEXT:    vlda x7, [p6], m1; vconv.bf16.fp32 x2, cml0; movxm ls, #.LBB0_1
+; CHECK-NEXT:    vlda x10, [p6], #64; mov m0, #-9
 ; CHECK-NEXT:    lda.s8 r30, [p0], m0; movxm le, #.L_LEnd0
-; CHECK-NEXT:    lda.s16 r1, [p0], #-6; vextbcst.16 x0, x0, #0
-; CHECK-NEXT:    lshl r0, r6, r10; vshuffle x10, x2, x4, r2
-; CHECK-NEXT:    lshl r6, r16, r10; vshuffle x1, x2, x4, r4
-; CHECK-NEXT:    lshl r16, r18, r10; vshuffle x3, x6, x8, r2; vmul.f cml2, x10, x9, r8
-; CHECK-NEXT:    lshl r18, r20, r10; vshuffle x7, x6, x8, r4
-; CHECK-NEXT:    vlda x3, [p6], #64; vshift x6, x1, x3, r18
-; CHECK-NEXT:    vlda x7, [p6], #64; lshl r20, r24, r10; vshift x11, x1, x3, r0
-; CHECK-NEXT:    movs m2, r1; vldb x6, [p6], #64; vshift x11, x11, x7, r20; vmul.f cml0, x6, x9, r8
-; CHECK-NEXT:    vlda x4, [p6], m2; vshift x2, x10, x1, r6
-; CHECK-NEXT:    vshift x4, x1, x3, r16
-; CHECK-NEXT:    lda m0, [p0], #-8; vldb x6, [p6], #64; lshl r22, r28, r10; vshift x1, x10, x1, r0; vmac.f cml1, cml0, x11, x9, r8
-; CHECK-NEXT:    lda dn0, [p0], #-8; lshl r24, r30, r10; vshift x2, x2, x3, r22
-; CHECK-NEXT:    lda dj0, [p0], #12; vshift x4, x4, x5, r24; vmac.f cml3, cml2, x1, x9, r8
-; CHECK-NEXT:    lda dn4, [p0, #0]; vshuffle x5, x8, x3, r2
-; CHECK-NEXT:    lda dj4, [p0, #-8]; vshuffle x11, x8, x3, r4; vmac.f cml4, cml1, x4, x0, r8
-; CHECK-NEXT:    vshuffle x10, x7, x6, r2; vmac.f cml5, cml3, x2, x0, r8
-; CHECK-NEXT:    vshuffle x8, x7, x6, r4
-; CHECK-NEXT:    vlda x10, [p6], #64; vshift x7, x11, x10, r18
-; CHECK-NEXT:    mova dc0, #0; vldb x5, [p6], #64; vshift x3, x11, x10, r0; vmac.f cml7, cml5, x5, x9, r8
-; CHECK-NEXT:    vlda x8, [p6], #64; vshift x3, x3, x8, r20; vmac.f cml6, cml4, x7, x9, r8
-; CHECK-NEXT:    movs dc4, dc0; vshift x2, x5, x11, r6
-; CHECK-NEXT:    vldb.3d x2, [p6], d0; vshift x1, x11, x10, r16
-; CHECK-NEXT:    vshift x11, x5, x11, r0; vmac.f cml6, cml6, x3, x9, r8
-; CHECK-NEXT:    vshift x2, x2, x10, r22
-; CHECK-NEXT:    vshift x1, x1, x4, r24; vmac.f cml7, cml7, x11, x9, r8
-; CHECK-NEXT:    vshuffle x4, x6, x10, r2
-; CHECK-NEXT:    vshuffle x3, x6, x10, r4; vmac.f cml6, cml6, x1, x0, r8
-; CHECK-NEXT:    vshuffle x7, x5, x8, r2; vmac.f cml7, cml7, x2, x0, r8
-; CHECK-NEXT:    add.nc lc, r26, #-1; vshift x6, x3, x7, r18
+; CHECK-NEXT:    lda.s16 r1, [p0], #-6; vextbcst.16 x2, x2, #0
+; CHECK-NEXT:    lshl r0, r6, r10; vshuffle x1, x4, x6, r2
+; CHECK-NEXT:    lshl r6, r16, r10; vshuffle x3, x4, x6, r4
+; CHECK-NEXT:    lshl r16, r18, r10; vshuffle x5, x8, x10, r2; vmul.f cml2, x1, x0, r8
+; CHECK-NEXT:    lshl r18, r20, r10; vshuffle x9, x8, x10, r4
+; CHECK-NEXT:    vlda x5, [p6], #64; vshift x8, x3, x5, r18
+; CHECK-NEXT:    vlda x9, [p6], #64; lshl r20, r24, r10; vshift x11, x3, x5, r0
+; CHECK-NEXT:    movs m2, r1; vldb x8, [p6], #64; vshift x11, x11, x9, r20; vmul.f cml0, x8, x0, r8
+; CHECK-NEXT:    vlda x6, [p6], m2; vshift x4, x1, x3, r6
+; CHECK-NEXT:    vshift x6, x3, x5, r16
+; CHECK-NEXT:    lda m0, [p0], #-8; vldb x8, [p6], #64; lshl r22, r28, r10; vshift x3, x1, x3, r0; vmac.f cml1, cml0, x11, x0, r8
+; CHECK-NEXT:    lda dn0, [p0], #-8; lshl r24, r30, r10; vshift x4, x4, x5, r22
+; CHECK-NEXT:    lda dj0, [p0], #12; vshift x6, x6, x7, r24; vmac.f cml3, cml2, x3, x0, r8
+; CHECK-NEXT:    lda dn4, [p0, #0]; vshuffle x7, x10, x5, r2
+; CHECK-NEXT:    lda dj4, [p0, #-8]; vshuffle x11, x10, x5, r4; vmac.f cml4, cml1, x6, x2, r8
+; CHECK-NEXT:    vshuffle x1, x9, x8, r2; vmac.f cml5, cml3, x4, x2, r8
+; CHECK-NEXT:    vshuffle x10, x9, x8, r4
+; CHECK-NEXT:    vlda x1, [p6], #64; vshift x9, x11, x1, r18
+; CHECK-NEXT:    mova dc0, #0; vldb x7, [p6], #64; vshift x5, x11, x1, r0; vmac.f cml7, cml5, x7, x0, r8
+; CHECK-NEXT:    vlda x10, [p6], #64; vshift x5, x5, x10, r20; vmac.f cml6, cml4, x9, x0, r8
+; CHECK-NEXT:    movs dc4, dc0; vshift x4, x7, x11, r6
+; CHECK-NEXT:    vldb.3d x4, [p6], d0; vshift x3, x11, x1, r16
+; CHECK-NEXT:    vshift x11, x7, x11, r0; vmac.f cml6, cml6, x5, x0, r8
+; CHECK-NEXT:    vshift x4, x4, x1, r22
+; CHECK-NEXT:    vshift x3, x3, x6, r24; vmac.f cml7, cml7, x11, x0, r8
+; CHECK-NEXT:    vshuffle x6, x8, x1, r2
+; CHECK-NEXT:    vshuffle x5, x8, x1, r4; vmac.f cml6, cml6, x3, x2, r8
+; CHECK-NEXT:    vshuffle x9, x7, x10, r2; vmac.f cml7, cml7, x4, x2, r8
+; CHECK-NEXT:    add.nc lc, r26, #-1; vshift x8, x5, x9, r18
 ; CHECK-NEXT:  .LBB0_1: // %for.body
 ; CHECK-NEXT:    // =>This Inner Loop Header: Depth=1
-; CHECK-NEXT:    nopa ; vldb x2, [p6], #64; nopx ; vshuffle x11, x5, x8, r4; nops
-; CHECK-NEXT:    vldb x4, [p6], #64; vshift x10, x4, x3, r0; vmac.f cml7, cml7, x4, x0, r8
-; CHECK-NEXT:    vldb x6, [p6], #64; vshift x5, x3, x7, r0; vmac.f cml6, cml6, x6, x0, r8
-; CHECK-NEXT:    vldb x8, [p6], #64; vshift x5, x5, x11, r20
-; CHECK-NEXT:    vlda x5, [p6], m1; vshift x1, x4, x3, r6; vmac.f cml7, cml7, x10, x0, r8
-; CHECK-NEXT:    vlda x8, [p6], #64; vshift x8, x3, x7, r16; vmac.f cml6, cml6, x5, x0, r8
-; CHECK-NEXT:    vshift x8, x8, x2, r24
-; CHECK-NEXT:    vshift x1, x1, x7, r22
-; CHECK-NEXT:    vshuffle x10, x2, x4, r2; vmac.f cml6, cml6, x8, x0, r8
-; CHECK-NEXT:    vshuffle x1, x2, x4, r4; vmac.f cml7, cml7, x1, x0, r8
-; CHECK-NEXT:    vshuffle x3, x6, x8, r2; vmul.f cml2, x10, x9, r8
-; CHECK-NEXT:    vshuffle x7, x6, x8, r4
-; CHECK-NEXT:    vlda x3, [p6], #64; vshift x6, x1, x3, r18
-; CHECK-NEXT:    vlda x7, [p6], #64; vshift x11, x1, x3, r0
-; CHECK-NEXT:    vldb x6, [p6], #64; vshift x11, x11, x7, r20; vmul.f cml0, x6, x9, r8
-; CHECK-NEXT:    vlda x4, [p6], m2; vshift x2, x10, x1, r6
-; CHECK-NEXT:    vshift x4, x1, x3, r16
-; CHECK-NEXT:    vst.conv.bf16.fp32 cml7, [p7], #64; vldb x6, [p6], #64; vshift x1, x10, x1, r0; vmac.f cml1, cml0, x11, x9, r8
-; CHECK-NEXT:    vst.conv.bf16.fp32 cml6, [p7], #64; vshift x2, x2, x3, r22
-; CHECK-NEXT:    vshift x4, x4, x5, r24; vmac.f cml3, cml2, x1, x9, r8
-; CHECK-NEXT:    vshuffle x5, x8, x3, r2
-; CHECK-NEXT:    vshuffle x11, x8, x3, r4; vmac.f cml4, cml1, x4, x0, r8
-; CHECK-NEXT:    vshuffle x10, x7, x6, r2; vmac.f cml5, cml3, x2, x0, r8
-; CHECK-NEXT:    vshuffle x8, x7, x6, r4
-; CHECK-NEXT:    vlda x10, [p6], #64; vshift x7, x11, x10, r18
-; CHECK-NEXT:    vldb x5, [p6], #64; vshift x3, x11, x10, r0; vmac.f cml7, cml5, x5, x9, r8
-; CHECK-NEXT:    vlda x8, [p6], #64; vshift x3, x3, x8, r20; vmac.f cml6, cml4, x7, x9, r8
-; CHECK-NEXT:    vshift x2, x5, x11, r6
-; CHECK-NEXT:    vldb.3d x2, [p6], d0; vshift x1, x11, x10, r16
-; CHECK-NEXT:    vshift x11, x5, x11, r0; vmac.f cml6, cml6, x3, x9, r8
-; CHECK-NEXT:    vshift x2, x2, x10, r22
-; CHECK-NEXT:    vshift x1, x1, x4, r24; vmac.f cml7, cml7, x11, x9, r8
-; CHECK-NEXT:    vshuffle x4, x6, x10, r2
-; CHECK-NEXT:    vshuffle x3, x6, x10, r4; vmac.f cml6, cml6, x1, x0, r8
-; CHECK-NEXT:    vshuffle x7, x5, x8, r2; vmac.f cml7, cml7, x2, x0, r8
+; CHECK-NEXT:    nopa ; vldb x4, [p6], #64; nopx ; vshuffle x11, x7, x10, r4; nops
+; CHECK-NEXT:    vldb x6, [p6], #64; vshift x1, x6, x5, r0; vmac.f cml7, cml7, x6, x2, r8
+; CHECK-NEXT:    vldb x8, [p6], #64; vshift x7, x5, x9, r0; vmac.f cml6, cml6, x8, x2, r8
+; CHECK-NEXT:    vldb x10, [p6], #64; vshift x7, x7, x11, r20
+; CHECK-NEXT:    vlda x7, [p6], m1; vshift x3, x6, x5, r6; vmac.f cml7, cml7, x1, x2, r8
+; CHECK-NEXT:    vlda x10, [p6], #64; vshift x10, x5, x9, r16; vmac.f cml6, cml6, x7, x2, r8
+; CHECK-NEXT:    vshift x10, x10, x4, r24
+; CHECK-NEXT:    vshift x3, x3, x9, r22
+; CHECK-NEXT:    vshuffle x1, x4, x6, r2; vmac.f cml6, cml6, x10, x2, r8
+; CHECK-NEXT:    vshuffle x3, x4, x6, r4; vmac.f cml7, cml7, x3, x2, r8
+; CHECK-NEXT:    vshuffle x5, x8, x10, r2; vmul.f cml2, x1, x0, r8
+; CHECK-NEXT:    vshuffle x9, x8, x10, r4
+; CHECK-NEXT:    vlda x5, [p6], #64; vshift x8, x3, x5, r18
+; CHECK-NEXT:    vlda x9, [p6], #64; vshift x11, x3, x5, r0
+; CHECK-NEXT:    vldb x8, [p6], #64; vshift x11, x11, x9, r20; vmul.f cml0, x8, x0, r8
+; CHECK-NEXT:    vlda x6, [p6], m2; vshift x4, x1, x3, r6
+; CHECK-NEXT:    vshift x6, x3, x5, r16
+; CHECK-NEXT:    vst.conv.bf16.fp32 cml7, [p7], #64; vldb x8, [p6], #64; vshift x3, x1, x3, r0; vmac.f cml1, cml0, x11, x0, r8
+; CHECK-NEXT:    vst.conv.bf16.fp32 cml6, [p7], #64; vshift x4, x4, x5, r22
+; CHECK-NEXT:    vshift x6, x6, x7, r24; vmac.f cml3, cml2, x3, x0, r8
+; CHECK-NEXT:    vshuffle x7, x10, x5, r2
+; CHECK-NEXT:    vshuffle x11, x10, x5, r4; vmac.f cml4, cml1, x6, x2, r8
+; CHECK-NEXT:    vshuffle x1, x9, x8, r2; vmac.f cml5, cml3, x4, x2, r8
+; CHECK-NEXT:    vshuffle x10, x9, x8, r4
+; CHECK-NEXT:    vlda x1, [p6], #64; vshift x9, x11, x1, r18
+; CHECK-NEXT:    vldb x7, [p6], #64; vshift x5, x11, x1, r0; vmac.f cml7, cml5, x7, x0, r8
+; CHECK-NEXT:    vlda x10, [p6], #64; vshift x5, x5, x10, r20; vmac.f cml6, cml4, x9, x0, r8
+; CHECK-NEXT:    vshift x4, x7, x11, r6
+; CHECK-NEXT:    vldb.3d x4, [p6], d0; vshift x3, x11, x1, r16
+; CHECK-NEXT:    vshift x11, x7, x11, r0; vmac.f cml6, cml6, x5, x0, r8
+; CHECK-NEXT:    vshift x4, x4, x1, r22
+; CHECK-NEXT:    vshift x3, x3, x6, r24; vmac.f cml7, cml7, x11, x0, r8
+; CHECK-NEXT:    vshuffle x6, x8, x1, r2
+; CHECK-NEXT:    vshuffle x5, x8, x1, r4; vmac.f cml6, cml6, x3, x2, r8
+; CHECK-NEXT:    vshuffle x9, x7, x10, r2; vmac.f cml7, cml7, x4, x2, r8
 ; CHECK-NEXT:  .L_LEnd0:
-; CHECK-NEXT:    nopa ; nopb ; nops ; nopx ; vshift x6, x3, x7, r18; nopv
+; CHECK-NEXT:    nopa ; nopb ; nops ; nopx ; vshift x8, x5, x9, r18; nopv
 ; CHECK-NEXT:  // %bb.2: // %for.cond.cleanup
-; CHECK-NEXT:    lda lr, [sp, #-64]; nopx ; vshuffle x11, x5, x8, r4 // 4-byte Folded Reload
-; CHECK-NEXT:    lda p6, [sp, #-44]; vshift x10, x4, x3, r0; vmac.f cml7, cml7, x4, x0, r8 // 4-byte Folded Reload
-; CHECK-NEXT:    lda r12, [sp, #-48]; vshift x5, x3, x7, r0; vmac.f cml6, cml6, x6, x0, r8 // 4-byte Folded Reload
-; CHECK-NEXT:    lda r10, [sp, #-52]; vshift x5, x5, x11, r20 // 4-byte Folded Reload
-; CHECK-NEXT:    lda r9, [sp, #-56]; vshift x1, x4, x3, r6; vmac.f cml7, cml7, x10, x0, r8 // 4-byte Folded Reload
-; CHECK-NEXT:    lda r8, [sp, #-60]; vshift x8, x3, x7, r16; vmac.f cml6, cml6, x5, x0, r8 // 4-byte Folded Reload
-; CHECK-NEXT:    vshift x8, x8, x2, r24
-; CHECK-NEXT:    vshift x1, x1, x7, r22
-; CHECK-NEXT:    vmac.f cml6, cml6, x8, x0, r8
-; CHECK-NEXT:    vmac.f cml7, cml7, x1, x0, r8
+; CHECK-NEXT:    lda lr, [sp, #-64]; nopx ; vshuffle x11, x7, x10, r4 // 4-byte Folded Reload
+; CHECK-NEXT:    lda p6, [sp, #-44]; vshift x1, x6, x5, r0; vmac.f cml7, cml7, x6, x2, r8 // 4-byte Folded Reload
+; CHECK-NEXT:    lda r12, [sp, #-48]; vshift x7, x5, x9, r0; vmac.f cml6, cml6, x8, x2, r8 // 4-byte Folded Reload
+; CHECK-NEXT:    lda r10, [sp, #-52]; vshift x7, x7, x11, r20 // 4-byte Folded Reload
+; CHECK-NEXT:    lda r9, [sp, #-56]; vshift x3, x6, x5, r6; vmac.f cml7, cml7, x1, x2, r8 // 4-byte Folded Reload
+; CHECK-NEXT:    lda r8, [sp, #-60]; vshift x10, x5, x9, r16; vmac.f cml6, cml6, x7, x2, r8 // 4-byte Folded Reload
+; CHECK-NEXT:    vshift x10, x10, x4, r24
+; CHECK-NEXT:    vshift x3, x3, x9, r22
+; CHECK-NEXT:    vmac.f cml6, cml6, x10, x2, r8
+; CHECK-NEXT:    vmac.f cml7, cml7, x3, x2, r8
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    lda p7, [sp, #-40] // 4-byte Folded Reload
-; CHECK-NEXT:    paddxm [sp], #-128
+; CHECK-NEXT:    paddxm [sp], #-64
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    vst.conv.bf16.fp32 cml7, [p7], #64


### PR DESCRIPTION
In AIEs default calling convention, all vector registers are caller saved. However, most compiler-rt builtin library functions do not use vector registers. To avoid having to spill vectors to memory in the caller function, we can attach a different calling convention to these library functions.

I manually inspected each library function where we apply the alternative calling convention to make sure none of them actually use vector registers. To make this actually save and robust, we should also add a custom calling convention attribute to the frontend that ensures vector registers are actually saved by the callee.