### PR TITLE
Fix undefined behavior in matchCombineShlOfAnd combine

### DIFF
--- a/llvm/lib/CodeGen/GlobalISel/CombinerHelper.cpp
+++ b/llvm/lib/CodeGen/GlobalISel/CombinerHelper.cpp
@@ -2628,11 +2628,19 @@ bool CombinerHelper::matchCombineShlOfAnd(MachineInstr &MI,
                 m_GShl(m_OneNonDBGUse(m_GAnd(m_Reg(Reg), m_ICst(AndImm))),
                        m_ICst(ShiftImm))))
     return false;
-  // Check if AndImm has bits set only in positions that will be shifted out by
-  // ShiftImm. If any significant bits remain after the shift, the AND operation
+
+  // Shift is out of range, handled by different combines.
+  if (ShiftImm < 0 || ShiftImm >= 64)
+    return false;
+
+  uint64_t AndVal = static_cast<uint64_t>(AndImm);
+  uint64_t ShAmount = static_cast<uint64_t>(ShiftImm);
+
+  // Check if AndVal has bits set only in positions that will be shifted out by
+  // ShAmount. If any significant bits remain after the shift, the AND operation
   // cannot be removed.
   uint64_t Mask = ~0ULL >> (64 - Size);
-  return !((~AndImm << ShiftImm) & Mask);
+  return !((~AndVal << ShAmount) & Mask);
 }
 
 void CombinerHelper::applyCombineShlOfAnd(MachineInstr &MI,


### PR DESCRIPTION
Fixes a bug found by the UndefinedBehavior sanitizer:

```
FAILED: CMakeFiles/clang_rt.builtins-aie2.dir/extendbfsf2.c.o 
clang --target=aie2-none-unknown-elf -DVISIBILITY_HIDDEN  --target=aie2-none-unknown-elf -O3 -DNDEBUG -fno-lto -std=c11 -fPIC -fno-builtin -fvisibility=hidden -fomit-frame-pointer -MD -MT CMakeFiles/clang_rt.builtins-aie2.dir/extendbfsf2.c.o -MF CMakeFiles/clang_rt.builtins-aie2.dir/extendbfsf2.c.o.d -o CMakeFiles/clang_rt.builtins-aie2.dir/extendbfsf2.c.o -c compiler-rt/lib/builtins/extendbfsf2.c
llvm/lib/CodeGen/GlobalISel/CombinerHelper.cpp:2635:21: runtime error: left shift of negative value -256
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior llvm/lib/CodeGen/GlobalISel/CombinerHelper.cpp:2635:21
```