### PR TITLE
[AIEX][NFC] Refactor Intrinsic Attributes

### DIFF
--- a/clang/test/CodeGen/aie/aie-intrinsics.cpp
+++ b/clang/test/CodeGen/aie/aie-intrinsics.cpp
@@ -279,7 +279,7 @@ extern void foo(v8acc48);
 // CHECK-LABEL: @_Z12call_v8acc48v(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[TMP0:%.*]] = tail call noundef <8 x i48> @llvm.aie.v8i48undef()
-// CHECK-NEXT:    tail call void @_Z3fooDv8_u7__acc48(<8 x i48> noundef [[TMP0]]) #[[ATTR10:[0-9]+]]
+// CHECK-NEXT:    tail call void @_Z3fooDv8_u7__acc48(<8 x i48> noundef [[TMP0]])
 // CHECK-NEXT:    ret void
 //
 void call_v8acc48()
@@ -291,7 +291,7 @@ extern void bar(v8acc80);
 // CHECK-LABEL: @_Z12call_v8acc80v(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[TMP0:%.*]] = tail call noundef <16 x i48> @llvm.aie.v16i48undef()
-// CHECK-NEXT:    tail call void @_Z3barDv16_u7__acc48(<16 x i48> noundef [[TMP0]]) #[[ATTR10]]
+// CHECK-NEXT:    tail call void @_Z3barDv16_u7__acc48(<16 x i48> noundef [[TMP0]])
 // CHECK-NEXT:    ret void
 //
 void call_v8acc80()
@@ -303,7 +303,7 @@ extern void foo_v4acc80(v4acc80);
 // CHECK-LABEL: @_Z12call_v4acc80v(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[TMP0:%.*]] = tail call noundef <8 x i48> @llvm.aie.v8i48undef()
-// CHECK-NEXT:    tail call void @_Z11foo_v4acc80Dv8_u7__acc48(<8 x i48> noundef [[TMP0]]) #[[ATTR10]]
+// CHECK-NEXT:    tail call void @_Z11foo_v4acc80Dv8_u7__acc48(<8 x i48> noundef [[TMP0]])
 // CHECK-NEXT:    ret void
 //
 void call_v4acc80()
@@ -315,7 +315,7 @@ extern void foo_v16acc48(v16acc48);
 // CHECK-LABEL: @_Z13call_v16acc48v(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[TMP0:%.*]] = tail call noundef <16 x i48> @llvm.aie.v16i48undef()
-// CHECK-NEXT:    tail call void @_Z12foo_v16acc48Dv16_u7__acc48(<16 x i48> noundef [[TMP0]]) #[[ATTR10]]
+// CHECK-NEXT:    tail call void @_Z12foo_v16acc48Dv16_u7__acc48(<16 x i48> noundef [[TMP0]])
 // CHECK-NEXT:    ret void
 //
 void call_v16acc48()
@@ -361,8 +361,9 @@ void bsrs_st_test()
 }
 // CHECK-LABEL: @_Z9mac16_symDv16_u7__acc48Dv64_sDv8_i(
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[TMP0:%.*]] = tail call noundef <16 x i48> @llvm.aie.mac16.v64int16(<64 x i16> [[LBUFF:%.*]], <8 x i32> [[RBUFF:%.*]], <16 x i48> [[ACC:%.*]], i32 2, i32 2, i32 12, <2 x i32> <i32 50462976, i32 8464>, <2 x i32> <i32 117835012, i32 4609>, <2 x i32> <i32 32768, i32 0>)
-// CHECK-NEXT:    ret <16 x i48> [[TMP0]]
+// CHECK-NEXT:    [[TMP0:%.*]] = tail call noundef <2 x i32> @llvm.aie.v2i32undef()
+// CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef <16 x i48> @llvm.aie.mac16.v64int16(<64 x i16> [[LBUFF:%.*]], <8 x i32> [[RBUFF:%.*]], <16 x i48> [[ACC:%.*]], i32 2, i32 2, i32 12, <2 x i32> <i32 50462976, i32 8464>, <2 x i32> <i32 117835012, i32 4609>, <2 x i32> <i32 32768, i32 0>)
+// CHECK-NEXT:    ret <16 x i48> [[TMP1]]
 //
 v16acc48 mac16_sym(v16acc48 acc, v64int16 lbuff, v8int32 rbuff) {
   return mac16_sym(acc, lbuff, 2, 0x03020100, 0x2110, 2, rbuff, 12, 0x07060504, 0x1201);
@@ -380,8 +381,9 @@ v16acc48 msc16(v16acc48 acc, v128int8 xbuff, v32int8 zbuff) {
 }
 // CHECK-LABEL: @_Z13mul16_antisymDv32_iDv16_s(
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[TMP0:%.*]] = tail call noundef <16 x i48> @llvm.aie.mul16.v32int32(<32 x i32> [[XBUFF:%.*]], <16 x i16> [[ZBUFF:%.*]], i32 0, i32 16, i32 0, <2 x i32> <i32 286265616, i32 12576>, <2 x i32> <i32 -2004353024, i32 12816>, <2 x i32> <i32 98304, i32 0>)
-// CHECK-NEXT:    ret <16 x i48> [[TMP0]]
+// CHECK-NEXT:    [[TMP0:%.*]] = tail call noundef <2 x i32> @llvm.aie.v2i32undef()
+// CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef <16 x i48> @llvm.aie.mul16.v32int32(<32 x i32> [[XBUFF:%.*]], <16 x i16> [[ZBUFF:%.*]], i32 0, i32 16, i32 0, <2 x i32> <i32 286265616, i32 12576>, <2 x i32> <i32 -2004353024, i32 12816>, <2 x i32> <i32 98304, i32 0>)
+// CHECK-NEXT:    ret <16 x i48> [[TMP1]]
 //
 v16acc48 mul16_antisym(v32int32 xbuff, v16int16 zbuff) {
   return mul16_antisym(xbuff, 0, 0x11101110, 0x3120, 16, zbuff, 0, 0x88880000, 0x3210);

--- a/clang/test/CodeGen/aie/aie-srs-intrinsics.cpp
+++ b/clang/test/CodeGen/aie/aie-srs-intrinsics.cpp
@@ -5,7 +5,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// (c) Copyright 2023-2024 Advanced Micro Devices, Inc. or its affiliates
+// (c) Copyright 2023-2025 Advanced Micro Devices, Inc. or its affiliates
 //
 //===----------------------------------------------------------------------===//
 // RUN: %clang -O2 %s --target=aie2 -nostdlibinc -S -emit-llvm -o - | FileCheck %s
@@ -45,7 +45,7 @@ v32int8 test_ssrs(v32acc32 acc, int shft, int sign) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call <32 x i8> @llvm.aie2.I256.v32.acc32.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <32 x i8> @llvm.aie2.I256.v32.acc32.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <32 x i8> [[TMP2]]
@@ -85,7 +85,7 @@ v32uint8 test_ussrs(v32acc32 acc, int shft, int sign) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call <32 x i8> @llvm.aie2.I256.v32.acc32.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <32 x i8> @llvm.aie2.I256.v32.acc32.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <32 x i8> [[TMP2]]
@@ -125,7 +125,7 @@ v32int16 test_lsrs(v32acc32 acc, int shft, int sign) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call <32 x i16> @llvm.aie2.I512.v32.acc32.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <32 x i16> @llvm.aie2.I512.v32.acc32.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <32 x i16> [[TMP2]]
@@ -165,7 +165,7 @@ v32uint16 test_ulsrs(v32acc32 acc, int shft, int sign) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call <32 x i16> @llvm.aie2.I512.v32.acc32.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <32 x i16> @llvm.aie2.I512.v32.acc32.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <32 x i16> [[TMP2]]
@@ -205,7 +205,7 @@ v16int16 test_lsrs(v16acc32 acc, int shft, int sign) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call <16 x i16> @llvm.aie2.I256.v16.acc32.srs(<8 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <16 x i16> @llvm.aie2.I256.v16.acc32.srs(<8 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <16 x i16> [[TMP2]]
@@ -245,7 +245,7 @@ v16uint16 test_ulsrs(v16acc32 acc, int shft, int sign) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call <16 x i16> @llvm.aie2.I256.v16.acc32.srs(<8 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <16 x i16> @llvm.aie2.I256.v16.acc32.srs(<8 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <16 x i16> [[TMP2]]
@@ -285,7 +285,7 @@ v16int16 test_ssrs(v16acc64 acc, int shft, int sign) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call <16 x i16> @llvm.aie2.I256.v16.acc64.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <16 x i16> @llvm.aie2.I256.v16.acc64.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <16 x i16> [[TMP2]]
@@ -325,7 +325,7 @@ v16uint16 test_ussrs(v16acc64 acc, int shft, int sign) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call <16 x i16> @llvm.aie2.I256.v16.acc64.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <16 x i16> @llvm.aie2.I256.v16.acc64.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <16 x i16> [[TMP2]]
@@ -365,7 +365,7 @@ v16int32 test_lsrs(v16acc64 acc, int shft, int sign) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call <16 x i32> @llvm.aie2.I512.v16.acc64.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <16 x i32> @llvm.aie2.I512.v16.acc64.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <16 x i32> [[TMP2]]
@@ -405,7 +405,7 @@ v16uint32 test_ulsrs(v16acc64 acc, int shft, int sign) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call <16 x i32> @llvm.aie2.I512.v16.acc64.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <16 x i32> @llvm.aie2.I512.v16.acc64.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <16 x i32> [[TMP2]]
@@ -445,7 +445,7 @@ v8int32 test_lsrs(v8acc64 acc, int shft, int sign) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call <8 x i32> @llvm.aie2.I256.v8.acc64.srs(<8 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <8 x i32> @llvm.aie2.I256.v8.acc64.srs(<8 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <8 x i32> [[TMP2]]
@@ -485,7 +485,7 @@ v8uint32 test_ulsrs(v8acc64 acc, int shft, int sign) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call <8 x i32> @llvm.aie2.I256.v8.acc64.srs(<8 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <8 x i32> @llvm.aie2.I256.v8.acc64.srs(<8 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <8 x i32> [[TMP2]]
@@ -525,7 +525,7 @@ v32int8 test_ssrs(v32acc32 acc, int shft) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call <32 x i8> @llvm.aie2.I256.v32.acc32.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 1)
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <32 x i8> @llvm.aie2.I256.v32.acc32.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 1)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <32 x i8> [[TMP2]]
@@ -565,7 +565,7 @@ v32uint8 test_ussrs(v32acc32 acc, int shft) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call <32 x i8> @llvm.aie2.I256.v32.acc32.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 0)
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <32 x i8> @llvm.aie2.I256.v32.acc32.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 0)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <32 x i8> [[TMP2]]
@@ -585,7 +585,6 @@ v32uint8 test_ussrs_conf(v32acc32 acc, int shft, crsat_t sat, crrnd_t rnd) {
   return ussrs_conf(acc, shft, sat, rnd);
 }
 
-//
 // CHECK-LABEL: @_Z9test_lsrsDv32_u7__acc32i(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[TMP0:%.*]] = tail call noundef <32 x i16> @llvm.aie2.I512.v32.acc32.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 1)
@@ -606,7 +605,7 @@ v32int16 test_lsrs(v32acc32 acc, int shft) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call <32 x i16> @llvm.aie2.I512.v32.acc32.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 1)
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <32 x i16> @llvm.aie2.I512.v32.acc32.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 1)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <32 x i16> [[TMP2]]
@@ -646,7 +645,7 @@ v32uint16 test_ulsrs(v32acc32 acc, int shft) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call <32 x i16> @llvm.aie2.I512.v32.acc32.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 0)
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <32 x i16> @llvm.aie2.I512.v32.acc32.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 0)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <32 x i16> [[TMP2]]
@@ -686,7 +685,7 @@ v16int16 test_lsrs(v16acc32 acc, int shft) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call <16 x i16> @llvm.aie2.I256.v16.acc32.srs(<8 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 1)
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <16 x i16> @llvm.aie2.I256.v16.acc32.srs(<8 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 1)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <16 x i16> [[TMP2]]
@@ -726,7 +725,7 @@ v16uint16 test_ulsrs(v16acc32 acc, int shft) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call <16 x i16> @llvm.aie2.I256.v16.acc32.srs(<8 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 0)
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <16 x i16> @llvm.aie2.I256.v16.acc32.srs(<8 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 0)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <16 x i16> [[TMP2]]
@@ -766,7 +765,7 @@ v16int16 test_ssrs(v16acc64 acc, int shft) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call <16 x i16> @llvm.aie2.I256.v16.acc64.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 1)
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <16 x i16> @llvm.aie2.I256.v16.acc64.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 1)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <16 x i16> [[TMP2]]
@@ -806,7 +805,7 @@ v16uint16 test_ussrs(v16acc64 acc, int shft) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call <16 x i16> @llvm.aie2.I256.v16.acc64.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 0)
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <16 x i16> @llvm.aie2.I256.v16.acc64.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 0)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <16 x i16> [[TMP2]]
@@ -846,7 +845,7 @@ v16int32 test_lsrs(v16acc64 acc, int shft) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call <16 x i32> @llvm.aie2.I512.v16.acc64.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 1)
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <16 x i32> @llvm.aie2.I512.v16.acc64.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 1)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <16 x i32> [[TMP2]]
@@ -886,7 +885,7 @@ v16uint32 test_ulsrs(v16acc64 acc, int shft) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call <16 x i32> @llvm.aie2.I512.v16.acc64.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 0)
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <16 x i32> @llvm.aie2.I512.v16.acc64.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 0)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <16 x i32> [[TMP2]]
@@ -926,7 +925,7 @@ v8int32 test_lsrs(v8acc64 acc, int shft) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call <8 x i32> @llvm.aie2.I256.v8.acc64.srs(<8 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 1)
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <8 x i32> @llvm.aie2.I256.v8.acc64.srs(<8 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 1)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <8 x i32> [[TMP2]]
@@ -966,7 +965,7 @@ v8uint32 test_ulsrs(v8acc64 acc, int shft) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call <8 x i32> @llvm.aie2.I256.v8.acc64.srs(<8 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 0)
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <8 x i32> @llvm.aie2.I256.v8.acc64.srs(<8 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 0)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <8 x i32> [[TMP2]]
@@ -1006,7 +1005,7 @@ v32int8 test_srs_to_v32int8(v32acc32 acc, int shft, int sign) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call <32 x i8> @llvm.aie2.I256.v32.acc32.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <32 x i8> @llvm.aie2.I256.v32.acc32.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <32 x i8> [[TMP2]]
@@ -1047,7 +1046,7 @@ v32uint8 test_srs_to_v32uint8(v32acc32 acc, int shft, int sign) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call <32 x i8> @llvm.aie2.I256.v32.acc32.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <32 x i8> @llvm.aie2.I256.v32.acc32.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <32 x i8> [[TMP2]]
@@ -1088,7 +1087,7 @@ v32int16 test_srs_to_v32int16(v32acc32 acc, int shft, int sign) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call <32 x i16> @llvm.aie2.I512.v32.acc32.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <32 x i16> @llvm.aie2.I512.v32.acc32.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <32 x i16> [[TMP2]]
@@ -1129,7 +1128,7 @@ v32uint16 test_srs_to_v32uint16(v32acc32 acc, int shft, int sign) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call <32 x i16> @llvm.aie2.I512.v32.acc32.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <32 x i16> @llvm.aie2.I512.v32.acc32.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <32 x i16> [[TMP2]]
@@ -1170,7 +1169,7 @@ v16int16 test_srs_to_v16int16(v16acc32 acc, int shft, int sign) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call <16 x i16> @llvm.aie2.I256.v16.acc32.srs(<8 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <16 x i16> @llvm.aie2.I256.v16.acc32.srs(<8 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <16 x i16> [[TMP2]]
@@ -1211,7 +1210,7 @@ v16uint16 test_srs_to_v16uint16(v16acc32 acc, int shft, int sign) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call <16 x i16> @llvm.aie2.I256.v16.acc32.srs(<8 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <16 x i16> @llvm.aie2.I256.v16.acc32.srs(<8 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <16 x i16> [[TMP2]]
@@ -1252,7 +1251,7 @@ v16int16 test_srs_to_v16int16(v16acc64 acc, int shft, int sign) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call <16 x i16> @llvm.aie2.I256.v16.acc64.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <16 x i16> @llvm.aie2.I256.v16.acc64.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <16 x i16> [[TMP2]]
@@ -1293,7 +1292,7 @@ v16uint16 test_srs_to_v16uint16(v16acc64 acc, int shft, int sign) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call <16 x i16> @llvm.aie2.I256.v16.acc64.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <16 x i16> @llvm.aie2.I256.v16.acc64.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <16 x i16> [[TMP2]]
@@ -1335,7 +1334,7 @@ v8int32 test_srs_to_v8int32(v8acc64 acc, int shft, int sign) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call <8 x i32> @llvm.aie2.I256.v8.acc64.srs(<8 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <8 x i32> @llvm.aie2.I256.v8.acc64.srs(<8 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <8 x i32> [[TMP2]]
@@ -1375,7 +1374,7 @@ v8uint32 test_srs_to_v8uint32(v8acc64 acc, int shft, int sign) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call <8 x i32> @llvm.aie2.I256.v8.acc64.srs(<8 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <8 x i32> @llvm.aie2.I256.v8.acc64.srs(<8 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <8 x i32> [[TMP2]]
@@ -1415,7 +1414,7 @@ v16int32 test_srs_to_v16int32(v16acc64 acc, int shft, int sign) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call <16 x i32> @llvm.aie2.I512.v16.acc64.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <16 x i32> @llvm.aie2.I512.v16.acc64.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <16 x i32> [[TMP2]]
@@ -1456,7 +1455,7 @@ v16uint32 test_srs_to_v16uint32(v16acc64 acc, int shft, int sign) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call <16 x i32> @llvm.aie2.I512.v16.acc64.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <16 x i32> @llvm.aie2.I512.v16.acc64.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <16 x i32> [[TMP2]]
@@ -1497,7 +1496,7 @@ v32int8 test_srs_to_v32int8(v32acc32 acc, int shft) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call <32 x i8> @llvm.aie2.I256.v32.acc32.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 1)
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <32 x i8> @llvm.aie2.I256.v32.acc32.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 1)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <32 x i8> [[TMP2]]
@@ -1538,7 +1537,7 @@ v32uint8 test_srs_to_v32uint8(v32acc32 acc, int shft) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call <32 x i8> @llvm.aie2.I256.v32.acc32.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 0)
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <32 x i8> @llvm.aie2.I256.v32.acc32.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 0)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <32 x i8> [[TMP2]]
@@ -1579,7 +1578,7 @@ v32int16 test_srs_to_v32int16(v32acc32 acc, int shft) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call <32 x i16> @llvm.aie2.I512.v32.acc32.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 1)
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <32 x i16> @llvm.aie2.I512.v32.acc32.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 1)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <32 x i16> [[TMP2]]
@@ -1620,7 +1619,7 @@ v32uint16 test_srs_to_v32uint16(v32acc32 acc, int shft) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call <32 x i16> @llvm.aie2.I512.v32.acc32.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 0)
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <32 x i16> @llvm.aie2.I512.v32.acc32.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 0)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <32 x i16> [[TMP2]]
@@ -1661,7 +1660,7 @@ v16int16 test_srs_to_v16int16(v16acc32 acc, int shft) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call <16 x i16> @llvm.aie2.I256.v16.acc32.srs(<8 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 1)
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <16 x i16> @llvm.aie2.I256.v16.acc32.srs(<8 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 1)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <16 x i16> [[TMP2]]
@@ -1702,7 +1701,7 @@ v16uint16 test_srs_to_v16uint16(v16acc32 acc, int shft) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call <16 x i16> @llvm.aie2.I256.v16.acc32.srs(<8 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 0)
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <16 x i16> @llvm.aie2.I256.v16.acc32.srs(<8 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 0)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <16 x i16> [[TMP2]]
@@ -1743,7 +1742,7 @@ v16int16 test_srs_to_v16int16(v16acc64 acc, int shft) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call <16 x i16> @llvm.aie2.I256.v16.acc64.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 1)
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <16 x i16> @llvm.aie2.I256.v16.acc64.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 1)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <16 x i16> [[TMP2]]
@@ -1784,7 +1783,7 @@ v16uint16 test_srs_to_v16uint16(v16acc64 acc, int shft) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call <16 x i16> @llvm.aie2.I256.v16.acc64.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 0)
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <16 x i16> @llvm.aie2.I256.v16.acc64.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 0)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <16 x i16> [[TMP2]]
@@ -1825,7 +1824,7 @@ v16int32 test_srs_to_v16int32(v16acc64 acc, int shft) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call <16 x i32> @llvm.aie2.I512.v16.acc64.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 1)
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <16 x i32> @llvm.aie2.I512.v16.acc64.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 1)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <16 x i32> [[TMP2]]
@@ -1866,7 +1865,7 @@ v16uint32 test_srs_to_v16uint32(v16acc64 acc, int shft) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call <16 x i32> @llvm.aie2.I512.v16.acc64.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 0)
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <16 x i32> @llvm.aie2.I512.v16.acc64.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 0)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <16 x i32> [[TMP2]]
@@ -1907,7 +1906,7 @@ v8int32 test_srs_to_v8int32(v8acc64 acc, int shft) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call <8 x i32> @llvm.aie2.I256.v8.acc64.srs(<8 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 1)
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <8 x i32> @llvm.aie2.I256.v8.acc64.srs(<8 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 1)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <8 x i32> [[TMP2]]
@@ -1948,7 +1947,7 @@ v8uint32 test_srs_to_v8uint32(v8acc64 acc, int shft) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call <8 x i32> @llvm.aie2.I256.v8.acc64.srs(<8 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 0)
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <8 x i32> @llvm.aie2.I256.v8.acc64.srs(<8 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 0)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <8 x i32> [[TMP2]]

--- a/clang/test/CodeGen/aie/aie-srs-intrinsics.cpp
+++ b/clang/test/CodeGen/aie/aie-srs-intrinsics.cpp
@@ -45,7 +45,7 @@ v32int8 test_ssrs(v32acc32 acc, int shft, int sign) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <32 x i8> @llvm.aie2.I256.v32.acc32.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call <32 x i8> @llvm.aie2.I256.v32.acc32.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <32 x i8> [[TMP2]]
@@ -85,7 +85,7 @@ v32uint8 test_ussrs(v32acc32 acc, int shft, int sign) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <32 x i8> @llvm.aie2.I256.v32.acc32.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call <32 x i8> @llvm.aie2.I256.v32.acc32.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <32 x i8> [[TMP2]]
@@ -125,7 +125,7 @@ v32int16 test_lsrs(v32acc32 acc, int shft, int sign) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <32 x i16> @llvm.aie2.I512.v32.acc32.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call <32 x i16> @llvm.aie2.I512.v32.acc32.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <32 x i16> [[TMP2]]
@@ -165,7 +165,7 @@ v32uint16 test_ulsrs(v32acc32 acc, int shft, int sign) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <32 x i16> @llvm.aie2.I512.v32.acc32.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call <32 x i16> @llvm.aie2.I512.v32.acc32.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <32 x i16> [[TMP2]]
@@ -205,7 +205,7 @@ v16int16 test_lsrs(v16acc32 acc, int shft, int sign) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <16 x i16> @llvm.aie2.I256.v16.acc32.srs(<8 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call <16 x i16> @llvm.aie2.I256.v16.acc32.srs(<8 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <16 x i16> [[TMP2]]
@@ -245,7 +245,7 @@ v16uint16 test_ulsrs(v16acc32 acc, int shft, int sign) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <16 x i16> @llvm.aie2.I256.v16.acc32.srs(<8 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call <16 x i16> @llvm.aie2.I256.v16.acc32.srs(<8 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <16 x i16> [[TMP2]]
@@ -285,7 +285,7 @@ v16int16 test_ssrs(v16acc64 acc, int shft, int sign) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <16 x i16> @llvm.aie2.I256.v16.acc64.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call <16 x i16> @llvm.aie2.I256.v16.acc64.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <16 x i16> [[TMP2]]
@@ -325,7 +325,7 @@ v16uint16 test_ussrs(v16acc64 acc, int shft, int sign) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <16 x i16> @llvm.aie2.I256.v16.acc64.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call <16 x i16> @llvm.aie2.I256.v16.acc64.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <16 x i16> [[TMP2]]
@@ -365,7 +365,7 @@ v16int32 test_lsrs(v16acc64 acc, int shft, int sign) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <16 x i32> @llvm.aie2.I512.v16.acc64.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call <16 x i32> @llvm.aie2.I512.v16.acc64.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <16 x i32> [[TMP2]]
@@ -405,7 +405,7 @@ v16uint32 test_ulsrs(v16acc64 acc, int shft, int sign) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <16 x i32> @llvm.aie2.I512.v16.acc64.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call <16 x i32> @llvm.aie2.I512.v16.acc64.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <16 x i32> [[TMP2]]
@@ -445,7 +445,7 @@ v8int32 test_lsrs(v8acc64 acc, int shft, int sign) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <8 x i32> @llvm.aie2.I256.v8.acc64.srs(<8 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call <8 x i32> @llvm.aie2.I256.v8.acc64.srs(<8 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <8 x i32> [[TMP2]]
@@ -485,7 +485,7 @@ v8uint32 test_ulsrs(v8acc64 acc, int shft, int sign) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <8 x i32> @llvm.aie2.I256.v8.acc64.srs(<8 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call <8 x i32> @llvm.aie2.I256.v8.acc64.srs(<8 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <8 x i32> [[TMP2]]
@@ -525,7 +525,7 @@ v32int8 test_ssrs(v32acc32 acc, int shft) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <32 x i8> @llvm.aie2.I256.v32.acc32.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 1)
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call <32 x i8> @llvm.aie2.I256.v32.acc32.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 1)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <32 x i8> [[TMP2]]
@@ -565,7 +565,7 @@ v32uint8 test_ussrs(v32acc32 acc, int shft) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <32 x i8> @llvm.aie2.I256.v32.acc32.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 0)
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call <32 x i8> @llvm.aie2.I256.v32.acc32.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 0)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <32 x i8> [[TMP2]]
@@ -585,6 +585,7 @@ v32uint8 test_ussrs_conf(v32acc32 acc, int shft, crsat_t sat, crrnd_t rnd) {
   return ussrs_conf(acc, shft, sat, rnd);
 }
 
+//
 // CHECK-LABEL: @_Z9test_lsrsDv32_u7__acc32i(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[TMP0:%.*]] = tail call noundef <32 x i16> @llvm.aie2.I512.v32.acc32.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 1)
@@ -605,7 +606,7 @@ v32int16 test_lsrs(v32acc32 acc, int shft) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <32 x i16> @llvm.aie2.I512.v32.acc32.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 1)
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call <32 x i16> @llvm.aie2.I512.v32.acc32.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 1)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <32 x i16> [[TMP2]]
@@ -645,7 +646,7 @@ v32uint16 test_ulsrs(v32acc32 acc, int shft) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <32 x i16> @llvm.aie2.I512.v32.acc32.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 0)
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call <32 x i16> @llvm.aie2.I512.v32.acc32.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 0)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <32 x i16> [[TMP2]]
@@ -685,7 +686,7 @@ v16int16 test_lsrs(v16acc32 acc, int shft) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <16 x i16> @llvm.aie2.I256.v16.acc32.srs(<8 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 1)
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call <16 x i16> @llvm.aie2.I256.v16.acc32.srs(<8 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 1)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <16 x i16> [[TMP2]]
@@ -725,7 +726,7 @@ v16uint16 test_ulsrs(v16acc32 acc, int shft) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <16 x i16> @llvm.aie2.I256.v16.acc32.srs(<8 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 0)
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call <16 x i16> @llvm.aie2.I256.v16.acc32.srs(<8 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 0)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <16 x i16> [[TMP2]]
@@ -765,7 +766,7 @@ v16int16 test_ssrs(v16acc64 acc, int shft) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <16 x i16> @llvm.aie2.I256.v16.acc64.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 1)
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call <16 x i16> @llvm.aie2.I256.v16.acc64.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 1)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <16 x i16> [[TMP2]]
@@ -805,7 +806,7 @@ v16uint16 test_ussrs(v16acc64 acc, int shft) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <16 x i16> @llvm.aie2.I256.v16.acc64.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 0)
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call <16 x i16> @llvm.aie2.I256.v16.acc64.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 0)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <16 x i16> [[TMP2]]
@@ -845,7 +846,7 @@ v16int32 test_lsrs(v16acc64 acc, int shft) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <16 x i32> @llvm.aie2.I512.v16.acc64.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 1)
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call <16 x i32> @llvm.aie2.I512.v16.acc64.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 1)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <16 x i32> [[TMP2]]
@@ -885,7 +886,7 @@ v16uint32 test_ulsrs(v16acc64 acc, int shft) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <16 x i32> @llvm.aie2.I512.v16.acc64.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 0)
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call <16 x i32> @llvm.aie2.I512.v16.acc64.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 0)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <16 x i32> [[TMP2]]
@@ -925,7 +926,7 @@ v8int32 test_lsrs(v8acc64 acc, int shft) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <8 x i32> @llvm.aie2.I256.v8.acc64.srs(<8 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 1)
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call <8 x i32> @llvm.aie2.I256.v8.acc64.srs(<8 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 1)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <8 x i32> [[TMP2]]
@@ -965,7 +966,7 @@ v8uint32 test_ulsrs(v8acc64 acc, int shft) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <8 x i32> @llvm.aie2.I256.v8.acc64.srs(<8 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 0)
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call <8 x i32> @llvm.aie2.I256.v8.acc64.srs(<8 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 0)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <8 x i32> [[TMP2]]
@@ -1005,7 +1006,7 @@ v32int8 test_srs_to_v32int8(v32acc32 acc, int shft, int sign) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <32 x i8> @llvm.aie2.I256.v32.acc32.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call <32 x i8> @llvm.aie2.I256.v32.acc32.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <32 x i8> [[TMP2]]
@@ -1046,7 +1047,7 @@ v32uint8 test_srs_to_v32uint8(v32acc32 acc, int shft, int sign) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <32 x i8> @llvm.aie2.I256.v32.acc32.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call <32 x i8> @llvm.aie2.I256.v32.acc32.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <32 x i8> [[TMP2]]
@@ -1087,7 +1088,7 @@ v32int16 test_srs_to_v32int16(v32acc32 acc, int shft, int sign) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <32 x i16> @llvm.aie2.I512.v32.acc32.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call <32 x i16> @llvm.aie2.I512.v32.acc32.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <32 x i16> [[TMP2]]
@@ -1128,7 +1129,7 @@ v32uint16 test_srs_to_v32uint16(v32acc32 acc, int shft, int sign) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <32 x i16> @llvm.aie2.I512.v32.acc32.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call <32 x i16> @llvm.aie2.I512.v32.acc32.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <32 x i16> [[TMP2]]
@@ -1169,7 +1170,7 @@ v16int16 test_srs_to_v16int16(v16acc32 acc, int shft, int sign) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <16 x i16> @llvm.aie2.I256.v16.acc32.srs(<8 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call <16 x i16> @llvm.aie2.I256.v16.acc32.srs(<8 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <16 x i16> [[TMP2]]
@@ -1210,7 +1211,7 @@ v16uint16 test_srs_to_v16uint16(v16acc32 acc, int shft, int sign) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <16 x i16> @llvm.aie2.I256.v16.acc32.srs(<8 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call <16 x i16> @llvm.aie2.I256.v16.acc32.srs(<8 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <16 x i16> [[TMP2]]
@@ -1251,7 +1252,7 @@ v16int16 test_srs_to_v16int16(v16acc64 acc, int shft, int sign) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <16 x i16> @llvm.aie2.I256.v16.acc64.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call <16 x i16> @llvm.aie2.I256.v16.acc64.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <16 x i16> [[TMP2]]
@@ -1292,7 +1293,7 @@ v16uint16 test_srs_to_v16uint16(v16acc64 acc, int shft, int sign) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <16 x i16> @llvm.aie2.I256.v16.acc64.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call <16 x i16> @llvm.aie2.I256.v16.acc64.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <16 x i16> [[TMP2]]
@@ -1334,7 +1335,7 @@ v8int32 test_srs_to_v8int32(v8acc64 acc, int shft, int sign) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <8 x i32> @llvm.aie2.I256.v8.acc64.srs(<8 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call <8 x i32> @llvm.aie2.I256.v8.acc64.srs(<8 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <8 x i32> [[TMP2]]
@@ -1374,7 +1375,7 @@ v8uint32 test_srs_to_v8uint32(v8acc64 acc, int shft, int sign) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <8 x i32> @llvm.aie2.I256.v8.acc64.srs(<8 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call <8 x i32> @llvm.aie2.I256.v8.acc64.srs(<8 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <8 x i32> [[TMP2]]
@@ -1414,7 +1415,7 @@ v16int32 test_srs_to_v16int32(v16acc64 acc, int shft, int sign) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <16 x i32> @llvm.aie2.I512.v16.acc64.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call <16 x i32> @llvm.aie2.I512.v16.acc64.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <16 x i32> [[TMP2]]
@@ -1455,7 +1456,7 @@ v16uint32 test_srs_to_v16uint32(v16acc64 acc, int shft, int sign) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <16 x i32> @llvm.aie2.I512.v16.acc64.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call <16 x i32> @llvm.aie2.I512.v16.acc64.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <16 x i32> [[TMP2]]
@@ -1496,7 +1497,7 @@ v32int8 test_srs_to_v32int8(v32acc32 acc, int shft) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <32 x i8> @llvm.aie2.I256.v32.acc32.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 1)
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call <32 x i8> @llvm.aie2.I256.v32.acc32.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 1)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <32 x i8> [[TMP2]]
@@ -1537,7 +1538,7 @@ v32uint8 test_srs_to_v32uint8(v32acc32 acc, int shft) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <32 x i8> @llvm.aie2.I256.v32.acc32.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 0)
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call <32 x i8> @llvm.aie2.I256.v32.acc32.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 0)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <32 x i8> [[TMP2]]
@@ -1578,7 +1579,7 @@ v32int16 test_srs_to_v32int16(v32acc32 acc, int shft) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <32 x i16> @llvm.aie2.I512.v32.acc32.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 1)
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call <32 x i16> @llvm.aie2.I512.v32.acc32.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 1)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <32 x i16> [[TMP2]]
@@ -1619,7 +1620,7 @@ v32uint16 test_srs_to_v32uint16(v32acc32 acc, int shft) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <32 x i16> @llvm.aie2.I512.v32.acc32.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 0)
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call <32 x i16> @llvm.aie2.I512.v32.acc32.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 0)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <32 x i16> [[TMP2]]
@@ -1660,7 +1661,7 @@ v16int16 test_srs_to_v16int16(v16acc32 acc, int shft) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <16 x i16> @llvm.aie2.I256.v16.acc32.srs(<8 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 1)
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call <16 x i16> @llvm.aie2.I256.v16.acc32.srs(<8 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 1)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <16 x i16> [[TMP2]]
@@ -1701,7 +1702,7 @@ v16uint16 test_srs_to_v16uint16(v16acc32 acc, int shft) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <16 x i16> @llvm.aie2.I256.v16.acc32.srs(<8 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 0)
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call <16 x i16> @llvm.aie2.I256.v16.acc32.srs(<8 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 0)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <16 x i16> [[TMP2]]
@@ -1742,7 +1743,7 @@ v16int16 test_srs_to_v16int16(v16acc64 acc, int shft) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <16 x i16> @llvm.aie2.I256.v16.acc64.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 1)
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call <16 x i16> @llvm.aie2.I256.v16.acc64.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 1)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <16 x i16> [[TMP2]]
@@ -1783,7 +1784,7 @@ v16uint16 test_srs_to_v16uint16(v16acc64 acc, int shft) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <16 x i16> @llvm.aie2.I256.v16.acc64.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 0)
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call <16 x i16> @llvm.aie2.I256.v16.acc64.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 0)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <16 x i16> [[TMP2]]
@@ -1824,7 +1825,7 @@ v16int32 test_srs_to_v16int32(v16acc64 acc, int shft) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <16 x i32> @llvm.aie2.I512.v16.acc64.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 1)
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call <16 x i32> @llvm.aie2.I512.v16.acc64.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 1)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <16 x i32> [[TMP2]]
@@ -1865,7 +1866,7 @@ v16uint32 test_srs_to_v16uint32(v16acc64 acc, int shft) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <16 x i32> @llvm.aie2.I512.v16.acc64.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 0)
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call <16 x i32> @llvm.aie2.I512.v16.acc64.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 0)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <16 x i32> [[TMP2]]
@@ -1906,7 +1907,7 @@ v8int32 test_srs_to_v8int32(v8acc64 acc, int shft) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <8 x i32> @llvm.aie2.I256.v8.acc64.srs(<8 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 1)
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call <8 x i32> @llvm.aie2.I256.v8.acc64.srs(<8 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 1)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <8 x i32> [[TMP2]]
@@ -1947,7 +1948,7 @@ v8uint32 test_srs_to_v8uint32(v8acc64 acc, int shft) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <8 x i32> @llvm.aie2.I256.v8.acc64.srs(<8 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 0)
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call <8 x i32> @llvm.aie2.I256.v8.acc64.srs(<8 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 0)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <8 x i32> [[TMP2]]

--- a/clang/test/CodeGen/aie/aie2/aie2-upd-ext-intrinsic.cpp
+++ b/clang/test/CodeGen/aie/aie2/aie2-upd-ext-intrinsic.cpp
@@ -135,12 +135,12 @@ v128uint4 test_set_v128uint4_force0( int idx, v32uint4 a ){
 
 // CHECK-LABEL: @_Z22test_set_v128uint4_idxiDv16_DU8_(
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[TMP0:%.*]] = tail call <16 x i32> @llvm.aie2.v16int32()
-// CHECK-NEXT:    [[TMP1:%.*]] = bitcast <16 x i8> [[A:%.*]] to <4 x i32>
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call <16 x i32> @llvm.aie2.set.I512.I128(<4 x i32> [[TMP1]])
+// CHECK-NEXT:    [[TMP0:%.*]] = bitcast <16 x i8> [[A:%.*]] to <4 x i32>
+// CHECK-NEXT:    [[TMP1:%.*]] = tail call <16 x i32> @llvm.aie2.set.I512.I128(<4 x i32> [[TMP0]])
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call <16 x i32> @llvm.aie2.v16int32()
 // CHECK-NEXT:    [[TMP3:%.*]] = shl i32 [[IDX:%.*]], 4
 // CHECK-NEXT:    [[MUL_I:%.*]] = sub i32 64, [[TMP3]]
-// CHECK-NEXT:    [[TMP4:%.*]] = tail call <16 x i32> @llvm.aie2.vshift.I512.I512(<16 x i32> [[TMP0]], <16 x i32> [[TMP2]], i32 0, i32 [[MUL_I]])
+// CHECK-NEXT:    [[TMP4:%.*]] = tail call <16 x i32> @llvm.aie2.vshift.I512.I512(<16 x i32> [[TMP2]], <16 x i32> [[TMP1]], i32 0, i32 [[MUL_I]])
 // CHECK-NEXT:    [[RETVAL_0_I:%.*]] = bitcast <16 x i32> [[TMP4]] to <64 x i8>
 // CHECK-NEXT:    ret <64 x i8> [[RETVAL_0_I]]
 //
@@ -210,6 +210,7 @@ v64uint4 test_extract_v64uint4 (v128uint4 a, int idx){
 }
 
 
+//
 // CHECK-LABEL: @_Z23test_insert_upd_512_256Dv64_DU8_iDv32_S_(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[CMP_I:%.*]] = icmp eq i32 [[IDX:%.*]], 0
@@ -452,17 +453,17 @@ v256uint4 test_concat_2x512 (v128uint4 a0, v128uint4 a1){
 
 // CHECK-LABEL: @_Z12insert_v64i4Dv32_DU8_iDv16_S_(
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[TMP0:%.*]] = tail call <16 x i32> @llvm.aie2.v16int32()
-// CHECK-NEXT:    [[TMP1:%.*]] = bitcast <16 x i8> [[B:%.*]] to <4 x i32>
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call <16 x i32> @llvm.aie2.set.I512.I128(<4 x i32> [[TMP1]])
-// CHECK-NEXT:    [[TMP3:%.*]] = shl i32 [[IDX:%.*]], 4
-// CHECK-NEXT:    [[MUL_I_I_I:%.*]] = sub i32 64, [[TMP3]]
-// CHECK-NEXT:    [[TMP4:%.*]] = tail call <16 x i32> @llvm.aie2.vshift.I512.I512(<16 x i32> [[TMP0]], <16 x i32> [[TMP2]], i32 0, i32 [[MUL_I_I_I]])
-// CHECK-NEXT:    [[TMP5:%.*]] = bitcast <32 x i8> [[A:%.*]] to <8 x i32>
-// CHECK-NEXT:    [[TMP6:%.*]] = tail call <16 x i32> @llvm.aie2.set.I512.I256(<8 x i32> [[TMP5]], i32 0)
+// CHECK-NEXT:    [[TMP0:%.*]] = bitcast <32 x i8> [[A:%.*]] to <8 x i32>
+// CHECK-NEXT:    [[TMP1:%.*]] = tail call <16 x i32> @llvm.aie2.set.I512.I256(<8 x i32> [[TMP0]], i32 0)
+// CHECK-NEXT:    [[TMP2:%.*]] = bitcast <16 x i8> [[B:%.*]] to <4 x i32>
+// CHECK-NEXT:    [[TMP3:%.*]] = tail call <16 x i32> @llvm.aie2.set.I512.I128(<4 x i32> [[TMP2]])
+// CHECK-NEXT:    [[TMP4:%.*]] = tail call <16 x i32> @llvm.aie2.v16int32()
+// CHECK-NEXT:    [[TMP5:%.*]] = shl i32 [[IDX:%.*]], 4
+// CHECK-NEXT:    [[MUL_I_I_I:%.*]] = sub i32 64, [[TMP5]]
+// CHECK-NEXT:    [[TMP6:%.*]] = tail call <16 x i32> @llvm.aie2.vshift.I512.I512(<16 x i32> [[TMP4]], <16 x i32> [[TMP3]], i32 0, i32 [[MUL_I_I_I]])
 // CHECK-NEXT:    [[MUL_I_I:%.*]] = shl i32 [[IDX]], 2
 // CHECK-NEXT:    [[SHL_I_I:%.*]] = shl i32 15, [[MUL_I_I]]
-// CHECK-NEXT:    [[TMP7:%.*]] = tail call <16 x i32> @llvm.aie2.vsel32(<16 x i32> [[TMP6]], <16 x i32> [[TMP4]], i32 [[SHL_I_I]])
+// CHECK-NEXT:    [[TMP7:%.*]] = tail call <16 x i32> @llvm.aie2.vsel32(<16 x i32> [[TMP1]], <16 x i32> [[TMP6]], i32 [[SHL_I_I]])
 // CHECK-NEXT:    [[TMP8:%.*]] = tail call <8 x i32> @llvm.aie2.ext.I256.I512(<16 x i32> [[TMP7]], i32 0)
 // CHECK-NEXT:    [[RETVAL_0_I3_I:%.*]] = bitcast <8 x i32> [[TMP8]] to <32 x i8>
 // CHECK-NEXT:    ret <32 x i8> [[RETVAL_0_I3_I]]
@@ -474,11 +475,11 @@ v64uint4 insert_v64i4  (v64uint4 a, int idx, v32uint4 b){
 
 // CHECK-LABEL: @_Z17insert_v64i4_idx0Dv32_DU8_iDv16_S_(
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[TMP0:%.*]] = bitcast <16 x i8> [[B:%.*]] to <4 x i32>
-// CHECK-NEXT:    [[TMP1:%.*]] = tail call <16 x i32> @llvm.aie2.set.I512.I128(<4 x i32> [[TMP0]])
-// CHECK-NEXT:    [[TMP2:%.*]] = bitcast <32 x i8> [[A:%.*]] to <8 x i32>
-// CHECK-NEXT:    [[TMP3:%.*]] = tail call <16 x i32> @llvm.aie2.set.I512.I256(<8 x i32> [[TMP2]], i32 0)
-// CHECK-NEXT:    [[TMP4:%.*]] = tail call <16 x i32> @llvm.aie2.vsel32(<16 x i32> [[TMP3]], <16 x i32> [[TMP1]], i32 15)
+// CHECK-NEXT:    [[TMP0:%.*]] = bitcast <32 x i8> [[A:%.*]] to <8 x i32>
+// CHECK-NEXT:    [[TMP1:%.*]] = tail call <16 x i32> @llvm.aie2.set.I512.I256(<8 x i32> [[TMP0]], i32 0)
+// CHECK-NEXT:    [[TMP2:%.*]] = bitcast <16 x i8> [[B:%.*]] to <4 x i32>
+// CHECK-NEXT:    [[TMP3:%.*]] = tail call <16 x i32> @llvm.aie2.set.I512.I128(<4 x i32> [[TMP2]])
+// CHECK-NEXT:    [[TMP4:%.*]] = tail call <16 x i32> @llvm.aie2.vsel32(<16 x i32> [[TMP1]], <16 x i32> [[TMP3]], i32 15)
 // CHECK-NEXT:    [[TMP5:%.*]] = tail call <8 x i32> @llvm.aie2.ext.I256.I512(<16 x i32> [[TMP4]], i32 0)
 // CHECK-NEXT:    [[RETVAL_0_I3_I:%.*]] = bitcast <8 x i32> [[TMP5]] to <32 x i8>
 // CHECK-NEXT:    ret <32 x i8> [[RETVAL_0_I3_I]]
@@ -490,12 +491,12 @@ v64uint4 insert_v64i4_idx0 (v64uint4 a, int idx, v32uint4 b){
 
 // CHECK-LABEL: @_Z17insert_128_in_512Dv64_DU8_iDv16_S_(
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[TMP0:%.*]] = tail call <16 x i32> @llvm.aie2.v16int32()
-// CHECK-NEXT:    [[TMP1:%.*]] = bitcast <16 x i8> [[B:%.*]] to <4 x i32>
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call <16 x i32> @llvm.aie2.set.I512.I128(<4 x i32> [[TMP1]])
+// CHECK-NEXT:    [[TMP0:%.*]] = bitcast <16 x i8> [[B:%.*]] to <4 x i32>
+// CHECK-NEXT:    [[TMP1:%.*]] = tail call <16 x i32> @llvm.aie2.set.I512.I128(<4 x i32> [[TMP0]])
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call <16 x i32> @llvm.aie2.v16int32()
 // CHECK-NEXT:    [[TMP3:%.*]] = shl i32 [[IDX:%.*]], 4
 // CHECK-NEXT:    [[MUL_I_I:%.*]] = sub i32 64, [[TMP3]]
-// CHECK-NEXT:    [[TMP4:%.*]] = tail call <16 x i32> @llvm.aie2.vshift.I512.I512(<16 x i32> [[TMP0]], <16 x i32> [[TMP2]], i32 0, i32 [[MUL_I_I]])
+// CHECK-NEXT:    [[TMP4:%.*]] = tail call <16 x i32> @llvm.aie2.vshift.I512.I512(<16 x i32> [[TMP2]], <16 x i32> [[TMP1]], i32 0, i32 [[MUL_I_I]])
 // CHECK-NEXT:    [[MUL_I:%.*]] = shl i32 [[IDX]], 2
 // CHECK-NEXT:    [[SHL_I:%.*]] = shl i32 15, [[MUL_I]]
 // CHECK-NEXT:    [[TMP5:%.*]] = bitcast <64 x i8> [[V:%.*]] to <16 x i32>
@@ -510,17 +511,17 @@ v128uint4 insert_128_in_512(v128uint4 v, int idx, v32uint4 b ) {
 
 // CHECK-LABEL: @_Z17insert_128_in_256Dv32_DU8_iDv16_S_(
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[TMP0:%.*]] = tail call <16 x i32> @llvm.aie2.v16int32()
-// CHECK-NEXT:    [[TMP1:%.*]] = bitcast <16 x i8> [[B:%.*]] to <4 x i32>
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call <16 x i32> @llvm.aie2.set.I512.I128(<4 x i32> [[TMP1]])
-// CHECK-NEXT:    [[TMP3:%.*]] = shl i32 [[IDX:%.*]], 4
-// CHECK-NEXT:    [[MUL_I_I_I:%.*]] = sub i32 64, [[TMP3]]
-// CHECK-NEXT:    [[TMP4:%.*]] = tail call <16 x i32> @llvm.aie2.vshift.I512.I512(<16 x i32> [[TMP0]], <16 x i32> [[TMP2]], i32 0, i32 [[MUL_I_I_I]])
-// CHECK-NEXT:    [[TMP5:%.*]] = bitcast <32 x i8> [[V:%.*]] to <8 x i32>
-// CHECK-NEXT:    [[TMP6:%.*]] = tail call <16 x i32> @llvm.aie2.set.I512.I256(<8 x i32> [[TMP5]], i32 0)
+// CHECK-NEXT:    [[TMP0:%.*]] = bitcast <32 x i8> [[V:%.*]] to <8 x i32>
+// CHECK-NEXT:    [[TMP1:%.*]] = tail call <16 x i32> @llvm.aie2.set.I512.I256(<8 x i32> [[TMP0]], i32 0)
+// CHECK-NEXT:    [[TMP2:%.*]] = bitcast <16 x i8> [[B:%.*]] to <4 x i32>
+// CHECK-NEXT:    [[TMP3:%.*]] = tail call <16 x i32> @llvm.aie2.set.I512.I128(<4 x i32> [[TMP2]])
+// CHECK-NEXT:    [[TMP4:%.*]] = tail call <16 x i32> @llvm.aie2.v16int32()
+// CHECK-NEXT:    [[TMP5:%.*]] = shl i32 [[IDX:%.*]], 4
+// CHECK-NEXT:    [[MUL_I_I_I:%.*]] = sub i32 64, [[TMP5]]
+// CHECK-NEXT:    [[TMP6:%.*]] = tail call <16 x i32> @llvm.aie2.vshift.I512.I512(<16 x i32> [[TMP4]], <16 x i32> [[TMP3]], i32 0, i32 [[MUL_I_I_I]])
 // CHECK-NEXT:    [[MUL_I_I:%.*]] = shl i32 [[IDX]], 2
 // CHECK-NEXT:    [[SHL_I_I:%.*]] = shl i32 15, [[MUL_I_I]]
-// CHECK-NEXT:    [[TMP7:%.*]] = tail call <16 x i32> @llvm.aie2.vsel32(<16 x i32> [[TMP6]], <16 x i32> [[TMP4]], i32 [[SHL_I_I]])
+// CHECK-NEXT:    [[TMP7:%.*]] = tail call <16 x i32> @llvm.aie2.vsel32(<16 x i32> [[TMP1]], <16 x i32> [[TMP6]], i32 [[SHL_I_I]])
 // CHECK-NEXT:    [[TMP8:%.*]] = tail call <8 x i32> @llvm.aie2.ext.I256.I512(<16 x i32> [[TMP7]], i32 0)
 // CHECK-NEXT:    [[RETVAL_0_I3_I:%.*]] = bitcast <8 x i32> [[TMP8]] to <32 x i8>
 // CHECK-NEXT:    ret <32 x i8> [[RETVAL_0_I3_I]]
@@ -562,10 +563,10 @@ v128uint4 test_concat_v32uint4  (v32uint4 v0, v32uint4 v1, v32uint4 v2, v32uint4
 // CHECK-NEXT:    [[TMP2:%.*]] = tail call <16 x i32> @llvm.aie2.v16int32()
 // CHECK-NEXT:    [[TMP3:%.*]] = tail call <16 x i32> @llvm.aie2.vshift.I512.I512(<16 x i32> [[TMP2]], <16 x i32> [[TMP1]], i32 0, i32 48)
 // CHECK-NEXT:    [[TMP4:%.*]] = tail call <8 x i32> @llvm.aie2.ext.I256.I512(<16 x i32> [[TMP3]], i32 0)
-// CHECK-NEXT:    [[TMP5:%.*]] = bitcast <16 x i8> [[V0:%.*]] to <4 x i32>
-// CHECK-NEXT:    [[TMP6:%.*]] = tail call <16 x i32> @llvm.aie2.set.I512.I128(<4 x i32> [[TMP5]])
-// CHECK-NEXT:    [[TMP7:%.*]] = tail call <16 x i32> @llvm.aie2.set.I512.I256(<8 x i32> [[TMP4]], i32 0)
-// CHECK-NEXT:    [[TMP8:%.*]] = tail call <16 x i32> @llvm.aie2.vsel32(<16 x i32> [[TMP7]], <16 x i32> [[TMP6]], i32 15)
+// CHECK-NEXT:    [[TMP5:%.*]] = tail call <16 x i32> @llvm.aie2.set.I512.I256(<8 x i32> [[TMP4]], i32 0)
+// CHECK-NEXT:    [[TMP6:%.*]] = bitcast <16 x i8> [[V0:%.*]] to <4 x i32>
+// CHECK-NEXT:    [[TMP7:%.*]] = tail call <16 x i32> @llvm.aie2.set.I512.I128(<4 x i32> [[TMP6]])
+// CHECK-NEXT:    [[TMP8:%.*]] = tail call <16 x i32> @llvm.aie2.vsel32(<16 x i32> [[TMP5]], <16 x i32> [[TMP7]], i32 15)
 // CHECK-NEXT:    [[TMP9:%.*]] = tail call <8 x i32> @llvm.aie2.ext.I256.I512(<16 x i32> [[TMP8]], i32 0)
 // CHECK-NEXT:    [[RETVAL_0_I3_I_I:%.*]] = bitcast <8 x i32> [[TMP9]] to <32 x i8>
 // CHECK-NEXT:    ret <32 x i8> [[RETVAL_0_I3_I_I]]
@@ -1400,6 +1401,7 @@ v16accfloat test_extract_v16accfloat(v32accfloat a, int idx) {
 
 /* Test Intrinsic using float type */
 
+//
 // CHECK-LABEL: @_Z11test_insertDv16_fiDv8_f(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[CMP_I:%.*]] = icmp eq i32 [[IDX:%.*]], 0
@@ -1769,13 +1771,13 @@ v16bfloat16 test_set_v16bfloat16(int idx, v8bfloat16 a) {
 
 // CHECK-LABEL: @_Z24test_set_v16bfloat16_idxiDv8_8bfloat16(
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[TMP0:%.*]] = tail call noundef <32 x i16> @llvm.aie2.v32int16()
-// CHECK-NEXT:    [[TMP1:%.*]] = bitcast <32 x i16> [[TMP0]] to <16 x i32>
-// CHECK-NEXT:    [[TMP2:%.*]] = bitcast <8 x bfloat> [[A:%.*]] to <4 x i32>
-// CHECK-NEXT:    [[TMP3:%.*]] = tail call <16 x i32> @llvm.aie2.set.I512.I128(<4 x i32> [[TMP2]])
+// CHECK-NEXT:    [[TMP0:%.*]] = bitcast <8 x bfloat> [[A:%.*]] to <4 x i32>
+// CHECK-NEXT:    [[TMP1:%.*]] = tail call <16 x i32> @llvm.aie2.set.I512.I128(<4 x i32> [[TMP0]])
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <32 x i16> @llvm.aie2.v32int16()
+// CHECK-NEXT:    [[TMP3:%.*]] = bitcast <32 x i16> [[TMP2]] to <16 x i32>
 // CHECK-NEXT:    [[TMP4:%.*]] = shl i32 [[IDX:%.*]], 4
 // CHECK-NEXT:    [[MUL_I_I_I:%.*]] = sub i32 64, [[TMP4]]
-// CHECK-NEXT:    [[TMP5:%.*]] = tail call <16 x i32> @llvm.aie2.vshift.I512.I512(<16 x i32> [[TMP1]], <16 x i32> [[TMP3]], i32 0, i32 [[MUL_I_I_I]])
+// CHECK-NEXT:    [[TMP5:%.*]] = tail call <16 x i32> @llvm.aie2.vshift.I512.I512(<16 x i32> [[TMP3]], <16 x i32> [[TMP1]], i32 0, i32 [[MUL_I_I_I]])
 // CHECK-NEXT:    [[TMP6:%.*]] = tail call <8 x i32> @llvm.aie2.ext.I256.I512(<16 x i32> [[TMP5]], i32 0)
 // CHECK-NEXT:    [[TMP7:%.*]] = bitcast <8 x i32> [[TMP6]] to <16 x bfloat>
 // CHECK-NEXT:    ret <16 x bfloat> [[TMP7]]
@@ -1786,13 +1788,13 @@ v16bfloat16 test_set_v16bfloat16_idx(int idx, v8bfloat16 a) {
 
 // CHECK-LABEL: @_Z11test_insertDv32_8bfloat16iDv8_S_(
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[TMP0:%.*]] = tail call noundef <32 x bfloat> @llvm.aie2.v32bfloat16()
-// CHECK-NEXT:    [[TMP1:%.*]] = bitcast <32 x bfloat> [[TMP0]] to <16 x i32>
-// CHECK-NEXT:    [[TMP2:%.*]] = bitcast <8 x bfloat> [[B:%.*]] to <4 x i32>
-// CHECK-NEXT:    [[TMP3:%.*]] = tail call <16 x i32> @llvm.aie2.set.I512.I128(<4 x i32> [[TMP2]])
+// CHECK-NEXT:    [[TMP0:%.*]] = bitcast <8 x bfloat> [[B:%.*]] to <4 x i32>
+// CHECK-NEXT:    [[TMP1:%.*]] = tail call <16 x i32> @llvm.aie2.set.I512.I128(<4 x i32> [[TMP0]])
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <32 x bfloat> @llvm.aie2.v32bfloat16()
+// CHECK-NEXT:    [[TMP3:%.*]] = bitcast <32 x bfloat> [[TMP2]] to <16 x i32>
 // CHECK-NEXT:    [[TMP4:%.*]] = shl i32 [[IDX:%.*]], 4
 // CHECK-NEXT:    [[MUL_I_I:%.*]] = sub i32 64, [[TMP4]]
-// CHECK-NEXT:    [[TMP5:%.*]] = tail call <16 x i32> @llvm.aie2.vshift.I512.I512(<16 x i32> [[TMP1]], <16 x i32> [[TMP3]], i32 0, i32 [[MUL_I_I]])
+// CHECK-NEXT:    [[TMP5:%.*]] = tail call <16 x i32> @llvm.aie2.vshift.I512.I512(<16 x i32> [[TMP3]], <16 x i32> [[TMP1]], i32 0, i32 [[MUL_I_I]])
 // CHECK-NEXT:    [[MUL_I:%.*]] = shl i32 [[IDX]], 2
 // CHECK-NEXT:    [[SHL_I:%.*]] = shl i32 15, [[MUL_I]]
 // CHECK-NEXT:    [[TMP6:%.*]] = bitcast <32 x bfloat> [[V:%.*]] to <16 x i32>
@@ -1837,13 +1839,13 @@ v8bfloat16 test_extract_v8bfloat16_256(v16bfloat16 a, int idx) {
 
 // CHECK-LABEL: @_Z16test_set_v8floatiDv4_f(
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[TMP0:%.*]] = tail call noundef <16 x float> @llvm.aie2.v16float()
-// CHECK-NEXT:    [[TMP1:%.*]] = bitcast <16 x float> [[TMP0]] to <16 x i32>
-// CHECK-NEXT:    [[TMP2:%.*]] = bitcast <4 x float> [[A:%.*]] to <4 x i32>
-// CHECK-NEXT:    [[TMP3:%.*]] = tail call <16 x i32> @llvm.aie2.set.I512.I128(<4 x i32> [[TMP2]])
+// CHECK-NEXT:    [[TMP0:%.*]] = bitcast <4 x float> [[A:%.*]] to <4 x i32>
+// CHECK-NEXT:    [[TMP1:%.*]] = tail call <16 x i32> @llvm.aie2.set.I512.I128(<4 x i32> [[TMP0]])
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <16 x float> @llvm.aie2.v16float()
+// CHECK-NEXT:    [[TMP3:%.*]] = bitcast <16 x float> [[TMP2]] to <16 x i32>
 // CHECK-NEXT:    [[TMP4:%.*]] = shl i32 [[IDX:%.*]], 4
 // CHECK-NEXT:    [[MUL_I_I:%.*]] = sub i32 64, [[TMP4]]
-// CHECK-NEXT:    [[TMP5:%.*]] = tail call <16 x i32> @llvm.aie2.vshift.I512.I512(<16 x i32> [[TMP1]], <16 x i32> [[TMP3]], i32 0, i32 [[MUL_I_I]])
+// CHECK-NEXT:    [[TMP5:%.*]] = tail call <16 x i32> @llvm.aie2.vshift.I512.I512(<16 x i32> [[TMP3]], <16 x i32> [[TMP1]], i32 0, i32 [[MUL_I_I]])
 // CHECK-NEXT:    [[TMP6:%.*]] = tail call <8 x i32> @llvm.aie2.ext.I256.I512(<16 x i32> [[TMP5]], i32 0)
 // CHECK-NEXT:    [[RETVAL_0_I:%.*]] = bitcast <8 x i32> [[TMP6]] to <8 x float>
 // CHECK-NEXT:    ret <8 x float> [[RETVAL_0_I]]
@@ -1854,13 +1856,13 @@ v8float test_set_v8float(int idx, v4float a) {
 
 // CHECK-LABEL: @_Z11test_insertDv16_fiDv4_f(
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[TMP0:%.*]] = tail call noundef <16 x float> @llvm.aie2.v16float()
-// CHECK-NEXT:    [[TMP1:%.*]] = bitcast <16 x float> [[TMP0]] to <16 x i32>
-// CHECK-NEXT:    [[TMP2:%.*]] = bitcast <4 x float> [[B:%.*]] to <4 x i32>
-// CHECK-NEXT:    [[TMP3:%.*]] = tail call <16 x i32> @llvm.aie2.set.I512.I128(<4 x i32> [[TMP2]])
+// CHECK-NEXT:    [[TMP0:%.*]] = bitcast <4 x float> [[B:%.*]] to <4 x i32>
+// CHECK-NEXT:    [[TMP1:%.*]] = tail call <16 x i32> @llvm.aie2.set.I512.I128(<4 x i32> [[TMP0]])
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <16 x float> @llvm.aie2.v16float()
+// CHECK-NEXT:    [[TMP3:%.*]] = bitcast <16 x float> [[TMP2]] to <16 x i32>
 // CHECK-NEXT:    [[TMP4:%.*]] = shl i32 [[IDX:%.*]], 4
 // CHECK-NEXT:    [[MUL_I_I:%.*]] = sub i32 64, [[TMP4]]
-// CHECK-NEXT:    [[TMP5:%.*]] = tail call <16 x i32> @llvm.aie2.vshift.I512.I512(<16 x i32> [[TMP1]], <16 x i32> [[TMP3]], i32 0, i32 [[MUL_I_I]])
+// CHECK-NEXT:    [[TMP5:%.*]] = tail call <16 x i32> @llvm.aie2.vshift.I512.I512(<16 x i32> [[TMP3]], <16 x i32> [[TMP1]], i32 0, i32 [[MUL_I_I]])
 // CHECK-NEXT:    [[MUL_I:%.*]] = shl i32 [[IDX]], 2
 // CHECK-NEXT:    [[SHL_I:%.*]] = shl i32 15, [[MUL_I]]
 // CHECK-NEXT:    [[TMP6:%.*]] = bitcast <16 x float> [[V:%.*]] to <16 x i32>
@@ -1874,18 +1876,18 @@ v16float test_insert(v16float v, int idx, v4float b) {
 
 // CHECK-LABEL: @_Z11test_insertDv8_fiDv4_f(
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[TMP0:%.*]] = tail call noundef <16 x float> @llvm.aie2.v16float()
-// CHECK-NEXT:    [[TMP1:%.*]] = bitcast <16 x float> [[TMP0]] to <16 x i32>
+// CHECK-NEXT:    [[TMP0:%.*]] = bitcast <8 x float> [[V:%.*]] to <8 x i32>
+// CHECK-NEXT:    [[TMP1:%.*]] = tail call <16 x i32> @llvm.aie2.set.I512.I256(<8 x i32> [[TMP0]], i32 0)
 // CHECK-NEXT:    [[TMP2:%.*]] = bitcast <4 x float> [[B:%.*]] to <4 x i32>
 // CHECK-NEXT:    [[TMP3:%.*]] = tail call <16 x i32> @llvm.aie2.set.I512.I128(<4 x i32> [[TMP2]])
-// CHECK-NEXT:    [[TMP4:%.*]] = shl i32 [[IDX:%.*]], 4
-// CHECK-NEXT:    [[MUL_I_I_I:%.*]] = sub i32 64, [[TMP4]]
-// CHECK-NEXT:    [[TMP5:%.*]] = tail call <16 x i32> @llvm.aie2.vshift.I512.I512(<16 x i32> [[TMP1]], <16 x i32> [[TMP3]], i32 0, i32 [[MUL_I_I_I]])
-// CHECK-NEXT:    [[TMP6:%.*]] = bitcast <8 x float> [[V:%.*]] to <8 x i32>
-// CHECK-NEXT:    [[TMP7:%.*]] = tail call <16 x i32> @llvm.aie2.set.I512.I256(<8 x i32> [[TMP6]], i32 0)
+// CHECK-NEXT:    [[TMP4:%.*]] = tail call noundef <16 x float> @llvm.aie2.v16float()
+// CHECK-NEXT:    [[TMP5:%.*]] = bitcast <16 x float> [[TMP4]] to <16 x i32>
+// CHECK-NEXT:    [[TMP6:%.*]] = shl i32 [[IDX:%.*]], 4
+// CHECK-NEXT:    [[MUL_I_I_I:%.*]] = sub i32 64, [[TMP6]]
+// CHECK-NEXT:    [[TMP7:%.*]] = tail call <16 x i32> @llvm.aie2.vshift.I512.I512(<16 x i32> [[TMP5]], <16 x i32> [[TMP3]], i32 0, i32 [[MUL_I_I_I]])
 // CHECK-NEXT:    [[MUL_I_I:%.*]] = shl i32 [[IDX]], 2
 // CHECK-NEXT:    [[SHL_I_I:%.*]] = shl i32 15, [[MUL_I_I]]
-// CHECK-NEXT:    [[TMP8:%.*]] = tail call <16 x i32> @llvm.aie2.vsel32(<16 x i32> [[TMP7]], <16 x i32> [[TMP5]], i32 [[SHL_I_I]])
+// CHECK-NEXT:    [[TMP8:%.*]] = tail call <16 x i32> @llvm.aie2.vsel32(<16 x i32> [[TMP1]], <16 x i32> [[TMP7]], i32 [[SHL_I_I]])
 // CHECK-NEXT:    [[TMP9:%.*]] = tail call <8 x i32> @llvm.aie2.ext.I256.I512(<16 x i32> [[TMP8]], i32 0)
 // CHECK-NEXT:    [[RETVAL_0_I3_I:%.*]] = bitcast <8 x i32> [[TMP9]] to <8 x float>
 // CHECK-NEXT:    ret <8 x float> [[RETVAL_0_I3_I]]
@@ -1933,10 +1935,10 @@ v4float test_extract_v4float(v8float v, int idx) {
 // CHECK-NEXT:    [[TMP3:%.*]] = bitcast <16 x float> [[TMP2]] to <16 x i32>
 // CHECK-NEXT:    [[TMP4:%.*]] = tail call <16 x i32> @llvm.aie2.vshift.I512.I512(<16 x i32> [[TMP3]], <16 x i32> [[TMP1]], i32 0, i32 48)
 // CHECK-NEXT:    [[TMP5:%.*]] = tail call <8 x i32> @llvm.aie2.ext.I256.I512(<16 x i32> [[TMP4]], i32 0)
-// CHECK-NEXT:    [[TMP6:%.*]] = bitcast <4 x float> [[V0:%.*]] to <4 x i32>
-// CHECK-NEXT:    [[TMP7:%.*]] = tail call <16 x i32> @llvm.aie2.set.I512.I128(<4 x i32> [[TMP6]])
-// CHECK-NEXT:    [[TMP8:%.*]] = tail call <16 x i32> @llvm.aie2.set.I512.I256(<8 x i32> [[TMP5]], i32 0)
-// CHECK-NEXT:    [[TMP9:%.*]] = tail call <16 x i32> @llvm.aie2.vsel32(<16 x i32> [[TMP8]], <16 x i32> [[TMP7]], i32 15)
+// CHECK-NEXT:    [[TMP6:%.*]] = tail call <16 x i32> @llvm.aie2.set.I512.I256(<8 x i32> [[TMP5]], i32 0)
+// CHECK-NEXT:    [[TMP7:%.*]] = bitcast <4 x float> [[V0:%.*]] to <4 x i32>
+// CHECK-NEXT:    [[TMP8:%.*]] = tail call <16 x i32> @llvm.aie2.set.I512.I128(<4 x i32> [[TMP7]])
+// CHECK-NEXT:    [[TMP9:%.*]] = tail call <16 x i32> @llvm.aie2.vsel32(<16 x i32> [[TMP6]], <16 x i32> [[TMP8]], i32 15)
 // CHECK-NEXT:    [[TMP10:%.*]] = tail call <8 x i32> @llvm.aie2.ext.I256.I512(<16 x i32> [[TMP9]], i32 0)
 // CHECK-NEXT:    [[RETVAL_0_I3_I_I:%.*]] = bitcast <8 x i32> [[TMP10]] to <8 x float>
 // CHECK-NEXT:    ret <8 x float> [[RETVAL_0_I3_I_I]]

--- a/clang/test/CodeGen/aie/aie2/aie2-upd-ext-intrinsic.cpp
+++ b/clang/test/CodeGen/aie/aie2/aie2-upd-ext-intrinsic.cpp
@@ -5,7 +5,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// (c) Copyright 2023-2024 Advanced Micro Devices, Inc. or its affiliates
+// (c) Copyright 2023-2025 Advanced Micro Devices, Inc. or its affiliates
 //
 //===----------------------------------------------------------------------===//
 // RUN: %clang -O2 %s --target=aie2 -nostdlibinc -S -emit-llvm -o - | FileCheck %s
@@ -135,12 +135,12 @@ v128uint4 test_set_v128uint4_force0( int idx, v32uint4 a ){
 
 // CHECK-LABEL: @_Z22test_set_v128uint4_idxiDv16_DU8_(
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[TMP0:%.*]] = bitcast <16 x i8> [[A:%.*]] to <4 x i32>
-// CHECK-NEXT:    [[TMP1:%.*]] = tail call <16 x i32> @llvm.aie2.set.I512.I128(<4 x i32> [[TMP0]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call <16 x i32> @llvm.aie2.v16int32()
+// CHECK-NEXT:    [[TMP0:%.*]] = tail call <16 x i32> @llvm.aie2.v16int32()
+// CHECK-NEXT:    [[TMP1:%.*]] = bitcast <16 x i8> [[A:%.*]] to <4 x i32>
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call <16 x i32> @llvm.aie2.set.I512.I128(<4 x i32> [[TMP1]])
 // CHECK-NEXT:    [[TMP3:%.*]] = shl i32 [[IDX:%.*]], 4
 // CHECK-NEXT:    [[MUL_I:%.*]] = sub i32 64, [[TMP3]]
-// CHECK-NEXT:    [[TMP4:%.*]] = tail call <16 x i32> @llvm.aie2.vshift.I512.I512(<16 x i32> [[TMP2]], <16 x i32> [[TMP1]], i32 0, i32 [[MUL_I]])
+// CHECK-NEXT:    [[TMP4:%.*]] = tail call <16 x i32> @llvm.aie2.vshift.I512.I512(<16 x i32> [[TMP0]], <16 x i32> [[TMP2]], i32 0, i32 [[MUL_I]])
 // CHECK-NEXT:    [[RETVAL_0_I:%.*]] = bitcast <16 x i32> [[TMP4]] to <64 x i8>
 // CHECK-NEXT:    ret <64 x i8> [[RETVAL_0_I]]
 //
@@ -210,7 +210,6 @@ v64uint4 test_extract_v64uint4 (v128uint4 a, int idx){
 }
 
 
-//
 // CHECK-LABEL: @_Z23test_insert_upd_512_256Dv64_DU8_iDv32_S_(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[CMP_I:%.*]] = icmp eq i32 [[IDX:%.*]], 0
@@ -453,17 +452,17 @@ v256uint4 test_concat_2x512 (v128uint4 a0, v128uint4 a1){
 
 // CHECK-LABEL: @_Z12insert_v64i4Dv32_DU8_iDv16_S_(
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[TMP0:%.*]] = bitcast <32 x i8> [[A:%.*]] to <8 x i32>
-// CHECK-NEXT:    [[TMP1:%.*]] = tail call <16 x i32> @llvm.aie2.set.I512.I256(<8 x i32> [[TMP0]], i32 0)
-// CHECK-NEXT:    [[TMP2:%.*]] = bitcast <16 x i8> [[B:%.*]] to <4 x i32>
-// CHECK-NEXT:    [[TMP3:%.*]] = tail call <16 x i32> @llvm.aie2.set.I512.I128(<4 x i32> [[TMP2]])
-// CHECK-NEXT:    [[TMP4:%.*]] = tail call <16 x i32> @llvm.aie2.v16int32()
-// CHECK-NEXT:    [[TMP5:%.*]] = shl i32 [[IDX:%.*]], 4
-// CHECK-NEXT:    [[MUL_I_I_I:%.*]] = sub i32 64, [[TMP5]]
-// CHECK-NEXT:    [[TMP6:%.*]] = tail call <16 x i32> @llvm.aie2.vshift.I512.I512(<16 x i32> [[TMP4]], <16 x i32> [[TMP3]], i32 0, i32 [[MUL_I_I_I]])
+// CHECK-NEXT:    [[TMP0:%.*]] = tail call <16 x i32> @llvm.aie2.v16int32()
+// CHECK-NEXT:    [[TMP1:%.*]] = bitcast <16 x i8> [[B:%.*]] to <4 x i32>
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call <16 x i32> @llvm.aie2.set.I512.I128(<4 x i32> [[TMP1]])
+// CHECK-NEXT:    [[TMP3:%.*]] = shl i32 [[IDX:%.*]], 4
+// CHECK-NEXT:    [[MUL_I_I_I:%.*]] = sub i32 64, [[TMP3]]
+// CHECK-NEXT:    [[TMP4:%.*]] = tail call <16 x i32> @llvm.aie2.vshift.I512.I512(<16 x i32> [[TMP0]], <16 x i32> [[TMP2]], i32 0, i32 [[MUL_I_I_I]])
+// CHECK-NEXT:    [[TMP5:%.*]] = bitcast <32 x i8> [[A:%.*]] to <8 x i32>
+// CHECK-NEXT:    [[TMP6:%.*]] = tail call <16 x i32> @llvm.aie2.set.I512.I256(<8 x i32> [[TMP5]], i32 0)
 // CHECK-NEXT:    [[MUL_I_I:%.*]] = shl i32 [[IDX]], 2
 // CHECK-NEXT:    [[SHL_I_I:%.*]] = shl i32 15, [[MUL_I_I]]
-// CHECK-NEXT:    [[TMP7:%.*]] = tail call <16 x i32> @llvm.aie2.vsel32(<16 x i32> [[TMP1]], <16 x i32> [[TMP6]], i32 [[SHL_I_I]])
+// CHECK-NEXT:    [[TMP7:%.*]] = tail call <16 x i32> @llvm.aie2.vsel32(<16 x i32> [[TMP6]], <16 x i32> [[TMP4]], i32 [[SHL_I_I]])
 // CHECK-NEXT:    [[TMP8:%.*]] = tail call <8 x i32> @llvm.aie2.ext.I256.I512(<16 x i32> [[TMP7]], i32 0)
 // CHECK-NEXT:    [[RETVAL_0_I3_I:%.*]] = bitcast <8 x i32> [[TMP8]] to <32 x i8>
 // CHECK-NEXT:    ret <32 x i8> [[RETVAL_0_I3_I]]
@@ -475,11 +474,11 @@ v64uint4 insert_v64i4  (v64uint4 a, int idx, v32uint4 b){
 
 // CHECK-LABEL: @_Z17insert_v64i4_idx0Dv32_DU8_iDv16_S_(
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[TMP0:%.*]] = bitcast <32 x i8> [[A:%.*]] to <8 x i32>
-// CHECK-NEXT:    [[TMP1:%.*]] = tail call <16 x i32> @llvm.aie2.set.I512.I256(<8 x i32> [[TMP0]], i32 0)
-// CHECK-NEXT:    [[TMP2:%.*]] = bitcast <16 x i8> [[B:%.*]] to <4 x i32>
-// CHECK-NEXT:    [[TMP3:%.*]] = tail call <16 x i32> @llvm.aie2.set.I512.I128(<4 x i32> [[TMP2]])
-// CHECK-NEXT:    [[TMP4:%.*]] = tail call <16 x i32> @llvm.aie2.vsel32(<16 x i32> [[TMP1]], <16 x i32> [[TMP3]], i32 15)
+// CHECK-NEXT:    [[TMP0:%.*]] = bitcast <16 x i8> [[B:%.*]] to <4 x i32>
+// CHECK-NEXT:    [[TMP1:%.*]] = tail call <16 x i32> @llvm.aie2.set.I512.I128(<4 x i32> [[TMP0]])
+// CHECK-NEXT:    [[TMP2:%.*]] = bitcast <32 x i8> [[A:%.*]] to <8 x i32>
+// CHECK-NEXT:    [[TMP3:%.*]] = tail call <16 x i32> @llvm.aie2.set.I512.I256(<8 x i32> [[TMP2]], i32 0)
+// CHECK-NEXT:    [[TMP4:%.*]] = tail call <16 x i32> @llvm.aie2.vsel32(<16 x i32> [[TMP3]], <16 x i32> [[TMP1]], i32 15)
 // CHECK-NEXT:    [[TMP5:%.*]] = tail call <8 x i32> @llvm.aie2.ext.I256.I512(<16 x i32> [[TMP4]], i32 0)
 // CHECK-NEXT:    [[RETVAL_0_I3_I:%.*]] = bitcast <8 x i32> [[TMP5]] to <32 x i8>
 // CHECK-NEXT:    ret <32 x i8> [[RETVAL_0_I3_I]]
@@ -491,12 +490,12 @@ v64uint4 insert_v64i4_idx0 (v64uint4 a, int idx, v32uint4 b){
 
 // CHECK-LABEL: @_Z17insert_128_in_512Dv64_DU8_iDv16_S_(
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[TMP0:%.*]] = bitcast <16 x i8> [[B:%.*]] to <4 x i32>
-// CHECK-NEXT:    [[TMP1:%.*]] = tail call <16 x i32> @llvm.aie2.set.I512.I128(<4 x i32> [[TMP0]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call <16 x i32> @llvm.aie2.v16int32()
+// CHECK-NEXT:    [[TMP0:%.*]] = tail call <16 x i32> @llvm.aie2.v16int32()
+// CHECK-NEXT:    [[TMP1:%.*]] = bitcast <16 x i8> [[B:%.*]] to <4 x i32>
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call <16 x i32> @llvm.aie2.set.I512.I128(<4 x i32> [[TMP1]])
 // CHECK-NEXT:    [[TMP3:%.*]] = shl i32 [[IDX:%.*]], 4
 // CHECK-NEXT:    [[MUL_I_I:%.*]] = sub i32 64, [[TMP3]]
-// CHECK-NEXT:    [[TMP4:%.*]] = tail call <16 x i32> @llvm.aie2.vshift.I512.I512(<16 x i32> [[TMP2]], <16 x i32> [[TMP1]], i32 0, i32 [[MUL_I_I]])
+// CHECK-NEXT:    [[TMP4:%.*]] = tail call <16 x i32> @llvm.aie2.vshift.I512.I512(<16 x i32> [[TMP0]], <16 x i32> [[TMP2]], i32 0, i32 [[MUL_I_I]])
 // CHECK-NEXT:    [[MUL_I:%.*]] = shl i32 [[IDX]], 2
 // CHECK-NEXT:    [[SHL_I:%.*]] = shl i32 15, [[MUL_I]]
 // CHECK-NEXT:    [[TMP5:%.*]] = bitcast <64 x i8> [[V:%.*]] to <16 x i32>
@@ -511,17 +510,17 @@ v128uint4 insert_128_in_512(v128uint4 v, int idx, v32uint4 b ) {
 
 // CHECK-LABEL: @_Z17insert_128_in_256Dv32_DU8_iDv16_S_(
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[TMP0:%.*]] = bitcast <32 x i8> [[V:%.*]] to <8 x i32>
-// CHECK-NEXT:    [[TMP1:%.*]] = tail call <16 x i32> @llvm.aie2.set.I512.I256(<8 x i32> [[TMP0]], i32 0)
-// CHECK-NEXT:    [[TMP2:%.*]] = bitcast <16 x i8> [[B:%.*]] to <4 x i32>
-// CHECK-NEXT:    [[TMP3:%.*]] = tail call <16 x i32> @llvm.aie2.set.I512.I128(<4 x i32> [[TMP2]])
-// CHECK-NEXT:    [[TMP4:%.*]] = tail call <16 x i32> @llvm.aie2.v16int32()
-// CHECK-NEXT:    [[TMP5:%.*]] = shl i32 [[IDX:%.*]], 4
-// CHECK-NEXT:    [[MUL_I_I_I:%.*]] = sub i32 64, [[TMP5]]
-// CHECK-NEXT:    [[TMP6:%.*]] = tail call <16 x i32> @llvm.aie2.vshift.I512.I512(<16 x i32> [[TMP4]], <16 x i32> [[TMP3]], i32 0, i32 [[MUL_I_I_I]])
+// CHECK-NEXT:    [[TMP0:%.*]] = tail call <16 x i32> @llvm.aie2.v16int32()
+// CHECK-NEXT:    [[TMP1:%.*]] = bitcast <16 x i8> [[B:%.*]] to <4 x i32>
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call <16 x i32> @llvm.aie2.set.I512.I128(<4 x i32> [[TMP1]])
+// CHECK-NEXT:    [[TMP3:%.*]] = shl i32 [[IDX:%.*]], 4
+// CHECK-NEXT:    [[MUL_I_I_I:%.*]] = sub i32 64, [[TMP3]]
+// CHECK-NEXT:    [[TMP4:%.*]] = tail call <16 x i32> @llvm.aie2.vshift.I512.I512(<16 x i32> [[TMP0]], <16 x i32> [[TMP2]], i32 0, i32 [[MUL_I_I_I]])
+// CHECK-NEXT:    [[TMP5:%.*]] = bitcast <32 x i8> [[V:%.*]] to <8 x i32>
+// CHECK-NEXT:    [[TMP6:%.*]] = tail call <16 x i32> @llvm.aie2.set.I512.I256(<8 x i32> [[TMP5]], i32 0)
 // CHECK-NEXT:    [[MUL_I_I:%.*]] = shl i32 [[IDX]], 2
 // CHECK-NEXT:    [[SHL_I_I:%.*]] = shl i32 15, [[MUL_I_I]]
-// CHECK-NEXT:    [[TMP7:%.*]] = tail call <16 x i32> @llvm.aie2.vsel32(<16 x i32> [[TMP1]], <16 x i32> [[TMP6]], i32 [[SHL_I_I]])
+// CHECK-NEXT:    [[TMP7:%.*]] = tail call <16 x i32> @llvm.aie2.vsel32(<16 x i32> [[TMP6]], <16 x i32> [[TMP4]], i32 [[SHL_I_I]])
 // CHECK-NEXT:    [[TMP8:%.*]] = tail call <8 x i32> @llvm.aie2.ext.I256.I512(<16 x i32> [[TMP7]], i32 0)
 // CHECK-NEXT:    [[RETVAL_0_I3_I:%.*]] = bitcast <8 x i32> [[TMP8]] to <32 x i8>
 // CHECK-NEXT:    ret <32 x i8> [[RETVAL_0_I3_I]]
@@ -563,10 +562,10 @@ v128uint4 test_concat_v32uint4  (v32uint4 v0, v32uint4 v1, v32uint4 v2, v32uint4
 // CHECK-NEXT:    [[TMP2:%.*]] = tail call <16 x i32> @llvm.aie2.v16int32()
 // CHECK-NEXT:    [[TMP3:%.*]] = tail call <16 x i32> @llvm.aie2.vshift.I512.I512(<16 x i32> [[TMP2]], <16 x i32> [[TMP1]], i32 0, i32 48)
 // CHECK-NEXT:    [[TMP4:%.*]] = tail call <8 x i32> @llvm.aie2.ext.I256.I512(<16 x i32> [[TMP3]], i32 0)
-// CHECK-NEXT:    [[TMP5:%.*]] = tail call <16 x i32> @llvm.aie2.set.I512.I256(<8 x i32> [[TMP4]], i32 0)
-// CHECK-NEXT:    [[TMP6:%.*]] = bitcast <16 x i8> [[V0:%.*]] to <4 x i32>
-// CHECK-NEXT:    [[TMP7:%.*]] = tail call <16 x i32> @llvm.aie2.set.I512.I128(<4 x i32> [[TMP6]])
-// CHECK-NEXT:    [[TMP8:%.*]] = tail call <16 x i32> @llvm.aie2.vsel32(<16 x i32> [[TMP5]], <16 x i32> [[TMP7]], i32 15)
+// CHECK-NEXT:    [[TMP5:%.*]] = bitcast <16 x i8> [[V0:%.*]] to <4 x i32>
+// CHECK-NEXT:    [[TMP6:%.*]] = tail call <16 x i32> @llvm.aie2.set.I512.I128(<4 x i32> [[TMP5]])
+// CHECK-NEXT:    [[TMP7:%.*]] = tail call <16 x i32> @llvm.aie2.set.I512.I256(<8 x i32> [[TMP4]], i32 0)
+// CHECK-NEXT:    [[TMP8:%.*]] = tail call <16 x i32> @llvm.aie2.vsel32(<16 x i32> [[TMP7]], <16 x i32> [[TMP6]], i32 15)
 // CHECK-NEXT:    [[TMP9:%.*]] = tail call <8 x i32> @llvm.aie2.ext.I256.I512(<16 x i32> [[TMP8]], i32 0)
 // CHECK-NEXT:    [[RETVAL_0_I3_I_I:%.*]] = bitcast <8 x i32> [[TMP9]] to <32 x i8>
 // CHECK-NEXT:    ret <32 x i8> [[RETVAL_0_I3_I_I]]
@@ -1401,7 +1400,6 @@ v16accfloat test_extract_v16accfloat(v32accfloat a, int idx) {
 
 /* Test Intrinsic using float type */
 
-//
 // CHECK-LABEL: @_Z11test_insertDv16_fiDv8_f(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[CMP_I:%.*]] = icmp eq i32 [[IDX:%.*]], 0
@@ -1771,13 +1769,13 @@ v16bfloat16 test_set_v16bfloat16(int idx, v8bfloat16 a) {
 
 // CHECK-LABEL: @_Z24test_set_v16bfloat16_idxiDv8_8bfloat16(
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[TMP0:%.*]] = bitcast <8 x bfloat> [[A:%.*]] to <4 x i32>
-// CHECK-NEXT:    [[TMP1:%.*]] = tail call <16 x i32> @llvm.aie2.set.I512.I128(<4 x i32> [[TMP0]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <32 x i16> @llvm.aie2.v32int16()
-// CHECK-NEXT:    [[TMP3:%.*]] = bitcast <32 x i16> [[TMP2]] to <16 x i32>
+// CHECK-NEXT:    [[TMP0:%.*]] = tail call noundef <32 x i16> @llvm.aie2.v32int16()
+// CHECK-NEXT:    [[TMP1:%.*]] = bitcast <32 x i16> [[TMP0]] to <16 x i32>
+// CHECK-NEXT:    [[TMP2:%.*]] = bitcast <8 x bfloat> [[A:%.*]] to <4 x i32>
+// CHECK-NEXT:    [[TMP3:%.*]] = tail call <16 x i32> @llvm.aie2.set.I512.I128(<4 x i32> [[TMP2]])
 // CHECK-NEXT:    [[TMP4:%.*]] = shl i32 [[IDX:%.*]], 4
 // CHECK-NEXT:    [[MUL_I_I_I:%.*]] = sub i32 64, [[TMP4]]
-// CHECK-NEXT:    [[TMP5:%.*]] = tail call <16 x i32> @llvm.aie2.vshift.I512.I512(<16 x i32> [[TMP3]], <16 x i32> [[TMP1]], i32 0, i32 [[MUL_I_I_I]])
+// CHECK-NEXT:    [[TMP5:%.*]] = tail call <16 x i32> @llvm.aie2.vshift.I512.I512(<16 x i32> [[TMP1]], <16 x i32> [[TMP3]], i32 0, i32 [[MUL_I_I_I]])
 // CHECK-NEXT:    [[TMP6:%.*]] = tail call <8 x i32> @llvm.aie2.ext.I256.I512(<16 x i32> [[TMP5]], i32 0)
 // CHECK-NEXT:    [[TMP7:%.*]] = bitcast <8 x i32> [[TMP6]] to <16 x bfloat>
 // CHECK-NEXT:    ret <16 x bfloat> [[TMP7]]
@@ -1788,13 +1786,13 @@ v16bfloat16 test_set_v16bfloat16_idx(int idx, v8bfloat16 a) {
 
 // CHECK-LABEL: @_Z11test_insertDv32_8bfloat16iDv8_S_(
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[TMP0:%.*]] = bitcast <8 x bfloat> [[B:%.*]] to <4 x i32>
-// CHECK-NEXT:    [[TMP1:%.*]] = tail call <16 x i32> @llvm.aie2.set.I512.I128(<4 x i32> [[TMP0]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <32 x bfloat> @llvm.aie2.v32bfloat16()
-// CHECK-NEXT:    [[TMP3:%.*]] = bitcast <32 x bfloat> [[TMP2]] to <16 x i32>
+// CHECK-NEXT:    [[TMP0:%.*]] = tail call noundef <32 x bfloat> @llvm.aie2.v32bfloat16()
+// CHECK-NEXT:    [[TMP1:%.*]] = bitcast <32 x bfloat> [[TMP0]] to <16 x i32>
+// CHECK-NEXT:    [[TMP2:%.*]] = bitcast <8 x bfloat> [[B:%.*]] to <4 x i32>
+// CHECK-NEXT:    [[TMP3:%.*]] = tail call <16 x i32> @llvm.aie2.set.I512.I128(<4 x i32> [[TMP2]])
 // CHECK-NEXT:    [[TMP4:%.*]] = shl i32 [[IDX:%.*]], 4
 // CHECK-NEXT:    [[MUL_I_I:%.*]] = sub i32 64, [[TMP4]]
-// CHECK-NEXT:    [[TMP5:%.*]] = tail call <16 x i32> @llvm.aie2.vshift.I512.I512(<16 x i32> [[TMP3]], <16 x i32> [[TMP1]], i32 0, i32 [[MUL_I_I]])
+// CHECK-NEXT:    [[TMP5:%.*]] = tail call <16 x i32> @llvm.aie2.vshift.I512.I512(<16 x i32> [[TMP1]], <16 x i32> [[TMP3]], i32 0, i32 [[MUL_I_I]])
 // CHECK-NEXT:    [[MUL_I:%.*]] = shl i32 [[IDX]], 2
 // CHECK-NEXT:    [[SHL_I:%.*]] = shl i32 15, [[MUL_I]]
 // CHECK-NEXT:    [[TMP6:%.*]] = bitcast <32 x bfloat> [[V:%.*]] to <16 x i32>
@@ -1839,13 +1837,13 @@ v8bfloat16 test_extract_v8bfloat16_256(v16bfloat16 a, int idx) {
 
 // CHECK-LABEL: @_Z16test_set_v8floatiDv4_f(
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[TMP0:%.*]] = bitcast <4 x float> [[A:%.*]] to <4 x i32>
-// CHECK-NEXT:    [[TMP1:%.*]] = tail call <16 x i32> @llvm.aie2.set.I512.I128(<4 x i32> [[TMP0]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <16 x float> @llvm.aie2.v16float()
-// CHECK-NEXT:    [[TMP3:%.*]] = bitcast <16 x float> [[TMP2]] to <16 x i32>
+// CHECK-NEXT:    [[TMP0:%.*]] = tail call noundef <16 x float> @llvm.aie2.v16float()
+// CHECK-NEXT:    [[TMP1:%.*]] = bitcast <16 x float> [[TMP0]] to <16 x i32>
+// CHECK-NEXT:    [[TMP2:%.*]] = bitcast <4 x float> [[A:%.*]] to <4 x i32>
+// CHECK-NEXT:    [[TMP3:%.*]] = tail call <16 x i32> @llvm.aie2.set.I512.I128(<4 x i32> [[TMP2]])
 // CHECK-NEXT:    [[TMP4:%.*]] = shl i32 [[IDX:%.*]], 4
 // CHECK-NEXT:    [[MUL_I_I:%.*]] = sub i32 64, [[TMP4]]
-// CHECK-NEXT:    [[TMP5:%.*]] = tail call <16 x i32> @llvm.aie2.vshift.I512.I512(<16 x i32> [[TMP3]], <16 x i32> [[TMP1]], i32 0, i32 [[MUL_I_I]])
+// CHECK-NEXT:    [[TMP5:%.*]] = tail call <16 x i32> @llvm.aie2.vshift.I512.I512(<16 x i32> [[TMP1]], <16 x i32> [[TMP3]], i32 0, i32 [[MUL_I_I]])
 // CHECK-NEXT:    [[TMP6:%.*]] = tail call <8 x i32> @llvm.aie2.ext.I256.I512(<16 x i32> [[TMP5]], i32 0)
 // CHECK-NEXT:    [[RETVAL_0_I:%.*]] = bitcast <8 x i32> [[TMP6]] to <8 x float>
 // CHECK-NEXT:    ret <8 x float> [[RETVAL_0_I]]
@@ -1856,13 +1854,13 @@ v8float test_set_v8float(int idx, v4float a) {
 
 // CHECK-LABEL: @_Z11test_insertDv16_fiDv4_f(
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[TMP0:%.*]] = bitcast <4 x float> [[B:%.*]] to <4 x i32>
-// CHECK-NEXT:    [[TMP1:%.*]] = tail call <16 x i32> @llvm.aie2.set.I512.I128(<4 x i32> [[TMP0]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <16 x float> @llvm.aie2.v16float()
-// CHECK-NEXT:    [[TMP3:%.*]] = bitcast <16 x float> [[TMP2]] to <16 x i32>
+// CHECK-NEXT:    [[TMP0:%.*]] = tail call noundef <16 x float> @llvm.aie2.v16float()
+// CHECK-NEXT:    [[TMP1:%.*]] = bitcast <16 x float> [[TMP0]] to <16 x i32>
+// CHECK-NEXT:    [[TMP2:%.*]] = bitcast <4 x float> [[B:%.*]] to <4 x i32>
+// CHECK-NEXT:    [[TMP3:%.*]] = tail call <16 x i32> @llvm.aie2.set.I512.I128(<4 x i32> [[TMP2]])
 // CHECK-NEXT:    [[TMP4:%.*]] = shl i32 [[IDX:%.*]], 4
 // CHECK-NEXT:    [[MUL_I_I:%.*]] = sub i32 64, [[TMP4]]
-// CHECK-NEXT:    [[TMP5:%.*]] = tail call <16 x i32> @llvm.aie2.vshift.I512.I512(<16 x i32> [[TMP3]], <16 x i32> [[TMP1]], i32 0, i32 [[MUL_I_I]])
+// CHECK-NEXT:    [[TMP5:%.*]] = tail call <16 x i32> @llvm.aie2.vshift.I512.I512(<16 x i32> [[TMP1]], <16 x i32> [[TMP3]], i32 0, i32 [[MUL_I_I]])
 // CHECK-NEXT:    [[MUL_I:%.*]] = shl i32 [[IDX]], 2
 // CHECK-NEXT:    [[SHL_I:%.*]] = shl i32 15, [[MUL_I]]
 // CHECK-NEXT:    [[TMP6:%.*]] = bitcast <16 x float> [[V:%.*]] to <16 x i32>
@@ -1876,18 +1874,18 @@ v16float test_insert(v16float v, int idx, v4float b) {
 
 // CHECK-LABEL: @_Z11test_insertDv8_fiDv4_f(
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[TMP0:%.*]] = bitcast <8 x float> [[V:%.*]] to <8 x i32>
-// CHECK-NEXT:    [[TMP1:%.*]] = tail call <16 x i32> @llvm.aie2.set.I512.I256(<8 x i32> [[TMP0]], i32 0)
+// CHECK-NEXT:    [[TMP0:%.*]] = tail call noundef <16 x float> @llvm.aie2.v16float()
+// CHECK-NEXT:    [[TMP1:%.*]] = bitcast <16 x float> [[TMP0]] to <16 x i32>
 // CHECK-NEXT:    [[TMP2:%.*]] = bitcast <4 x float> [[B:%.*]] to <4 x i32>
 // CHECK-NEXT:    [[TMP3:%.*]] = tail call <16 x i32> @llvm.aie2.set.I512.I128(<4 x i32> [[TMP2]])
-// CHECK-NEXT:    [[TMP4:%.*]] = tail call noundef <16 x float> @llvm.aie2.v16float()
-// CHECK-NEXT:    [[TMP5:%.*]] = bitcast <16 x float> [[TMP4]] to <16 x i32>
-// CHECK-NEXT:    [[TMP6:%.*]] = shl i32 [[IDX:%.*]], 4
-// CHECK-NEXT:    [[MUL_I_I_I:%.*]] = sub i32 64, [[TMP6]]
-// CHECK-NEXT:    [[TMP7:%.*]] = tail call <16 x i32> @llvm.aie2.vshift.I512.I512(<16 x i32> [[TMP5]], <16 x i32> [[TMP3]], i32 0, i32 [[MUL_I_I_I]])
+// CHECK-NEXT:    [[TMP4:%.*]] = shl i32 [[IDX:%.*]], 4
+// CHECK-NEXT:    [[MUL_I_I_I:%.*]] = sub i32 64, [[TMP4]]
+// CHECK-NEXT:    [[TMP5:%.*]] = tail call <16 x i32> @llvm.aie2.vshift.I512.I512(<16 x i32> [[TMP1]], <16 x i32> [[TMP3]], i32 0, i32 [[MUL_I_I_I]])
+// CHECK-NEXT:    [[TMP6:%.*]] = bitcast <8 x float> [[V:%.*]] to <8 x i32>
+// CHECK-NEXT:    [[TMP7:%.*]] = tail call <16 x i32> @llvm.aie2.set.I512.I256(<8 x i32> [[TMP6]], i32 0)
 // CHECK-NEXT:    [[MUL_I_I:%.*]] = shl i32 [[IDX]], 2
 // CHECK-NEXT:    [[SHL_I_I:%.*]] = shl i32 15, [[MUL_I_I]]
-// CHECK-NEXT:    [[TMP8:%.*]] = tail call <16 x i32> @llvm.aie2.vsel32(<16 x i32> [[TMP1]], <16 x i32> [[TMP7]], i32 [[SHL_I_I]])
+// CHECK-NEXT:    [[TMP8:%.*]] = tail call <16 x i32> @llvm.aie2.vsel32(<16 x i32> [[TMP7]], <16 x i32> [[TMP5]], i32 [[SHL_I_I]])
 // CHECK-NEXT:    [[TMP9:%.*]] = tail call <8 x i32> @llvm.aie2.ext.I256.I512(<16 x i32> [[TMP8]], i32 0)
 // CHECK-NEXT:    [[RETVAL_0_I3_I:%.*]] = bitcast <8 x i32> [[TMP9]] to <8 x float>
 // CHECK-NEXT:    ret <8 x float> [[RETVAL_0_I3_I]]
@@ -1935,10 +1933,10 @@ v4float test_extract_v4float(v8float v, int idx) {
 // CHECK-NEXT:    [[TMP3:%.*]] = bitcast <16 x float> [[TMP2]] to <16 x i32>
 // CHECK-NEXT:    [[TMP4:%.*]] = tail call <16 x i32> @llvm.aie2.vshift.I512.I512(<16 x i32> [[TMP3]], <16 x i32> [[TMP1]], i32 0, i32 48)
 // CHECK-NEXT:    [[TMP5:%.*]] = tail call <8 x i32> @llvm.aie2.ext.I256.I512(<16 x i32> [[TMP4]], i32 0)
-// CHECK-NEXT:    [[TMP6:%.*]] = tail call <16 x i32> @llvm.aie2.set.I512.I256(<8 x i32> [[TMP5]], i32 0)
-// CHECK-NEXT:    [[TMP7:%.*]] = bitcast <4 x float> [[V0:%.*]] to <4 x i32>
-// CHECK-NEXT:    [[TMP8:%.*]] = tail call <16 x i32> @llvm.aie2.set.I512.I128(<4 x i32> [[TMP7]])
-// CHECK-NEXT:    [[TMP9:%.*]] = tail call <16 x i32> @llvm.aie2.vsel32(<16 x i32> [[TMP6]], <16 x i32> [[TMP8]], i32 15)
+// CHECK-NEXT:    [[TMP6:%.*]] = bitcast <4 x float> [[V0:%.*]] to <4 x i32>
+// CHECK-NEXT:    [[TMP7:%.*]] = tail call <16 x i32> @llvm.aie2.set.I512.I128(<4 x i32> [[TMP6]])
+// CHECK-NEXT:    [[TMP8:%.*]] = tail call <16 x i32> @llvm.aie2.set.I512.I256(<8 x i32> [[TMP5]], i32 0)
+// CHECK-NEXT:    [[TMP9:%.*]] = tail call <16 x i32> @llvm.aie2.vsel32(<16 x i32> [[TMP8]], <16 x i32> [[TMP7]], i32 15)
 // CHECK-NEXT:    [[TMP10:%.*]] = tail call <8 x i32> @llvm.aie2.ext.I256.I512(<16 x i32> [[TMP9]], i32 0)
 // CHECK-NEXT:    [[RETVAL_0_I3_I_I:%.*]] = bitcast <8 x i32> [[TMP10]] to <8 x float>
 // CHECK-NEXT:    ret <8 x float> [[RETVAL_0_I3_I_I]]

--- a/clang/test/CodeGen/aie/aie2/aiev2-srs-intrinsics.cpp
+++ b/clang/test/CodeGen/aie/aie2/aiev2-srs-intrinsics.cpp
@@ -5,7 +5,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// (c) Copyright 2023-2024 Advanced Micro Devices, Inc. or its affiliates
+// (c) Copyright 2023-2025 Advanced Micro Devices, Inc. or its affiliates
 //
 //===----------------------------------------------------------------------===//
 // RUN: %clang -O2 %s --target=aie2 -nostdlibinc -S -emit-llvm -o - | FileCheck %s
@@ -26,7 +26,7 @@ v16int32 test_srs_to_int32(v16acc64 acc, int shft, int sign) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call <16 x i32> @llvm.aie2.I512.v16.acc64.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <16 x i32> @llvm.aie2.I512.v16.acc64.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <16 x i32> [[TMP2]]
@@ -50,7 +50,7 @@ v16uint32 test_srs_to_uint32(v16acc64 acc, int shft, int sign) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call <16 x i32> @llvm.aie2.I512.v16.acc64.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <16 x i32> @llvm.aie2.I512.v16.acc64.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <16 x i32> [[TMP2]]

--- a/clang/test/CodeGen/aie/aie2/aiev2-srs-intrinsics.cpp
+++ b/clang/test/CodeGen/aie/aie2/aiev2-srs-intrinsics.cpp
@@ -26,7 +26,7 @@ v16int32 test_srs_to_int32(v16acc64 acc, int shft, int sign) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <16 x i32> @llvm.aie2.I512.v16.acc64.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call <16 x i32> @llvm.aie2.I512.v16.acc64.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <16 x i32> [[TMP2]]
@@ -50,7 +50,7 @@ v16uint32 test_srs_to_uint32(v16acc64 acc, int shft, int sign) {
 // CHECK-NEXT:    [[TMP1:%.*]] = tail call noundef i32 @llvm.aie2.get.ctrl.reg(i32 6)
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[SAT:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[RND:%.*]])
-// CHECK-NEXT:    [[TMP2:%.*]] = tail call noundef <16 x i32> @llvm.aie2.I512.v16.acc64.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
+// CHECK-NEXT:    [[TMP2:%.*]] = tail call <16 x i32> @llvm.aie2.I512.v16.acc64.srs(<16 x i64> [[ACC:%.*]], i32 [[SHFT:%.*]], i32 [[SIGN:%.*]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 9, i32 [[TMP0]])
 // CHECK-NEXT:    tail call void @llvm.aie2.set.ctrl.reg(i32 6, i32 [[TMP1]])
 // CHECK-NEXT:    ret <16 x i32> [[TMP2]]

--- a/clang/test/CodeGen/aie/aie2p/aie2p-bank-annotation.cpp
+++ b/clang/test/CodeGen/aie/aie2p/aie2p-bank-annotation.cpp
@@ -185,7 +185,7 @@ v128uint4 test_intrinsic_annotated_pointer_reference_fill_pop(v64bfp16ebs8_unali
 }
 
 // CHECK-LABEL: define dso_local void @_Z47test_intrinsic_annotated_pointer_reference_loopRPU3AS522v64bfp16ebs8_unaligned12v64bfp16ebs8i(
-// CHECK-SAME: ptr nocapture nonnull align 4 dereferenceable(4) [[P:%.*]], [[STRUCT_V64BFP16EBS8:%.*]] [[V_COERCE:%.*]], i32 noundef [[NUM:%.*]]) local_unnamed_addr #[[ATTR4:[0-9]+]] {
+// CHECK-SAME: ptr nocapture nonnull align 4 dereferenceable(4) [[P:%.*]], [[STRUCT_V64BFP16EBS8:%.*]] [[V_COERCE:%.*]], i32 noundef [[NUM:%.*]]) local_unnamed_addr #[[ATTR2]] {
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[CMP6:%.*]] = icmp sgt i32 [[NUM]], 0
 // CHECK-NEXT:    br i1 [[CMP6]], label [[FOR_BODY_LR_PH:%.*]], label [[FOR_COND_CLEANUP:%.*]]
@@ -212,7 +212,7 @@ v128uint4 test_intrinsic_annotated_pointer_reference_fill_pop(v64bfp16ebs8_unali
 // CHECK-NEXT:    store ptr addrspace(5) [[TMP8]], ptr [[P]], align 4
 // CHECK-NEXT:    [[INC]] = add nuw nsw i32 [[I_09]], 1
 // CHECK-NEXT:    [[EXITCOND_NOT:%.*]] = icmp eq i32 [[INC]], [[NUM]]
-// CHECK-NEXT:    br i1 [[EXITCOND_NOT]], label [[FOR_COND_CLEANUP]], label [[FOR_BODY]], !llvm.loop [[LOOP10:![0-9]+]]
+// CHECK-NEXT:    br i1 [[EXITCOND_NOT]], label [[FOR_COND_CLEANUP]], label [[FOR_BODY]], !llvm.loop [[LOOP9:![0-9]+]]
 //
 void test_intrinsic_annotated_pointer_reference_loop(
     v64bfp16ebs8_unaligned __aie_dm_resource_a *&p, v64bfp16ebs8 v, int num) {
@@ -225,7 +225,7 @@ void test_intrinsic_annotated_pointer_reference_loop(
 }
 
 // CHECK-LABEL: define dso_local void @_Z45test_intrinsic_default_pointer_reference_loopRP22v64bfp16ebs8_unaligned12v64bfp16ebs8i(
-// CHECK-SAME: ptr nocapture nonnull align 4 dereferenceable(4) [[P:%.*]], [[STRUCT_V64BFP16EBS8:%.*]] [[V_COERCE:%.*]], i32 noundef [[NUM:%.*]]) local_unnamed_addr #[[ATTR4]] {
+// CHECK-SAME: ptr nocapture nonnull align 4 dereferenceable(4) [[P:%.*]], [[STRUCT_V64BFP16EBS8:%.*]] [[V_COERCE:%.*]], i32 noundef [[NUM:%.*]]) local_unnamed_addr #[[ATTR2]] {
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[CMP6:%.*]] = icmp sgt i32 [[NUM]], 0
 // CHECK-NEXT:    br i1 [[CMP6]], label [[FOR_BODY_LR_PH:%.*]], label [[FOR_COND_CLEANUP:%.*]]
@@ -252,7 +252,7 @@ void test_intrinsic_annotated_pointer_reference_loop(
 // CHECK-NEXT:    store ptr [[TMP8]], ptr [[P]], align 4
 // CHECK-NEXT:    [[INC]] = add nuw nsw i32 [[I_09]], 1
 // CHECK-NEXT:    [[EXITCOND_NOT:%.*]] = icmp eq i32 [[INC]], [[NUM]]
-// CHECK-NEXT:    br i1 [[EXITCOND_NOT]], label [[FOR_COND_CLEANUP]], label [[FOR_BODY]], !llvm.loop [[LOOP13:![0-9]+]]
+// CHECK-NEXT:    br i1 [[EXITCOND_NOT]], label [[FOR_COND_CLEANUP]], label [[FOR_BODY]], !llvm.loop [[LOOP12:![0-9]+]]
 //
 void test_intrinsic_default_pointer_reference_loop(
     v64bfp16ebs8_unaligned *&p, v64bfp16ebs8 v, int num) {
@@ -272,8 +272,8 @@ void test_intrinsic_default_pointer_reference_loop(
 // CHECK: [[TBAA7]] = !{[[META8:![0-9]+]], [[META8]], i64 0}
 // CHECK: [[META8]] = !{!"p1 void", [[META9:![0-9]+]], i64 0}
 // CHECK: [[META9]] = !{!"any pointer", [[META3]], i64 0}
-// CHECK: [[LOOP10]] = distinct !{[[LOOP10]], [[META11:![0-9]+]], [[META12:![0-9]+]]}
-// CHECK: [[META11]] = !{!"llvm.loop.mustprogress"}
-// CHECK: [[META12]] = !{!"llvm.loop.unroll.disable"}
-// CHECK: [[LOOP13]] = distinct !{[[LOOP13]], [[META11]], [[META12]]}
+// CHECK: [[LOOP9]] = distinct !{[[LOOP9]], [[META10:![0-9]+]], [[META11:![0-9]+]]}
+// CHECK: [[META10]] = !{!"llvm.loop.mustprogress"}
+// CHECK: [[META11]] = !{!"llvm.loop.unroll.disable"}
+// CHECK: [[LOOP12]] = distinct !{[[LOOP12]], [[META10]], [[META11]]}
 //.

--- a/clang/test/CodeGen/aie/aie2p/aie2p-bank-annotation.cpp
+++ b/clang/test/CodeGen/aie/aie2p/aie2p-bank-annotation.cpp
@@ -35,7 +35,7 @@ void test_intrinsic_annotated_pointer(v64bfp16ebs8_unaligned __aie_dm_resource_a
 }
 
 // CHECK-LABEL: define dso_local noundef <64 x i8> @_Z43test_intrinsic_annotated_pointer_fillx_popxPU3AS522v64bfp16ebs8_unalignedPU3AS6Dv64_DB8_R12fifo_state_t(
-// CHECK-SAME: ptr addrspace(5) [[P_UNALIGNED:%.*]], ptr addrspace(6) [[P:%.*]], ptr nocapture nonnull align 64 dereferenceable(256) [[S:%.*]]) local_unnamed_addr #[[ATTR1:[0-9]+]] {
+// CHECK-SAME: ptr addrspace(5) [[P_UNALIGNED:%.*]], ptr addrspace(6) [[P:%.*]], ptr nocapture nonnull align 64 dereferenceable(256) [[S:%.*]]) local_unnamed_addr #[[ATTR0]] {
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[POS1_I_I:%.*]] = getelementptr inbounds nuw i8, ptr [[S]], i20 128
 // CHECK-NEXT:    [[EXTRA3_I_I:%.*]] = getelementptr inbounds nuw i8, ptr [[S]], i20 192
@@ -65,7 +65,7 @@ v128uint4 test_intrinsic_annotated_pointer_fillx_popx(v64bfp16ebs8_unaligned __a
 }
 
 // CHECK-LABEL: define dso_local noundef <64 x i8> @_Z41test_intrinsic_annotated_pointer_fill_popPU3AS522v64bfp16ebs8_unalignedPU3AS6Dv64_DB8_R12fifo_state_t(
-// CHECK-SAME: ptr addrspace(5) [[P_UNALIGNED:%.*]], ptr addrspace(6) [[P:%.*]], ptr nocapture nonnull align 64 dereferenceable(256) [[S:%.*]]) local_unnamed_addr #[[ATTR1]] {
+// CHECK-SAME: ptr addrspace(5) [[P_UNALIGNED:%.*]], ptr addrspace(6) [[P:%.*]], ptr nocapture nonnull align 64 dereferenceable(256) [[S:%.*]]) local_unnamed_addr #[[ATTR0]] {
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[POS1_I:%.*]] = getelementptr inbounds nuw i8, ptr [[S]], i20 128
 // CHECK-NEXT:    [[TMP0:%.*]] = load <32 x i32>, ptr [[S]], align 64, !tbaa [[TBAA2]]
@@ -89,7 +89,7 @@ v128uint4 test_intrinsic_annotated_pointer_fill_pop(v64bfp16ebs8_unaligned __aie
 }
 
 // CHECK-LABEL: define dso_local void @_Z42test_intrinsic_annotated_pointer_referenceRPU3AS522v64bfp16ebs8_unaligned12v64bfp16ebs8R12fifo_state_t(
-// CHECK-SAME: ptr nocapture nonnull align 4 dereferenceable(4) [[P:%.*]], [[STRUCT_V64BFP16EBS8:%.*]] [[V_COERCE:%.*]], ptr nocapture nonnull align 64 dereferenceable(256) [[S:%.*]]) local_unnamed_addr #[[ATTR2:[0-9]+]] {
+// CHECK-SAME: ptr nocapture nonnull align 4 dereferenceable(4) [[P:%.*]], [[STRUCT_V64BFP16EBS8:%.*]] [[V_COERCE:%.*]], ptr nocapture nonnull align 64 dereferenceable(256) [[S:%.*]]) local_unnamed_addr #[[ATTR1:[0-9]+]] {
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[TMP0:%.*]] = extractvalue [[STRUCT_V64BFP16EBS8]] [[V_COERCE]], 0
 // CHECK-NEXT:    [[TMP1:%.*]] = extractvalue [[STRUCT_V64BFP16EBS8]] [[V_COERCE]], 1
@@ -114,7 +114,7 @@ void test_intrinsic_annotated_pointer_reference(v64bfp16ebs8_unaligned __aie_dm_
 
 
 // CHECK-LABEL: define dso_local noundef <64 x i8> @_Z53test_intrinsic_annotated_pointer_reference_fillx_popxRPU3AS522v64bfp16ebs8_unalignedRPU3AS6Dv64_DB8_R12fifo_state_t(
-// CHECK-SAME: ptr nocapture nonnull align 4 dereferenceable(4) [[P_UNALIGNED:%.*]], ptr nocapture nonnull align 4 dereferenceable(4) [[P:%.*]], ptr nocapture nonnull align 64 dereferenceable(256) [[S:%.*]]) local_unnamed_addr #[[ATTR3:[0-9]+]] {
+// CHECK-SAME: ptr nocapture nonnull align 4 dereferenceable(4) [[P_UNALIGNED:%.*]], ptr nocapture nonnull align 4 dereferenceable(4) [[P:%.*]], ptr nocapture nonnull align 64 dereferenceable(256) [[S:%.*]]) local_unnamed_addr #[[ATTR2:[0-9]+]] {
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[POS1_I_I:%.*]] = getelementptr inbounds nuw i8, ptr [[S]], i20 128
 // CHECK-NEXT:    [[EXTRA3_I_I:%.*]] = getelementptr inbounds nuw i8, ptr [[S]], i20 192
@@ -153,7 +153,7 @@ v128uint4 test_intrinsic_annotated_pointer_reference_fillx_popx(v64bfp16ebs8_una
 }
 
 // CHECK-LABEL: define dso_local noundef <64 x i8> @_Z51test_intrinsic_annotated_pointer_reference_fill_popRPU3AS522v64bfp16ebs8_unalignedRPU3AS6Dv64_DB8_R12fifo_state_t(
-// CHECK-SAME: ptr nocapture nonnull align 4 dereferenceable(4) [[P_UNALIGNED:%.*]], ptr nocapture nonnull align 4 dereferenceable(4) [[P:%.*]], ptr nocapture nonnull align 64 dereferenceable(256) [[S:%.*]]) local_unnamed_addr #[[ATTR3]] {
+// CHECK-SAME: ptr nocapture nonnull align 4 dereferenceable(4) [[P_UNALIGNED:%.*]], ptr nocapture nonnull align 4 dereferenceable(4) [[P:%.*]], ptr nocapture nonnull align 64 dereferenceable(256) [[S:%.*]]) local_unnamed_addr #[[ATTR2]] {
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[POS1_I:%.*]] = getelementptr inbounds nuw i8, ptr [[S]], i20 128
 // CHECK-NEXT:    [[TMP0:%.*]] = load ptr addrspace(5), ptr [[P_UNALIGNED]], align 4, !tbaa [[TBAA7]]
@@ -185,7 +185,7 @@ v128uint4 test_intrinsic_annotated_pointer_reference_fill_pop(v64bfp16ebs8_unali
 }
 
 // CHECK-LABEL: define dso_local void @_Z47test_intrinsic_annotated_pointer_reference_loopRPU3AS522v64bfp16ebs8_unaligned12v64bfp16ebs8i(
-// CHECK-SAME: ptr nocapture nonnull align 4 dereferenceable(4) [[P:%.*]], [[STRUCT_V64BFP16EBS8:%.*]] [[V_COERCE:%.*]], i32 noundef [[NUM:%.*]]) local_unnamed_addr #[[ATTR2]] {
+// CHECK-SAME: ptr nocapture nonnull align 4 dereferenceable(4) [[P:%.*]], [[STRUCT_V64BFP16EBS8:%.*]] [[V_COERCE:%.*]], i32 noundef [[NUM:%.*]]) local_unnamed_addr #[[ATTR3:[0-9]+]] {
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[CMP6:%.*]] = icmp sgt i32 [[NUM]], 0
 // CHECK-NEXT:    br i1 [[CMP6]], label [[FOR_BODY_LR_PH:%.*]], label [[FOR_COND_CLEANUP:%.*]]
@@ -212,7 +212,7 @@ v128uint4 test_intrinsic_annotated_pointer_reference_fill_pop(v64bfp16ebs8_unali
 // CHECK-NEXT:    store ptr addrspace(5) [[TMP8]], ptr [[P]], align 4
 // CHECK-NEXT:    [[INC]] = add nuw nsw i32 [[I_09]], 1
 // CHECK-NEXT:    [[EXITCOND_NOT:%.*]] = icmp eq i32 [[INC]], [[NUM]]
-// CHECK-NEXT:    br i1 [[EXITCOND_NOT]], label [[FOR_COND_CLEANUP]], label [[FOR_BODY]], !llvm.loop [[LOOP9:![0-9]+]]
+// CHECK-NEXT:    br i1 [[EXITCOND_NOT]], label [[FOR_COND_CLEANUP]], label [[FOR_BODY]], !llvm.loop [[LOOP10:![0-9]+]]
 //
 void test_intrinsic_annotated_pointer_reference_loop(
     v64bfp16ebs8_unaligned __aie_dm_resource_a *&p, v64bfp16ebs8 v, int num) {
@@ -225,7 +225,7 @@ void test_intrinsic_annotated_pointer_reference_loop(
 }
 
 // CHECK-LABEL: define dso_local void @_Z45test_intrinsic_default_pointer_reference_loopRP22v64bfp16ebs8_unaligned12v64bfp16ebs8i(
-// CHECK-SAME: ptr nocapture nonnull align 4 dereferenceable(4) [[P:%.*]], [[STRUCT_V64BFP16EBS8:%.*]] [[V_COERCE:%.*]], i32 noundef [[NUM:%.*]]) local_unnamed_addr #[[ATTR2]] {
+// CHECK-SAME: ptr nocapture nonnull align 4 dereferenceable(4) [[P:%.*]], [[STRUCT_V64BFP16EBS8:%.*]] [[V_COERCE:%.*]], i32 noundef [[NUM:%.*]]) local_unnamed_addr #[[ATTR3]] {
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[CMP6:%.*]] = icmp sgt i32 [[NUM]], 0
 // CHECK-NEXT:    br i1 [[CMP6]], label [[FOR_BODY_LR_PH:%.*]], label [[FOR_COND_CLEANUP:%.*]]
@@ -252,7 +252,7 @@ void test_intrinsic_annotated_pointer_reference_loop(
 // CHECK-NEXT:    store ptr [[TMP8]], ptr [[P]], align 4
 // CHECK-NEXT:    [[INC]] = add nuw nsw i32 [[I_09]], 1
 // CHECK-NEXT:    [[EXITCOND_NOT:%.*]] = icmp eq i32 [[INC]], [[NUM]]
-// CHECK-NEXT:    br i1 [[EXITCOND_NOT]], label [[FOR_COND_CLEANUP]], label [[FOR_BODY]], !llvm.loop [[LOOP12:![0-9]+]]
+// CHECK-NEXT:    br i1 [[EXITCOND_NOT]], label [[FOR_COND_CLEANUP]], label [[FOR_BODY]], !llvm.loop [[LOOP13:![0-9]+]]
 //
 void test_intrinsic_default_pointer_reference_loop(
     v64bfp16ebs8_unaligned *&p, v64bfp16ebs8 v, int num) {
@@ -272,8 +272,8 @@ void test_intrinsic_default_pointer_reference_loop(
 // CHECK: [[TBAA7]] = !{[[META8:![0-9]+]], [[META8]], i64 0}
 // CHECK: [[META8]] = !{!"p1 void", [[META9:![0-9]+]], i64 0}
 // CHECK: [[META9]] = !{!"any pointer", [[META3]], i64 0}
-// CHECK: [[LOOP9]] = distinct !{[[LOOP9]], [[META10:![0-9]+]], [[META11:![0-9]+]]}
-// CHECK: [[META10]] = !{!"llvm.loop.mustprogress"}
-// CHECK: [[META11]] = !{!"llvm.loop.unroll.disable"}
-// CHECK: [[LOOP12]] = distinct !{[[LOOP12]], [[META10]], [[META11]]}
+// CHECK: [[LOOP10]] = distinct !{[[LOOP10]], [[META11:![0-9]+]], [[META12:![0-9]+]]}
+// CHECK: [[META11]] = !{!"llvm.loop.mustprogress"}
+// CHECK: [[META12]] = !{!"llvm.loop.unroll.disable"}
+// CHECK: [[LOOP13]] = distinct !{[[LOOP13]], [[META11]], [[META12]]}
 //.

--- a/llvm/include/llvm/IR/IntrinsicsAIE.td
+++ b/llvm/include/llvm/IR/IntrinsicsAIE.td
@@ -18,14 +18,14 @@ let TargetPrefix = "aie" in {
 class EventIntrinsic
     : Intrinsic<[],
                 [llvm_i32_ty],
-                [IntrHasSideEffects, IntrNoMem, IntrWillReturn]>; //[IntrHasSideEffects, IntrNoMem, ImmArg<ArgIndex<0>>]>;
+                [IntrHasSideEffects, IntrNoMem]>; //[IntrHasSideEffects, IntrNoMem, ImmArg<ArgIndex<0>>]>;
 // Atomics
 // FIXME: The flags for this are wrong.  However, when setting the
 // flags "correctly", then clang -O3 complains.
 class LockIntrinsic
     : Intrinsic<[],
                 [llvm_i32_ty, llvm_i32_ty],
-                [IntrWillReturn]>; // IntrHasSideEffects, IntrNoMem]>; //, ImmArg<ArgIndex<1>>]>;
+                []>; // IntrHasSideEffects, IntrNoMem]>; //, ImmArg<ArgIndex<1>>]>;
 // class LockImmIntrinsic
 //     : Intrinsic<[],
 //                 [llvm_i32_ty, llvm_i32_ty],
@@ -33,160 +33,160 @@ class LockIntrinsic
 class PacketHeaderIntrinsic
     : Intrinsic<[llvm_i32_ty],
                 [llvm_i32_ty, llvm_i32_ty],
-                [IntrWillReturn]>; //IntrHasSideEffects, IntrNoMem]; //, ImmArg<ArgIndex<1>>, ImmArg<ArgIndex<2>>]>;
+                []>; //IntrHasSideEffects, IntrNoMem]; //, ImmArg<ArgIndex<1>>, ImmArg<ArgIndex<2>>]>;
 class CtrlPacketHeaderIntrinsic
     : Intrinsic<[llvm_i32_ty],
                 [llvm_i20_ty, llvm_i32_ty, llvm_i32_ty, llvm_i32_ty],
-                [IntrWillReturn]>; //IntrHasSideEffects, IntrNoMem, ImmArg<ArgIndex<1>>, ImmArg<ArgIndex<2>>]>;
+                []>; //IntrHasSideEffects, IntrNoMem, ImmArg<ArgIndex<1>>, ImmArg<ArgIndex<2>>]>;
 class StreamReadIntrinsic
     : Intrinsic<[llvm_i32_ty],
                 [llvm_i32_ty],
-					 [IntrNoMem, IntrWillReturn]>; //, ImmArg<ArgIndex<0>>]>;
+					 [IntrNoMem]>; //, ImmArg<ArgIndex<0>>]>;
                 //[IntrHasSideEffects, IntrNoMem]>; //, ImmArg<ArgIndex<0>>]>;
 class StreamWriteIntrinsic
     : Intrinsic<[],
                 [llvm_i32_ty, llvm_i32_ty],
-                [IntrHasSideEffects, IntrNoMem, IntrWillReturn]>; //, ImmArg<ArgIndex<0>>]>;
+                [IntrHasSideEffects, IntrNoMem]>; //, ImmArg<ArgIndex<0>>]>;
 class StreamWriteLastIntrinsic
     : Intrinsic<[],
                 [llvm_i32_ty, llvm_i32_ty, llvm_i32_ty],
-                [IntrHasSideEffects, IntrNoMem, IntrWillReturn, ImmArg<ArgIndex<0>>]>;
+                [IntrHasSideEffects, IntrNoMem, ImmArg<ArgIndex<0>>]>;
 class StreamReadFIntrinsic
     : Intrinsic<[llvm_float_ty],
                 [llvm_i32_ty],
-                [IntrHasSideEffects, IntrNoMem, IntrWillReturn, ImmArg<ArgIndex<0>>]>;
+                [IntrHasSideEffects, IntrNoMem, ImmArg<ArgIndex<0>>]>;
 class StreamWriteFIntrinsic
     : Intrinsic<[],
                 [llvm_i32_ty, llvm_float_ty],
-                [IntrHasSideEffects, IntrNoMem, IntrWillReturn, ImmArg<ArgIndex<0>>]>;
+                [IntrHasSideEffects, IntrNoMem, ImmArg<ArgIndex<0>>]>;
 class StreamWriteFLastIntrinsic
     : Intrinsic<[],
                 [llvm_i32_ty, llvm_float_ty, llvm_i32_ty],
-                [IntrHasSideEffects, IntrNoMem, IntrWillReturn, ImmArg<ArgIndex<0>>]>;
+                [IntrHasSideEffects, IntrNoMem, ImmArg<ArgIndex<0>>]>;
 
 // Set/Get a bit in a value, mapped to a GPR
 class BitSetIntrinsic
 	 : Intrinsic<[llvm_i32_ty],
 		          [llvm_i32_ty, llvm_i32_ty, llvm_i32_ty],
-					 [IntrNoMem, IntrWillReturn]>; //, ImmArg<ArgIndex<2>>]>;
+					 [IntrNoMem]>; //, ImmArg<ArgIndex<2>>]>;
 class BitGetIntrinsic
 	 : Intrinsic<[llvm_i32_ty],
 		          [llvm_i32_ty, llvm_i32_ty],
-					 [IntrNoMem, IntrWillReturn]>; //, ImmArg<ArgIndex<1>>]>;
+					 [IntrNoMem]>; //, ImmArg<ArgIndex<1>>]>;
 
 // Set/Get a bit in a specific control/status register
 class BitSetRegIntrinsic
 	 : Intrinsic<[llvm_i32_ty],
 		          [llvm_i32_ty, llvm_i32_ty],
-					 [IntrNoMem, IntrWillReturn]>; //, ImmArg<ArgIndex<1>>]>;
+					 [IntrNoMem]>; //, ImmArg<ArgIndex<1>>]>;
 class BitGetRegIntrinsic
 	 : Intrinsic<[llvm_i32_ty],
 		          [llvm_i32_ty],
-					 [IntrNoMem, IntrWillReturn]>; //, ImmArg<ArgIndex<0>>]>;
+					 [IntrNoMem]>; //, ImmArg<ArgIndex<0>>]>;
 
 // Non-linear functions
 class NLFFltFltIntrinsic
     : Intrinsic<[llvm_float_ty],
                 [llvm_float_ty],
-                [IntrNoMem, IntrWillReturn]>;
+                [IntrNoMem]>;
 class NLFFltFixIntrinsic
     : Intrinsic<[llvm_float_ty],
                 [llvm_i32_ty, llvm_i32_ty],
-                [IntrNoMem, IntrWillReturn]>;
+                [IntrNoMem]>;
 class NLFFixFltIntrinsic
     : Intrinsic<[llvm_i32_ty],
                 [llvm_i32_ty, llvm_float_ty],
-                [IntrNoMem, IntrWillReturn]>;
+                [IntrNoMem]>;
 class NLFFixFixIntrinsic
     : Intrinsic<[llvm_i32_ty],
                 [llvm_i32_ty, llvm_i32_ty, llvm_i32_ty],
-                [IntrNoMem, IntrWillReturn]>;
+                [IntrNoMem]>;
 
 class VecFP4Intrinsic
-     : Intrinsic<[llvm_v4f32_ty], [], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v4f32_ty], [], [IntrNoMem]>;
 class VecFP8Intrinsic
-     : Intrinsic<[llvm_v8f32_ty], [], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v8f32_ty], [], [IntrNoMem]>;
 class VecFP16Intrinsic
-     : Intrinsic<[llvm_v16f32_ty], [], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v16f32_ty], [], [IntrNoMem]>;
 class VecFP32Intrinsic
-     : Intrinsic<[llvm_v32f32_ty], [], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v32f32_ty], [], [IntrNoMem]>;
 //Vector Int
 class VecV2I32Intrinsic
-     : Intrinsic<[llvm_v2i32_ty], [], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v2i32_ty], [], [IntrNoMem]>;
 class VecV16I16Intrinsic
-     : Intrinsic<[llvm_v16i16_ty], [], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v16i16_ty], [], [IntrNoMem]>;
 class VecV32I16Intrinsic
-     : Intrinsic<[llvm_v32i16_ty], [], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v32i16_ty], [], [IntrNoMem]>;
 class VecV16I32Intrinsic
-     : Intrinsic<[llvm_v16i32_ty], [], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v16i32_ty], [], [IntrNoMem]>;
 class VecV32I32Intrinsic
-     : Intrinsic<[llvm_v32i32_ty], [], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v32i32_ty], [], [IntrNoMem]>;
 class VecV128I8Intrinsic
-     : Intrinsic<[llvm_v128i8_ty], [], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v128i8_ty], [], [IntrNoMem]>;
 
 class VecV8I48Intrinsic
-     : Intrinsic<[llvm_v8i48_ty], [], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v8i48_ty], [], [IntrNoMem]>;
 
 class VecV16I48Intrinsic
-     : Intrinsic<[llvm_v16i48_ty], [], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v16i48_ty], [], [IntrNoMem]>;
 
 class UPDVV8I32Intrinsic
 	 : Intrinsic<[llvm_v8i32_ty],
 		          [llvm_v8i32_ty, llvm_v4i32_ty],
-					 [IntrNoMem, IntrWillReturn]>; //, ImmArg<ArgIndex<0>>]>;
+					 [IntrNoMem]>; //, ImmArg<ArgIndex<0>>]>;
 
 class UPDWV16I32Intrinsic
 	 : Intrinsic<[llvm_v16i32_ty],
 		          [llvm_v16i32_ty, llvm_v8i32_ty],
-					 [IntrNoMem, IntrWillReturn]>; //, ImmArg<ArgIndex<0>>]>;
+					 [IntrNoMem]>; //, ImmArg<ArgIndex<0>>]>;
 class EXTVV8I32Intrinsic
 	 : Intrinsic<[llvm_v4i32_ty],
 		          [llvm_v8i32_ty],
-					 [IntrNoMem, IntrWillReturn]>; //, ImmArg<ArgIndex<0>>]>;
+					 [IntrNoMem]>; //, ImmArg<ArgIndex<0>>]>;
 
 class EXTWV16I32Intrinsic
 	 : Intrinsic<[llvm_v8i32_ty],
 		          [llvm_v16i32_ty],
-					 [IntrNoMem, IntrWillReturn]>; //, ImmArg<ArgIndex<0>>]>;
+					 [IntrNoMem]>; //, ImmArg<ArgIndex<0>>]>;
 class EXTWV32I16Intrinsic
 	 : Intrinsic<[llvm_v16i16_ty],
 		          [llvm_v32i16_ty],
-					 [IntrNoMem, IntrWillReturn]>; //, ImmArg<ArgIndex<0>>]>;
+					 [IntrNoMem]>; //, ImmArg<ArgIndex<0>>]>;
 class ConcatV32I16Intrinsic
 	 : Intrinsic<[llvm_v32i16_ty],
 		          [llvm_v16i16_ty, llvm_v16i16_ty],
-					 [IntrNoMem, IntrWillReturn]>; //, ImmArg<ArgIndex<0>>]>;
+					 [IntrNoMem]>; //, ImmArg<ArgIndex<0>>]>;
 class ConcatV64I16Intrinsic
 	 : Intrinsic<[llvm_v64i16_ty],
 		          [llvm_v32i16_ty, llvm_v32i16_ty],
-					 [IntrNoMem, IntrWillReturn]>; //, ImmArg<ArgIndex<0>>]>;
+					 [IntrNoMem]>; //, ImmArg<ArgIndex<0>>]>;
 
 class VLMUL4V32I32Intrinsic
 	 : Intrinsic<[llvm_v8i48_ty],
 		          [llvm_v32i32_ty, llvm_v8i32_ty, llvm_i32_ty, llvm_i32_ty,
                    llvm_i32_ty, llvm_v2i32_ty, llvm_v2i32_ty, llvm_v2i32_ty],
-					 [IntrNoMem, IntrWillReturn]>; //, ImmArg<ArgIndex<0>>]>;
+					 [IntrNoMem]>; //, ImmArg<ArgIndex<0>>]>;
 class VLMUL4V16I32Intrinsic
 	 : Intrinsic<[llvm_v8i48_ty],
 		          [llvm_v16i32_ty, llvm_v8i32_ty, llvm_i32_ty, llvm_i32_ty,
                    llvm_i32_ty, llvm_v2i32_ty, llvm_v2i32_ty, llvm_v2i32_ty],
-					 [IntrNoMem, IntrWillReturn]>; //, ImmArg<ArgIndex<0>>]>;
+					 [IntrNoMem]>; //, ImmArg<ArgIndex<0>>]>;
 class VLMUL8V32I32Intrinsic
 	 : Intrinsic<[llvm_v16i48_ty],
 		          [llvm_v32i32_ty, llvm_v8i32_ty, llvm_i32_ty, llvm_i32_ty,
                    llvm_i32_ty, llvm_v2i32_ty, llvm_v2i32_ty, llvm_v2i32_ty],
-					 [IntrNoMem, IntrWillReturn]>; //, ImmArg<ArgIndex<0>>]>;
+					 [IntrNoMem]>; //, ImmArg<ArgIndex<0>>]>;
 class VMUL16V32I32Intrinsic
 	 : Intrinsic<[llvm_v16i48_ty],
 		          [llvm_v32i32_ty, llvm_v16i16_ty, llvm_i32_ty, llvm_i32_ty,
                    llvm_i32_ty, llvm_v2i32_ty, llvm_v2i32_ty, llvm_v2i32_ty],
-					 [IntrNoMem, IntrWillReturn]>; //, ImmArg<ArgIndex<0>>]>;
+					 [IntrNoMem]>; //, ImmArg<ArgIndex<0>>]>;
 
 class VMUL16V128I8Intrinsic
 	 : Intrinsic<[llvm_v16i48_ty],
 		          [llvm_v128i8_ty, llvm_v32i8_ty, llvm_i32_ty, llvm_i32_ty,
                    llvm_i32_ty, llvm_v2i32_ty, llvm_v2i32_ty, llvm_v2i32_ty],
-					 [IntrNoMem, IntrWillReturn]>; //, ImmArg<ArgIndex<0>>]>;
+					 [IntrNoMem]>; //, ImmArg<ArgIndex<0>>]>;
 //class VMUL16V128I8Intrinsic
 //	 : Intrinsic<[llvm_v16i48_ty],
 //		          [llvm_v128i8_ty, llvm_i32_ty, llvm_v2i32_ty, llvm_i32_ty,
@@ -196,68 +196,68 @@ class VMAC16V32I32Intrinsic
 	 : Intrinsic<[llvm_v16i48_ty],
 		          [llvm_v32i32_ty, llvm_v16i16_ty, llvm_v16i48_ty, llvm_i32_ty, llvm_i32_ty,
                    llvm_i32_ty, llvm_v2i32_ty, llvm_v2i32_ty, llvm_v2i32_ty],
-					 [IntrNoMem, IntrWillReturn]>; //, ImmArg<ArgIndex<0>>]>;
+					 [IntrNoMem]>; //, ImmArg<ArgIndex<0>>]>;
 class VMAC16V64I16Intrinsic
 	 : Intrinsic<[llvm_v16i48_ty],
 		          [llvm_v64i16_ty, llvm_v8i32_ty, llvm_v16i48_ty, llvm_i32_ty, llvm_i32_ty,
                    llvm_i32_ty, llvm_v2i32_ty, llvm_v2i32_ty, llvm_v2i32_ty],
-					 [IntrNoMem, IntrWillReturn]>; //, ImmArg<ArgIndex<0>>]>;
+					 [IntrNoMem]>; //, ImmArg<ArgIndex<0>>]>;
 class VMAC16V128I8Intrinsic
 	 : Intrinsic<[llvm_v16i48_ty],
 		          [llvm_v128i8_ty, llvm_v32i8_ty, llvm_v16i48_ty, llvm_i32_ty, llvm_i32_ty,
                    llvm_i32_ty, llvm_v2i32_ty, llvm_v2i32_ty, llvm_v2i32_ty],
-					 [IntrNoMem, IntrWillReturn]>; //, ImmArg<ArgIndex<0>>]>;
+					 [IntrNoMem]>; //, ImmArg<ArgIndex<0>>]>;
 class VMAC80Intrinsic
 	 : Intrinsic<[llvm_v16i48_ty],
 		          [llvm_v8i64_ty, llvm_v32i32_ty, llvm_v16i48_ty, llvm_i32_ty, llvm_i32_ty,
                    llvm_i32_ty, llvm_v2i32_ty, llvm_v2i32_ty, llvm_v2i32_ty],
-					 [IntrNoMem, IntrWillReturn]>; //, ImmArg<ArgIndex<0>>]>;
+					 [IntrNoMem]>; //, ImmArg<ArgIndex<0>>]>;
 class VecFPMULIntrinsic
 	 : Intrinsic<[llvm_v8f32_ty],
 		          [llvm_v32f32_ty, llvm_i32_ty, llvm_i32_ty,
                    llvm_v8f32_ty, llvm_i32_ty, llvm_i32_ty, llvm_i32_ty, llvm_i32_ty],
-					 [IntrNoMem, IntrWillReturn]>; //, ImmArg<ArgIndex<0>>]>;
+					 [IntrNoMem]>; //, ImmArg<ArgIndex<0>>]>;
 class VecFPMACIntrinsic
 	 : Intrinsic<[llvm_v8f32_ty],
 		          [llvm_v8f32_ty, llvm_v32f32_ty, llvm_i32_ty, llvm_i32_ty,
                                   llvm_v8f32_ty, llvm_i32_ty, llvm_i32_ty,
                                   llvm_i32_ty, llvm_i32_ty],
-					 [IntrNoMem, IntrWillReturn]>; //, ImmArg<ArgIndex<0>>]>;
+					 [IntrNoMem]>; //, ImmArg<ArgIndex<0>>]>;
 
 // Floating point intrinsics with symmetric operand types
 class VecFPSimpleMULIntrinsic
 	 : Intrinsic<[llvm_v8f32_ty/*, llvm_i32_ty*/], [llvm_v8f32_ty, llvm_v8f32_ty,
                                    llvm_i32_ty, llvm_i32_ty],
-					 [IntrNoMem, IntrWillReturn]>; //, ImmArg<ArgIndex<0>>]>;
+					 [IntrNoMem]>; //, ImmArg<ArgIndex<0>>]>;
 class VecFPSimpleMACIntrinsic
 	 : Intrinsic<[llvm_v8f32_ty/*, llvm_i32_ty*/], [llvm_v8f32_ty,
                                    llvm_v8f32_ty, llvm_v8f32_ty,
                                    llvm_i32_ty, llvm_i32_ty],
-					 [IntrNoMem, IntrWillReturn]>; //, ImmArg<ArgIndex<0>>]>;
+					 [IntrNoMem]>; //, ImmArg<ArgIndex<0>>]>;
 //srs
 class BsrsV16I8V16Acc48
 	 : Intrinsic<[llvm_v16i8_ty], [llvm_v16i48_ty, llvm_i32_ty],
-					 [IntrNoMem, IntrWillReturn]>; //, ImmArg<ArgIndex<0>>]>;
+					 [IntrNoMem]>; //, ImmArg<ArgIndex<0>>]>;
 //compare intrinsic
 class VCMPV32INT16
 	 : Intrinsic<[llvm_v32i16_ty],
 		          [llvm_v32i16_ty, llvm_i32_ty, llvm_i32_ty,
                            llvm_v2i32_ty, llvm_v2i32_ty, llvm_v2i32_ty],
-					 [IntrNoMem, IntrWillReturn]>;
+					 [IntrNoMem]>;
 class VCMPV32INT16_CMP
 	 : Intrinsic<[llvm_v32i16_ty],
 		          [llvm_v32i16_ty, llvm_i32_ty, llvm_i32_ty,
                            llvm_v2i32_ty, llvm_v2i32_ty, llvm_v2i32_ty, llvm_i32_ty],
-					 [IntrNoMem, IntrWillReturn]>;
+					 [IntrNoMem]>;
 class VCMPV32INT16_SELECT
 	 : Intrinsic<[llvm_v32i16_ty],
 		          [llvm_v32i16_ty, llvm_i32_ty, llvm_i32_ty, llvm_i32_ty,
                            llvm_v2i32_ty, llvm_v2i32_ty, llvm_v2i32_ty],
-					 [IntrNoMem, IntrWillReturn]>;
+					 [IntrNoMem]>;
 //pac-unpack
 class VPACKV16INT16
 	 : Intrinsic<[llvm_v16i8_ty], [llvm_v16i16_ty],
-					 [IntrNoMem, IntrWillReturn]>;
+					 [IntrNoMem]>;
 
 def int_aie_event : ClangBuiltin<"__builtin_aie_event">, EventIntrinsic;
 def int_aie_lock_acquire_reg :

--- a/llvm/include/llvm/IR/IntrinsicsAIE2.td
+++ b/llvm/include/llvm/IR/IntrinsicsAIE2.td
@@ -17,88 +17,88 @@ let TargetPrefix = "aie2" in {
 
 //===----------------------------------------------------------------------===//
 class AIE2EventIntrinsic
-    : Intrinsic<[],
+    : DefaultAttrsIntrinsic<[],
                 [llvm_i32_ty],
                 [IntrHasSideEffects, IntrNoMem]>; //[IntrHasSideEffects, IntrNoMem, ImmArg<ArgIndex<0>>]>;
 //Semaphores
 class AIE2LockIntr
-     : Intrinsic<[],
+     : DefaultAttrsIntrinsic<[],
                  [llvm_i32_ty /* unsigned */, llvm_i32_ty /* (un)signed */],
                  [IntrHasSideEffects, IntrNoMem]>;
 class AIE2LockCondIntr
-     : Intrinsic<[],
+     : DefaultAttrsIntrinsic<[],
                  [llvm_i32_ty /* unsigned */, llvm_i32_ty /* (un)signed */, llvm_i32_ty /* (un)signed */],
                  [IntrHasSideEffects, IntrNoMem]>;
 class AIE2DoneIntr
-     : Intrinsic<[], [], [IntrHasSideEffects, IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[], [], [IntrHasSideEffects, IntrNoMem]>;
 
 // Sparse
 class AIEV2I512I1024MULConf
-      : Intrinsic<[llvm_v16i64_ty], [llvm_v64i8_ty, llvm_v64i8_ty, llvm_i128_ty, llvm_i32_ty],
+      : DefaultAttrsIntrinsic<[llvm_v16i64_ty], [llvm_v64i8_ty, llvm_v64i8_ty, llvm_i128_ty, llvm_i32_ty],
 					 [IntrNoMem]>;
 
 class AIEV2I512I1024MACConf
-      : Intrinsic<[llvm_v16i64_ty], [llvm_v64i8_ty, llvm_v64i8_ty, llvm_i128_ty, llvm_v16i64_ty, llvm_i32_ty],
+      : DefaultAttrsIntrinsic<[llvm_v16i64_ty], [llvm_v64i8_ty, llvm_v64i8_ty, llvm_i128_ty, llvm_v16i64_ty, llvm_i32_ty],
 					 [IntrNoMem]>;
 
 class AIEV2I512I1024ADDMACConf
-      : Intrinsic<[llvm_v16i64_ty], [llvm_v64i8_ty, llvm_v64i8_ty, llvm_i128_ty, llvm_v16i64_ty, llvm_v16i64_ty, llvm_i32_ty],
+      : DefaultAttrsIntrinsic<[llvm_v16i64_ty], [llvm_v64i8_ty, llvm_v64i8_ty, llvm_i128_ty, llvm_v16i64_ty, llvm_v16i64_ty, llvm_i32_ty],
 					 [IntrNoMem]>;
 
 class AIEV2I1024I1024MULConf
-      : Intrinsic<[llvm_v16i64_ty], [llvm_v128i8_ty, llvm_v16i32_ty, llvm_i128_ty, llvm_i32_ty],
+      : DefaultAttrsIntrinsic<[llvm_v16i64_ty], [llvm_v128i8_ty, llvm_v16i32_ty, llvm_i128_ty, llvm_i32_ty],
 					 [IntrNoMem]>;
 
 class AIEV2I1024I1024MACConf
-      : Intrinsic<[llvm_v16i64_ty], [llvm_v128i8_ty, llvm_v16i32_ty, llvm_i128_ty, llvm_v16i64_ty, llvm_i32_ty],
+      : DefaultAttrsIntrinsic<[llvm_v16i64_ty], [llvm_v128i8_ty, llvm_v16i32_ty, llvm_i128_ty, llvm_v16i64_ty, llvm_i32_ty],
 					 [IntrNoMem]>;
 
 class AIEV2I1024I1024ADDMACConf
-      : Intrinsic<[llvm_v16i64_ty], [llvm_v128i8_ty, llvm_v16i32_ty, llvm_i128_ty, llvm_v16i64_ty, llvm_v16i64_ty, llvm_i32_ty],
+      : DefaultAttrsIntrinsic<[llvm_v16i64_ty], [llvm_v128i8_ty, llvm_v16i32_ty, llvm_i128_ty, llvm_v16i64_ty, llvm_v16i64_ty, llvm_i32_ty],
 					 [IntrNoMem]>;
 
 class AIEV2I1024I1024MULConfBF16
-      : Intrinsic<[llvm_v8i64_ty], [llvm_v64bf16_ty, llvm_v32bf16_ty, llvm_i128_ty, llvm_i32_ty],
+      : DefaultAttrsIntrinsic<[llvm_v8i64_ty], [llvm_v64bf16_ty, llvm_v32bf16_ty, llvm_i128_ty, llvm_i32_ty],
 					 [IntrReadMem, IntrInaccessibleMemOnly]>;
 
 class AIEV2I1024I1024MACConfBF16
-      : Intrinsic<[llvm_v8i64_ty], [llvm_v64bf16_ty, llvm_v32bf16_ty, llvm_i128_ty, llvm_v8i64_ty, llvm_i32_ty],
+      : DefaultAttrsIntrinsic<[llvm_v8i64_ty], [llvm_v64bf16_ty, llvm_v32bf16_ty, llvm_i128_ty, llvm_v8i64_ty, llvm_i32_ty],
 					 [IntrReadMem, IntrInaccessibleMemOnly]>;
 
 class AIEV2I1024I1024ADDMACConfBF16
-      : Intrinsic<[llvm_v8i64_ty], [llvm_v64bf16_ty, llvm_v32bf16_ty, llvm_i128_ty, llvm_v8i64_ty, llvm_v8i64_ty, llvm_i32_ty],
+      : DefaultAttrsIntrinsic<[llvm_v8i64_ty], [llvm_v64bf16_ty, llvm_v32bf16_ty, llvm_i128_ty, llvm_v8i64_ty, llvm_v8i64_ty, llvm_i32_ty],
 					 [IntrReadMem, IntrInaccessibleMemOnly]>;
 
 class AIEV2I512I1024MULConfBF16
-      : Intrinsic<[llvm_v8i64_ty], [llvm_v32bf16_ty, llvm_v32bf16_ty, llvm_i128_ty, llvm_i32_ty],
+      : DefaultAttrsIntrinsic<[llvm_v8i64_ty], [llvm_v32bf16_ty, llvm_v32bf16_ty, llvm_i128_ty, llvm_i32_ty],
 					 [IntrReadMem, IntrInaccessibleMemOnly]>;
 
 class AIEV2I512I1024MACConfBF16
-      : Intrinsic<[llvm_v8i64_ty], [llvm_v32bf16_ty, llvm_v32bf16_ty, llvm_i128_ty, llvm_v8i64_ty, llvm_i32_ty],
+      : DefaultAttrsIntrinsic<[llvm_v8i64_ty], [llvm_v32bf16_ty, llvm_v32bf16_ty, llvm_i128_ty, llvm_v8i64_ty, llvm_i32_ty],
 					 [IntrReadMem, IntrInaccessibleMemOnly]>;
 
 class AIEV2I512I1024ADDMACConfBF16
-      : Intrinsic<[llvm_v8i64_ty], [llvm_v32bf16_ty, llvm_v32bf16_ty, llvm_i128_ty, llvm_v8i64_ty, llvm_v8i64_ty, llvm_i32_ty],
+      : DefaultAttrsIntrinsic<[llvm_v8i64_ty], [llvm_v32bf16_ty, llvm_v32bf16_ty, llvm_i128_ty, llvm_v8i64_ty, llvm_v8i64_ty, llvm_i32_ty],
 					 [IntrReadMem, IntrInaccessibleMemOnly]>;
 
 class AIEV2I512I512MULConf
-	 : Intrinsic<[llvm_v16i64_ty], [llvm_v64i8_ty, llvm_v16i32_ty, llvm_i32_ty],
+	 : DefaultAttrsIntrinsic<[llvm_v16i64_ty], [llvm_v64i8_ty, llvm_v16i32_ty, llvm_i32_ty],
 					 [IntrNoMem]>;
 class AIEV2I512I512MACConf
-	 : Intrinsic<[llvm_v16i64_ty], [llvm_v64i8_ty, llvm_v16i32_ty, llvm_v16i64_ty, llvm_i32_ty],
+	 : DefaultAttrsIntrinsic<[llvm_v16i64_ty], [llvm_v64i8_ty, llvm_v16i32_ty, llvm_v16i64_ty, llvm_i32_ty],
 					 [IntrNoMem]>;
 class AIEV2I512I512AddMaconf
-	 : Intrinsic<[llvm_v16i64_ty], [llvm_v64i8_ty, llvm_v16i32_ty, llvm_v16i64_ty, llvm_v16i64_ty, llvm_i32_ty],
+	 : DefaultAttrsIntrinsic<[llvm_v16i64_ty], [llvm_v64i8_ty, llvm_v16i32_ty, llvm_v16i64_ty, llvm_v16i64_ty, llvm_i32_ty],
 					 [IntrNoMem]>;
 
 class AIE2bf16MULConf
-    : Intrinsic<[llvm_v8i64_ty], [llvm_v32bf16_ty, llvm_v32bf16_ty, llvm_i32_ty],
+    : DefaultAttrsIntrinsic<[llvm_v8i64_ty], [llvm_v32bf16_ty, llvm_v32bf16_ty, llvm_i32_ty],
 	   	       [IntrReadMem, IntrInaccessibleMemOnly]>;
 class AIE2bf16MACConf 
-    : Intrinsic<[llvm_v8i64_ty], [llvm_v32bf16_ty, llvm_v32bf16_ty, llvm_v8i64_ty, llvm_i32_ty],
+    : DefaultAttrsIntrinsic<[llvm_v8i64_ty], [llvm_v32bf16_ty, llvm_v32bf16_ty, llvm_v8i64_ty, llvm_i32_ty],
 					 [IntrReadMem, IntrInaccessibleMemOnly]>;
 class AIE2bf16AddMACConf 
-    : Intrinsic<[llvm_v8i64_ty], [llvm_v32bf16_ty, llvm_v32bf16_ty, llvm_v8i64_ty, llvm_v8i64_ty, llvm_i32_ty],
+    : DefaultAttrsIntrinsic<[llvm_v8i64_ty], [llvm_v32bf16_ty, llvm_v32bf16_ty, llvm_v8i64_ty, llvm_v8i64_ty, llvm_i32_ty],
 					 [IntrReadMem, IntrInaccessibleMemOnly]>;
  
 class AIEV2AddSubAcc : DefaultAttrsIntrinsic<[llvm_v16i64_ty], [llvm_v16i64_ty, llvm_v16i64_ty, llvm_i32_ty],
@@ -113,246 +113,246 @@ class AIEV2NEGFPCONF : DefaultAttrsIntrinsic<[llvm_v8i64_ty],
                                              [llvm_v8i64_ty, llvm_i32_ty],
                                              [IntrReadMem, IntrInaccessibleMemOnly]>;
 
-class AIEV2V16AccFloatToV16Bf : Intrinsic<[llvm_v16bf16_ty],
+class AIEV2V16AccFloatToV16Bf : DefaultAttrsIntrinsic<[llvm_v16bf16_ty],
                                           [llvm_v8i64_ty],
                                           [IntrReadMem, IntrInaccessibleMemOnly]>;
-class AIEV2V16BfToV16AccFloat : Intrinsic<[llvm_v8i64_ty], [llvm_v16bf16_ty], [IntrNoMem]>;
+class AIEV2V16BfToV16AccFloat : DefaultAttrsIntrinsic<[llvm_v8i64_ty], [llvm_v16bf16_ty], [IntrNoMem]>;
 
 class AIEV2UNDV4Int32
-     : Intrinsic<[llvm_v4i32_ty], [], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v4i32_ty], [], [IntrNoMem]>;
 class AIEV2UNDV16Int8
-     : Intrinsic<[llvm_v16i8_ty], [], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v16i8_ty], [], [IntrNoMem]>;
 class AIEV2UNDV8Int16
-     : Intrinsic<[llvm_v8i16_ty], [], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v8i16_ty], [], [IntrNoMem]>;
 class AIEV2UNDV8Int32
-     : Intrinsic<[llvm_v8i32_ty], [], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v8i32_ty], [], [IntrNoMem]>;
 class AIEV2UNDV32Int8
-     : Intrinsic<[llvm_v32i8_ty], [], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v32i8_ty], [], [IntrNoMem]>;
 class AIEV2UNDV16Int16
-     : Intrinsic<[llvm_v16i16_ty], [], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v16i16_ty], [], [IntrNoMem]>;
 class AIEV2UNDV16Int32
-     : Intrinsic<[llvm_v16i32_ty], [], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v16i32_ty], [], [IntrNoMem]>;
 class AIEV2UNDV32Int32
-     : Intrinsic<[llvm_v32i32_ty], [], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v32i32_ty], [], [IntrNoMem]>;
 class AIEV2UNDV64Int8
-     : Intrinsic<[llvm_v64i8_ty], [], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v64i8_ty], [], [IntrNoMem]>;
 class AIEV2UNDV32Int16
-     : Intrinsic<[llvm_v32i16_ty], [], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v32i16_ty], [], [IntrNoMem]>;
 class AIEV2UNDV128Int8
-     : Intrinsic<[llvm_v128i8_ty], [], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v128i8_ty], [], [IntrNoMem]>;
 class AIEV2UNDV64Int16
-     : Intrinsic<[llvm_v64i16_ty], [], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v64i16_ty], [], [IntrNoMem]>;
 class AIEV2UNDV4ACC64
-     : Intrinsic<[llvm_v4i64_ty], [], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v4i64_ty], [], [IntrNoMem]>;
 class AIEV2UNDV8ACC64
-     : Intrinsic<[llvm_v8i64_ty], [], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v8i64_ty], [], [IntrNoMem]>;
 class AIEV2UNDV16ACC64
-     : Intrinsic<[llvm_v16i64_ty], [], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v16i64_ty], [], [IntrNoMem]>;
 class AIEV2UND8Bf16
-     : Intrinsic<[llvm_v8bf16_ty], [], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v8bf16_ty], [], [IntrNoMem]>;
 class AIEV2UND16Bf16
-     : Intrinsic<[llvm_v16bf16_ty], [], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v16bf16_ty], [], [IntrNoMem]>;
 class AIEV2UND32Bf16
-     : Intrinsic<[llvm_v32bf16_ty], [], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v32bf16_ty], [], [IntrNoMem]>;
 class AIEV2UND64Bf16
-     : Intrinsic<[llvm_v64bf16_ty], [], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v64bf16_ty], [], [IntrNoMem]>;
 class AIEV2UNDV8Float
-     : Intrinsic<[llvm_v8f32_ty], [], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v8f32_ty], [], [IntrNoMem]>;
 class AIEV2UNDV16Float
-     : Intrinsic<[llvm_v16f32_ty], [], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v16f32_ty], [], [IntrNoMem]>;
 class AIEV2UNDV32Float
-     : Intrinsic<[llvm_v32f32_ty], [], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v32f32_ty], [], [IntrNoMem]>;
 
 class AIEV2GET_I256_I128
-     : Intrinsic<[llvm_v8i32_ty], [llvm_v4i32_ty], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v8i32_ty], [llvm_v4i32_ty], [IntrNoMem]>;
 
 // VSHIFT
 class AIEV2VShift_I512_I512
-     : Intrinsic<[llvm_v16i32_ty], [llvm_v16i32_ty,llvm_v16i32_ty,llvm_i32_ty,llvm_i32_ty], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v16i32_ty], [llvm_v16i32_ty,llvm_v16i32_ty,llvm_i32_ty,llvm_i32_ty], [IntrNoMem]>;
 class AIEV2VShift_bf128_bf512
-     : Intrinsic<[llvm_v8bf16_ty], [llvm_v32bf16_ty,llvm_v32bf16_ty,llvm_i32_ty,llvm_i32_ty], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v8bf16_ty], [llvm_v32bf16_ty,llvm_v32bf16_ty,llvm_i32_ty,llvm_i32_ty], [IntrNoMem]>;
 class AIEV2VShift_bf512_bf512
-     : Intrinsic<[llvm_v32bf16_ty], [llvm_v32bf16_ty,llvm_v32bf16_ty,llvm_i32_ty,llvm_i32_ty], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v32bf16_ty], [llvm_v32bf16_ty,llvm_v32bf16_ty,llvm_i32_ty,llvm_i32_ty], [IntrNoMem]>;
 // VINSERT.X
 class AIEV2VInsert8_I512
-     : Intrinsic<[llvm_v16i32_ty], [llvm_v16i32_ty,llvm_i32_ty,llvm_i32_ty], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v16i32_ty], [llvm_v16i32_ty,llvm_i32_ty,llvm_i32_ty], [IntrNoMem]>;
 class AIEV2VInsert16_I512
-     : Intrinsic<[llvm_v16i32_ty], [llvm_v16i32_ty,llvm_i32_ty,llvm_i32_ty], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v16i32_ty], [llvm_v16i32_ty,llvm_i32_ty,llvm_i32_ty], [IntrNoMem]>;
 class AIEV2VInsert32_I512
-     : Intrinsic<[llvm_v16i32_ty], [llvm_v16i32_ty,llvm_i32_ty,llvm_i32_ty], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v16i32_ty], [llvm_v16i32_ty,llvm_i32_ty,llvm_i32_ty], [IntrNoMem]>;
 class AIEV2VInsert64_I512
-     : Intrinsic<[llvm_v16i32_ty], [llvm_v16i32_ty,llvm_i32_ty,llvm_v2i32_ty], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v16i32_ty], [llvm_v16i32_ty,llvm_i32_ty,llvm_v2i32_ty], [IntrNoMem]>;
 class AIEV2VInsert16_bf512
-     : Intrinsic<[llvm_v32bf16_ty], [llvm_v32bf16_ty,llvm_i32_ty,llvm_bfloat_ty], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v32bf16_ty], [llvm_v32bf16_ty,llvm_i32_ty,llvm_bfloat_ty], [IntrNoMem]>;
 class AIEV2VInsert32_bf512
-     : Intrinsic<[llvm_v32bf16_ty], [llvm_v32bf16_ty,llvm_i32_ty,llvm_v2bf16_ty], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v32bf16_ty], [llvm_v32bf16_ty,llvm_i32_ty,llvm_v2bf16_ty], [IntrNoMem]>;
 class AIEV2VInsert64_bf512
-     : Intrinsic<[llvm_v32bf16_ty], [llvm_v32bf16_ty,llvm_i32_ty,llvm_v4bf16_ty], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v32bf16_ty], [llvm_v32bf16_ty,llvm_i32_ty,llvm_v4bf16_ty], [IntrNoMem]>;
 class AIEV2VInsert32_accfloat
-     : Intrinsic<[llvm_v8i64_ty], [llvm_v8i64_ty,llvm_i32_ty,llvm_float_ty], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v8i64_ty], [llvm_v8i64_ty,llvm_i32_ty,llvm_float_ty], [IntrNoMem]>;
 
 // VBCST.X
 class AIEV2VBCST8I512
-     : Intrinsic<[llvm_v64i8_ty], [llvm_i32_ty], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v64i8_ty], [llvm_i32_ty], [IntrNoMem]>;
 class AIEV2VBCST16I512
-     : Intrinsic<[llvm_v32i16_ty], [llvm_i32_ty], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v32i16_ty], [llvm_i32_ty], [IntrNoMem]>;
 class AIEV2VBCST32I512
-     : Intrinsic<[llvm_v16i32_ty], [llvm_i32_ty], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v16i32_ty], [llvm_i32_ty], [IntrNoMem]>;
 class AIEV2VBCST64I512
-     : Intrinsic<[llvm_v16i32_ty], [llvm_v2i32_ty], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v16i32_ty], [llvm_v2i32_ty], [IntrNoMem]>;
 class AIEV2VBCST16bf512
-     : Intrinsic<[llvm_v32bf16_ty], [llvm_bfloat_ty], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v32bf16_ty], [llvm_bfloat_ty], [IntrNoMem]>;
 class AIEV2VBCST32bf512
-     : Intrinsic<[llvm_v32bf16_ty], [llvm_v2bf16_ty], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v32bf16_ty], [llvm_v2bf16_ty], [IntrNoMem]>;
 class AIEV2VBCST64bf512
-     : Intrinsic<[llvm_v32bf16_ty], [llvm_v4bf16_ty], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v32bf16_ty], [llvm_v4bf16_ty], [IntrNoMem]>;
 class AIEV2VBCSTF32I512
-     : Intrinsic<[llvm_v16f32_ty], [llvm_float_ty], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v16f32_ty], [llvm_float_ty], [IntrNoMem]>;
 // VEXTBCST.X
 class AIEV2VEXTBCST8I512
-     : Intrinsic<[llvm_v64i8_ty], [llvm_v64i8_ty, llvm_i32_ty], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v64i8_ty], [llvm_v64i8_ty, llvm_i32_ty], [IntrNoMem]>;
 class AIEV2VEXTBCST16I512
-     : Intrinsic<[llvm_v32i16_ty], [llvm_v32i16_ty, llvm_i32_ty], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v32i16_ty], [llvm_v32i16_ty, llvm_i32_ty], [IntrNoMem]>;
 class AIEV2VEXTBCST32I512
-     : Intrinsic<[llvm_v16i32_ty], [llvm_v16i32_ty, llvm_i32_ty], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v16i32_ty], [llvm_v16i32_ty, llvm_i32_ty], [IntrNoMem]>;
 class AIEV2VEXTBCST32Bf512
-     : Intrinsic<[llvm_v32bf16_ty], [llvm_v32bf16_ty, llvm_i32_ty], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v32bf16_ty], [llvm_v32bf16_ty, llvm_i32_ty], [IntrNoMem]>;
 // VEXTRACT
 class AIEV2VExtElem8I512
-     : Intrinsic<[llvm_i32_ty], [llvm_v64i8_ty, llvm_i32_ty, llvm_i32_ty], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_i32_ty], [llvm_v64i8_ty, llvm_i32_ty, llvm_i32_ty], [IntrNoMem]>;
 class AIEV2VExtElem16I512
-     : Intrinsic<[llvm_i32_ty], [llvm_v32i16_ty, llvm_i32_ty, llvm_i32_ty], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_i32_ty], [llvm_v32i16_ty, llvm_i32_ty, llvm_i32_ty], [IntrNoMem]>;
 class AIEV2VExtElem32I512
-     : Intrinsic<[llvm_i32_ty], [llvm_v16i32_ty, llvm_i32_ty, llvm_i32_ty], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_i32_ty], [llvm_v16i32_ty, llvm_i32_ty, llvm_i32_ty], [IntrNoMem]>;
 class AIEV2VExtElem64I512
-     : Intrinsic<[llvm_v2i32_ty], [llvm_v16i32_ty, llvm_i32_ty, llvm_i32_ty], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v2i32_ty], [llvm_v16i32_ty, llvm_i32_ty, llvm_i32_ty], [IntrNoMem]>;
 // VSEL.X
 class AIEV2Sel8_I512
-     : Intrinsic<[llvm_v16i32_ty], [llvm_v16i32_ty,llvm_v16i32_ty,llvm_v2i32_ty], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v16i32_ty], [llvm_v16i32_ty,llvm_v16i32_ty,llvm_v2i32_ty], [IntrNoMem]>;
 class AIEV2Sel16_I512
-     : Intrinsic<[llvm_v16i32_ty], [llvm_v16i32_ty,llvm_v16i32_ty,llvm_i32_ty], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v16i32_ty], [llvm_v16i32_ty,llvm_v16i32_ty,llvm_i32_ty], [IntrNoMem]>;
 class AIEV2Sel32_I512
-     : Intrinsic<[llvm_v16i32_ty], [llvm_v16i32_ty,llvm_v16i32_ty,llvm_i32_ty], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v16i32_ty], [llvm_v16i32_ty,llvm_v16i32_ty,llvm_i32_ty], [IntrNoMem]>;
 // UPD
 class AIEV2UPD_I64_I32
-     : Intrinsic<[llvm_v2i32_ty], [llvm_v2i32_ty,llvm_i32_ty,llvm_i32_ty], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v2i32_ty], [llvm_v2i32_ty,llvm_i32_ty,llvm_i32_ty], [IntrNoMem]>;
 class AIEV2UPD_I512_I256
-     : Intrinsic<[llvm_v16i32_ty], [llvm_v16i32_ty,llvm_v8i32_ty,llvm_i32_ty], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v16i32_ty], [llvm_v16i32_ty,llvm_v8i32_ty,llvm_i32_ty], [IntrNoMem]>;
 class AIEV2UPD_I1024_I512
-     : Intrinsic<[llvm_v32i32_ty], [llvm_v32i32_ty,llvm_v16i32_ty,llvm_i32_ty], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v32i32_ty], [llvm_v32i32_ty,llvm_v16i32_ty,llvm_i32_ty], [IntrNoMem]>;
 class AIEV2UPD_I1024_I256
-     : Intrinsic<[llvm_v32i32_ty], [llvm_v32i32_ty,llvm_v8i32_ty,llvm_i32_ty], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v32i32_ty], [llvm_v32i32_ty,llvm_v8i32_ty,llvm_i32_ty], [IntrNoMem]>;
 class AIEV2UPD_bf512_bf256
-     : Intrinsic<[llvm_v32bf16_ty], [llvm_v32bf16_ty,llvm_v16bf16_ty,llvm_i32_ty], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v32bf16_ty], [llvm_v32bf16_ty,llvm_v16bf16_ty,llvm_i32_ty], [IntrNoMem]>;
 class AIEV2UPD_bf1024_bf512
-     : Intrinsic<[llvm_v64bf16_ty], [llvm_v64bf16_ty,llvm_v32bf16_ty,llvm_i32_ty], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v64bf16_ty], [llvm_v64bf16_ty,llvm_v32bf16_ty,llvm_i32_ty], [IntrNoMem]>;
 class AIEV2UPD_bf1024_bf256
-     : Intrinsic<[llvm_v64bf16_ty], [llvm_v64bf16_ty,llvm_v16bf16_ty,llvm_i32_ty], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v64bf16_ty], [llvm_v64bf16_ty,llvm_v16bf16_ty,llvm_i32_ty], [IntrNoMem]>;
 class AIEV2UPD_512_256_acc
-     : Intrinsic<[llvm_v8i64_ty], [llvm_v8i64_ty,llvm_v4i64_ty,llvm_i32_ty], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v8i64_ty], [llvm_v8i64_ty,llvm_v4i64_ty,llvm_i32_ty], [IntrNoMem]>;
 class AIEV2UPD_1024_512_acc
-     : Intrinsic<[llvm_v16i64_ty], [llvm_v16i64_ty,llvm_v8i64_ty,llvm_i32_ty], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v16i64_ty], [llvm_v16i64_ty,llvm_v8i64_ty,llvm_i32_ty], [IntrNoMem]>;
 class AIEV2UPD_1024_256_acc
-     : Intrinsic<[llvm_v16i64_ty], [llvm_v16i64_ty,llvm_v4i64_ty,llvm_i32_ty], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v16i64_ty], [llvm_v16i64_ty,llvm_v4i64_ty,llvm_i32_ty], [IntrNoMem]>;
 // SET
 class AIEV2SET_I64_I32
-     : Intrinsic<[llvm_v2i32_ty], [llvm_i32_ty,llvm_i32_ty], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v2i32_ty], [llvm_i32_ty,llvm_i32_ty], [IntrNoMem]>;
 class AIEV2SET_I512_I256
-     : Intrinsic<[llvm_v16i32_ty], [llvm_v8i32_ty,llvm_i32_ty], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v16i32_ty], [llvm_v8i32_ty,llvm_i32_ty], [IntrNoMem]>;
 class AIEV2SET_I1024_I512
-     : Intrinsic<[llvm_v32i32_ty], [llvm_v16i32_ty,llvm_i32_ty], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v32i32_ty], [llvm_v16i32_ty,llvm_i32_ty], [IntrNoMem]>;
 class AIEV2SET_I1024_I256
-     : Intrinsic<[llvm_v32i32_ty], [llvm_v8i32_ty,llvm_i32_ty], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v32i32_ty], [llvm_v8i32_ty,llvm_i32_ty], [IntrNoMem]>;
 class AIEV2SET_bf512_bf256
-     : Intrinsic<[llvm_v32bf16_ty], [llvm_v16bf16_ty,llvm_i32_ty], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v32bf16_ty], [llvm_v16bf16_ty,llvm_i32_ty], [IntrNoMem]>;
 class AIEV2SET_bf1024_bf512
-     : Intrinsic<[llvm_v64bf16_ty], [llvm_v32bf16_ty,llvm_i32_ty], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v64bf16_ty], [llvm_v32bf16_ty,llvm_i32_ty], [IntrNoMem]>;
 class AIEV2SET_bf1024_bf256
-     : Intrinsic<[llvm_v64bf16_ty], [llvm_v16bf16_ty,llvm_i32_ty], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v64bf16_ty], [llvm_v16bf16_ty,llvm_i32_ty], [IntrNoMem]>;
 class AIEV2SET_512_256_acc
-     : Intrinsic<[llvm_v8i64_ty], [llvm_v4i64_ty,llvm_i32_ty], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v8i64_ty], [llvm_v4i64_ty,llvm_i32_ty], [IntrNoMem]>;
 class AIEV2SET_1024_512_acc
-     : Intrinsic<[llvm_v16i64_ty], [llvm_v8i64_ty,llvm_i32_ty], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v16i64_ty], [llvm_v8i64_ty,llvm_i32_ty], [IntrNoMem]>;
 class AIEV2SET_1024_256_acc
-     : Intrinsic<[llvm_v16i64_ty], [llvm_v4i64_ty,llvm_i32_ty], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v16i64_ty], [llvm_v4i64_ty,llvm_i32_ty], [IntrNoMem]>;
 // EXT
 class AIEV2EXT_I32_I64
-     : Intrinsic<[llvm_i32_ty], [llvm_v2i32_ty,llvm_i32_ty], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_i32_ty], [llvm_v2i32_ty,llvm_i32_ty], [IntrNoMem]>;
 class AIEV2EXT_I256_I512
-     : Intrinsic<[llvm_v8i32_ty] , [llvm_v16i32_ty,llvm_i32_ty], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v8i32_ty] , [llvm_v16i32_ty,llvm_i32_ty], [IntrNoMem]>;
 class AIEV2EXT_I512_I1024
-     : Intrinsic<[llvm_v16i32_ty], [llvm_v32i32_ty,llvm_i32_ty], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v16i32_ty], [llvm_v32i32_ty,llvm_i32_ty], [IntrNoMem]>;
 class AIEV2EXT_I256_I1024
-     : Intrinsic<[llvm_v8i32_ty] , [llvm_v32i32_ty,llvm_i32_ty], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v8i32_ty] , [llvm_v32i32_ty,llvm_i32_ty], [IntrNoMem]>;
 class AIEV2EXT_bf256_bf512
-     : Intrinsic<[llvm_v16bf16_ty] , [llvm_v32bf16_ty,llvm_i32_ty], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v16bf16_ty] , [llvm_v32bf16_ty,llvm_i32_ty], [IntrNoMem]>;
 class AIEV2EXT_bf512_bf1024
-     : Intrinsic<[llvm_v32bf16_ty], [llvm_v64bf16_ty,llvm_i32_ty], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v32bf16_ty], [llvm_v64bf16_ty,llvm_i32_ty], [IntrNoMem]>;
 class AIEV2EXT_bf256_bf1024
-     : Intrinsic<[llvm_v16bf16_ty] , [llvm_v64bf16_ty,llvm_i32_ty], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v16bf16_ty] , [llvm_v64bf16_ty,llvm_i32_ty], [IntrNoMem]>;
 class AIEV2EXT_256_512_acc
-     : Intrinsic<[llvm_v4i64_ty] , [llvm_v8i64_ty,llvm_i32_ty], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v4i64_ty] , [llvm_v8i64_ty,llvm_i32_ty], [IntrNoMem]>;
 class AIEV2EXT_512_1024_acc
-     : Intrinsic<[llvm_v8i64_ty], [llvm_v16i64_ty,llvm_i32_ty], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v8i64_ty], [llvm_v16i64_ty,llvm_i32_ty], [IntrNoMem]>;
 class AIEV2EXT_256_1024_acc
-     : Intrinsic<[llvm_v4i64_ty] , [llvm_v16i64_ty,llvm_i32_ty], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v4i64_ty] , [llvm_v16i64_ty,llvm_i32_ty], [IntrNoMem]>;
 // Concat
 class AIEV2Concat_I512_I256
-     : Intrinsic<[llvm_v16i32_ty], [llvm_v8i32_ty,llvm_v8i32_ty], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v16i32_ty], [llvm_v8i32_ty,llvm_v8i32_ty], [IntrNoMem]>;
 class AIEV2Concat_I1024_I256
-     : Intrinsic<[llvm_v32i32_ty], [llvm_v8i32_ty,llvm_v8i32_ty,llvm_v8i32_ty,llvm_v8i32_ty], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v32i32_ty], [llvm_v8i32_ty,llvm_v8i32_ty,llvm_v8i32_ty,llvm_v8i32_ty], [IntrNoMem]>;
 class AIEV2Concat_I1024_I512
-     : Intrinsic<[llvm_v32i32_ty], [llvm_v16i32_ty,llvm_v16i32_ty], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v32i32_ty], [llvm_v16i32_ty,llvm_v16i32_ty], [IntrNoMem]>;
 class AIEV2Concat_bf512_bf256
-     : Intrinsic<[llvm_v32bf16_ty], [llvm_v16bf16_ty,llvm_v16bf16_ty], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v32bf16_ty], [llvm_v16bf16_ty,llvm_v16bf16_ty], [IntrNoMem]>;
 class AIEV2Concat_bf1024_bf256
-     : Intrinsic<[llvm_v64bf16_ty], [llvm_v16bf16_ty,llvm_v16bf16_ty,llvm_v16bf16_ty,llvm_v16bf16_ty], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v64bf16_ty], [llvm_v16bf16_ty,llvm_v16bf16_ty,llvm_v16bf16_ty,llvm_v16bf16_ty], [IntrNoMem]>;
 class AIEV2Concat_bf1024_bf512
-     : Intrinsic<[llvm_v64bf16_ty], [llvm_v32bf16_ty,llvm_v32bf16_ty], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v64bf16_ty], [llvm_v32bf16_ty,llvm_v32bf16_ty], [IntrNoMem]>;
 class AIEV2Concat_512_256_acc
-     : Intrinsic<[llvm_v8i64_ty], [llvm_v4i64_ty,llvm_v4i64_ty], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v8i64_ty], [llvm_v4i64_ty,llvm_v4i64_ty], [IntrNoMem]>;
 class AIEV2Concat_1024_256_acc
-     : Intrinsic<[llvm_v16i64_ty], [llvm_v4i64_ty,llvm_v4i64_ty,llvm_v4i64_ty,llvm_v4i64_ty], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v16i64_ty], [llvm_v4i64_ty,llvm_v4i64_ty,llvm_v4i64_ty,llvm_v4i64_ty], [IntrNoMem]>;
 class AIEV2Concat_1024_512_acc
-     : Intrinsic<[llvm_v16i64_ty], [llvm_v8i64_ty,llvm_v8i64_ty], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v16i64_ty], [llvm_v8i64_ty,llvm_v8i64_ty], [IntrNoMem]>;
 
 //srs
 class AIEV2I256V16Acc32I
-	 : Intrinsic<[llvm_v16i16_ty], [llvm_v8i64_ty, llvm_i32_ty, llvm_i32_ty],
+	 : DefaultAttrsIntrinsic<[llvm_v16i16_ty], [llvm_v8i64_ty, llvm_i32_ty, llvm_i32_ty],
 					 [IntrReadMem, IntrInaccessibleMemOnly]>;
 class AIEV2I256V16Acc64I
-	 : Intrinsic<[llvm_v16i16_ty], [llvm_v16i64_ty, llvm_i32_ty, llvm_i32_ty],
+	 : DefaultAttrsIntrinsic<[llvm_v16i16_ty], [llvm_v16i64_ty, llvm_i32_ty, llvm_i32_ty],
 					 [IntrReadMem, IntrInaccessibleMemOnly]>;
 class AIEV2I256V32Acc32I
-	 : Intrinsic<[llvm_v32i8_ty], [llvm_v16i64_ty, llvm_i32_ty, llvm_i32_ty],
+	 : DefaultAttrsIntrinsic<[llvm_v32i8_ty], [llvm_v16i64_ty, llvm_i32_ty, llvm_i32_ty],
 					 [IntrReadMem, IntrInaccessibleMemOnly]>;
 class AIEV2I256V8Acc64I
-	 : Intrinsic<[llvm_v8i32_ty], [llvm_v8i64_ty, llvm_i32_ty, llvm_i32_ty],
+	 : DefaultAttrsIntrinsic<[llvm_v8i32_ty], [llvm_v8i64_ty, llvm_i32_ty, llvm_i32_ty],
 					 [IntrReadMem, IntrInaccessibleMemOnly]>;
 class AIEV2I512V16Acc64I
-	 : Intrinsic<[llvm_v16i32_ty], [llvm_v16i64_ty, llvm_i32_ty, llvm_i32_ty],
+	 : DefaultAttrsIntrinsic<[llvm_v16i32_ty], [llvm_v16i64_ty, llvm_i32_ty, llvm_i32_ty],
 					 [IntrReadMem, IntrInaccessibleMemOnly]>;
 class AIEV2I512V32Acc32I
-	 : Intrinsic<[llvm_v32i16_ty], [llvm_v16i64_ty, llvm_i32_ty, llvm_i32_ty],
+	 : DefaultAttrsIntrinsic<[llvm_v32i16_ty], [llvm_v16i64_ty, llvm_i32_ty, llvm_i32_ty],
 					 [IntrReadMem, IntrInaccessibleMemOnly]>;
 
 // VUPS
-class AIEV2Acc32V16I256I : Intrinsic<[llvm_v8i64_ty],
+class AIEV2Acc32V16I256I : DefaultAttrsIntrinsic<[llvm_v8i64_ty],
                               [llvm_v16i16_ty, llvm_i32_ty, llvm_i32_ty],
                               [IntrReadMem, IntrInaccessibleMemOnly]>;
-class AIEV2Acc32V32I256I : Intrinsic<[llvm_v16i64_ty],
+class AIEV2Acc32V32I256I : DefaultAttrsIntrinsic<[llvm_v16i64_ty],
                               [llvm_v32i8_ty, llvm_i32_ty, llvm_i32_ty],
                               [IntrReadMem, IntrInaccessibleMemOnly]>;
-class AIEV2Acc32V32I512I : Intrinsic<[llvm_v16i64_ty],
+class AIEV2Acc32V32I512I : DefaultAttrsIntrinsic<[llvm_v16i64_ty],
                               [llvm_v32i16_ty, llvm_i32_ty, llvm_i32_ty],
                               [IntrReadMem, IntrInaccessibleMemOnly]>;
-class AIEV2Acc64V16I256I : Intrinsic<[llvm_v16i64_ty],
+class AIEV2Acc64V16I256I : DefaultAttrsIntrinsic<[llvm_v16i64_ty],
                               [llvm_v16i16_ty, llvm_i32_ty, llvm_i32_ty],
                               [IntrReadMem, IntrInaccessibleMemOnly]>;
-class AIEV2Acc64V16I512I : Intrinsic<[llvm_v16i64_ty],
+class AIEV2Acc64V16I512I : DefaultAttrsIntrinsic<[llvm_v16i64_ty],
                               [llvm_v16i32_ty, llvm_i32_ty, llvm_i32_ty],
                               [IntrReadMem, IntrInaccessibleMemOnly]>;
-class AIEV2Acc64V8I256I  : Intrinsic<[llvm_v8i64_ty],
+class AIEV2Acc64V8I256I  : DefaultAttrsIntrinsic<[llvm_v8i64_ty],
                               [llvm_v8i32_ty, llvm_i32_ty, llvm_i32_ty],
                               [IntrReadMem, IntrInaccessibleMemOnly]>;
 
@@ -383,53 +383,53 @@ class AIEV2V16I32I32V16I32V16I32I32 : DefaultAttrsIntrinsic<[llvm_v16i32_ty, llv
 class AIEV2V32BF16I32V32BF16V32BF16I32 : DefaultAttrsIntrinsic<[llvm_v32bf16_ty, llvm_i32_ty], [llvm_v32bf16_ty, llvm_v32bf16_ty], [IntrNoMem]>;
 
 // VBCSTSHFL
-class AIEV2VBcstShfl_bf16 : Intrinsic<[llvm_v32bf16_ty], [llvm_bfloat_ty, llvm_i32_ty], [IntrNoMem]>;
-class AIEV2VBcstShfl_I32 : Intrinsic<[llvm_v16i32_ty], [llvm_i32_ty, llvm_i32_ty], [IntrNoMem]>;
-class AIEV2VBcstShfl_I64 : Intrinsic<[llvm_v16i32_ty], [llvm_v2i32_ty, llvm_i32_ty], [IntrNoMem]>;
+class AIEV2VBcstShfl_bf16 : DefaultAttrsIntrinsic<[llvm_v32bf16_ty], [llvm_bfloat_ty, llvm_i32_ty], [IntrNoMem]>;
+class AIEV2VBcstShfl_I32 : DefaultAttrsIntrinsic<[llvm_v16i32_ty], [llvm_i32_ty, llvm_i32_ty], [IntrNoMem]>;
+class AIEV2VBcstShfl_I64 : DefaultAttrsIntrinsic<[llvm_v16i32_ty], [llvm_v2i32_ty, llvm_i32_ty], [IntrNoMem]>;
 
 // VSHUFFLE
-class AIEV2VShuffle : Intrinsic<[llvm_v16i32_ty], [llvm_v16i32_ty, llvm_v16i32_ty, llvm_i32_ty], [IntrNoMem]>;
-class AIEV2VShuffleBf16 : Intrinsic<[llvm_v32bf16_ty], [llvm_v32bf16_ty, llvm_v32bf16_ty, llvm_i32_ty], [IntrNoMem]>;
+class AIEV2VShuffle : DefaultAttrsIntrinsic<[llvm_v16i32_ty], [llvm_v16i32_ty, llvm_v16i32_ty, llvm_i32_ty], [IntrNoMem]>;
+class AIEV2VShuffleBf16 : DefaultAttrsIntrinsic<[llvm_v32bf16_ty], [llvm_v32bf16_ty, llvm_v32bf16_ty, llvm_i32_ty], [IntrNoMem]>;
 
 
 // PADDX.XX
-class AIEV2Add2D : Intrinsic<[llvm_ptr_ty, llvm_i20_ty],
+class AIEV2Add2D : DefaultAttrsIntrinsic<[llvm_ptr_ty, llvm_i20_ty],
       [llvm_ptr_ty, llvm_i20_ty, llvm_i20_ty, llvm_i20_ty, llvm_i20_ty],
       [IntrNoMem]>;
-class AIEV2Add3D : Intrinsic<[llvm_ptr_ty, llvm_i20_ty, llvm_i20_ty],
+class AIEV2Add3D : DefaultAttrsIntrinsic<[llvm_ptr_ty, llvm_i20_ty, llvm_i20_ty],
       [llvm_ptr_ty, llvm_i20_ty, llvm_i20_ty, llvm_i20_ty, llvm_i20_ty, llvm_i20_ty, llvm_i20_ty, llvm_i20_ty],
       [IntrNoMem]>;
 
 // VLD.SPARSE.POP / VLD.SPARSE.PEEK
-class AIEV2SPARSE_OP_V64I16_set_lo : Intrinsic<[llvm_ptr_ty, llvm_v32i16_ty, llvm_i128_ty],
+class AIEV2SPARSE_OP_V64I16_set_lo : DefaultAttrsIntrinsic<[llvm_ptr_ty, llvm_v32i16_ty, llvm_i128_ty],
      [llvm_v32i16_ty, llvm_i128_ty, llvm_ptr_ty],
      []>;
-class AIEV2SPARSE_OP_V64I16_insert_hi : Intrinsic<[llvm_ptr_ty, llvm_v32i16_ty, llvm_i128_ty],
+class AIEV2SPARSE_OP_V64I16_insert_hi : DefaultAttrsIntrinsic<[llvm_ptr_ty, llvm_v32i16_ty, llvm_i128_ty],
      [llvm_v32i16_ty, llvm_i128_ty, llvm_v32i16_ty, llvm_i128_ty, llvm_ptr_ty],
      []>;
 
-class AIEV2SPARSE_OP_V128I8_set_lo : Intrinsic<[llvm_ptr_ty, llvm_v64i8_ty, llvm_i128_ty],
+class AIEV2SPARSE_OP_V128I8_set_lo : DefaultAttrsIntrinsic<[llvm_ptr_ty, llvm_v64i8_ty, llvm_i128_ty],
      [llvm_v64i8_ty, llvm_i128_ty, llvm_ptr_ty],
      []>;
-class AIEV2SPARSE_OP_V128I8_insert_hi : Intrinsic<[llvm_ptr_ty, llvm_v64i8_ty, llvm_i128_ty],
+class AIEV2SPARSE_OP_V128I8_insert_hi : DefaultAttrsIntrinsic<[llvm_ptr_ty, llvm_v64i8_ty, llvm_i128_ty],
      [llvm_v64i8_ty, llvm_i128_ty, llvm_v64i8_ty, llvm_i128_ty, llvm_ptr_ty],
      []>;
 
-class AIEV2SPARSE_OP_V256I4_set_lo : Intrinsic<[llvm_ptr_ty, llvm_v16i32_ty, llvm_i128_ty],
+class AIEV2SPARSE_OP_V256I4_set_lo : DefaultAttrsIntrinsic<[llvm_ptr_ty, llvm_v16i32_ty, llvm_i128_ty],
      [llvm_v16i32_ty, llvm_i128_ty, llvm_ptr_ty],
      []>;
-class AIEV2SPARSE_OP_V256I4_insert_hi : Intrinsic<[llvm_ptr_ty, llvm_v16i32_ty, llvm_i128_ty],
+class AIEV2SPARSE_OP_V256I4_insert_hi : DefaultAttrsIntrinsic<[llvm_ptr_ty, llvm_v16i32_ty, llvm_i128_ty],
      [llvm_v16i32_ty, llvm_i128_ty, llvm_v16i32_ty, llvm_i128_ty, llvm_ptr_ty],
      []>;
 
-class AIEV2SPARSE_OP_V64BF16_set_lo : Intrinsic<[llvm_ptr_ty, llvm_v32bf16_ty, llvm_i128_ty],
+class AIEV2SPARSE_OP_V64BF16_set_lo : DefaultAttrsIntrinsic<[llvm_ptr_ty, llvm_v32bf16_ty, llvm_i128_ty],
      [llvm_v32bf16_ty, llvm_i128_ty, llvm_ptr_ty],
      []>;
-class AIEV2SPARSE_OP_V64BF16_insert_hi : Intrinsic<[llvm_ptr_ty, llvm_v32bf16_ty, llvm_i128_ty],
+class AIEV2SPARSE_OP_V64BF16_insert_hi : DefaultAttrsIntrinsic<[llvm_ptr_ty, llvm_v32bf16_ty, llvm_i128_ty],
      [llvm_v32bf16_ty, llvm_i128_ty, llvm_v32bf16_ty, llvm_i128_ty, llvm_ptr_ty],
      []>;
 
-class AIEV2SPARSE_RESET_FILL : Intrinsic<[llvm_ptr_ty],
+class AIEV2SPARSE_RESET_FILL : DefaultAttrsIntrinsic<[llvm_ptr_ty],
      [llvm_ptr_ty],
      []>;
 
@@ -439,10 +439,10 @@ class AIEV2LOAD4X : DefaultAttrsIntrinsic<[llvm_v8i32_ty], [llvm_v8i32_ty],
 
 
 // bfloat16 conversions
-class AIEV2BF16ToInt : Intrinsic<[llvm_i32_ty],
+class AIEV2BF16ToInt : DefaultAttrsIntrinsic<[llvm_i32_ty],
       [llvm_bfloat_ty],
       [IntrNoMem]>;
-class AIEV2V16BF16ToV16I : Intrinsic<[llvm_v16i32_ty],
+class AIEV2V16BF16ToV16I : DefaultAttrsIntrinsic<[llvm_v16i32_ty],
       [llvm_v16bf16_ty, llvm_i32_ty],
       [IntrReadMem, IntrInaccessibleMemOnly]>;
 
@@ -466,45 +466,45 @@ class AIEV2I32I32I32I32I32I32 : DefaultAttrsIntrinsic<[llvm_i32_ty],
                                                        [llvm_i32_ty, llvm_i32_ty, llvm_i32_ty, llvm_i32_ty, llvm_i32_ty],
                                                        [IntrInaccessibleMemOnly]>;
 
-class AIEV2ReadTM : Intrinsic<[llvm_i32_ty], [llvm_ptr_ty], [IntrReadMem]>;
-class AIEV2WriteTM : Intrinsic<[], [llvm_i32_ty, llvm_ptr_ty], [IntrWriteMem]>;
+class AIEV2ReadTM : DefaultAttrsIntrinsic<[llvm_i32_ty], [llvm_ptr_ty], [IntrReadMem]>;
+class AIEV2WriteTM : DefaultAttrsIntrinsic<[], [llvm_i32_ty, llvm_ptr_ty], [IntrWriteMem]>;
 
 // Mode Settings
 // Set Control Reg
-class AIEV2SetCtrlReg : Intrinsic<[], [llvm_i32_ty, llvm_i32_ty], [IntrWriteMem, IntrInaccessibleMemOnly]>;
+class AIEV2SetCtrlReg : DefaultAttrsIntrinsic<[], [llvm_i32_ty, llvm_i32_ty], [IntrWriteMem, IntrInaccessibleMemOnly]>;
 // Get Control Reg
-class AIEV2GetCtrlReg : Intrinsic<[llvm_i32_ty], [llvm_i32_ty], [IntrReadMem, IntrInaccessibleMemOnly]>;
+class AIEV2GetCtrlReg : DefaultAttrsIntrinsic<[llvm_i32_ty], [llvm_i32_ty], [IntrReadMem, IntrInaccessibleMemOnly]>;
 
 
 // Get CoreID
-class AIEV2GetCoreID : Intrinsic<[llvm_i32_ty], [], [IntrNoMem]>;
+class AIEV2GetCoreID : DefaultAttrsIntrinsic<[llvm_i32_ty], [], [IntrNoMem]>;
 
 // CLB
-class AIEV2CLB : Intrinsic<[llvm_i32_ty], [llvm_i32_ty], [IntrNoMem]>;
+class AIEV2CLB : DefaultAttrsIntrinsic<[llvm_i32_ty], [llvm_i32_ty], [IntrNoMem]>;
 
 // DIVS
-class AIEV2DIVS : Intrinsic<[llvm_i32_ty, llvm_i32_ty], [llvm_i32_ty, llvm_i32_ty, llvm_i32_ty], [IntrNoMem]>;
+class AIEV2DIVS : DefaultAttrsIntrinsic<[llvm_i32_ty, llvm_i32_ty], [llvm_i32_ty, llvm_i32_ty, llvm_i32_ty], [IntrNoMem]>;
 
 // Pack-Unpack
-class AIEV2PackI4I8 : Intrinsic<[llvm_v32i8_ty], [llvm_v32i16_ty, llvm_i32_ty], [IntrReadMem, IntrInaccessibleMemOnly]>;
-class AIEV2PackI8I16 : Intrinsic<[llvm_v32i8_ty], [llvm_v32i16_ty, llvm_i32_ty], [IntrReadMem, IntrInaccessibleMemOnly]>;
-class AIEV2UnPackI8I4 : Intrinsic<[llvm_v32i16_ty], [llvm_v32i8_ty, llvm_i32_ty], [IntrNoMem]>;
-class AIEV2UnPackI16I8 : Intrinsic<[llvm_v32i16_ty], [llvm_v32i8_ty, llvm_i32_ty], [IntrNoMem]>;
+class AIEV2PackI4I8 : DefaultAttrsIntrinsic<[llvm_v32i8_ty], [llvm_v32i16_ty, llvm_i32_ty], [IntrReadMem, IntrInaccessibleMemOnly]>;
+class AIEV2PackI8I16 : DefaultAttrsIntrinsic<[llvm_v32i8_ty], [llvm_v32i16_ty, llvm_i32_ty], [IntrReadMem, IntrInaccessibleMemOnly]>;
+class AIEV2UnPackI8I4 : DefaultAttrsIntrinsic<[llvm_v32i16_ty], [llvm_v32i8_ty, llvm_i32_ty], [IntrNoMem]>;
+class AIEV2UnPackI16I8 : DefaultAttrsIntrinsic<[llvm_v32i16_ty], [llvm_v32i8_ty, llvm_i32_ty], [IntrNoMem]>;
 
 // Scheduling barrier
-class AIEV2SchedBarrier : Intrinsic<[], [], [IntrNoMem, IntrHasSideEffects, IntrConvergent, IntrWillReturn]>;
+class AIEV2SchedBarrier : DefaultAttrsIntrinsic<[], [], [IntrNoMem, IntrHasSideEffects, IntrConvergent, IntrWillReturn]>;
 
 // clear accumulator
-class AIEV2CLR16F : Intrinsic<[llvm_v8i64_ty], [], [IntrReadMem, IntrInaccessibleMemOnly]>;
-class AIEV2VCLRACC1024 : Intrinsic<[llvm_v16i64_ty], [], [IntrNoMem]>;
+class AIEV2CLR16F : DefaultAttrsIntrinsic<[llvm_v8i64_ty], [], [IntrReadMem, IntrInaccessibleMemOnly]>;
+class AIEV2VCLRACC1024 : DefaultAttrsIntrinsic<[llvm_v16i64_ty], [], [IntrNoMem]>;
 
 // Extract Sub-Vector
 class AIEV2Extract_I128_I512
-     : Intrinsic<[llvm_v4i32_ty], [llvm_v16i32_ty], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v4i32_ty], [llvm_v16i32_ty], [IntrNoMem]>;
 
 // Set Sub-Vector
 class AIEV2Set_I512_I128
-     : Intrinsic<[llvm_v16i32_ty], [llvm_v4i32_ty], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v16i32_ty], [llvm_v4i32_ty], [IntrNoMem]>;
 
 def int_aie2_event : ClangBuiltin<"__builtin_aiev2_event">, AIE2EventIntrinsic;
 //Locks

--- a/llvm/include/llvm/IR/IntrinsicsAIE2.td
+++ b/llvm/include/llvm/IR/IntrinsicsAIE2.td
@@ -19,492 +19,492 @@ let TargetPrefix = "aie2" in {
 class AIE2EventIntrinsic
     : Intrinsic<[],
                 [llvm_i32_ty],
-                [IntrHasSideEffects, IntrNoMem, IntrWillReturn]>; //[IntrHasSideEffects, IntrNoMem, ImmArg<ArgIndex<0>>]>;
+                [IntrHasSideEffects, IntrNoMem]>; //[IntrHasSideEffects, IntrNoMem, ImmArg<ArgIndex<0>>]>;
 //Semaphores
 class AIE2LockIntr
      : Intrinsic<[],
                  [llvm_i32_ty /* unsigned */, llvm_i32_ty /* (un)signed */],
-                 [IntrHasSideEffects, IntrNoMem, IntrWillReturn]>;
+                 [IntrHasSideEffects, IntrNoMem]>;
 class AIE2LockCondIntr
      : Intrinsic<[],
                  [llvm_i32_ty /* unsigned */, llvm_i32_ty /* (un)signed */, llvm_i32_ty /* (un)signed */],
-                 [IntrHasSideEffects, IntrNoMem, IntrWillReturn]>;
+                 [IntrHasSideEffects, IntrNoMem]>;
 class AIE2DoneIntr
-     : Intrinsic<[], [], [IntrHasSideEffects, IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[], [], [IntrHasSideEffects, IntrNoMem]>;
 
 // Sparse
 class AIEV2I512I1024MULConf
       : Intrinsic<[llvm_v16i64_ty], [llvm_v64i8_ty, llvm_v64i8_ty, llvm_i128_ty, llvm_i32_ty],
-					 [IntrNoMem, IntrWillReturn]>;
+					 [IntrNoMem]>;
 
 class AIEV2I512I1024MACConf
       : Intrinsic<[llvm_v16i64_ty], [llvm_v64i8_ty, llvm_v64i8_ty, llvm_i128_ty, llvm_v16i64_ty, llvm_i32_ty],
-					 [IntrNoMem, IntrWillReturn]>;
+					 [IntrNoMem]>;
 
 class AIEV2I512I1024ADDMACConf
       : Intrinsic<[llvm_v16i64_ty], [llvm_v64i8_ty, llvm_v64i8_ty, llvm_i128_ty, llvm_v16i64_ty, llvm_v16i64_ty, llvm_i32_ty],
-					 [IntrNoMem, IntrWillReturn]>;
+					 [IntrNoMem]>;
 
 class AIEV2I1024I1024MULConf
       : Intrinsic<[llvm_v16i64_ty], [llvm_v128i8_ty, llvm_v16i32_ty, llvm_i128_ty, llvm_i32_ty],
-					 [IntrNoMem, IntrWillReturn]>;
+					 [IntrNoMem]>;
 
 class AIEV2I1024I1024MACConf
       : Intrinsic<[llvm_v16i64_ty], [llvm_v128i8_ty, llvm_v16i32_ty, llvm_i128_ty, llvm_v16i64_ty, llvm_i32_ty],
-					 [IntrNoMem, IntrWillReturn]>;
+					 [IntrNoMem]>;
 
 class AIEV2I1024I1024ADDMACConf
       : Intrinsic<[llvm_v16i64_ty], [llvm_v128i8_ty, llvm_v16i32_ty, llvm_i128_ty, llvm_v16i64_ty, llvm_v16i64_ty, llvm_i32_ty],
-					 [IntrNoMem, IntrWillReturn]>;
+					 [IntrNoMem]>;
 
 class AIEV2I1024I1024MULConfBF16
       : Intrinsic<[llvm_v8i64_ty], [llvm_v64bf16_ty, llvm_v32bf16_ty, llvm_i128_ty, llvm_i32_ty],
-					 [IntrReadMem, IntrWillReturn, IntrInaccessibleMemOnly]>;
+					 [IntrReadMem, IntrInaccessibleMemOnly]>;
 
 class AIEV2I1024I1024MACConfBF16
       : Intrinsic<[llvm_v8i64_ty], [llvm_v64bf16_ty, llvm_v32bf16_ty, llvm_i128_ty, llvm_v8i64_ty, llvm_i32_ty],
-					 [IntrReadMem, IntrWillReturn, IntrInaccessibleMemOnly]>;
+					 [IntrReadMem, IntrInaccessibleMemOnly]>;
 
 class AIEV2I1024I1024ADDMACConfBF16
       : Intrinsic<[llvm_v8i64_ty], [llvm_v64bf16_ty, llvm_v32bf16_ty, llvm_i128_ty, llvm_v8i64_ty, llvm_v8i64_ty, llvm_i32_ty],
-					 [IntrReadMem, IntrWillReturn, IntrInaccessibleMemOnly]>;
+					 [IntrReadMem, IntrInaccessibleMemOnly]>;
 
 class AIEV2I512I1024MULConfBF16
       : Intrinsic<[llvm_v8i64_ty], [llvm_v32bf16_ty, llvm_v32bf16_ty, llvm_i128_ty, llvm_i32_ty],
-					 [IntrReadMem, IntrWillReturn, IntrInaccessibleMemOnly]>;
+					 [IntrReadMem, IntrInaccessibleMemOnly]>;
 
 class AIEV2I512I1024MACConfBF16
       : Intrinsic<[llvm_v8i64_ty], [llvm_v32bf16_ty, llvm_v32bf16_ty, llvm_i128_ty, llvm_v8i64_ty, llvm_i32_ty],
-					 [IntrReadMem, IntrWillReturn, IntrInaccessibleMemOnly]>;
+					 [IntrReadMem, IntrInaccessibleMemOnly]>;
 
 class AIEV2I512I1024ADDMACConfBF16
       : Intrinsic<[llvm_v8i64_ty], [llvm_v32bf16_ty, llvm_v32bf16_ty, llvm_i128_ty, llvm_v8i64_ty, llvm_v8i64_ty, llvm_i32_ty],
-					 [IntrReadMem, IntrWillReturn, IntrInaccessibleMemOnly]>;
+					 [IntrReadMem, IntrInaccessibleMemOnly]>;
 
 class AIEV2I512I512MULConf
 	 : Intrinsic<[llvm_v16i64_ty], [llvm_v64i8_ty, llvm_v16i32_ty, llvm_i32_ty],
-					 [IntrNoMem, IntrWillReturn]>;
+					 [IntrNoMem]>;
 class AIEV2I512I512MACConf
 	 : Intrinsic<[llvm_v16i64_ty], [llvm_v64i8_ty, llvm_v16i32_ty, llvm_v16i64_ty, llvm_i32_ty],
-					 [IntrNoMem, IntrWillReturn]>;
+					 [IntrNoMem]>;
 class AIEV2I512I512AddMaconf
 	 : Intrinsic<[llvm_v16i64_ty], [llvm_v64i8_ty, llvm_v16i32_ty, llvm_v16i64_ty, llvm_v16i64_ty, llvm_i32_ty],
-					 [IntrNoMem, IntrWillReturn]>;
+					 [IntrNoMem]>;
 
 class AIE2bf16MULConf
     : Intrinsic<[llvm_v8i64_ty], [llvm_v32bf16_ty, llvm_v32bf16_ty, llvm_i32_ty],
-	   	       [IntrReadMem, IntrWillReturn, IntrInaccessibleMemOnly]>;
+	   	       [IntrReadMem, IntrInaccessibleMemOnly]>;
 class AIE2bf16MACConf 
     : Intrinsic<[llvm_v8i64_ty], [llvm_v32bf16_ty, llvm_v32bf16_ty, llvm_v8i64_ty, llvm_i32_ty],
-					 [IntrReadMem, IntrWillReturn, IntrInaccessibleMemOnly]>;
+					 [IntrReadMem, IntrInaccessibleMemOnly]>;
 class AIE2bf16AddMACConf 
     : Intrinsic<[llvm_v8i64_ty], [llvm_v32bf16_ty, llvm_v32bf16_ty, llvm_v8i64_ty, llvm_v8i64_ty, llvm_i32_ty],
-					 [IntrReadMem, IntrWillReturn, IntrInaccessibleMemOnly]>;
+					 [IntrReadMem, IntrInaccessibleMemOnly]>;
  
 class AIEV2AddSubAcc : DefaultAttrsIntrinsic<[llvm_v16i64_ty], [llvm_v16i64_ty, llvm_v16i64_ty, llvm_i32_ty],
-					 [IntrNoMem, IntrWillReturn]>;
+					 [IntrNoMem]>;
 
 class AIEV2AddSubAccFloat : DefaultAttrsIntrinsic<[llvm_v8i64_ty],
 [llvm_v8i64_ty, llvm_v8i64_ty, llvm_i32_ty],
-[IntrReadMem, IntrWillReturn, IntrInaccessibleMemOnly]>;
+[IntrReadMem, IntrInaccessibleMemOnly]>;
 
-class AIEV2NEGCONF : DefaultAttrsIntrinsic<[llvm_v16i64_ty], [llvm_v16i64_ty, llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
+class AIEV2NEGCONF : DefaultAttrsIntrinsic<[llvm_v16i64_ty], [llvm_v16i64_ty, llvm_i32_ty], [IntrNoMem]>;
 class AIEV2NEGFPCONF : DefaultAttrsIntrinsic<[llvm_v8i64_ty],
                                              [llvm_v8i64_ty, llvm_i32_ty],
-                                             [IntrReadMem, IntrWillReturn, IntrInaccessibleMemOnly]>;
+                                             [IntrReadMem, IntrInaccessibleMemOnly]>;
 
 class AIEV2V16AccFloatToV16Bf : Intrinsic<[llvm_v16bf16_ty],
                                           [llvm_v8i64_ty],
-                                          [IntrReadMem, IntrWillReturn, IntrInaccessibleMemOnly]>;
-class AIEV2V16BfToV16AccFloat : Intrinsic<[llvm_v8i64_ty], [llvm_v16bf16_ty], [IntrNoMem, IntrWillReturn]>;
+                                          [IntrReadMem, IntrInaccessibleMemOnly]>;
+class AIEV2V16BfToV16AccFloat : Intrinsic<[llvm_v8i64_ty], [llvm_v16bf16_ty], [IntrNoMem]>;
 
 class AIEV2UNDV4Int32
-     : Intrinsic<[llvm_v4i32_ty], [], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v4i32_ty], [], [IntrNoMem]>;
 class AIEV2UNDV16Int8
-     : Intrinsic<[llvm_v16i8_ty], [], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v16i8_ty], [], [IntrNoMem]>;
 class AIEV2UNDV8Int16
-     : Intrinsic<[llvm_v8i16_ty], [], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v8i16_ty], [], [IntrNoMem]>;
 class AIEV2UNDV8Int32
-     : Intrinsic<[llvm_v8i32_ty], [], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v8i32_ty], [], [IntrNoMem]>;
 class AIEV2UNDV32Int8
-     : Intrinsic<[llvm_v32i8_ty], [], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v32i8_ty], [], [IntrNoMem]>;
 class AIEV2UNDV16Int16
-     : Intrinsic<[llvm_v16i16_ty], [], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v16i16_ty], [], [IntrNoMem]>;
 class AIEV2UNDV16Int32
-     : Intrinsic<[llvm_v16i32_ty], [], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v16i32_ty], [], [IntrNoMem]>;
 class AIEV2UNDV32Int32
-     : Intrinsic<[llvm_v32i32_ty], [], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v32i32_ty], [], [IntrNoMem]>;
 class AIEV2UNDV64Int8
-     : Intrinsic<[llvm_v64i8_ty], [], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v64i8_ty], [], [IntrNoMem]>;
 class AIEV2UNDV32Int16
-     : Intrinsic<[llvm_v32i16_ty], [], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v32i16_ty], [], [IntrNoMem]>;
 class AIEV2UNDV128Int8
-     : Intrinsic<[llvm_v128i8_ty], [], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v128i8_ty], [], [IntrNoMem]>;
 class AIEV2UNDV64Int16
-     : Intrinsic<[llvm_v64i16_ty], [], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v64i16_ty], [], [IntrNoMem]>;
 class AIEV2UNDV4ACC64
-     : Intrinsic<[llvm_v4i64_ty], [], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v4i64_ty], [], [IntrNoMem]>;
 class AIEV2UNDV8ACC64
-     : Intrinsic<[llvm_v8i64_ty], [], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v8i64_ty], [], [IntrNoMem]>;
 class AIEV2UNDV16ACC64
-     : Intrinsic<[llvm_v16i64_ty], [], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v16i64_ty], [], [IntrNoMem]>;
 class AIEV2UND8Bf16
-     : Intrinsic<[llvm_v8bf16_ty], [], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v8bf16_ty], [], [IntrNoMem]>;
 class AIEV2UND16Bf16
-     : Intrinsic<[llvm_v16bf16_ty], [], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v16bf16_ty], [], [IntrNoMem]>;
 class AIEV2UND32Bf16
-     : Intrinsic<[llvm_v32bf16_ty], [], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v32bf16_ty], [], [IntrNoMem]>;
 class AIEV2UND64Bf16
-     : Intrinsic<[llvm_v64bf16_ty], [], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v64bf16_ty], [], [IntrNoMem]>;
 class AIEV2UNDV8Float
-     : Intrinsic<[llvm_v8f32_ty], [], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v8f32_ty], [], [IntrNoMem]>;
 class AIEV2UNDV16Float
-     : Intrinsic<[llvm_v16f32_ty], [], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v16f32_ty], [], [IntrNoMem]>;
 class AIEV2UNDV32Float
-     : Intrinsic<[llvm_v32f32_ty], [], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v32f32_ty], [], [IntrNoMem]>;
 
 class AIEV2GET_I256_I128
-     : Intrinsic<[llvm_v8i32_ty], [llvm_v4i32_ty], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v8i32_ty], [llvm_v4i32_ty], [IntrNoMem]>;
 
 // VSHIFT
 class AIEV2VShift_I512_I512
-     : Intrinsic<[llvm_v16i32_ty], [llvm_v16i32_ty,llvm_v16i32_ty,llvm_i32_ty,llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v16i32_ty], [llvm_v16i32_ty,llvm_v16i32_ty,llvm_i32_ty,llvm_i32_ty], [IntrNoMem]>;
 class AIEV2VShift_bf128_bf512
-     : Intrinsic<[llvm_v8bf16_ty], [llvm_v32bf16_ty,llvm_v32bf16_ty,llvm_i32_ty,llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v8bf16_ty], [llvm_v32bf16_ty,llvm_v32bf16_ty,llvm_i32_ty,llvm_i32_ty], [IntrNoMem]>;
 class AIEV2VShift_bf512_bf512
-     : Intrinsic<[llvm_v32bf16_ty], [llvm_v32bf16_ty,llvm_v32bf16_ty,llvm_i32_ty,llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v32bf16_ty], [llvm_v32bf16_ty,llvm_v32bf16_ty,llvm_i32_ty,llvm_i32_ty], [IntrNoMem]>;
 // VINSERT.X
 class AIEV2VInsert8_I512
-     : Intrinsic<[llvm_v16i32_ty], [llvm_v16i32_ty,llvm_i32_ty,llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v16i32_ty], [llvm_v16i32_ty,llvm_i32_ty,llvm_i32_ty], [IntrNoMem]>;
 class AIEV2VInsert16_I512
-     : Intrinsic<[llvm_v16i32_ty], [llvm_v16i32_ty,llvm_i32_ty,llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v16i32_ty], [llvm_v16i32_ty,llvm_i32_ty,llvm_i32_ty], [IntrNoMem]>;
 class AIEV2VInsert32_I512
-     : Intrinsic<[llvm_v16i32_ty], [llvm_v16i32_ty,llvm_i32_ty,llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v16i32_ty], [llvm_v16i32_ty,llvm_i32_ty,llvm_i32_ty], [IntrNoMem]>;
 class AIEV2VInsert64_I512
-     : Intrinsic<[llvm_v16i32_ty], [llvm_v16i32_ty,llvm_i32_ty,llvm_v2i32_ty], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v16i32_ty], [llvm_v16i32_ty,llvm_i32_ty,llvm_v2i32_ty], [IntrNoMem]>;
 class AIEV2VInsert16_bf512
-     : Intrinsic<[llvm_v32bf16_ty], [llvm_v32bf16_ty,llvm_i32_ty,llvm_bfloat_ty], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v32bf16_ty], [llvm_v32bf16_ty,llvm_i32_ty,llvm_bfloat_ty], [IntrNoMem]>;
 class AIEV2VInsert32_bf512
-     : Intrinsic<[llvm_v32bf16_ty], [llvm_v32bf16_ty,llvm_i32_ty,llvm_v2bf16_ty], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v32bf16_ty], [llvm_v32bf16_ty,llvm_i32_ty,llvm_v2bf16_ty], [IntrNoMem]>;
 class AIEV2VInsert64_bf512
-     : Intrinsic<[llvm_v32bf16_ty], [llvm_v32bf16_ty,llvm_i32_ty,llvm_v4bf16_ty], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v32bf16_ty], [llvm_v32bf16_ty,llvm_i32_ty,llvm_v4bf16_ty], [IntrNoMem]>;
 class AIEV2VInsert32_accfloat
-     : Intrinsic<[llvm_v8i64_ty], [llvm_v8i64_ty,llvm_i32_ty,llvm_float_ty], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v8i64_ty], [llvm_v8i64_ty,llvm_i32_ty,llvm_float_ty], [IntrNoMem]>;
 
 // VBCST.X
 class AIEV2VBCST8I512
-     : Intrinsic<[llvm_v64i8_ty], [llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v64i8_ty], [llvm_i32_ty], [IntrNoMem]>;
 class AIEV2VBCST16I512
-     : Intrinsic<[llvm_v32i16_ty], [llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v32i16_ty], [llvm_i32_ty], [IntrNoMem]>;
 class AIEV2VBCST32I512
-     : Intrinsic<[llvm_v16i32_ty], [llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v16i32_ty], [llvm_i32_ty], [IntrNoMem]>;
 class AIEV2VBCST64I512
-     : Intrinsic<[llvm_v16i32_ty], [llvm_v2i32_ty], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v16i32_ty], [llvm_v2i32_ty], [IntrNoMem]>;
 class AIEV2VBCST16bf512
-     : Intrinsic<[llvm_v32bf16_ty], [llvm_bfloat_ty], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v32bf16_ty], [llvm_bfloat_ty], [IntrNoMem]>;
 class AIEV2VBCST32bf512
-     : Intrinsic<[llvm_v32bf16_ty], [llvm_v2bf16_ty], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v32bf16_ty], [llvm_v2bf16_ty], [IntrNoMem]>;
 class AIEV2VBCST64bf512
-     : Intrinsic<[llvm_v32bf16_ty], [llvm_v4bf16_ty], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v32bf16_ty], [llvm_v4bf16_ty], [IntrNoMem]>;
 class AIEV2VBCSTF32I512
-     : Intrinsic<[llvm_v16f32_ty], [llvm_float_ty], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v16f32_ty], [llvm_float_ty], [IntrNoMem]>;
 // VEXTBCST.X
 class AIEV2VEXTBCST8I512
-     : Intrinsic<[llvm_v64i8_ty], [llvm_v64i8_ty, llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v64i8_ty], [llvm_v64i8_ty, llvm_i32_ty], [IntrNoMem]>;
 class AIEV2VEXTBCST16I512
-     : Intrinsic<[llvm_v32i16_ty], [llvm_v32i16_ty, llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v32i16_ty], [llvm_v32i16_ty, llvm_i32_ty], [IntrNoMem]>;
 class AIEV2VEXTBCST32I512
-     : Intrinsic<[llvm_v16i32_ty], [llvm_v16i32_ty, llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v16i32_ty], [llvm_v16i32_ty, llvm_i32_ty], [IntrNoMem]>;
 class AIEV2VEXTBCST32Bf512
-     : Intrinsic<[llvm_v32bf16_ty], [llvm_v32bf16_ty, llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v32bf16_ty], [llvm_v32bf16_ty, llvm_i32_ty], [IntrNoMem]>;
 // VEXTRACT
 class AIEV2VExtElem8I512
-     : Intrinsic<[llvm_i32_ty], [llvm_v64i8_ty, llvm_i32_ty, llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_i32_ty], [llvm_v64i8_ty, llvm_i32_ty, llvm_i32_ty], [IntrNoMem]>;
 class AIEV2VExtElem16I512
-     : Intrinsic<[llvm_i32_ty], [llvm_v32i16_ty, llvm_i32_ty, llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_i32_ty], [llvm_v32i16_ty, llvm_i32_ty, llvm_i32_ty], [IntrNoMem]>;
 class AIEV2VExtElem32I512
-     : Intrinsic<[llvm_i32_ty], [llvm_v16i32_ty, llvm_i32_ty, llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_i32_ty], [llvm_v16i32_ty, llvm_i32_ty, llvm_i32_ty], [IntrNoMem]>;
 class AIEV2VExtElem64I512
-     : Intrinsic<[llvm_v2i32_ty], [llvm_v16i32_ty, llvm_i32_ty, llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v2i32_ty], [llvm_v16i32_ty, llvm_i32_ty, llvm_i32_ty], [IntrNoMem]>;
 // VSEL.X
 class AIEV2Sel8_I512
-     : Intrinsic<[llvm_v16i32_ty], [llvm_v16i32_ty,llvm_v16i32_ty,llvm_v2i32_ty], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v16i32_ty], [llvm_v16i32_ty,llvm_v16i32_ty,llvm_v2i32_ty], [IntrNoMem]>;
 class AIEV2Sel16_I512
-     : Intrinsic<[llvm_v16i32_ty], [llvm_v16i32_ty,llvm_v16i32_ty,llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v16i32_ty], [llvm_v16i32_ty,llvm_v16i32_ty,llvm_i32_ty], [IntrNoMem]>;
 class AIEV2Sel32_I512
-     : Intrinsic<[llvm_v16i32_ty], [llvm_v16i32_ty,llvm_v16i32_ty,llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v16i32_ty], [llvm_v16i32_ty,llvm_v16i32_ty,llvm_i32_ty], [IntrNoMem]>;
 // UPD
 class AIEV2UPD_I64_I32
-     : Intrinsic<[llvm_v2i32_ty], [llvm_v2i32_ty,llvm_i32_ty,llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v2i32_ty], [llvm_v2i32_ty,llvm_i32_ty,llvm_i32_ty], [IntrNoMem]>;
 class AIEV2UPD_I512_I256
-     : Intrinsic<[llvm_v16i32_ty], [llvm_v16i32_ty,llvm_v8i32_ty,llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v16i32_ty], [llvm_v16i32_ty,llvm_v8i32_ty,llvm_i32_ty], [IntrNoMem]>;
 class AIEV2UPD_I1024_I512
-     : Intrinsic<[llvm_v32i32_ty], [llvm_v32i32_ty,llvm_v16i32_ty,llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v32i32_ty], [llvm_v32i32_ty,llvm_v16i32_ty,llvm_i32_ty], [IntrNoMem]>;
 class AIEV2UPD_I1024_I256
-     : Intrinsic<[llvm_v32i32_ty], [llvm_v32i32_ty,llvm_v8i32_ty,llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v32i32_ty], [llvm_v32i32_ty,llvm_v8i32_ty,llvm_i32_ty], [IntrNoMem]>;
 class AIEV2UPD_bf512_bf256
-     : Intrinsic<[llvm_v32bf16_ty], [llvm_v32bf16_ty,llvm_v16bf16_ty,llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v32bf16_ty], [llvm_v32bf16_ty,llvm_v16bf16_ty,llvm_i32_ty], [IntrNoMem]>;
 class AIEV2UPD_bf1024_bf512
-     : Intrinsic<[llvm_v64bf16_ty], [llvm_v64bf16_ty,llvm_v32bf16_ty,llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v64bf16_ty], [llvm_v64bf16_ty,llvm_v32bf16_ty,llvm_i32_ty], [IntrNoMem]>;
 class AIEV2UPD_bf1024_bf256
-     : Intrinsic<[llvm_v64bf16_ty], [llvm_v64bf16_ty,llvm_v16bf16_ty,llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v64bf16_ty], [llvm_v64bf16_ty,llvm_v16bf16_ty,llvm_i32_ty], [IntrNoMem]>;
 class AIEV2UPD_512_256_acc
-     : Intrinsic<[llvm_v8i64_ty], [llvm_v8i64_ty,llvm_v4i64_ty,llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v8i64_ty], [llvm_v8i64_ty,llvm_v4i64_ty,llvm_i32_ty], [IntrNoMem]>;
 class AIEV2UPD_1024_512_acc
-     : Intrinsic<[llvm_v16i64_ty], [llvm_v16i64_ty,llvm_v8i64_ty,llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v16i64_ty], [llvm_v16i64_ty,llvm_v8i64_ty,llvm_i32_ty], [IntrNoMem]>;
 class AIEV2UPD_1024_256_acc
-     : Intrinsic<[llvm_v16i64_ty], [llvm_v16i64_ty,llvm_v4i64_ty,llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v16i64_ty], [llvm_v16i64_ty,llvm_v4i64_ty,llvm_i32_ty], [IntrNoMem]>;
 // SET
 class AIEV2SET_I64_I32
-     : Intrinsic<[llvm_v2i32_ty], [llvm_i32_ty,llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v2i32_ty], [llvm_i32_ty,llvm_i32_ty], [IntrNoMem]>;
 class AIEV2SET_I512_I256
-     : Intrinsic<[llvm_v16i32_ty], [llvm_v8i32_ty,llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v16i32_ty], [llvm_v8i32_ty,llvm_i32_ty], [IntrNoMem]>;
 class AIEV2SET_I1024_I512
-     : Intrinsic<[llvm_v32i32_ty], [llvm_v16i32_ty,llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v32i32_ty], [llvm_v16i32_ty,llvm_i32_ty], [IntrNoMem]>;
 class AIEV2SET_I1024_I256
-     : Intrinsic<[llvm_v32i32_ty], [llvm_v8i32_ty,llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v32i32_ty], [llvm_v8i32_ty,llvm_i32_ty], [IntrNoMem]>;
 class AIEV2SET_bf512_bf256
-     : Intrinsic<[llvm_v32bf16_ty], [llvm_v16bf16_ty,llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v32bf16_ty], [llvm_v16bf16_ty,llvm_i32_ty], [IntrNoMem]>;
 class AIEV2SET_bf1024_bf512
-     : Intrinsic<[llvm_v64bf16_ty], [llvm_v32bf16_ty,llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v64bf16_ty], [llvm_v32bf16_ty,llvm_i32_ty], [IntrNoMem]>;
 class AIEV2SET_bf1024_bf256
-     : Intrinsic<[llvm_v64bf16_ty], [llvm_v16bf16_ty,llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v64bf16_ty], [llvm_v16bf16_ty,llvm_i32_ty], [IntrNoMem]>;
 class AIEV2SET_512_256_acc
-     : Intrinsic<[llvm_v8i64_ty], [llvm_v4i64_ty,llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v8i64_ty], [llvm_v4i64_ty,llvm_i32_ty], [IntrNoMem]>;
 class AIEV2SET_1024_512_acc
-     : Intrinsic<[llvm_v16i64_ty], [llvm_v8i64_ty,llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v16i64_ty], [llvm_v8i64_ty,llvm_i32_ty], [IntrNoMem]>;
 class AIEV2SET_1024_256_acc
-     : Intrinsic<[llvm_v16i64_ty], [llvm_v4i64_ty,llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v16i64_ty], [llvm_v4i64_ty,llvm_i32_ty], [IntrNoMem]>;
 // EXT
 class AIEV2EXT_I32_I64
-     : Intrinsic<[llvm_i32_ty], [llvm_v2i32_ty,llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_i32_ty], [llvm_v2i32_ty,llvm_i32_ty], [IntrNoMem]>;
 class AIEV2EXT_I256_I512
-     : Intrinsic<[llvm_v8i32_ty] , [llvm_v16i32_ty,llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v8i32_ty] , [llvm_v16i32_ty,llvm_i32_ty], [IntrNoMem]>;
 class AIEV2EXT_I512_I1024
-     : Intrinsic<[llvm_v16i32_ty], [llvm_v32i32_ty,llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v16i32_ty], [llvm_v32i32_ty,llvm_i32_ty], [IntrNoMem]>;
 class AIEV2EXT_I256_I1024
-     : Intrinsic<[llvm_v8i32_ty] , [llvm_v32i32_ty,llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v8i32_ty] , [llvm_v32i32_ty,llvm_i32_ty], [IntrNoMem]>;
 class AIEV2EXT_bf256_bf512
-     : Intrinsic<[llvm_v16bf16_ty] , [llvm_v32bf16_ty,llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v16bf16_ty] , [llvm_v32bf16_ty,llvm_i32_ty], [IntrNoMem]>;
 class AIEV2EXT_bf512_bf1024
-     : Intrinsic<[llvm_v32bf16_ty], [llvm_v64bf16_ty,llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v32bf16_ty], [llvm_v64bf16_ty,llvm_i32_ty], [IntrNoMem]>;
 class AIEV2EXT_bf256_bf1024
-     : Intrinsic<[llvm_v16bf16_ty] , [llvm_v64bf16_ty,llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v16bf16_ty] , [llvm_v64bf16_ty,llvm_i32_ty], [IntrNoMem]>;
 class AIEV2EXT_256_512_acc
-     : Intrinsic<[llvm_v4i64_ty] , [llvm_v8i64_ty,llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v4i64_ty] , [llvm_v8i64_ty,llvm_i32_ty], [IntrNoMem]>;
 class AIEV2EXT_512_1024_acc
-     : Intrinsic<[llvm_v8i64_ty], [llvm_v16i64_ty,llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v8i64_ty], [llvm_v16i64_ty,llvm_i32_ty], [IntrNoMem]>;
 class AIEV2EXT_256_1024_acc
-     : Intrinsic<[llvm_v4i64_ty] , [llvm_v16i64_ty,llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v4i64_ty] , [llvm_v16i64_ty,llvm_i32_ty], [IntrNoMem]>;
 // Concat
 class AIEV2Concat_I512_I256
-     : Intrinsic<[llvm_v16i32_ty], [llvm_v8i32_ty,llvm_v8i32_ty], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v16i32_ty], [llvm_v8i32_ty,llvm_v8i32_ty], [IntrNoMem]>;
 class AIEV2Concat_I1024_I256
-     : Intrinsic<[llvm_v32i32_ty], [llvm_v8i32_ty,llvm_v8i32_ty,llvm_v8i32_ty,llvm_v8i32_ty], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v32i32_ty], [llvm_v8i32_ty,llvm_v8i32_ty,llvm_v8i32_ty,llvm_v8i32_ty], [IntrNoMem]>;
 class AIEV2Concat_I1024_I512
-     : Intrinsic<[llvm_v32i32_ty], [llvm_v16i32_ty,llvm_v16i32_ty], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v32i32_ty], [llvm_v16i32_ty,llvm_v16i32_ty], [IntrNoMem]>;
 class AIEV2Concat_bf512_bf256
-     : Intrinsic<[llvm_v32bf16_ty], [llvm_v16bf16_ty,llvm_v16bf16_ty], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v32bf16_ty], [llvm_v16bf16_ty,llvm_v16bf16_ty], [IntrNoMem]>;
 class AIEV2Concat_bf1024_bf256
-     : Intrinsic<[llvm_v64bf16_ty], [llvm_v16bf16_ty,llvm_v16bf16_ty,llvm_v16bf16_ty,llvm_v16bf16_ty], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v64bf16_ty], [llvm_v16bf16_ty,llvm_v16bf16_ty,llvm_v16bf16_ty,llvm_v16bf16_ty], [IntrNoMem]>;
 class AIEV2Concat_bf1024_bf512
-     : Intrinsic<[llvm_v64bf16_ty], [llvm_v32bf16_ty,llvm_v32bf16_ty], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v64bf16_ty], [llvm_v32bf16_ty,llvm_v32bf16_ty], [IntrNoMem]>;
 class AIEV2Concat_512_256_acc
-     : Intrinsic<[llvm_v8i64_ty], [llvm_v4i64_ty,llvm_v4i64_ty], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v8i64_ty], [llvm_v4i64_ty,llvm_v4i64_ty], [IntrNoMem]>;
 class AIEV2Concat_1024_256_acc
-     : Intrinsic<[llvm_v16i64_ty], [llvm_v4i64_ty,llvm_v4i64_ty,llvm_v4i64_ty,llvm_v4i64_ty], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v16i64_ty], [llvm_v4i64_ty,llvm_v4i64_ty,llvm_v4i64_ty,llvm_v4i64_ty], [IntrNoMem]>;
 class AIEV2Concat_1024_512_acc
-     : Intrinsic<[llvm_v16i64_ty], [llvm_v8i64_ty,llvm_v8i64_ty], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v16i64_ty], [llvm_v8i64_ty,llvm_v8i64_ty], [IntrNoMem]>;
 
 //srs
 class AIEV2I256V16Acc32I
 	 : Intrinsic<[llvm_v16i16_ty], [llvm_v8i64_ty, llvm_i32_ty, llvm_i32_ty],
-					 [IntrReadMem, IntrWillReturn, IntrInaccessibleMemOnly]>;
+					 [IntrReadMem, IntrInaccessibleMemOnly]>;
 class AIEV2I256V16Acc64I
 	 : Intrinsic<[llvm_v16i16_ty], [llvm_v16i64_ty, llvm_i32_ty, llvm_i32_ty],
-					 [IntrReadMem, IntrWillReturn, IntrInaccessibleMemOnly]>;
+					 [IntrReadMem, IntrInaccessibleMemOnly]>;
 class AIEV2I256V32Acc32I
 	 : Intrinsic<[llvm_v32i8_ty], [llvm_v16i64_ty, llvm_i32_ty, llvm_i32_ty],
-					 [IntrReadMem, IntrWillReturn, IntrInaccessibleMemOnly]>;
+					 [IntrReadMem, IntrInaccessibleMemOnly]>;
 class AIEV2I256V8Acc64I
 	 : Intrinsic<[llvm_v8i32_ty], [llvm_v8i64_ty, llvm_i32_ty, llvm_i32_ty],
-					 [IntrReadMem, IntrWillReturn, IntrInaccessibleMemOnly]>;
+					 [IntrReadMem, IntrInaccessibleMemOnly]>;
 class AIEV2I512V16Acc64I
 	 : Intrinsic<[llvm_v16i32_ty], [llvm_v16i64_ty, llvm_i32_ty, llvm_i32_ty],
-					 [IntrReadMem, IntrWillReturn, IntrInaccessibleMemOnly]>;
+					 [IntrReadMem, IntrInaccessibleMemOnly]>;
 class AIEV2I512V32Acc32I
 	 : Intrinsic<[llvm_v32i16_ty], [llvm_v16i64_ty, llvm_i32_ty, llvm_i32_ty],
-					 [IntrReadMem, IntrWillReturn, IntrInaccessibleMemOnly]>;
+					 [IntrReadMem, IntrInaccessibleMemOnly]>;
 
 // VUPS
 class AIEV2Acc32V16I256I : Intrinsic<[llvm_v8i64_ty],
                               [llvm_v16i16_ty, llvm_i32_ty, llvm_i32_ty],
-                              [IntrReadMem, IntrWillReturn, IntrInaccessibleMemOnly]>;
+                              [IntrReadMem, IntrInaccessibleMemOnly]>;
 class AIEV2Acc32V32I256I : Intrinsic<[llvm_v16i64_ty],
                               [llvm_v32i8_ty, llvm_i32_ty, llvm_i32_ty],
-                              [IntrReadMem, IntrWillReturn, IntrInaccessibleMemOnly]>;
+                              [IntrReadMem, IntrInaccessibleMemOnly]>;
 class AIEV2Acc32V32I512I : Intrinsic<[llvm_v16i64_ty],
                               [llvm_v32i16_ty, llvm_i32_ty, llvm_i32_ty],
-                              [IntrReadMem, IntrWillReturn, IntrInaccessibleMemOnly]>;
+                              [IntrReadMem, IntrInaccessibleMemOnly]>;
 class AIEV2Acc64V16I256I : Intrinsic<[llvm_v16i64_ty],
                               [llvm_v16i16_ty, llvm_i32_ty, llvm_i32_ty],
-                              [IntrReadMem, IntrWillReturn, IntrInaccessibleMemOnly]>;
+                              [IntrReadMem, IntrInaccessibleMemOnly]>;
 class AIEV2Acc64V16I512I : Intrinsic<[llvm_v16i64_ty],
                               [llvm_v16i32_ty, llvm_i32_ty, llvm_i32_ty],
-                              [IntrReadMem, IntrWillReturn, IntrInaccessibleMemOnly]>;
+                              [IntrReadMem, IntrInaccessibleMemOnly]>;
 class AIEV2Acc64V8I256I  : Intrinsic<[llvm_v8i64_ty],
                               [llvm_v8i32_ty, llvm_i32_ty, llvm_i32_ty],
-                              [IntrReadMem, IntrWillReturn, IntrInaccessibleMemOnly]>;
+                              [IntrReadMem, IntrInaccessibleMemOnly]>;
 
-class AIEV2V64I8V2I32V64I8I32 : DefaultAttrsIntrinsic<[llvm_v64i8_ty, llvm_v2i32_ty], [llvm_v64i8_ty, llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
-class AIEV2V32I16I32V32I16I32 : DefaultAttrsIntrinsic<[llvm_v32i16_ty, llvm_i32_ty], [llvm_v32i16_ty, llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
-class AIEV2V16I32I32V16I32I32 : DefaultAttrsIntrinsic<[llvm_v16i32_ty, llvm_i32_ty], [llvm_v16i32_ty, llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
+class AIEV2V64I8V2I32V64I8I32 : DefaultAttrsIntrinsic<[llvm_v64i8_ty, llvm_v2i32_ty], [llvm_v64i8_ty, llvm_i32_ty], [IntrNoMem]>;
+class AIEV2V32I16I32V32I16I32 : DefaultAttrsIntrinsic<[llvm_v32i16_ty, llvm_i32_ty], [llvm_v32i16_ty, llvm_i32_ty], [IntrNoMem]>;
+class AIEV2V16I32I32V16I32I32 : DefaultAttrsIntrinsic<[llvm_v16i32_ty, llvm_i32_ty], [llvm_v16i32_ty, llvm_i32_ty], [IntrNoMem]>;
 
-class AIEV2V64I8V64I8V64I8I64 : DefaultAttrsIntrinsic<[llvm_v64i8_ty], [llvm_v64i8_ty, llvm_v64i8_ty, llvm_v2i32_ty], [IntrNoMem, IntrWillReturn]>;
-class AIEV2V32I16V32I16V32I16I32 : DefaultAttrsIntrinsic<[llvm_v32i16_ty], [llvm_v32i16_ty, llvm_v32i16_ty, llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
-class AIEV2V16I32V16I32V16I32I32 : DefaultAttrsIntrinsic<[llvm_v16i32_ty], [llvm_v16i32_ty, llvm_v16i32_ty, llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
+class AIEV2V64I8V64I8V64I8I64 : DefaultAttrsIntrinsic<[llvm_v64i8_ty], [llvm_v64i8_ty, llvm_v64i8_ty, llvm_v2i32_ty], [IntrNoMem]>;
+class AIEV2V32I16V32I16V32I16I32 : DefaultAttrsIntrinsic<[llvm_v32i16_ty], [llvm_v32i16_ty, llvm_v32i16_ty, llvm_i32_ty], [IntrNoMem]>;
+class AIEV2V16I32V16I32V16I32I32 : DefaultAttrsIntrinsic<[llvm_v16i32_ty], [llvm_v16i32_ty, llvm_v16i32_ty, llvm_i32_ty], [IntrNoMem]>;
 
-class AIEV2V64I8V2I32V64I8 : DefaultAttrsIntrinsic<[llvm_v64i8_ty, llvm_v2i32_ty], [llvm_v64i8_ty], [IntrNoMem, IntrWillReturn]>;
-class AIEV2V32I16I32V32I16 : DefaultAttrsIntrinsic<[llvm_v32i16_ty, llvm_i32_ty], [llvm_v32i16_ty], [IntrNoMem, IntrWillReturn]>;
-class AIEV2V16I32I32V16I32 : DefaultAttrsIntrinsic<[llvm_v16i32_ty, llvm_i32_ty], [llvm_v16i32_ty], [IntrNoMem, IntrWillReturn]>;
+class AIEV2V64I8V2I32V64I8 : DefaultAttrsIntrinsic<[llvm_v64i8_ty, llvm_v2i32_ty], [llvm_v64i8_ty], [IntrNoMem]>;
+class AIEV2V32I16I32V32I16 : DefaultAttrsIntrinsic<[llvm_v32i16_ty, llvm_i32_ty], [llvm_v32i16_ty], [IntrNoMem]>;
+class AIEV2V16I32I32V16I32 : DefaultAttrsIntrinsic<[llvm_v16i32_ty, llvm_i32_ty], [llvm_v16i32_ty], [IntrNoMem]>;
 
-class AIEV2V2I32V64I8 : DefaultAttrsIntrinsic<[llvm_v2i32_ty], [llvm_v64i8_ty], [IntrNoMem, IntrWillReturn]>;
-class AIEV2I32V32I16 : DefaultAttrsIntrinsic<[llvm_i32_ty], [llvm_v32i16_ty], [IntrNoMem, IntrWillReturn]>;
-class AIEV2I32V16I32 : DefaultAttrsIntrinsic<[llvm_i32_ty], [llvm_v16i32_ty], [IntrNoMem, IntrWillReturn]>;
+class AIEV2V2I32V64I8 : DefaultAttrsIntrinsic<[llvm_v2i32_ty], [llvm_v64i8_ty], [IntrNoMem]>;
+class AIEV2I32V32I16 : DefaultAttrsIntrinsic<[llvm_i32_ty], [llvm_v32i16_ty], [IntrNoMem]>;
+class AIEV2I32V16I32 : DefaultAttrsIntrinsic<[llvm_i32_ty], [llvm_v16i32_ty], [IntrNoMem]>;
 
-class AIEV2V2I32V64I8V64I8I32 : DefaultAttrsIntrinsic<[llvm_v2i32_ty], [llvm_v64i8_ty, llvm_v64i8_ty, llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
-class AIEV2I32V32I16V32I16I32 : DefaultAttrsIntrinsic<[llvm_i32_ty], [llvm_v32i16_ty, llvm_v32i16_ty, llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
-class AIEV2I32V16I32V16I32I32 : DefaultAttrsIntrinsic<[llvm_i32_ty], [llvm_v16i32_ty, llvm_v16i32_ty, llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
-class AIEV2I32V32BF16V32BF16 : DefaultAttrsIntrinsic<[llvm_i32_ty], [llvm_v32bf16_ty, llvm_v32bf16_ty], [IntrNoMem, IntrWillReturn]>;
+class AIEV2V2I32V64I8V64I8I32 : DefaultAttrsIntrinsic<[llvm_v2i32_ty], [llvm_v64i8_ty, llvm_v64i8_ty, llvm_i32_ty], [IntrNoMem]>;
+class AIEV2I32V32I16V32I16I32 : DefaultAttrsIntrinsic<[llvm_i32_ty], [llvm_v32i16_ty, llvm_v32i16_ty, llvm_i32_ty], [IntrNoMem]>;
+class AIEV2I32V16I32V16I32I32 : DefaultAttrsIntrinsic<[llvm_i32_ty], [llvm_v16i32_ty, llvm_v16i32_ty, llvm_i32_ty], [IntrNoMem]>;
+class AIEV2I32V32BF16V32BF16 : DefaultAttrsIntrinsic<[llvm_i32_ty], [llvm_v32bf16_ty, llvm_v32bf16_ty], [IntrNoMem]>;
 
-class AIEV2V64I8I64V64I8V64I8I32 : DefaultAttrsIntrinsic<[llvm_v64i8_ty, llvm_v2i32_ty], [llvm_v64i8_ty, llvm_v64i8_ty, llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
-class AIEV2V32I16I32V32I16V32I16I32 : DefaultAttrsIntrinsic<[llvm_v32i16_ty, llvm_i32_ty], [llvm_v32i16_ty, llvm_v32i16_ty, llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
-class AIEV2V16I32I32V16I32V16I32I32 : DefaultAttrsIntrinsic<[llvm_v16i32_ty, llvm_i32_ty], [llvm_v16i32_ty, llvm_v16i32_ty, llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
-class AIEV2V32BF16I32V32BF16V32BF16I32 : DefaultAttrsIntrinsic<[llvm_v32bf16_ty, llvm_i32_ty], [llvm_v32bf16_ty, llvm_v32bf16_ty], [IntrNoMem, IntrWillReturn]>;
+class AIEV2V64I8I64V64I8V64I8I32 : DefaultAttrsIntrinsic<[llvm_v64i8_ty, llvm_v2i32_ty], [llvm_v64i8_ty, llvm_v64i8_ty, llvm_i32_ty], [IntrNoMem]>;
+class AIEV2V32I16I32V32I16V32I16I32 : DefaultAttrsIntrinsic<[llvm_v32i16_ty, llvm_i32_ty], [llvm_v32i16_ty, llvm_v32i16_ty, llvm_i32_ty], [IntrNoMem]>;
+class AIEV2V16I32I32V16I32V16I32I32 : DefaultAttrsIntrinsic<[llvm_v16i32_ty, llvm_i32_ty], [llvm_v16i32_ty, llvm_v16i32_ty, llvm_i32_ty], [IntrNoMem]>;
+class AIEV2V32BF16I32V32BF16V32BF16I32 : DefaultAttrsIntrinsic<[llvm_v32bf16_ty, llvm_i32_ty], [llvm_v32bf16_ty, llvm_v32bf16_ty], [IntrNoMem]>;
 
 // VBCSTSHFL
-class AIEV2VBcstShfl_bf16 : Intrinsic<[llvm_v32bf16_ty], [llvm_bfloat_ty, llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
-class AIEV2VBcstShfl_I32 : Intrinsic<[llvm_v16i32_ty], [llvm_i32_ty, llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
-class AIEV2VBcstShfl_I64 : Intrinsic<[llvm_v16i32_ty], [llvm_v2i32_ty, llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
+class AIEV2VBcstShfl_bf16 : Intrinsic<[llvm_v32bf16_ty], [llvm_bfloat_ty, llvm_i32_ty], [IntrNoMem]>;
+class AIEV2VBcstShfl_I32 : Intrinsic<[llvm_v16i32_ty], [llvm_i32_ty, llvm_i32_ty], [IntrNoMem]>;
+class AIEV2VBcstShfl_I64 : Intrinsic<[llvm_v16i32_ty], [llvm_v2i32_ty, llvm_i32_ty], [IntrNoMem]>;
 
 // VSHUFFLE
-class AIEV2VShuffle : Intrinsic<[llvm_v16i32_ty], [llvm_v16i32_ty, llvm_v16i32_ty, llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
-class AIEV2VShuffleBf16 : Intrinsic<[llvm_v32bf16_ty], [llvm_v32bf16_ty, llvm_v32bf16_ty, llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
+class AIEV2VShuffle : Intrinsic<[llvm_v16i32_ty], [llvm_v16i32_ty, llvm_v16i32_ty, llvm_i32_ty], [IntrNoMem]>;
+class AIEV2VShuffleBf16 : Intrinsic<[llvm_v32bf16_ty], [llvm_v32bf16_ty, llvm_v32bf16_ty, llvm_i32_ty], [IntrNoMem]>;
 
 
 // PADDX.XX
 class AIEV2Add2D : Intrinsic<[llvm_ptr_ty, llvm_i20_ty],
       [llvm_ptr_ty, llvm_i20_ty, llvm_i20_ty, llvm_i20_ty, llvm_i20_ty],
-      [IntrNoMem, IntrWillReturn]>;
+      [IntrNoMem]>;
 class AIEV2Add3D : Intrinsic<[llvm_ptr_ty, llvm_i20_ty, llvm_i20_ty],
       [llvm_ptr_ty, llvm_i20_ty, llvm_i20_ty, llvm_i20_ty, llvm_i20_ty, llvm_i20_ty, llvm_i20_ty, llvm_i20_ty],
-      [IntrNoMem, IntrWillReturn]>;
+      [IntrNoMem]>;
 
 // VLD.SPARSE.POP / VLD.SPARSE.PEEK
 class AIEV2SPARSE_OP_V64I16_set_lo : Intrinsic<[llvm_ptr_ty, llvm_v32i16_ty, llvm_i128_ty],
      [llvm_v32i16_ty, llvm_i128_ty, llvm_ptr_ty],
-     [IntrWillReturn]>;
+     []>;
 class AIEV2SPARSE_OP_V64I16_insert_hi : Intrinsic<[llvm_ptr_ty, llvm_v32i16_ty, llvm_i128_ty],
      [llvm_v32i16_ty, llvm_i128_ty, llvm_v32i16_ty, llvm_i128_ty, llvm_ptr_ty],
-     [IntrWillReturn]>;
+     []>;
 
 class AIEV2SPARSE_OP_V128I8_set_lo : Intrinsic<[llvm_ptr_ty, llvm_v64i8_ty, llvm_i128_ty],
      [llvm_v64i8_ty, llvm_i128_ty, llvm_ptr_ty],
-     [IntrWillReturn]>;
+     []>;
 class AIEV2SPARSE_OP_V128I8_insert_hi : Intrinsic<[llvm_ptr_ty, llvm_v64i8_ty, llvm_i128_ty],
      [llvm_v64i8_ty, llvm_i128_ty, llvm_v64i8_ty, llvm_i128_ty, llvm_ptr_ty],
-     [IntrWillReturn]>;
+     []>;
 
 class AIEV2SPARSE_OP_V256I4_set_lo : Intrinsic<[llvm_ptr_ty, llvm_v16i32_ty, llvm_i128_ty],
      [llvm_v16i32_ty, llvm_i128_ty, llvm_ptr_ty],
-     [IntrWillReturn]>;
+     []>;
 class AIEV2SPARSE_OP_V256I4_insert_hi : Intrinsic<[llvm_ptr_ty, llvm_v16i32_ty, llvm_i128_ty],
      [llvm_v16i32_ty, llvm_i128_ty, llvm_v16i32_ty, llvm_i128_ty, llvm_ptr_ty],
-     [IntrWillReturn]>;
+     []>;
 
 class AIEV2SPARSE_OP_V64BF16_set_lo : Intrinsic<[llvm_ptr_ty, llvm_v32bf16_ty, llvm_i128_ty],
      [llvm_v32bf16_ty, llvm_i128_ty, llvm_ptr_ty],
-     [IntrWillReturn]>;
+     []>;
 class AIEV2SPARSE_OP_V64BF16_insert_hi : Intrinsic<[llvm_ptr_ty, llvm_v32bf16_ty, llvm_i128_ty],
      [llvm_v32bf16_ty, llvm_i128_ty, llvm_v32bf16_ty, llvm_i128_ty, llvm_ptr_ty],
-     [IntrWillReturn]>;
+     []>;
 
 class AIEV2SPARSE_RESET_FILL : Intrinsic<[llvm_ptr_ty],
      [llvm_ptr_ty],
-     [IntrWillReturn]>;
+     []>;
 
 // LOAD_4X
 class AIEV2LOAD4X : DefaultAttrsIntrinsic<[llvm_v8i32_ty], [llvm_v8i32_ty],
-      [IntrReadMem, IntrWillReturn]>;
+      [IntrReadMem]>;
 
 
 // bfloat16 conversions
 class AIEV2BF16ToInt : Intrinsic<[llvm_i32_ty],
       [llvm_bfloat_ty],
-      [IntrNoMem, IntrWillReturn]>;
+      [IntrNoMem]>;
 class AIEV2V16BF16ToV16I : Intrinsic<[llvm_v16i32_ty],
       [llvm_v16bf16_ty, llvm_i32_ty],
-      [IntrReadMem, IntrWillReturn, IntrInaccessibleMemOnly]>;
+      [IntrReadMem, IntrInaccessibleMemOnly]>;
 
 // Streams
-class AIEV2V16I32I32I32 : DefaultAttrsIntrinsic<[llvm_v16i32_ty], [llvm_i32_ty], [IntrInaccessibleMemOnly, IntrWillReturn]>;
-class AIEV2V16Acc32I32I32 : DefaultAttrsIntrinsic<[llvm_v8i64_ty], [llvm_i32_ty], [IntrInaccessibleMemOnly, IntrWillReturn]>;
-class AIEV2V32Acc32I32 : DefaultAttrsIntrinsic<[llvm_v16i64_ty], [llvm_i32_ty], [IntrInaccessibleMemOnly, IntrWillReturn]>;
-class AIEV2vV16I32I32 : DefaultAttrsIntrinsic<[], [llvm_v16i32_ty, llvm_i32_ty], [IntrInaccessibleMemOnly, IntrWillReturn]>;
-class AIEV2vV16Acc32I32 : DefaultAttrsIntrinsic<[], [llvm_v8i64_ty, llvm_i32_ty], [IntrInaccessibleMemOnly, IntrWillReturn]>;
-class AIEV2I32I32 : DefaultAttrsIntrinsic<[llvm_i32_ty, llvm_i32_ty], [], [IntrInaccessibleMemOnly, IntrWillReturn]>;
-class AIEV2vI32I32 : DefaultAttrsIntrinsic<[], [llvm_i32_ty, llvm_i32_ty], [IntrInaccessibleMemOnly, IntrWillReturn]>;
-class AIEV2I32I32I32 : DefaultAttrsIntrinsic<[llvm_i32_ty], [llvm_i32_ty, llvm_i32_ty], [IntrInaccessibleMemOnly, IntrWillReturn]>;
-class AIEV2vI32I32I32 : DefaultAttrsIntrinsic<[], [llvm_i32_ty, llvm_i32_ty, llvm_i32_ty], [IntrInaccessibleMemOnly, IntrWillReturn]>;
+class AIEV2V16I32I32I32 : DefaultAttrsIntrinsic<[llvm_v16i32_ty], [llvm_i32_ty], [IntrInaccessibleMemOnly]>;
+class AIEV2V16Acc32I32I32 : DefaultAttrsIntrinsic<[llvm_v8i64_ty], [llvm_i32_ty], [IntrInaccessibleMemOnly]>;
+class AIEV2V32Acc32I32 : DefaultAttrsIntrinsic<[llvm_v16i64_ty], [llvm_i32_ty], [IntrInaccessibleMemOnly]>;
+class AIEV2vV16I32I32 : DefaultAttrsIntrinsic<[], [llvm_v16i32_ty, llvm_i32_ty], [IntrInaccessibleMemOnly]>;
+class AIEV2vV16Acc32I32 : DefaultAttrsIntrinsic<[], [llvm_v8i64_ty, llvm_i32_ty], [IntrInaccessibleMemOnly]>;
+class AIEV2I32I32 : DefaultAttrsIntrinsic<[llvm_i32_ty, llvm_i32_ty], [], [IntrInaccessibleMemOnly]>;
+class AIEV2vI32I32 : DefaultAttrsIntrinsic<[], [llvm_i32_ty, llvm_i32_ty], [IntrInaccessibleMemOnly]>;
+class AIEV2I32I32I32 : DefaultAttrsIntrinsic<[llvm_i32_ty], [llvm_i32_ty, llvm_i32_ty], [IntrInaccessibleMemOnly]>;
+class AIEV2vI32I32I32 : DefaultAttrsIntrinsic<[], [llvm_i32_ty, llvm_i32_ty, llvm_i32_ty], [IntrInaccessibleMemOnly]>;
 class AIEV2I32I32I32I32 : DefaultAttrsIntrinsic<[llvm_i32_ty],
                                                 [llvm_i32_ty, llvm_i32_ty, llvm_i32_ty],
-                                                [IntrInaccessibleMemOnly, IntrWillReturn]>;
+                                                [IntrInaccessibleMemOnly]>;
 class AIEV2vI32I32I32I32I32 : DefaultAttrsIntrinsic<[],
                                                     [llvm_i32_ty, llvm_i32_ty, llvm_i32_ty, llvm_i32_ty, llvm_i32_ty],
-                                                    [IntrInaccessibleMemOnly, IntrWillReturn]>;
+                                                    [IntrInaccessibleMemOnly]>;
 class AIEV2I32I32I32I32I32I32 : DefaultAttrsIntrinsic<[llvm_i32_ty],
                                                        [llvm_i32_ty, llvm_i32_ty, llvm_i32_ty, llvm_i32_ty, llvm_i32_ty],
-                                                       [IntrInaccessibleMemOnly, IntrWillReturn]>;
+                                                       [IntrInaccessibleMemOnly]>;
 
-class AIEV2ReadTM : Intrinsic<[llvm_i32_ty], [llvm_ptr_ty], [IntrReadMem, IntrWillReturn]>;
-class AIEV2WriteTM : Intrinsic<[], [llvm_i32_ty, llvm_ptr_ty], [IntrWriteMem, IntrWillReturn]>;
+class AIEV2ReadTM : Intrinsic<[llvm_i32_ty], [llvm_ptr_ty], [IntrReadMem]>;
+class AIEV2WriteTM : Intrinsic<[], [llvm_i32_ty, llvm_ptr_ty], [IntrWriteMem]>;
 
 // Mode Settings
 // Set Control Reg
-class AIEV2SetCtrlReg : Intrinsic<[], [llvm_i32_ty, llvm_i32_ty], [IntrWriteMem, IntrInaccessibleMemOnly, IntrWillReturn]>;
+class AIEV2SetCtrlReg : Intrinsic<[], [llvm_i32_ty, llvm_i32_ty], [IntrWriteMem, IntrInaccessibleMemOnly]>;
 // Get Control Reg
-class AIEV2GetCtrlReg : Intrinsic<[llvm_i32_ty], [llvm_i32_ty], [IntrReadMem, IntrWillReturn, IntrInaccessibleMemOnly]>;
+class AIEV2GetCtrlReg : Intrinsic<[llvm_i32_ty], [llvm_i32_ty], [IntrReadMem, IntrInaccessibleMemOnly]>;
 
 
 // Get CoreID
-class AIEV2GetCoreID : Intrinsic<[llvm_i32_ty], [], [IntrNoMem, IntrWillReturn]>;
+class AIEV2GetCoreID : Intrinsic<[llvm_i32_ty], [], [IntrNoMem]>;
 
 // CLB
-class AIEV2CLB : Intrinsic<[llvm_i32_ty], [llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
+class AIEV2CLB : Intrinsic<[llvm_i32_ty], [llvm_i32_ty], [IntrNoMem]>;
 
 // DIVS
-class AIEV2DIVS : Intrinsic<[llvm_i32_ty, llvm_i32_ty], [llvm_i32_ty, llvm_i32_ty, llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
+class AIEV2DIVS : Intrinsic<[llvm_i32_ty, llvm_i32_ty], [llvm_i32_ty, llvm_i32_ty, llvm_i32_ty], [IntrNoMem]>;
 
 // Pack-Unpack
-class AIEV2PackI4I8 : Intrinsic<[llvm_v32i8_ty], [llvm_v32i16_ty, llvm_i32_ty], [IntrReadMem, IntrWillReturn, IntrInaccessibleMemOnly]>;
-class AIEV2PackI8I16 : Intrinsic<[llvm_v32i8_ty], [llvm_v32i16_ty, llvm_i32_ty], [IntrReadMem, IntrWillReturn, IntrInaccessibleMemOnly]>;
-class AIEV2UnPackI8I4 : Intrinsic<[llvm_v32i16_ty], [llvm_v32i8_ty, llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
-class AIEV2UnPackI16I8 : Intrinsic<[llvm_v32i16_ty], [llvm_v32i8_ty, llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
+class AIEV2PackI4I8 : Intrinsic<[llvm_v32i8_ty], [llvm_v32i16_ty, llvm_i32_ty], [IntrReadMem, IntrInaccessibleMemOnly]>;
+class AIEV2PackI8I16 : Intrinsic<[llvm_v32i8_ty], [llvm_v32i16_ty, llvm_i32_ty], [IntrReadMem, IntrInaccessibleMemOnly]>;
+class AIEV2UnPackI8I4 : Intrinsic<[llvm_v32i16_ty], [llvm_v32i8_ty, llvm_i32_ty], [IntrNoMem]>;
+class AIEV2UnPackI16I8 : Intrinsic<[llvm_v32i16_ty], [llvm_v32i8_ty, llvm_i32_ty], [IntrNoMem]>;
 
 // Scheduling barrier
-class AIEV2SchedBarrier : Intrinsic<[], [], [IntrNoMem, IntrWillReturn, IntrHasSideEffects, IntrConvergent, IntrWillReturn]>;
+class AIEV2SchedBarrier : Intrinsic<[], [], [IntrNoMem, IntrHasSideEffects, IntrConvergent, IntrWillReturn]>;
 
 // clear accumulator
-class AIEV2CLR16F : Intrinsic<[llvm_v8i64_ty], [], [IntrReadMem, IntrWillReturn, IntrInaccessibleMemOnly]>;
-class AIEV2VCLRACC1024 : Intrinsic<[llvm_v16i64_ty], [], [IntrNoMem, IntrWillReturn]>;
+class AIEV2CLR16F : Intrinsic<[llvm_v8i64_ty], [], [IntrReadMem, IntrInaccessibleMemOnly]>;
+class AIEV2VCLRACC1024 : Intrinsic<[llvm_v16i64_ty], [], [IntrNoMem]>;
 
 // Extract Sub-Vector
 class AIEV2Extract_I128_I512
-     : Intrinsic<[llvm_v4i32_ty], [llvm_v16i32_ty], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v4i32_ty], [llvm_v16i32_ty], [IntrNoMem]>;
 
 // Set Sub-Vector
 class AIEV2Set_I512_I128
-     : Intrinsic<[llvm_v16i32_ty], [llvm_v4i32_ty], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v16i32_ty], [llvm_v4i32_ty], [IntrNoMem]>;
 
 def int_aie2_event : ClangBuiltin<"__builtin_aiev2_event">, AIE2EventIntrinsic;
 //Locks
@@ -912,14 +912,14 @@ def int_aie2_mcd_write_vec : ClangBuiltin<"__builtin_aiev2_mcd_write_vec">, AIEV
 def int_aie2_mcd_write_acc32 : ClangBuiltin<"__builtin_aiev2_mcd_write_acc32">, AIEV2vV16Acc32I32;
 
 // Scalar stream read
-class AIEV2_get_ss : DefaultAttrsIntrinsic<[llvm_i32_ty, llvm_i32_ty], [], [IntrHasSideEffects, IntrNoMem, IntrWillReturn]>;
+class AIEV2_get_ss : DefaultAttrsIntrinsic<[llvm_i32_ty, llvm_i32_ty], [], [IntrHasSideEffects, IntrNoMem]>;
 def int_aie2_get_ss : AIEV2_get_ss;
 def int_aie2_get_ss_nb : AIEV2_get_ss;
 
 // Scalar stream write with tlast
-class AIEV2_put_ms : DefaultAttrsIntrinsic<[], [llvm_i32_ty, llvm_i32_ty], [IntrHasSideEffects, IntrNoMem, IntrWillReturn]>;
+class AIEV2_put_ms : DefaultAttrsIntrinsic<[], [llvm_i32_ty, llvm_i32_ty], [IntrHasSideEffects, IntrNoMem]>;
 def int_aie2_put_ms : ClangBuiltin<"__builtin_aiev2_put_ms">, AIEV2_put_ms;
-def int_aie2_put_ms_nb : DefaultAttrsIntrinsic<[llvm_i32_ty], [llvm_i32_ty, llvm_i32_ty], [IntrHasSideEffects, IntrNoMem, IntrWillReturn]>;
+def int_aie2_put_ms_nb : DefaultAttrsIntrinsic<[llvm_i32_ty], [llvm_i32_ty, llvm_i32_ty], [IntrHasSideEffects, IntrNoMem]>;
 
 // Packet switched stream
 // Packet header

--- a/llvm/include/llvm/IR/IntrinsicsAIE2P.td
+++ b/llvm/include/llvm/IR/IntrinsicsAIE2P.td
@@ -16,128 +16,128 @@ let TargetPrefix = "aie2p" in {
 
 //===----------------------------------------------------------------------===//
 class AIE2PEventIntrinsic
-    : Intrinsic<[],
+    : DefaultAttrsIntrinsic<[],
                 [llvm_i32_ty],
                 [IntrHasSideEffects, IntrNoMem]>; //[IntrHasSideEffects, IntrNoMem, ImmArg<ArgIndex<0>>]>;
 class AIEV2PEXT_I32_I64
-     : Intrinsic<[llvm_i32_ty], [llvm_v2i32_ty,llvm_i32_ty], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_i32_ty], [llvm_v2i32_ty,llvm_i32_ty], [IntrNoMem]>;
 class AIEV2PSET_I64_I32
-     : Intrinsic<[llvm_v2i32_ty], [llvm_i32_ty,llvm_i32_ty], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v2i32_ty], [llvm_i32_ty,llvm_i32_ty], [IntrNoMem]>;
 class AIEV2PUPD_I64_I32
-     : Intrinsic<[llvm_v2i32_ty], [llvm_v2i32_ty,llvm_i32_ty,llvm_i32_ty], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v2i32_ty], [llvm_v2i32_ty,llvm_i32_ty,llvm_i32_ty], [IntrNoMem]>;
 // bfloat16 conversions
-class AIEV2PBF16ToInt : Intrinsic<[llvm_i32_ty],
+class AIEV2PBF16ToInt : DefaultAttrsIntrinsic<[llvm_i32_ty],
       [llvm_bfloat_ty],
       [IntrNoMem]>;
 
 // TM
-class AIE2PReadTM : Intrinsic<[llvm_i32_ty], [llvm_ptr_ty], [IntrArgMemOnly]>;
-class AIE2PWriteTM : Intrinsic<[], [llvm_i32_ty, llvm_ptr_ty], [IntrWriteMem]>;
+class AIE2PReadTM : DefaultAttrsIntrinsic<[llvm_i32_ty], [llvm_ptr_ty], [IntrArgMemOnly]>;
+class AIE2PWriteTM : DefaultAttrsIntrinsic<[], [llvm_i32_ty, llvm_ptr_ty], [IntrWriteMem]>;
 // FLT2FX, FX2FLT
-class AIE2PFX2FLT : Intrinsic<[llvm_float_ty], [llvm_i32_ty, llvm_i32_ty], 
+class AIE2PFX2FLT : DefaultAttrsIntrinsic<[llvm_float_ty], [llvm_i32_ty, llvm_i32_ty], 
       [IntrNoMem]>;
-class AIE2PFLT2FX : Intrinsic<[llvm_i32_ty], [llvm_float_ty, llvm_i32_ty], 
+class AIE2PFLT2FX : DefaultAttrsIntrinsic<[llvm_i32_ty], [llvm_float_ty, llvm_i32_ty], 
       [IntrNoMem]>;
 // non-linear float
-class AIE2PNLFVec : Intrinsic<[llvm_v16bf16_ty], [llvm_v16f32_ty],
+class AIE2PNLFVec : DefaultAttrsIntrinsic<[llvm_v16bf16_ty], [llvm_v16f32_ty],
       [IntrNoMem]>;
-class AIE2PNLF : Intrinsic<[llvm_float_ty], [llvm_float_ty],
+class AIE2PNLF : DefaultAttrsIntrinsic<[llvm_float_ty], [llvm_float_ty],
       [IntrNoMem]>;
 // DIVS
-class AIE2PDIVS : Intrinsic<[llvm_i32_ty, llvm_i32_ty], [llvm_i32_ty, llvm_i32_ty, llvm_i32_ty], [IntrNoMem]>;
+class AIE2PDIVS : DefaultAttrsIntrinsic<[llvm_i32_ty, llvm_i32_ty], [llvm_i32_ty, llvm_i32_ty, llvm_i32_ty], [IntrNoMem]>;
 
 //srs
 class AIE2PI256V16Acc32I
-	 : Intrinsic<[llvm_v16i16_ty], [llvm_v16i32_ty, llvm_i32_ty, llvm_i32_ty],
+	 : DefaultAttrsIntrinsic<[llvm_v16i16_ty], [llvm_v16i32_ty, llvm_i32_ty, llvm_i32_ty],
 					 [IntrReadMem, IntrInaccessibleMemOnly]>;
 class AIE2PI256V16Acc64I
-	 : Intrinsic<[llvm_v16i16_ty], [llvm_v16i64_ty, llvm_i32_ty, llvm_i32_ty],
+	 : DefaultAttrsIntrinsic<[llvm_v16i16_ty], [llvm_v16i64_ty, llvm_i32_ty, llvm_i32_ty],
 					 [IntrReadMem, IntrInaccessibleMemOnly]>;
 class AIE2PI256V32Acc32I
-	 : Intrinsic<[llvm_v32i8_ty], [llvm_v32i32_ty, llvm_i32_ty, llvm_i32_ty],
+	 : DefaultAttrsIntrinsic<[llvm_v32i8_ty], [llvm_v32i32_ty, llvm_i32_ty, llvm_i32_ty],
 					 [IntrReadMem, IntrInaccessibleMemOnly]>;
 class AIE2PI256V8Acc64I
-	 : Intrinsic<[llvm_v8i32_ty], [llvm_v8i64_ty, llvm_i32_ty, llvm_i32_ty],
+	 : DefaultAttrsIntrinsic<[llvm_v8i32_ty], [llvm_v8i64_ty, llvm_i32_ty, llvm_i32_ty],
 					 [IntrReadMem, IntrInaccessibleMemOnly]>;
 class AIE2PI512V16Acc64I
-	 : Intrinsic<[llvm_v16i32_ty], [llvm_v16i64_ty, llvm_i32_ty, llvm_i32_ty],
+	 : DefaultAttrsIntrinsic<[llvm_v16i32_ty], [llvm_v16i64_ty, llvm_i32_ty, llvm_i32_ty],
 					 [IntrReadMem, IntrInaccessibleMemOnly]>;
 class AIE2PI512V32Acc32I
-	 : Intrinsic<[llvm_v32i16_ty], [llvm_v32i32_ty, llvm_i32_ty, llvm_i32_ty],
+	 : DefaultAttrsIntrinsic<[llvm_v32i16_ty], [llvm_v32i32_ty, llvm_i32_ty, llvm_i32_ty],
 					 [IntrReadMem, IntrInaccessibleMemOnly]>;
 class AIE2PI512V32Acc64I
-	 : Intrinsic<[llvm_v32i16_ty], [llvm_v32i64_ty, llvm_i32_ty, llvm_i32_ty],
+	 : DefaultAttrsIntrinsic<[llvm_v32i16_ty], [llvm_v32i64_ty, llvm_i32_ty, llvm_i32_ty],
 					 [IntrReadMem, IntrInaccessibleMemOnly]>;
 class AIE2PI512V64Acc32I
-	 : Intrinsic<[llvm_v64i8_ty], [llvm_v64i32_ty, llvm_i32_ty, llvm_i32_ty],
+	 : DefaultAttrsIntrinsic<[llvm_v64i8_ty], [llvm_v64i32_ty, llvm_i32_ty, llvm_i32_ty],
 					 [IntrReadMem, IntrInaccessibleMemOnly]>;
 
 // UPS
-class AIE2PAcc32V16I256I : Intrinsic<[llvm_v16i32_ty],
+class AIE2PAcc32V16I256I : DefaultAttrsIntrinsic<[llvm_v16i32_ty],
                               [llvm_v16i16_ty, llvm_i32_ty, llvm_i32_ty],
                               [IntrReadMem, IntrInaccessibleMemOnly]>;
-class AIE2PAcc32V32I256I : Intrinsic<[llvm_v32i32_ty],
+class AIE2PAcc32V32I256I : DefaultAttrsIntrinsic<[llvm_v32i32_ty],
                               [llvm_v32i8_ty, llvm_i32_ty, llvm_i32_ty],
                               [IntrReadMem, IntrInaccessibleMemOnly]>;
-class AIE2PAcc32V32I512I : Intrinsic<[llvm_v32i32_ty],
+class AIE2PAcc32V32I512I : DefaultAttrsIntrinsic<[llvm_v32i32_ty],
                               [llvm_v32i16_ty, llvm_i32_ty, llvm_i32_ty],
                               [IntrReadMem, IntrInaccessibleMemOnly]>;
-class AIE2PAcc64V16I256I : Intrinsic<[llvm_v16i64_ty],
+class AIE2PAcc64V16I256I : DefaultAttrsIntrinsic<[llvm_v16i64_ty],
                               [llvm_v16i16_ty, llvm_i32_ty, llvm_i32_ty],
                               [IntrReadMem, IntrInaccessibleMemOnly]>;
-class AIE2PAcc64V16I512I : Intrinsic<[llvm_v16i64_ty],
+class AIE2PAcc64V16I512I : DefaultAttrsIntrinsic<[llvm_v16i64_ty],
                               [llvm_v16i32_ty, llvm_i32_ty, llvm_i32_ty],
                               [IntrReadMem, IntrInaccessibleMemOnly]>;
-class AIE2PAcc64V8I256I  : Intrinsic<[llvm_v8i64_ty],
+class AIE2PAcc64V8I256I  : DefaultAttrsIntrinsic<[llvm_v8i64_ty],
                               [llvm_v8i32_ty, llvm_i32_ty, llvm_i32_ty],
                               [IntrReadMem, IntrInaccessibleMemOnly]>;
-class AIE2PAcc32V64I512I  : Intrinsic<[llvm_v64i32_ty],
+class AIE2PAcc32V64I512I  : DefaultAttrsIntrinsic<[llvm_v64i32_ty],
                               [llvm_v64i8_ty, llvm_i32_ty, llvm_i32_ty],
                               [IntrReadMem, IntrInaccessibleMemOnly]>;
-class AIE2PAcc64V32I512I  : Intrinsic<[llvm_v32i64_ty],
+class AIE2PAcc64V32I512I  : DefaultAttrsIntrinsic<[llvm_v32i64_ty],
                               [llvm_v32i16_ty, llvm_i32_ty, llvm_i32_ty],
                               [IntrReadMem, IntrInaccessibleMemOnly]>;
 // v16accfloat to v16bfloat16
-class AIE2PV16AccFloatToV16Bf : Intrinsic<[llvm_v16bf16_ty],
+class AIE2PV16AccFloatToV16Bf : DefaultAttrsIntrinsic<[llvm_v16bf16_ty],
                                           [llvm_v16f32_ty],
                                           [IntrReadMem, IntrInaccessibleMemOnly]>;
-class AIE2PV16BfToV16AccFloat : Intrinsic<[llvm_v16f32_ty], [llvm_v16bf16_ty], [IntrNoMem]>;
+class AIE2PV16BfToV16AccFloat : DefaultAttrsIntrinsic<[llvm_v16f32_ty], [llvm_v16bf16_ty], [IntrNoMem]>;
 
 // v32accfloat to v32bfloat16
-class AIE2PV32AccFloatToV32Bf : Intrinsic<[llvm_v32bf16_ty],
+class AIE2PV32AccFloatToV32Bf : DefaultAttrsIntrinsic<[llvm_v32bf16_ty],
                                           [llvm_v32f32_ty],
                                           [IntrReadMem, IntrInaccessibleMemOnly]>;
-class AIE2PV32BfToV32AccFloat : Intrinsic<[llvm_v32f32_ty], [llvm_v32bf16_ty], [IntrNoMem]>;
+class AIE2PV32BfToV32AccFloat : DefaultAttrsIntrinsic<[llvm_v32f32_ty], [llvm_v32bf16_ty], [IntrNoMem]>;
 
 // v16accfloat to v8float
-class AIE2PV16AccFloatToV8Float : Intrinsic<[llvm_v8f32_ty],
+class AIE2PV16AccFloatToV8Float : DefaultAttrsIntrinsic<[llvm_v8f32_ty],
                                           [llvm_v16f32_ty],
                                           [IntrReadMem, IntrInaccessibleMemOnly]>;
-class AIE2PV8FloatToV16AccFloat : Intrinsic<[llvm_v16f32_ty], [llvm_v8f32_ty], [IntrNoMem]>;
+class AIE2PV8FloatToV16AccFloat : DefaultAttrsIntrinsic<[llvm_v16f32_ty], [llvm_v8f32_ty], [IntrNoMem]>;
 
 // Floating-point accumulator to block floating-point vector register
-class AIE2PV64AccFloatToV64bfp16 : Intrinsic<[llvm_v64i8_ty, llvm_v8i8_ty],
+class AIE2PV64AccFloatToV64bfp16 : DefaultAttrsIntrinsic<[llvm_v64i8_ty, llvm_v8i8_ty],
                                           [llvm_v64f32_ty],
                                           [IntrReadMem, IntrInaccessibleMemOnly]>;
-class AIE2PV64bfp16ebs8ToV64bfp16ebs16 : Intrinsic<[llvm_v64i8_ty, llvm_v8i8_ty],
+class AIE2PV64bfp16ebs8ToV64bfp16ebs16 : DefaultAttrsIntrinsic<[llvm_v64i8_ty, llvm_v8i8_ty],
                                           [llvm_v64i8_ty, llvm_v8i8_ty],
                                           [IntrReadMem, IntrInaccessibleMemOnly]>;
 
 // v32accfloat to v16float
-class AIE2PV32AccFloatToV16Float : Intrinsic<[llvm_v16f32_ty],
+class AIE2PV32AccFloatToV16Float : DefaultAttrsIntrinsic<[llvm_v16f32_ty],
                                           [llvm_v32f32_ty],
                                           [IntrReadMem, IntrInaccessibleMemOnly]>;
-class AIE2PV16FloatToV32AccFloat : Intrinsic<[llvm_v32f32_ty], [llvm_v16f32_ty], [IntrNoMem]>;
+class AIE2PV16FloatToV32AccFloat : DefaultAttrsIntrinsic<[llvm_v32f32_ty], [llvm_v16f32_ty], [IntrNoMem]>;
 
 // Pack-Unpack
-class AIE2PPackI512I8I16 : Intrinsic<[llvm_v32i8_ty], [llvm_v32i16_ty, llvm_i32_ty], [IntrReadMem, IntrInaccessibleMemOnly]>;
-class AIE2PPackI512I4I8 : Intrinsic<[llvm_v32i8_ty], [llvm_v64i8_ty, llvm_i32_ty], [IntrReadMem, IntrInaccessibleMemOnly]>;
-class AIE2PUnPackI512I16I8 : Intrinsic<[llvm_v32i16_ty], [llvm_v32i8_ty, llvm_i32_ty], [IntrNoMem]>;
-class AIE2PUnPackI512I8I4 : Intrinsic<[llvm_v64i8_ty], [llvm_v32i8_ty, llvm_i32_ty], [IntrNoMem]>;
-class AIE2PPackI1024I8I16 : Intrinsic<[llvm_v64i8_ty], [llvm_v64i16_ty, llvm_i32_ty], [IntrReadMem, IntrInaccessibleMemOnly]>;
-class AIE2PPackI1024I4I8 : Intrinsic<[llvm_v64i8_ty], [llvm_v128i8_ty, llvm_i32_ty], [IntrReadMem, IntrInaccessibleMemOnly]>;
-class AIE2PUnPackI1024I16I8 : Intrinsic<[llvm_v64i16_ty], [llvm_v64i8_ty, llvm_i32_ty], [IntrNoMem]>;
-class AIE2PUnPackI1024I8I4 : Intrinsic<[llvm_v128i8_ty], [llvm_v64i8_ty, llvm_i32_ty], [IntrNoMem]>;
+class AIE2PPackI512I8I16 : DefaultAttrsIntrinsic<[llvm_v32i8_ty], [llvm_v32i16_ty, llvm_i32_ty], [IntrReadMem, IntrInaccessibleMemOnly]>;
+class AIE2PPackI512I4I8 : DefaultAttrsIntrinsic<[llvm_v32i8_ty], [llvm_v64i8_ty, llvm_i32_ty], [IntrReadMem, IntrInaccessibleMemOnly]>;
+class AIE2PUnPackI512I16I8 : DefaultAttrsIntrinsic<[llvm_v32i16_ty], [llvm_v32i8_ty, llvm_i32_ty], [IntrNoMem]>;
+class AIE2PUnPackI512I8I4 : DefaultAttrsIntrinsic<[llvm_v64i8_ty], [llvm_v32i8_ty, llvm_i32_ty], [IntrNoMem]>;
+class AIE2PPackI1024I8I16 : DefaultAttrsIntrinsic<[llvm_v64i8_ty], [llvm_v64i16_ty, llvm_i32_ty], [IntrReadMem, IntrInaccessibleMemOnly]>;
+class AIE2PPackI1024I4I8 : DefaultAttrsIntrinsic<[llvm_v64i8_ty], [llvm_v128i8_ty, llvm_i32_ty], [IntrReadMem, IntrInaccessibleMemOnly]>;
+class AIE2PUnPackI1024I16I8 : DefaultAttrsIntrinsic<[llvm_v64i16_ty], [llvm_v64i8_ty, llvm_i32_ty], [IntrNoMem]>;
+class AIE2PUnPackI1024I8I4 : DefaultAttrsIntrinsic<[llvm_v128i8_ty], [llvm_v64i8_ty, llvm_i32_ty], [IntrNoMem]>;
 //Locks
 def int_aie2p_event : ClangBuiltin<"__builtin_aie2p_event">, AIE2PEventIntrinsic;
 // EXT
@@ -194,70 +194,70 @@ class AIE2PSUBACC2048BFADD : DefaultAttrsIntrinsic<[llvm_v64f32_ty], [llvm_v64f3
 
 // Mode Settings
 // Set Control Reg
-class AIE2PSetCtrlReg : Intrinsic<[], [llvm_i32_ty, llvm_i32_ty], [IntrWriteMem, IntrInaccessibleMemOnly]>;
+class AIE2PSetCtrlReg : DefaultAttrsIntrinsic<[], [llvm_i32_ty, llvm_i32_ty], [IntrWriteMem, IntrInaccessibleMemOnly]>;
 // Get Control Reg
-class AIE2PGetCtrlReg : Intrinsic<[llvm_i32_ty], [llvm_i32_ty], [IntrReadMem, IntrInaccessibleMemOnly]>;
+class AIE2PGetCtrlReg : DefaultAttrsIntrinsic<[llvm_i32_ty], [llvm_i32_ty], [IntrReadMem, IntrInaccessibleMemOnly]>;
 
 // Set Status Reg
-class AIE2PSetStatusReg : Intrinsic<[], [llvm_i32_ty, llvm_i32_ty], [IntrWriteMem, IntrInaccessibleMemOnly]>;
+class AIE2PSetStatusReg : DefaultAttrsIntrinsic<[], [llvm_i32_ty, llvm_i32_ty], [IntrWriteMem, IntrInaccessibleMemOnly]>;
 // Get Status Reg
-class AIE2PGetStatusReg : Intrinsic<[llvm_i32_ty], [llvm_i32_ty], [IntrReadMem, IntrInaccessibleMemOnly]>;
+class AIE2PGetStatusReg : DefaultAttrsIntrinsic<[llvm_i32_ty], [llvm_i32_ty], [IntrReadMem, IntrInaccessibleMemOnly]>;
 //Semaphores
 class AIE2PLockIntr
-     : Intrinsic<[],
+     : DefaultAttrsIntrinsic<[],
                  [llvm_i32_ty /* unsigned */, llvm_i32_ty /* (un)signed */],
                  [IntrHasSideEffects, IntrNoMem]>;
 class AIE2PLockCondIntr
-     : Intrinsic<[],
+     : DefaultAttrsIntrinsic<[],
                  [llvm_i32_ty /* unsigned */, llvm_i32_ty /* (un)signed */, llvm_i32_ty /* (un)signed */],
                  [IntrHasSideEffects, IntrNoMem]>;
 class AIE2PDoneIntr
-     : Intrinsic<[], [], [IntrHasSideEffects, IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[], [], [IntrHasSideEffects, IntrNoMem]>;
 // Scheduling barrier
-class AIE2PSchedBarrier : Intrinsic<[], [], [IntrNoMem, IntrHasSideEffects, IntrConvergent, IntrWillReturn]>;
+class AIE2PSchedBarrier : DefaultAttrsIntrinsic<[], [], [IntrNoMem, IntrHasSideEffects, IntrConvergent, IntrWillReturn]>;
 // Get CoreID
-class AIE2PGetCoreID : Intrinsic<[llvm_i32_ty], [], [IntrNoMem]>;
+class AIE2PGetCoreID : DefaultAttrsIntrinsic<[llvm_i32_ty], [], [IntrNoMem]>;
 
 // CLB
-class AIE2PCLB : Intrinsic<[llvm_i32_ty], [llvm_i32_ty], [IntrNoMem]>;
+class AIE2PCLB : DefaultAttrsIntrinsic<[llvm_i32_ty], [llvm_i32_ty], [IntrNoMem]>;
 
 // VSHIFT
 class AIE2PVShift_I512_I512
-     : Intrinsic<[llvm_v16i32_ty], [llvm_v16i32_ty,llvm_v16i32_ty,llvm_i32_ty,llvm_i32_ty], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v16i32_ty], [llvm_v16i32_ty,llvm_v16i32_ty,llvm_i32_ty,llvm_i32_ty], [IntrNoMem]>;
 class AIE2PVShift_bf512_bf512
-     : Intrinsic<[llvm_v32bf16_ty], [llvm_v32bf16_ty,llvm_v32bf16_ty,llvm_i32_ty,llvm_i32_ty], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v32bf16_ty], [llvm_v32bf16_ty,llvm_v32bf16_ty,llvm_i32_ty,llvm_i32_ty], [IntrNoMem]>;
 // VINSERT.X
 class AIE2PVInsert32_bf512
-     : Intrinsic<[llvm_v32bf16_ty], [llvm_v32bf16_ty,llvm_i32_ty,llvm_v2bf16_ty], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v32bf16_ty], [llvm_v32bf16_ty,llvm_i32_ty,llvm_v2bf16_ty], [IntrNoMem]>;
 class AIE2PVInsert64_bf512
-     : Intrinsic<[llvm_v32bf16_ty], [llvm_v32bf16_ty,llvm_i32_ty,llvm_v4bf16_ty], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v32bf16_ty], [llvm_v32bf16_ty,llvm_i32_ty,llvm_v4bf16_ty], [IntrNoMem]>;
 class AIE2PVInsert32_accfloat
-     : Intrinsic<[llvm_v8i64_ty], [llvm_v8i64_ty,llvm_i32_ty,llvm_float_ty], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v8i64_ty], [llvm_v8i64_ty,llvm_i32_ty,llvm_float_ty], [IntrNoMem]>;
 
 // VBCST.X
 class AIE2PVBCST128I512
-     : Intrinsic<[llvm_v16i32_ty], [llvm_v16i32_ty, llvm_i32_ty], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v16i32_ty], [llvm_v16i32_ty, llvm_i32_ty], [IntrNoMem]>;
 class AIE2PVBCST32bf512
-     : Intrinsic<[llvm_v32bf16_ty], [llvm_v2bf16_ty], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v32bf16_ty], [llvm_v2bf16_ty], [IntrNoMem]>;
 class AIE2PVBCST64bf512
-     : Intrinsic<[llvm_v32bf16_ty], [llvm_v4bf16_ty], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v32bf16_ty], [llvm_v4bf16_ty], [IntrNoMem]>;
 class AIE2PVBCSTF32I512
-     : Intrinsic<[llvm_v16f32_ty], [llvm_float_ty], [IntrNoMem]>;
-class AIE2PVCLRACC1024 : Intrinsic<[llvm_v16i64_ty], [], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v16f32_ty], [llvm_float_ty], [IntrNoMem]>;
+class AIE2PVCLRACC1024 : DefaultAttrsIntrinsic<[llvm_v16i64_ty], [], [IntrNoMem]>;
 // VEXTBCST.X
 class AIE2PVEXTBCST32Bf512
-     : Intrinsic<[llvm_v32bf16_ty], [llvm_v32bf16_ty, llvm_i32_ty], [IntrNoMem]>;
+     : DefaultAttrsIntrinsic<[llvm_v32bf16_ty], [llvm_v32bf16_ty, llvm_i32_ty], [IntrNoMem]>;
 // VBCSTSHFL
-class AIE2PVBcstShfl_I32 : Intrinsic<[llvm_v16i32_ty], [llvm_i32_ty, llvm_i32_ty], [IntrNoMem]>;
-class AIE2PVBcstShfl_I64 : Intrinsic<[llvm_v16i32_ty], [llvm_v2i32_ty, llvm_i32_ty], [IntrNoMem]>;
+class AIE2PVBcstShfl_I32 : DefaultAttrsIntrinsic<[llvm_v16i32_ty], [llvm_i32_ty, llvm_i32_ty], [IntrNoMem]>;
+class AIE2PVBcstShfl_I64 : DefaultAttrsIntrinsic<[llvm_v16i32_ty], [llvm_v2i32_ty, llvm_i32_ty], [IntrNoMem]>;
 // VSHUFFLE
-class AIE2PVShuffle : Intrinsic<[llvm_v16i32_ty], [llvm_v16i32_ty, llvm_v16i32_ty, llvm_i32_ty], [IntrNoMem]>;
+class AIE2PVShuffle : DefaultAttrsIntrinsic<[llvm_v16i32_ty], [llvm_v16i32_ty, llvm_v16i32_ty, llvm_i32_ty], [IntrNoMem]>;
 
 // PADDX.XX
-class AIE2PAdd2D : Intrinsic<[llvm_ptr_ty, llvm_i20_ty],
+class AIE2PAdd2D : DefaultAttrsIntrinsic<[llvm_ptr_ty, llvm_i20_ty],
       [llvm_ptr_ty, llvm_i20_ty, llvm_i20_ty, llvm_i20_ty, llvm_i20_ty],
       [IntrNoMem]>;
-class AIE2PAdd3D : Intrinsic<[llvm_ptr_ty, llvm_i20_ty, llvm_i20_ty],
+class AIE2PAdd3D : DefaultAttrsIntrinsic<[llvm_ptr_ty, llvm_i20_ty, llvm_i20_ty],
       [llvm_ptr_ty, llvm_i20_ty, llvm_i20_ty, llvm_i20_ty, llvm_i20_ty, llvm_i20_ty, llvm_i20_ty, llvm_i20_ty],
       [IntrNoMem]>;
 
@@ -303,7 +303,7 @@ class AIE2PV16I32I32V16I32V16I32I32 : DefaultAttrsIntrinsic<[llvm_v16i32_ty, llv
 class AIE2PV32BF16I32V32BF16V32BF16I32 : DefaultAttrsIntrinsic<[llvm_v32bf16_ty, llvm_i32_ty], [llvm_v32bf16_ty, llvm_v32bf16_ty], [IntrNoMem]>;
 
 // bfloat16 conversions
-class AIE2PV16BF16ToV16I : Intrinsic<[llvm_v16i32_ty],
+class AIE2PV16BF16ToV16I : DefaultAttrsIntrinsic<[llvm_v16i32_ty],
       [llvm_v16bf16_ty, llvm_i32_ty],
       [IntrReadMem, IntrInaccessibleMemOnly]>;
 
@@ -370,22 +370,22 @@ def int_aie2p_I512_I512_ACC512_bf_negmul_conf : ClangBuiltin<"__builtin_aie2p_I5
 
 // BFP16 MAC MUL
 class AIE2PMUL_BFP16V64BFP16
-      : Intrinsic<[llvm_v64i32_ty], [llvm_v64i8_ty, llvm_v8i8_ty, llvm_v64i8_ty, llvm_v8i8_ty, llvm_i32_ty],
+      : DefaultAttrsIntrinsic<[llvm_v64i32_ty], [llvm_v64i8_ty, llvm_v8i8_ty, llvm_v64i8_ty, llvm_v8i8_ty, llvm_i32_ty],
 					 [IntrReadMem, IntrInaccessibleMemOnly]>;
 class AIE2PMAC_BFP16V64BFP16
-      : Intrinsic<[llvm_v64i32_ty], [llvm_v64i8_ty, llvm_v8i8_ty, llvm_v64i8_ty, llvm_v8i8_ty, llvm_v64i32_ty, llvm_i32_ty],
+      : DefaultAttrsIntrinsic<[llvm_v64i32_ty], [llvm_v64i8_ty, llvm_v8i8_ty, llvm_v64i8_ty, llvm_v8i8_ty, llvm_v64i32_ty, llvm_i32_ty],
 					 [IntrReadMem, IntrInaccessibleMemOnly]>;
 class AIE2PADDMAC_BFP16V64BFP16
-      : Intrinsic<[llvm_v64i32_ty], [llvm_v64i8_ty, llvm_v8i8_ty, llvm_v64i8_ty, llvm_v8i8_ty, llvm_v64i32_ty, llvm_v64i32_ty, llvm_i32_ty],
+      : DefaultAttrsIntrinsic<[llvm_v64i32_ty], [llvm_v64i8_ty, llvm_v8i8_ty, llvm_v64i8_ty, llvm_v8i8_ty, llvm_v64i32_ty, llvm_v64i32_ty, llvm_i32_ty],
 					 [IntrReadMem, IntrInaccessibleMemOnly]>;
 class AIE2PMUL_BFP16V128BFP16
-      : Intrinsic<[llvm_v64i32_ty], [llvm_v64i8_ty, llvm_v8i8_ty, llvm_v64i8_ty , llvm_v64i8_ty, llvm_v8i8_ty, llvm_v8i8_ty, llvm_i32_ty],
+      : DefaultAttrsIntrinsic<[llvm_v64i32_ty], [llvm_v64i8_ty, llvm_v8i8_ty, llvm_v64i8_ty , llvm_v64i8_ty, llvm_v8i8_ty, llvm_v8i8_ty, llvm_i32_ty],
 					 [IntrReadMem, IntrInaccessibleMemOnly]>;
 class AIE2PMAC_BFP16V128BFP16
-      : Intrinsic<[llvm_v64i32_ty], [llvm_v64i8_ty, llvm_v8i8_ty, llvm_v64i8_ty , llvm_v64i8_ty, llvm_v8i8_ty, llvm_v8i8_ty, llvm_v64i32_ty, llvm_i32_ty],
+      : DefaultAttrsIntrinsic<[llvm_v64i32_ty], [llvm_v64i8_ty, llvm_v8i8_ty, llvm_v64i8_ty , llvm_v64i8_ty, llvm_v8i8_ty, llvm_v8i8_ty, llvm_v64i32_ty, llvm_i32_ty],
 					 [IntrReadMem, IntrInaccessibleMemOnly]>;
 class AIE2PADDMAC_BFP16V128BFP16
-      : Intrinsic<[llvm_v64i32_ty], [llvm_v64i8_ty, llvm_v8i8_ty, llvm_v64i8_ty , llvm_v64i8_ty, llvm_v8i8_ty, llvm_v8i8_ty, llvm_v64i32_ty, llvm_v64i32_ty, llvm_i32_ty],
+      : DefaultAttrsIntrinsic<[llvm_v64i32_ty], [llvm_v64i8_ty, llvm_v8i8_ty, llvm_v64i8_ty , llvm_v64i8_ty, llvm_v8i8_ty, llvm_v8i8_ty, llvm_v64i32_ty, llvm_v64i32_ty, llvm_i32_ty],
 					 [IntrReadMem, IntrInaccessibleMemOnly]>;
 
 def int_aie2p_BFP576_BFP576_ACC2048_mul_conf : ClangBuiltin<"__builtin_aie2p_BFP576_BFP576_ACC2048_mul_conf">, AIE2PMUL_BFP16V64BFP16;
@@ -627,67 +627,67 @@ class AIE2PSHUFFLEBFP16
 def int_aie2p_vshuffle_576_bfp16 :  AIE2PSHUFFLEBFP16;
 
 // PUSH
-class AIE2PFIFO_ST_PUSH_576_BFP16 : Intrinsic<[llvm_anyptr_ty, llvm_v32i32_ty, llvm_i32_ty],
+class AIE2PFIFO_ST_PUSH_576_BFP16 : DefaultAttrsIntrinsic<[llvm_anyptr_ty, llvm_v32i32_ty, llvm_i32_ty],
      [llvm_anyptr_ty, llvm_v64i8_ty, llvm_v8i8_ty, llvm_v32i32_ty, llvm_i32_ty],
      [IntrWriteMem, IntrArgMemOnly]>;
 def int_aie2p_fifo_st_push_576_bfp16: AIE2PFIFO_ST_PUSH_576_BFP16;
 def int_aie2p_fifo_st_push_544_bfp16: AIE2PFIFO_ST_PUSH_576_BFP16;
-class AIE2PFIFO_ST_PUSH_512_BFP16 : Intrinsic<[llvm_anyptr_ty, llvm_v32i32_ty, llvm_i32_ty],
+class AIE2PFIFO_ST_PUSH_512_BFP16 : DefaultAttrsIntrinsic<[llvm_anyptr_ty, llvm_v32i32_ty, llvm_i32_ty],
      [llvm_anyptr_ty, llvm_v16i32_ty, llvm_v32i32_ty, llvm_i32_ty],
      [IntrWriteMem, IntrArgMemOnly]>;
 def int_aie2p_fifo_st_push_512_bfp16: AIE2PFIFO_ST_PUSH_512_BFP16;
 
 // FLUSH normal
-class AIE2PFIFO_ST_FLUSH : Intrinsic<[llvm_anyptr_ty, llvm_v32i32_ty, llvm_i32_ty],
+class AIE2PFIFO_ST_FLUSH : DefaultAttrsIntrinsic<[llvm_anyptr_ty, llvm_v32i32_ty, llvm_i32_ty],
      [llvm_anyptr_ty, llvm_v32i32_ty, llvm_i32_ty],
      [IntrWriteMem, IntrArgMemOnly]>;
 def int_aie2p_fifo_st_flush: AIE2PFIFO_ST_FLUSH;
 def int_aie2p_fifo_st_flush_conv: AIE2PFIFO_ST_FLUSH;
 
 // FLUSH 1D
-class AIE2PFIFO_ST_FLUSH_1D : Intrinsic<[llvm_anyptr_ty, llvm_v32i32_ty, llvm_i32_ty],
+class AIE2PFIFO_ST_FLUSH_1D : DefaultAttrsIntrinsic<[llvm_anyptr_ty, llvm_v32i32_ty, llvm_i32_ty],
      [llvm_anyptr_ty, llvm_v32i32_ty, llvm_i32_ty, llvm_i20_ty],
      [IntrWriteMem, IntrArgMemOnly]>;
 def int_aie2p_fifo_st_flush_1d: AIE2PFIFO_ST_FLUSH_1D;
 def int_aie2p_fifo_st_flush_1d_conv: AIE2PFIFO_ST_FLUSH_1D;
 
 // FLUSH 2D
-class AIE2PFIFO_ST_FLUSH_2D : Intrinsic<[llvm_anyptr_ty, llvm_v32i32_ty, llvm_i32_ty, llvm_i20_ty],
+class AIE2PFIFO_ST_FLUSH_2D : DefaultAttrsIntrinsic<[llvm_anyptr_ty, llvm_v32i32_ty, llvm_i32_ty, llvm_i20_ty],
      [llvm_anyptr_ty, llvm_v32i32_ty, llvm_i32_ty, llvm_i20_ty, llvm_i20_ty, llvm_i20_ty, llvm_i20_ty],
      [IntrWriteMem, IntrArgMemOnly]>;
 def int_aie2p_fifo_st_flush_2d: AIE2PFIFO_ST_FLUSH_2D;
 def int_aie2p_fifo_st_flush_2d_conv: AIE2PFIFO_ST_FLUSH_2D;
 
 // FLUSH 3D
-class AIE2PFIFO_ST_FLUSH_3D : Intrinsic<[llvm_anyptr_ty, llvm_v32i32_ty, llvm_i32_ty, llvm_i20_ty, llvm_i20_ty],
+class AIE2PFIFO_ST_FLUSH_3D : DefaultAttrsIntrinsic<[llvm_anyptr_ty, llvm_v32i32_ty, llvm_i32_ty, llvm_i20_ty, llvm_i20_ty],
      [llvm_anyptr_ty, llvm_v32i32_ty, llvm_i32_ty, llvm_i20_ty, llvm_i20_ty, llvm_i20_ty, llvm_i20_ty, llvm_i20_ty, llvm_i20_ty, llvm_i20_ty],
      [IntrWriteMem, IntrArgMemOnly]>;
 def int_aie2p_fifo_st_flush_3d: AIE2PFIFO_ST_FLUSH_3D;
 def int_aie2p_fifo_st_flush_3d_conv: AIE2PFIFO_ST_FLUSH_3D;
 
 // FILLX
-class AIE2PFIFO_LD_FILLX : Intrinsic<[llvm_anyptr_ty, llvm_v32i32_ty, llvm_i32_ty, llvm_v16i32_ty],
+class AIE2PFIFO_LD_FILLX : DefaultAttrsIntrinsic<[llvm_anyptr_ty, llvm_v32i32_ty, llvm_i32_ty, llvm_v16i32_ty],
      [llvm_anyptr_ty, llvm_v32i32_ty, llvm_i32_ty, llvm_v16i32_ty, llvm_i32_ty],
      [IntrReadMem, IntrArgMemOnly]>;
 def int_aie2p_fifo_ld_fillx: AIE2PFIFO_LD_FILLX;
 
 // POPX
-class AIE2PFIFO_LD_POPX : Intrinsic<[llvm_v64i8_ty, llvm_anyptr_ty, llvm_v32i32_ty, llvm_i32_ty, llvm_v16i32_ty],
+class AIE2PFIFO_LD_POPX : DefaultAttrsIntrinsic<[llvm_v64i8_ty, llvm_anyptr_ty, llvm_v32i32_ty, llvm_i32_ty, llvm_v16i32_ty],
      [llvm_anyptr_ty, llvm_v32i32_ty, llvm_i32_ty, llvm_v16i32_ty, llvm_i32_ty],
      [IntrReadMem, IntrArgMemOnly]>;
 def int_aie2p_fifo_ld_popx: AIE2PFIFO_LD_POPX;
 
 // FILL
-class AIE2PFIFO_LD_FILL : Intrinsic<[llvm_anyptr_ty, llvm_v32i32_ty, llvm_i32_ty],
+class AIE2PFIFO_LD_FILL : DefaultAttrsIntrinsic<[llvm_anyptr_ty, llvm_v32i32_ty, llvm_i32_ty],
      [llvm_anyptr_ty, llvm_v32i32_ty, llvm_i32_ty],
      [IntrReadMem, IntrArgMemOnly]>;
 def int_aie2p_fifo_ld_fill: AIE2PFIFO_LD_FILL;
 
 // POP normal
-class AIE2PFIFO_LD_POPUnaligned : Intrinsic<[llvm_v64i8_ty, llvm_anyptr_ty, llvm_v32i32_ty, llvm_i32_ty],
+class AIE2PFIFO_LD_POPUnaligned : DefaultAttrsIntrinsic<[llvm_v64i8_ty, llvm_anyptr_ty, llvm_v32i32_ty, llvm_i32_ty],
      [llvm_anyptr_ty, llvm_v32i32_ty, llvm_i32_ty],
      [IntrReadMem, IntrArgMemOnly]>;
-class AIE2PFIFO_LD_POP_576_BFP16 : Intrinsic<[llvm_anyptr_ty, llvm_v32i32_ty, llvm_i32_ty, llvm_v64i8_ty, llvm_v8i8_ty],
+class AIE2PFIFO_LD_POP_576_BFP16 : DefaultAttrsIntrinsic<[llvm_anyptr_ty, llvm_v32i32_ty, llvm_i32_ty, llvm_v64i8_ty, llvm_v8i8_ty],
      [llvm_anyptr_ty, llvm_v32i32_ty, llvm_i32_ty],
      [IntrReadMem, IntrArgMemOnly]>;
 def int_aie2p_fifo_ld_pop_unaligned: AIE2PFIFO_LD_POPUnaligned;
@@ -695,10 +695,10 @@ def int_aie2p_fifo_ld_pop_576_bfp16: AIE2PFIFO_LD_POP_576_BFP16;
 def int_aie2p_fifo_ld_pop_544_bfp16: AIE2PFIFO_LD_POP_576_BFP16;
 
 // POP 1D
-class AIE2PFIFO_LD_POPUnaligned1D : Intrinsic<[llvm_v64i8_ty, llvm_anyptr_ty, llvm_v32i32_ty, llvm_i32_ty],
+class AIE2PFIFO_LD_POPUnaligned1D : DefaultAttrsIntrinsic<[llvm_v64i8_ty, llvm_anyptr_ty, llvm_v32i32_ty, llvm_i32_ty],
      [llvm_anyptr_ty, llvm_v32i32_ty, llvm_i32_ty, llvm_i20_ty],
      [IntrReadMem, IntrArgMemOnly]>;
-class AIE2PFIFO_LD_POP_576_BFP161D : Intrinsic<[llvm_anyptr_ty, llvm_v32i32_ty, llvm_i32_ty, llvm_v64i8_ty, llvm_v8i8_ty],
+class AIE2PFIFO_LD_POP_576_BFP161D : DefaultAttrsIntrinsic<[llvm_anyptr_ty, llvm_v32i32_ty, llvm_i32_ty, llvm_v64i8_ty, llvm_v8i8_ty],
      [llvm_anyptr_ty, llvm_v32i32_ty, llvm_i32_ty, llvm_i20_ty],
      [IntrReadMem, IntrArgMemOnly]>;
 def int_aie2p_fifo_ld_pop_1d_unaligned: AIE2PFIFO_LD_POPUnaligned1D;
@@ -706,10 +706,10 @@ def int_aie2p_fifo_ld_pop_576_1d_bfp16: AIE2PFIFO_LD_POP_576_BFP161D;
 def int_aie2p_fifo_ld_pop_544_1d_bfp16: AIE2PFIFO_LD_POP_576_BFP161D;
 
 // POP 2D
-class AIE2PFIFO_LD_POPUnaligned2D : Intrinsic<[llvm_v64i8_ty, llvm_anyptr_ty, llvm_v32i32_ty, llvm_i32_ty, llvm_i20_ty],
+class AIE2PFIFO_LD_POPUnaligned2D : DefaultAttrsIntrinsic<[llvm_v64i8_ty, llvm_anyptr_ty, llvm_v32i32_ty, llvm_i32_ty, llvm_i20_ty],
      [llvm_anyptr_ty, llvm_v32i32_ty, llvm_i32_ty, llvm_i20_ty, llvm_i20_ty, llvm_i20_ty, llvm_i20_ty],
      [IntrReadMem, IntrArgMemOnly]>;
-class AIE2PFIFO_LD_POP_576_BFP162D : Intrinsic<[llvm_anyptr_ty, llvm_v32i32_ty, llvm_i32_ty, llvm_i20_ty, llvm_v64i8_ty, llvm_v8i8_ty],
+class AIE2PFIFO_LD_POP_576_BFP162D : DefaultAttrsIntrinsic<[llvm_anyptr_ty, llvm_v32i32_ty, llvm_i32_ty, llvm_i20_ty, llvm_v64i8_ty, llvm_v8i8_ty],
      [llvm_anyptr_ty, llvm_v32i32_ty, llvm_i32_ty, llvm_i20_ty, llvm_i20_ty, llvm_i20_ty, llvm_i20_ty],
      [IntrReadMem, IntrArgMemOnly]>;
 def int_aie2p_fifo_ld_pop_2d_unaligned: AIE2PFIFO_LD_POPUnaligned2D;
@@ -717,10 +717,10 @@ def int_aie2p_fifo_ld_pop_576_2d_bfp16: AIE2PFIFO_LD_POP_576_BFP162D;
 def int_aie2p_fifo_ld_pop_544_2d_bfp16: AIE2PFIFO_LD_POP_576_BFP162D;
 
 // POP 3D
-class AIE2PFIFO_LD_POPUnaligned3D : Intrinsic<[llvm_v64i8_ty, llvm_anyptr_ty, llvm_v32i32_ty, llvm_i32_ty, llvm_i20_ty, llvm_i20_ty],
+class AIE2PFIFO_LD_POPUnaligned3D : DefaultAttrsIntrinsic<[llvm_v64i8_ty, llvm_anyptr_ty, llvm_v32i32_ty, llvm_i32_ty, llvm_i20_ty, llvm_i20_ty],
      [llvm_anyptr_ty, llvm_v32i32_ty, llvm_i32_ty, llvm_i20_ty, llvm_i20_ty, llvm_i20_ty, llvm_i20_ty, llvm_i20_ty, llvm_i20_ty, llvm_i20_ty],
      [IntrReadMem, IntrArgMemOnly]>;
-class AIE2PFIFO_LD_POP_576_BFP163D : Intrinsic<[llvm_anyptr_ty, llvm_v32i32_ty, llvm_i32_ty, llvm_i20_ty, llvm_i20_ty, llvm_v64i8_ty, llvm_v8i8_ty],
+class AIE2PFIFO_LD_POP_576_BFP163D : DefaultAttrsIntrinsic<[llvm_anyptr_ty, llvm_v32i32_ty, llvm_i32_ty, llvm_i20_ty, llvm_i20_ty, llvm_v64i8_ty, llvm_v8i8_ty],
      [llvm_anyptr_ty, llvm_v32i32_ty, llvm_i32_ty, llvm_i20_ty, llvm_i20_ty, llvm_i20_ty, llvm_i20_ty, llvm_i20_ty, llvm_i20_ty, llvm_i20_ty],
      [IntrReadMem, IntrArgMemOnly]>;
 def int_aie2p_fifo_ld_pop_3d_unaligned: AIE2PFIFO_LD_POPUnaligned3D;

--- a/llvm/include/llvm/IR/IntrinsicsAIE2P.td
+++ b/llvm/include/llvm/IR/IntrinsicsAIE2P.td
@@ -18,126 +18,126 @@ let TargetPrefix = "aie2p" in {
 class AIE2PEventIntrinsic
     : Intrinsic<[],
                 [llvm_i32_ty],
-                [IntrHasSideEffects, IntrNoMem, IntrWillReturn]>; //[IntrHasSideEffects, IntrNoMem, ImmArg<ArgIndex<0>>]>;
+                [IntrHasSideEffects, IntrNoMem]>; //[IntrHasSideEffects, IntrNoMem, ImmArg<ArgIndex<0>>]>;
 class AIEV2PEXT_I32_I64
-     : Intrinsic<[llvm_i32_ty], [llvm_v2i32_ty,llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_i32_ty], [llvm_v2i32_ty,llvm_i32_ty], [IntrNoMem]>;
 class AIEV2PSET_I64_I32
-     : Intrinsic<[llvm_v2i32_ty], [llvm_i32_ty,llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v2i32_ty], [llvm_i32_ty,llvm_i32_ty], [IntrNoMem]>;
 class AIEV2PUPD_I64_I32
-     : Intrinsic<[llvm_v2i32_ty], [llvm_v2i32_ty,llvm_i32_ty,llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v2i32_ty], [llvm_v2i32_ty,llvm_i32_ty,llvm_i32_ty], [IntrNoMem]>;
 // bfloat16 conversions
 class AIEV2PBF16ToInt : Intrinsic<[llvm_i32_ty],
       [llvm_bfloat_ty],
-      [IntrNoMem, IntrWillReturn]>;
+      [IntrNoMem]>;
 
 // TM
-class AIE2PReadTM : Intrinsic<[llvm_i32_ty], [llvm_ptr_ty], [IntrArgMemOnly, IntrWillReturn]>;
+class AIE2PReadTM : Intrinsic<[llvm_i32_ty], [llvm_ptr_ty], [IntrArgMemOnly]>;
 class AIE2PWriteTM : Intrinsic<[], [llvm_i32_ty, llvm_ptr_ty], [IntrWriteMem]>;
 // FLT2FX, FX2FLT
 class AIE2PFX2FLT : Intrinsic<[llvm_float_ty], [llvm_i32_ty, llvm_i32_ty], 
-      [IntrNoMem, IntrWillReturn]>;
+      [IntrNoMem]>;
 class AIE2PFLT2FX : Intrinsic<[llvm_i32_ty], [llvm_float_ty, llvm_i32_ty], 
-      [IntrNoMem, IntrWillReturn]>;
+      [IntrNoMem]>;
 // non-linear float
 class AIE2PNLFVec : Intrinsic<[llvm_v16bf16_ty], [llvm_v16f32_ty],
-      [IntrNoMem, IntrWillReturn]>;
+      [IntrNoMem]>;
 class AIE2PNLF : Intrinsic<[llvm_float_ty], [llvm_float_ty],
-      [IntrNoMem, IntrWillReturn]>;
+      [IntrNoMem]>;
 // DIVS
-class AIE2PDIVS : Intrinsic<[llvm_i32_ty, llvm_i32_ty], [llvm_i32_ty, llvm_i32_ty, llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
+class AIE2PDIVS : Intrinsic<[llvm_i32_ty, llvm_i32_ty], [llvm_i32_ty, llvm_i32_ty, llvm_i32_ty], [IntrNoMem]>;
 
 //srs
 class AIE2PI256V16Acc32I
 	 : Intrinsic<[llvm_v16i16_ty], [llvm_v16i32_ty, llvm_i32_ty, llvm_i32_ty],
-					 [IntrReadMem, IntrWillReturn, IntrInaccessibleMemOnly]>;
+					 [IntrReadMem, IntrInaccessibleMemOnly]>;
 class AIE2PI256V16Acc64I
 	 : Intrinsic<[llvm_v16i16_ty], [llvm_v16i64_ty, llvm_i32_ty, llvm_i32_ty],
-					 [IntrReadMem, IntrWillReturn, IntrInaccessibleMemOnly]>;
+					 [IntrReadMem, IntrInaccessibleMemOnly]>;
 class AIE2PI256V32Acc32I
 	 : Intrinsic<[llvm_v32i8_ty], [llvm_v32i32_ty, llvm_i32_ty, llvm_i32_ty],
-					 [IntrReadMem, IntrWillReturn, IntrInaccessibleMemOnly]>;
+					 [IntrReadMem, IntrInaccessibleMemOnly]>;
 class AIE2PI256V8Acc64I
 	 : Intrinsic<[llvm_v8i32_ty], [llvm_v8i64_ty, llvm_i32_ty, llvm_i32_ty],
-					 [IntrReadMem, IntrWillReturn, IntrInaccessibleMemOnly]>;
+					 [IntrReadMem, IntrInaccessibleMemOnly]>;
 class AIE2PI512V16Acc64I
 	 : Intrinsic<[llvm_v16i32_ty], [llvm_v16i64_ty, llvm_i32_ty, llvm_i32_ty],
-					 [IntrReadMem, IntrWillReturn, IntrInaccessibleMemOnly]>;
+					 [IntrReadMem, IntrInaccessibleMemOnly]>;
 class AIE2PI512V32Acc32I
 	 : Intrinsic<[llvm_v32i16_ty], [llvm_v32i32_ty, llvm_i32_ty, llvm_i32_ty],
-					 [IntrReadMem, IntrWillReturn, IntrInaccessibleMemOnly]>;
+					 [IntrReadMem, IntrInaccessibleMemOnly]>;
 class AIE2PI512V32Acc64I
 	 : Intrinsic<[llvm_v32i16_ty], [llvm_v32i64_ty, llvm_i32_ty, llvm_i32_ty],
-					 [IntrReadMem, IntrWillReturn, IntrInaccessibleMemOnly]>;
+					 [IntrReadMem, IntrInaccessibleMemOnly]>;
 class AIE2PI512V64Acc32I
 	 : Intrinsic<[llvm_v64i8_ty], [llvm_v64i32_ty, llvm_i32_ty, llvm_i32_ty],
-					 [IntrReadMem, IntrWillReturn, IntrInaccessibleMemOnly]>;
+					 [IntrReadMem, IntrInaccessibleMemOnly]>;
 
 // UPS
 class AIE2PAcc32V16I256I : Intrinsic<[llvm_v16i32_ty],
                               [llvm_v16i16_ty, llvm_i32_ty, llvm_i32_ty],
-                              [IntrReadMem, IntrWillReturn, IntrInaccessibleMemOnly]>;
+                              [IntrReadMem, IntrInaccessibleMemOnly]>;
 class AIE2PAcc32V32I256I : Intrinsic<[llvm_v32i32_ty],
                               [llvm_v32i8_ty, llvm_i32_ty, llvm_i32_ty],
-                              [IntrReadMem, IntrWillReturn, IntrInaccessibleMemOnly]>;
+                              [IntrReadMem, IntrInaccessibleMemOnly]>;
 class AIE2PAcc32V32I512I : Intrinsic<[llvm_v32i32_ty],
                               [llvm_v32i16_ty, llvm_i32_ty, llvm_i32_ty],
-                              [IntrReadMem, IntrWillReturn, IntrInaccessibleMemOnly]>;
+                              [IntrReadMem, IntrInaccessibleMemOnly]>;
 class AIE2PAcc64V16I256I : Intrinsic<[llvm_v16i64_ty],
                               [llvm_v16i16_ty, llvm_i32_ty, llvm_i32_ty],
-                              [IntrReadMem, IntrWillReturn, IntrInaccessibleMemOnly]>;
+                              [IntrReadMem, IntrInaccessibleMemOnly]>;
 class AIE2PAcc64V16I512I : Intrinsic<[llvm_v16i64_ty],
                               [llvm_v16i32_ty, llvm_i32_ty, llvm_i32_ty],
-                              [IntrReadMem, IntrWillReturn, IntrInaccessibleMemOnly]>;
+                              [IntrReadMem, IntrInaccessibleMemOnly]>;
 class AIE2PAcc64V8I256I  : Intrinsic<[llvm_v8i64_ty],
                               [llvm_v8i32_ty, llvm_i32_ty, llvm_i32_ty],
-                              [IntrReadMem, IntrWillReturn, IntrInaccessibleMemOnly]>;
+                              [IntrReadMem, IntrInaccessibleMemOnly]>;
 class AIE2PAcc32V64I512I  : Intrinsic<[llvm_v64i32_ty],
                               [llvm_v64i8_ty, llvm_i32_ty, llvm_i32_ty],
-                              [IntrReadMem, IntrWillReturn, IntrInaccessibleMemOnly]>;
+                              [IntrReadMem, IntrInaccessibleMemOnly]>;
 class AIE2PAcc64V32I512I  : Intrinsic<[llvm_v32i64_ty],
                               [llvm_v32i16_ty, llvm_i32_ty, llvm_i32_ty],
-                              [IntrReadMem, IntrWillReturn, IntrInaccessibleMemOnly]>;
+                              [IntrReadMem, IntrInaccessibleMemOnly]>;
 // v16accfloat to v16bfloat16
 class AIE2PV16AccFloatToV16Bf : Intrinsic<[llvm_v16bf16_ty],
                                           [llvm_v16f32_ty],
-                                          [IntrReadMem, IntrWillReturn, IntrInaccessibleMemOnly]>;
-class AIE2PV16BfToV16AccFloat : Intrinsic<[llvm_v16f32_ty], [llvm_v16bf16_ty], [IntrNoMem, IntrWillReturn]>;
+                                          [IntrReadMem, IntrInaccessibleMemOnly]>;
+class AIE2PV16BfToV16AccFloat : Intrinsic<[llvm_v16f32_ty], [llvm_v16bf16_ty], [IntrNoMem]>;
 
 // v32accfloat to v32bfloat16
 class AIE2PV32AccFloatToV32Bf : Intrinsic<[llvm_v32bf16_ty],
                                           [llvm_v32f32_ty],
-                                          [IntrReadMem, IntrWillReturn, IntrInaccessibleMemOnly]>;
-class AIE2PV32BfToV32AccFloat : Intrinsic<[llvm_v32f32_ty], [llvm_v32bf16_ty], [IntrNoMem, IntrWillReturn]>;
+                                          [IntrReadMem, IntrInaccessibleMemOnly]>;
+class AIE2PV32BfToV32AccFloat : Intrinsic<[llvm_v32f32_ty], [llvm_v32bf16_ty], [IntrNoMem]>;
 
 // v16accfloat to v8float
 class AIE2PV16AccFloatToV8Float : Intrinsic<[llvm_v8f32_ty],
                                           [llvm_v16f32_ty],
-                                          [IntrReadMem, IntrWillReturn, IntrInaccessibleMemOnly]>;
-class AIE2PV8FloatToV16AccFloat : Intrinsic<[llvm_v16f32_ty], [llvm_v8f32_ty], [IntrNoMem, IntrWillReturn]>;
+                                          [IntrReadMem, IntrInaccessibleMemOnly]>;
+class AIE2PV8FloatToV16AccFloat : Intrinsic<[llvm_v16f32_ty], [llvm_v8f32_ty], [IntrNoMem]>;
 
 // Floating-point accumulator to block floating-point vector register
 class AIE2PV64AccFloatToV64bfp16 : Intrinsic<[llvm_v64i8_ty, llvm_v8i8_ty],
                                           [llvm_v64f32_ty],
-                                          [IntrReadMem, IntrWillReturn, IntrInaccessibleMemOnly]>;
+                                          [IntrReadMem, IntrInaccessibleMemOnly]>;
 class AIE2PV64bfp16ebs8ToV64bfp16ebs16 : Intrinsic<[llvm_v64i8_ty, llvm_v8i8_ty],
                                           [llvm_v64i8_ty, llvm_v8i8_ty],
-                                          [IntrReadMem, IntrWillReturn, IntrInaccessibleMemOnly]>;
+                                          [IntrReadMem, IntrInaccessibleMemOnly]>;
 
 // v32accfloat to v16float
 class AIE2PV32AccFloatToV16Float : Intrinsic<[llvm_v16f32_ty],
                                           [llvm_v32f32_ty],
-                                          [IntrReadMem, IntrWillReturn, IntrInaccessibleMemOnly]>;
-class AIE2PV16FloatToV32AccFloat : Intrinsic<[llvm_v32f32_ty], [llvm_v16f32_ty], [IntrNoMem, IntrWillReturn]>;
+                                          [IntrReadMem, IntrInaccessibleMemOnly]>;
+class AIE2PV16FloatToV32AccFloat : Intrinsic<[llvm_v32f32_ty], [llvm_v16f32_ty], [IntrNoMem]>;
 
 // Pack-Unpack
-class AIE2PPackI512I8I16 : Intrinsic<[llvm_v32i8_ty], [llvm_v32i16_ty, llvm_i32_ty], [IntrReadMem, IntrWillReturn, IntrInaccessibleMemOnly]>;
-class AIE2PPackI512I4I8 : Intrinsic<[llvm_v32i8_ty], [llvm_v64i8_ty, llvm_i32_ty], [IntrReadMem, IntrWillReturn, IntrInaccessibleMemOnly]>;
-class AIE2PUnPackI512I16I8 : Intrinsic<[llvm_v32i16_ty], [llvm_v32i8_ty, llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
-class AIE2PUnPackI512I8I4 : Intrinsic<[llvm_v64i8_ty], [llvm_v32i8_ty, llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
-class AIE2PPackI1024I8I16 : Intrinsic<[llvm_v64i8_ty], [llvm_v64i16_ty, llvm_i32_ty], [IntrReadMem, IntrWillReturn, IntrInaccessibleMemOnly]>;
-class AIE2PPackI1024I4I8 : Intrinsic<[llvm_v64i8_ty], [llvm_v128i8_ty, llvm_i32_ty], [IntrReadMem, IntrWillReturn, IntrInaccessibleMemOnly]>;
-class AIE2PUnPackI1024I16I8 : Intrinsic<[llvm_v64i16_ty], [llvm_v64i8_ty, llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
-class AIE2PUnPackI1024I8I4 : Intrinsic<[llvm_v128i8_ty], [llvm_v64i8_ty, llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
+class AIE2PPackI512I8I16 : Intrinsic<[llvm_v32i8_ty], [llvm_v32i16_ty, llvm_i32_ty], [IntrReadMem, IntrInaccessibleMemOnly]>;
+class AIE2PPackI512I4I8 : Intrinsic<[llvm_v32i8_ty], [llvm_v64i8_ty, llvm_i32_ty], [IntrReadMem, IntrInaccessibleMemOnly]>;
+class AIE2PUnPackI512I16I8 : Intrinsic<[llvm_v32i16_ty], [llvm_v32i8_ty, llvm_i32_ty], [IntrNoMem]>;
+class AIE2PUnPackI512I8I4 : Intrinsic<[llvm_v64i8_ty], [llvm_v32i8_ty, llvm_i32_ty], [IntrNoMem]>;
+class AIE2PPackI1024I8I16 : Intrinsic<[llvm_v64i8_ty], [llvm_v64i16_ty, llvm_i32_ty], [IntrReadMem, IntrInaccessibleMemOnly]>;
+class AIE2PPackI1024I4I8 : Intrinsic<[llvm_v64i8_ty], [llvm_v128i8_ty, llvm_i32_ty], [IntrReadMem, IntrInaccessibleMemOnly]>;
+class AIE2PUnPackI1024I16I8 : Intrinsic<[llvm_v64i16_ty], [llvm_v64i8_ty, llvm_i32_ty], [IntrNoMem]>;
+class AIE2PUnPackI1024I8I4 : Intrinsic<[llvm_v128i8_ty], [llvm_v64i8_ty, llvm_i32_ty], [IntrNoMem]>;
 //Locks
 def int_aie2p_event : ClangBuiltin<"__builtin_aie2p_event">, AIE2PEventIntrinsic;
 // EXT
@@ -157,109 +157,109 @@ def int_aie2p_pack_I1024_I4_I8 : ClangBuiltin<"__builtin_aie2p_pack_I1024_I4_I8"
 def int_aie2p_unpack_I1024_I16_I8 : ClangBuiltin<"__builtin_aie2p_unpack_I1024_I16_I8">, AIE2PUnPackI1024I16I8;
 def int_aie2p_unpack_I1024_I8_I4 : ClangBuiltin<"__builtin_aie2p_unpack_I1024_I8_I4">, AIE2PUnPackI1024I8I4;
 // MAC-MUL
-class AIE2PADDACC2048ADD : DefaultAttrsIntrinsic<[llvm_v32i64_ty], [llvm_v32i64_ty, llvm_v32i64_ty, llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
-class AIE2PADDACC2048BFADD : DefaultAttrsIntrinsic<[llvm_v64f32_ty], [llvm_v64f32_ty, llvm_v64f32_ty, llvm_i32_ty], [IntrReadMem, IntrWillReturn, IntrInaccessibleMemOnly]>;
-class AIE2PI1024I1024ACC2048ADDMAC : DefaultAttrsIntrinsic<[llvm_v32i64_ty], [llvm_v32i32_ty, llvm_v64i16_ty, llvm_v32i64_ty, llvm_v32i64_ty, llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
-class AIE2PI1024I1024ACC2048BFADDMAC : DefaultAttrsIntrinsic<[llvm_v64f32_ty], [llvm_v64bf16_ty, llvm_v64bf16_ty, llvm_v64f32_ty, llvm_v64f32_ty, llvm_i32_ty], [IntrReadMem, IntrWillReturn, IntrInaccessibleMemOnly]>;
-class AIE2PI1024I1024ACC2048BFMAC : DefaultAttrsIntrinsic<[llvm_v64f32_ty], [llvm_v64bf16_ty, llvm_v64bf16_ty, llvm_v64f32_ty, llvm_i32_ty], [IntrReadMem, IntrWillReturn, IntrInaccessibleMemOnly]>;
-class AIE2PI1024I1024ACC2048BFMUL : DefaultAttrsIntrinsic<[llvm_v64f32_ty], [llvm_v64bf16_ty, llvm_v64bf16_ty, llvm_i32_ty], [IntrReadMem, IntrWillReturn, IntrInaccessibleMemOnly]>;
-class AIE2PI1024I1024ACC2048MAC : DefaultAttrsIntrinsic<[llvm_v32i64_ty], [llvm_v32i32_ty, llvm_v64i16_ty, llvm_v32i64_ty, llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
-class AIE2PI1024I1024ACC2048MUL : DefaultAttrsIntrinsic<[llvm_v32i64_ty], [llvm_v32i32_ty, llvm_v64i16_ty, llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
-class AIE2PI1024I512ACC2048ADDMAC : DefaultAttrsIntrinsic<[llvm_v32i64_ty], [llvm_v32i32_ty, llvm_v32i16_ty, llvm_v32i64_ty, llvm_v32i64_ty, llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
-class AIE2PI1024I512ACC2048MAC : DefaultAttrsIntrinsic<[llvm_v32i64_ty], [llvm_v32i32_ty, llvm_v32i16_ty, llvm_v32i64_ty, llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
+class AIE2PADDACC2048ADD : DefaultAttrsIntrinsic<[llvm_v32i64_ty], [llvm_v32i64_ty, llvm_v32i64_ty, llvm_i32_ty], [IntrNoMem]>;
+class AIE2PADDACC2048BFADD : DefaultAttrsIntrinsic<[llvm_v64f32_ty], [llvm_v64f32_ty, llvm_v64f32_ty, llvm_i32_ty], [IntrReadMem, IntrInaccessibleMemOnly]>;
+class AIE2PI1024I1024ACC2048ADDMAC : DefaultAttrsIntrinsic<[llvm_v32i64_ty], [llvm_v32i32_ty, llvm_v64i16_ty, llvm_v32i64_ty, llvm_v32i64_ty, llvm_i32_ty], [IntrNoMem]>;
+class AIE2PI1024I1024ACC2048BFADDMAC : DefaultAttrsIntrinsic<[llvm_v64f32_ty], [llvm_v64bf16_ty, llvm_v64bf16_ty, llvm_v64f32_ty, llvm_v64f32_ty, llvm_i32_ty], [IntrReadMem, IntrInaccessibleMemOnly]>;
+class AIE2PI1024I1024ACC2048BFMAC : DefaultAttrsIntrinsic<[llvm_v64f32_ty], [llvm_v64bf16_ty, llvm_v64bf16_ty, llvm_v64f32_ty, llvm_i32_ty], [IntrReadMem, IntrInaccessibleMemOnly]>;
+class AIE2PI1024I1024ACC2048BFMUL : DefaultAttrsIntrinsic<[llvm_v64f32_ty], [llvm_v64bf16_ty, llvm_v64bf16_ty, llvm_i32_ty], [IntrReadMem, IntrInaccessibleMemOnly]>;
+class AIE2PI1024I1024ACC2048MAC : DefaultAttrsIntrinsic<[llvm_v32i64_ty], [llvm_v32i32_ty, llvm_v64i16_ty, llvm_v32i64_ty, llvm_i32_ty], [IntrNoMem]>;
+class AIE2PI1024I1024ACC2048MUL : DefaultAttrsIntrinsic<[llvm_v32i64_ty], [llvm_v32i32_ty, llvm_v64i16_ty, llvm_i32_ty], [IntrNoMem]>;
+class AIE2PI1024I512ACC2048ADDMAC : DefaultAttrsIntrinsic<[llvm_v32i64_ty], [llvm_v32i32_ty, llvm_v32i16_ty, llvm_v32i64_ty, llvm_v32i64_ty, llvm_i32_ty], [IntrNoMem]>;
+class AIE2PI1024I512ACC2048MAC : DefaultAttrsIntrinsic<[llvm_v32i64_ty], [llvm_v32i32_ty, llvm_v32i16_ty, llvm_v32i64_ty, llvm_i32_ty], [IntrNoMem]>;
 class AIE2PI1024I512ACC2048MUL : DefaultAttrsIntrinsic<[llvm_v32i64_ty], [llvm_v32i32_ty, llvm_v32i16_ty, llvm_i32_ty],
-[IntrNoMem, IntrWillReturn]>;
-class AIE2PI512I1024ACC2048ADDMAC : DefaultAttrsIntrinsic<[llvm_v32i64_ty], [llvm_v16i32_ty, llvm_v64i16_ty, llvm_v32i64_ty, llvm_v32i64_ty, llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
-class AIE2PI512I1024ACC2048MAC : DefaultAttrsIntrinsic<[llvm_v32i64_ty], [llvm_v16i32_ty, llvm_v64i16_ty, llvm_v32i64_ty, llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
-class AIE2PI512I1024ACC2048MUL : DefaultAttrsIntrinsic<[llvm_v32i64_ty], [llvm_v16i32_ty, llvm_v64i16_ty, llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
-class AIE2PI512I512ACC1024ADDMAC : DefaultAttrsIntrinsic<[llvm_v16i64_ty], [llvm_v32i16_ty, llvm_v32i16_ty, llvm_v16i64_ty, llvm_v16i64_ty, llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
-class AIE2PI512I512ACC1024BFADDMAC : DefaultAttrsIntrinsic<[llvm_v32f32_ty], [llvm_v32bf16_ty, llvm_v32bf16_ty, llvm_v32f32_ty, llvm_v32f32_ty, llvm_i32_ty], [IntrReadMem, IntrWillReturn, IntrInaccessibleMemOnly]>;
-class AIE2PI512I512ACC1024BFMAC : DefaultAttrsIntrinsic<[llvm_v32f32_ty], [llvm_v32bf16_ty, llvm_v32bf16_ty, llvm_v32f32_ty, llvm_i32_ty], [IntrReadMem, IntrWillReturn, IntrInaccessibleMemOnly]>;
-class AIE2PI512I512ACC1024BFMUL : DefaultAttrsIntrinsic<[llvm_v32f32_ty], [llvm_v32bf16_ty, llvm_v32bf16_ty, llvm_i32_ty], [IntrReadMem, IntrWillReturn, IntrInaccessibleMemOnly]>;
-class AIE2PI512I512ACC1024MAC : DefaultAttrsIntrinsic<[llvm_v16i64_ty], [llvm_v32i16_ty, llvm_v32i16_ty, llvm_v16i64_ty, llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
-class AIE2PI512I512ACC1024MUL : DefaultAttrsIntrinsic<[llvm_v16i64_ty], [llvm_v32i16_ty, llvm_v32i16_ty, llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
-class AIE2PI512I512ACC2048ADDMAC : DefaultAttrsIntrinsic<[llvm_v32i64_ty], [llvm_v16i32_ty, llvm_v32i16_ty, llvm_v32i64_ty, llvm_v32i64_ty, llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
-class AIE2PI512I512ACC2048BFADDMAC : DefaultAttrsIntrinsic<[llvm_v64f32_ty], [llvm_v32bf16_ty, llvm_v32bf16_ty, llvm_v64f32_ty, llvm_v64f32_ty, llvm_i32_ty], [IntrReadMem, IntrWillReturn, IntrInaccessibleMemOnly]>;
-class AIE2PI512I512ACC2048BFMAC : DefaultAttrsIntrinsic<[llvm_v64f32_ty], [llvm_v32bf16_ty, llvm_v32bf16_ty, llvm_v64f32_ty, llvm_i32_ty], [IntrReadMem, IntrWillReturn, IntrInaccessibleMemOnly]>;
-class AIE2PI512I512ACC2048BFMUL : DefaultAttrsIntrinsic<[llvm_v64f32_ty], [llvm_v32bf16_ty, llvm_v32bf16_ty, llvm_i32_ty], [IntrReadMem, IntrWillReturn, IntrInaccessibleMemOnly]>;
-class AIE2PI512I512ACC2048MAC : DefaultAttrsIntrinsic<[llvm_v32i64_ty], [llvm_v16i32_ty, llvm_v32i16_ty, llvm_v32i64_ty, llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
-class AIE2PI512I512ACC2048MUL : DefaultAttrsIntrinsic<[llvm_v32i64_ty], [llvm_v16i32_ty, llvm_v32i16_ty, llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
-class AIE2PI512I512ACC512BFADDMAC : DefaultAttrsIntrinsic<[llvm_v16f32_ty], [llvm_v32bf16_ty, llvm_v32bf16_ty, llvm_v16f32_ty, llvm_v16f32_ty, llvm_i32_ty], [IntrReadMem, IntrWillReturn, IntrInaccessibleMemOnly]>;
-class AIE2PI512I512ACC512BFMAC : DefaultAttrsIntrinsic<[llvm_v16f32_ty], [llvm_v32bf16_ty, llvm_v32bf16_ty, llvm_v16f32_ty, llvm_i32_ty], [IntrReadMem, IntrWillReturn, IntrInaccessibleMemOnly]>;
-class AIE2PI512I512ACC512BFMUL : DefaultAttrsIntrinsic<[llvm_v16f32_ty], [llvm_v32bf16_ty, llvm_v32bf16_ty, llvm_i32_ty], [IntrReadMem, IntrWillReturn, IntrInaccessibleMemOnly]>;
-class AIE2PNEGACC2048BFNEG : DefaultAttrsIntrinsic<[llvm_v64f32_ty], [llvm_v64f32_ty, llvm_i32_ty], [IntrReadMem, IntrWillReturn, IntrInaccessibleMemOnly]>;
-class AIE2PNEGACC2048NEG : DefaultAttrsIntrinsic<[llvm_v32i64_ty], [llvm_v32i64_ty, llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
-class AIE2PSUBACC2048ADD : DefaultAttrsIntrinsic<[llvm_v32i64_ty], [llvm_v32i64_ty, llvm_v32i64_ty, llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
-class AIE2PSUBACC2048BFADD : DefaultAttrsIntrinsic<[llvm_v64f32_ty], [llvm_v64f32_ty, llvm_v64f32_ty, llvm_i32_ty], [IntrReadMem, IntrWillReturn, IntrInaccessibleMemOnly]>;
+[IntrNoMem]>;
+class AIE2PI512I1024ACC2048ADDMAC : DefaultAttrsIntrinsic<[llvm_v32i64_ty], [llvm_v16i32_ty, llvm_v64i16_ty, llvm_v32i64_ty, llvm_v32i64_ty, llvm_i32_ty], [IntrNoMem]>;
+class AIE2PI512I1024ACC2048MAC : DefaultAttrsIntrinsic<[llvm_v32i64_ty], [llvm_v16i32_ty, llvm_v64i16_ty, llvm_v32i64_ty, llvm_i32_ty], [IntrNoMem]>;
+class AIE2PI512I1024ACC2048MUL : DefaultAttrsIntrinsic<[llvm_v32i64_ty], [llvm_v16i32_ty, llvm_v64i16_ty, llvm_i32_ty], [IntrNoMem]>;
+class AIE2PI512I512ACC1024ADDMAC : DefaultAttrsIntrinsic<[llvm_v16i64_ty], [llvm_v32i16_ty, llvm_v32i16_ty, llvm_v16i64_ty, llvm_v16i64_ty, llvm_i32_ty], [IntrNoMem]>;
+class AIE2PI512I512ACC1024BFADDMAC : DefaultAttrsIntrinsic<[llvm_v32f32_ty], [llvm_v32bf16_ty, llvm_v32bf16_ty, llvm_v32f32_ty, llvm_v32f32_ty, llvm_i32_ty], [IntrReadMem, IntrInaccessibleMemOnly]>;
+class AIE2PI512I512ACC1024BFMAC : DefaultAttrsIntrinsic<[llvm_v32f32_ty], [llvm_v32bf16_ty, llvm_v32bf16_ty, llvm_v32f32_ty, llvm_i32_ty], [IntrReadMem, IntrInaccessibleMemOnly]>;
+class AIE2PI512I512ACC1024BFMUL : DefaultAttrsIntrinsic<[llvm_v32f32_ty], [llvm_v32bf16_ty, llvm_v32bf16_ty, llvm_i32_ty], [IntrReadMem, IntrInaccessibleMemOnly]>;
+class AIE2PI512I512ACC1024MAC : DefaultAttrsIntrinsic<[llvm_v16i64_ty], [llvm_v32i16_ty, llvm_v32i16_ty, llvm_v16i64_ty, llvm_i32_ty], [IntrNoMem]>;
+class AIE2PI512I512ACC1024MUL : DefaultAttrsIntrinsic<[llvm_v16i64_ty], [llvm_v32i16_ty, llvm_v32i16_ty, llvm_i32_ty], [IntrNoMem]>;
+class AIE2PI512I512ACC2048ADDMAC : DefaultAttrsIntrinsic<[llvm_v32i64_ty], [llvm_v16i32_ty, llvm_v32i16_ty, llvm_v32i64_ty, llvm_v32i64_ty, llvm_i32_ty], [IntrNoMem]>;
+class AIE2PI512I512ACC2048BFADDMAC : DefaultAttrsIntrinsic<[llvm_v64f32_ty], [llvm_v32bf16_ty, llvm_v32bf16_ty, llvm_v64f32_ty, llvm_v64f32_ty, llvm_i32_ty], [IntrReadMem, IntrInaccessibleMemOnly]>;
+class AIE2PI512I512ACC2048BFMAC : DefaultAttrsIntrinsic<[llvm_v64f32_ty], [llvm_v32bf16_ty, llvm_v32bf16_ty, llvm_v64f32_ty, llvm_i32_ty], [IntrReadMem, IntrInaccessibleMemOnly]>;
+class AIE2PI512I512ACC2048BFMUL : DefaultAttrsIntrinsic<[llvm_v64f32_ty], [llvm_v32bf16_ty, llvm_v32bf16_ty, llvm_i32_ty], [IntrReadMem, IntrInaccessibleMemOnly]>;
+class AIE2PI512I512ACC2048MAC : DefaultAttrsIntrinsic<[llvm_v32i64_ty], [llvm_v16i32_ty, llvm_v32i16_ty, llvm_v32i64_ty, llvm_i32_ty], [IntrNoMem]>;
+class AIE2PI512I512ACC2048MUL : DefaultAttrsIntrinsic<[llvm_v32i64_ty], [llvm_v16i32_ty, llvm_v32i16_ty, llvm_i32_ty], [IntrNoMem]>;
+class AIE2PI512I512ACC512BFADDMAC : DefaultAttrsIntrinsic<[llvm_v16f32_ty], [llvm_v32bf16_ty, llvm_v32bf16_ty, llvm_v16f32_ty, llvm_v16f32_ty, llvm_i32_ty], [IntrReadMem, IntrInaccessibleMemOnly]>;
+class AIE2PI512I512ACC512BFMAC : DefaultAttrsIntrinsic<[llvm_v16f32_ty], [llvm_v32bf16_ty, llvm_v32bf16_ty, llvm_v16f32_ty, llvm_i32_ty], [IntrReadMem, IntrInaccessibleMemOnly]>;
+class AIE2PI512I512ACC512BFMUL : DefaultAttrsIntrinsic<[llvm_v16f32_ty], [llvm_v32bf16_ty, llvm_v32bf16_ty, llvm_i32_ty], [IntrReadMem, IntrInaccessibleMemOnly]>;
+class AIE2PNEGACC2048BFNEG : DefaultAttrsIntrinsic<[llvm_v64f32_ty], [llvm_v64f32_ty, llvm_i32_ty], [IntrReadMem, IntrInaccessibleMemOnly]>;
+class AIE2PNEGACC2048NEG : DefaultAttrsIntrinsic<[llvm_v32i64_ty], [llvm_v32i64_ty, llvm_i32_ty], [IntrNoMem]>;
+class AIE2PSUBACC2048ADD : DefaultAttrsIntrinsic<[llvm_v32i64_ty], [llvm_v32i64_ty, llvm_v32i64_ty, llvm_i32_ty], [IntrNoMem]>;
+class AIE2PSUBACC2048BFADD : DefaultAttrsIntrinsic<[llvm_v64f32_ty], [llvm_v64f32_ty, llvm_v64f32_ty, llvm_i32_ty], [IntrReadMem, IntrInaccessibleMemOnly]>;
 
 // Mode Settings
 // Set Control Reg
-class AIE2PSetCtrlReg : Intrinsic<[], [llvm_i32_ty, llvm_i32_ty], [IntrWriteMem, IntrWillReturn, IntrInaccessibleMemOnly]>;
+class AIE2PSetCtrlReg : Intrinsic<[], [llvm_i32_ty, llvm_i32_ty], [IntrWriteMem, IntrInaccessibleMemOnly]>;
 // Get Control Reg
-class AIE2PGetCtrlReg : Intrinsic<[llvm_i32_ty], [llvm_i32_ty], [IntrReadMem, IntrWillReturn, IntrInaccessibleMemOnly]>;
+class AIE2PGetCtrlReg : Intrinsic<[llvm_i32_ty], [llvm_i32_ty], [IntrReadMem, IntrInaccessibleMemOnly]>;
 
 // Set Status Reg
-class AIE2PSetStatusReg : Intrinsic<[], [llvm_i32_ty, llvm_i32_ty], [IntrWriteMem, IntrWillReturn, IntrInaccessibleMemOnly]>;
+class AIE2PSetStatusReg : Intrinsic<[], [llvm_i32_ty, llvm_i32_ty], [IntrWriteMem, IntrInaccessibleMemOnly]>;
 // Get Status Reg
-class AIE2PGetStatusReg : Intrinsic<[llvm_i32_ty], [llvm_i32_ty], [IntrReadMem, IntrWillReturn, IntrInaccessibleMemOnly]>;
+class AIE2PGetStatusReg : Intrinsic<[llvm_i32_ty], [llvm_i32_ty], [IntrReadMem, IntrInaccessibleMemOnly]>;
 //Semaphores
 class AIE2PLockIntr
      : Intrinsic<[],
                  [llvm_i32_ty /* unsigned */, llvm_i32_ty /* (un)signed */],
-                 [IntrHasSideEffects, IntrNoMem, IntrWillReturn]>;
+                 [IntrHasSideEffects, IntrNoMem]>;
 class AIE2PLockCondIntr
      : Intrinsic<[],
                  [llvm_i32_ty /* unsigned */, llvm_i32_ty /* (un)signed */, llvm_i32_ty /* (un)signed */],
-                 [IntrHasSideEffects, IntrNoMem, IntrWillReturn]>;
+                 [IntrHasSideEffects, IntrNoMem]>;
 class AIE2PDoneIntr
-     : Intrinsic<[], [], [IntrHasSideEffects, IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[], [], [IntrHasSideEffects, IntrNoMem]>;
 // Scheduling barrier
-class AIE2PSchedBarrier : Intrinsic<[], [], [IntrNoMem, IntrWillReturn, IntrHasSideEffects, IntrConvergent, IntrWillReturn]>;
+class AIE2PSchedBarrier : Intrinsic<[], [], [IntrNoMem, IntrHasSideEffects, IntrConvergent, IntrWillReturn]>;
 // Get CoreID
-class AIE2PGetCoreID : Intrinsic<[llvm_i32_ty], [], [IntrNoMem, IntrWillReturn]>;
+class AIE2PGetCoreID : Intrinsic<[llvm_i32_ty], [], [IntrNoMem]>;
 
 // CLB
-class AIE2PCLB : Intrinsic<[llvm_i32_ty], [llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
+class AIE2PCLB : Intrinsic<[llvm_i32_ty], [llvm_i32_ty], [IntrNoMem]>;
 
 // VSHIFT
 class AIE2PVShift_I512_I512
-     : Intrinsic<[llvm_v16i32_ty], [llvm_v16i32_ty,llvm_v16i32_ty,llvm_i32_ty,llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v16i32_ty], [llvm_v16i32_ty,llvm_v16i32_ty,llvm_i32_ty,llvm_i32_ty], [IntrNoMem]>;
 class AIE2PVShift_bf512_bf512
-     : Intrinsic<[llvm_v32bf16_ty], [llvm_v32bf16_ty,llvm_v32bf16_ty,llvm_i32_ty,llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v32bf16_ty], [llvm_v32bf16_ty,llvm_v32bf16_ty,llvm_i32_ty,llvm_i32_ty], [IntrNoMem]>;
 // VINSERT.X
 class AIE2PVInsert32_bf512
-     : Intrinsic<[llvm_v32bf16_ty], [llvm_v32bf16_ty,llvm_i32_ty,llvm_v2bf16_ty], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v32bf16_ty], [llvm_v32bf16_ty,llvm_i32_ty,llvm_v2bf16_ty], [IntrNoMem]>;
 class AIE2PVInsert64_bf512
-     : Intrinsic<[llvm_v32bf16_ty], [llvm_v32bf16_ty,llvm_i32_ty,llvm_v4bf16_ty], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v32bf16_ty], [llvm_v32bf16_ty,llvm_i32_ty,llvm_v4bf16_ty], [IntrNoMem]>;
 class AIE2PVInsert32_accfloat
-     : Intrinsic<[llvm_v8i64_ty], [llvm_v8i64_ty,llvm_i32_ty,llvm_float_ty], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v8i64_ty], [llvm_v8i64_ty,llvm_i32_ty,llvm_float_ty], [IntrNoMem]>;
 
 // VBCST.X
 class AIE2PVBCST128I512
-     : Intrinsic<[llvm_v16i32_ty], [llvm_v16i32_ty, llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v16i32_ty], [llvm_v16i32_ty, llvm_i32_ty], [IntrNoMem]>;
 class AIE2PVBCST32bf512
-     : Intrinsic<[llvm_v32bf16_ty], [llvm_v2bf16_ty], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v32bf16_ty], [llvm_v2bf16_ty], [IntrNoMem]>;
 class AIE2PVBCST64bf512
-     : Intrinsic<[llvm_v32bf16_ty], [llvm_v4bf16_ty], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v32bf16_ty], [llvm_v4bf16_ty], [IntrNoMem]>;
 class AIE2PVBCSTF32I512
-     : Intrinsic<[llvm_v16f32_ty], [llvm_float_ty], [IntrNoMem, IntrWillReturn]>;
-class AIE2PVCLRACC1024 : Intrinsic<[llvm_v16i64_ty], [], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v16f32_ty], [llvm_float_ty], [IntrNoMem]>;
+class AIE2PVCLRACC1024 : Intrinsic<[llvm_v16i64_ty], [], [IntrNoMem]>;
 // VEXTBCST.X
 class AIE2PVEXTBCST32Bf512
-     : Intrinsic<[llvm_v32bf16_ty], [llvm_v32bf16_ty, llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
+     : Intrinsic<[llvm_v32bf16_ty], [llvm_v32bf16_ty, llvm_i32_ty], [IntrNoMem]>;
 // VBCSTSHFL
-class AIE2PVBcstShfl_I32 : Intrinsic<[llvm_v16i32_ty], [llvm_i32_ty, llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
-class AIE2PVBcstShfl_I64 : Intrinsic<[llvm_v16i32_ty], [llvm_v2i32_ty, llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
+class AIE2PVBcstShfl_I32 : Intrinsic<[llvm_v16i32_ty], [llvm_i32_ty, llvm_i32_ty], [IntrNoMem]>;
+class AIE2PVBcstShfl_I64 : Intrinsic<[llvm_v16i32_ty], [llvm_v2i32_ty, llvm_i32_ty], [IntrNoMem]>;
 // VSHUFFLE
-class AIE2PVShuffle : Intrinsic<[llvm_v16i32_ty], [llvm_v16i32_ty, llvm_v16i32_ty, llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
+class AIE2PVShuffle : Intrinsic<[llvm_v16i32_ty], [llvm_v16i32_ty, llvm_v16i32_ty, llvm_i32_ty], [IntrNoMem]>;
 
 // PADDX.XX
 class AIE2PAdd2D : Intrinsic<[llvm_ptr_ty, llvm_i20_ty],
       [llvm_ptr_ty, llvm_i20_ty, llvm_i20_ty, llvm_i20_ty, llvm_i20_ty],
-      [IntrNoMem, IntrWillReturn]>;
+      [IntrNoMem]>;
 class AIE2PAdd3D : Intrinsic<[llvm_ptr_ty, llvm_i20_ty, llvm_i20_ty],
       [llvm_ptr_ty, llvm_i20_ty, llvm_i20_ty, llvm_i20_ty, llvm_i20_ty, llvm_i20_ty, llvm_i20_ty, llvm_i20_ty],
-      [IntrNoMem, IntrWillReturn]>;
+      [IntrNoMem]>;
 
 // Addressing intrinsics
 def int_aie2p_add_2d : AIE2PAdd2D;
@@ -267,7 +267,7 @@ def int_aie2p_add_3d : AIE2PAdd3D;
 
 // LOAD_4X
 class AIE2PLOAD4X : DefaultAttrsIntrinsic<[llvm_v8i32_ty], [llvm_v8i32_ty],
-      [IntrReadMem, IntrWillReturn]>;
+      [IntrReadMem]>;
 
 def int_aie2p_load_4x16_lo : ClangBuiltin<"__builtin_aie2p_load_4x16_lo">, AIE2PLOAD4X;
 def int_aie2p_load_4x16_hi : ClangBuiltin<"__builtin_aie2p_load_4x16_hi">, AIE2PLOAD4X;
@@ -276,36 +276,36 @@ def int_aie2p_load_4x32_hi : ClangBuiltin<"__builtin_aie2p_load_4x32_hi">, AIE2P
 def int_aie2p_load_4x64_lo : ClangBuiltin<"__builtin_aie2p_load_4x64_lo">, AIE2PLOAD4X;
 def int_aie2p_load_4x64_hi : ClangBuiltin<"__builtin_aie2p_load_4x64_hi">, AIE2PLOAD4X;
 
-class AIE2PV64I8V2I32V64I8I32 : DefaultAttrsIntrinsic<[llvm_v64i8_ty, llvm_v2i32_ty], [llvm_v64i8_ty, llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
-class AIE2PV32I16I32V32I16I32 : DefaultAttrsIntrinsic<[llvm_v32i16_ty, llvm_i32_ty], [llvm_v32i16_ty, llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
-class AIE2PV16I32I32V16I32I32 : DefaultAttrsIntrinsic<[llvm_v16i32_ty, llvm_i32_ty], [llvm_v16i32_ty, llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
+class AIE2PV64I8V2I32V64I8I32 : DefaultAttrsIntrinsic<[llvm_v64i8_ty, llvm_v2i32_ty], [llvm_v64i8_ty, llvm_i32_ty], [IntrNoMem]>;
+class AIE2PV32I16I32V32I16I32 : DefaultAttrsIntrinsic<[llvm_v32i16_ty, llvm_i32_ty], [llvm_v32i16_ty, llvm_i32_ty], [IntrNoMem]>;
+class AIE2PV16I32I32V16I32I32 : DefaultAttrsIntrinsic<[llvm_v16i32_ty, llvm_i32_ty], [llvm_v16i32_ty, llvm_i32_ty], [IntrNoMem]>;
 
-class AIE2PV64I8V64I8V64I8I64 : DefaultAttrsIntrinsic<[llvm_v64i8_ty], [llvm_v64i8_ty, llvm_v64i8_ty, llvm_v2i32_ty], [IntrNoMem, IntrWillReturn]>;
-class AIE2PV32I16V32I16V32I16I32 : DefaultAttrsIntrinsic<[llvm_v32i16_ty], [llvm_v32i16_ty, llvm_v32i16_ty, llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
-class AIE2PV16I32V16I32V16I32I32 : DefaultAttrsIntrinsic<[llvm_v16i32_ty], [llvm_v16i32_ty, llvm_v16i32_ty, llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
+class AIE2PV64I8V64I8V64I8I64 : DefaultAttrsIntrinsic<[llvm_v64i8_ty], [llvm_v64i8_ty, llvm_v64i8_ty, llvm_v2i32_ty], [IntrNoMem]>;
+class AIE2PV32I16V32I16V32I16I32 : DefaultAttrsIntrinsic<[llvm_v32i16_ty], [llvm_v32i16_ty, llvm_v32i16_ty, llvm_i32_ty], [IntrNoMem]>;
+class AIE2PV16I32V16I32V16I32I32 : DefaultAttrsIntrinsic<[llvm_v16i32_ty], [llvm_v16i32_ty, llvm_v16i32_ty, llvm_i32_ty], [IntrNoMem]>;
 
-class AIE2PV64I8V2I32V64I8 : DefaultAttrsIntrinsic<[llvm_v64i8_ty, llvm_v2i32_ty], [llvm_v64i8_ty], [IntrNoMem, IntrWillReturn]>;
-class AIE2PV32I16I32V32I16 : DefaultAttrsIntrinsic<[llvm_v32i16_ty, llvm_i32_ty], [llvm_v32i16_ty], [IntrNoMem, IntrWillReturn]>;
-class AIE2PV16I32I32V16I32 : DefaultAttrsIntrinsic<[llvm_v16i32_ty, llvm_i32_ty], [llvm_v16i32_ty], [IntrNoMem, IntrWillReturn]>;
+class AIE2PV64I8V2I32V64I8 : DefaultAttrsIntrinsic<[llvm_v64i8_ty, llvm_v2i32_ty], [llvm_v64i8_ty], [IntrNoMem]>;
+class AIE2PV32I16I32V32I16 : DefaultAttrsIntrinsic<[llvm_v32i16_ty, llvm_i32_ty], [llvm_v32i16_ty], [IntrNoMem]>;
+class AIE2PV16I32I32V16I32 : DefaultAttrsIntrinsic<[llvm_v16i32_ty, llvm_i32_ty], [llvm_v16i32_ty], [IntrNoMem]>;
 
-class AIE2PV2I32V64I8 : DefaultAttrsIntrinsic<[llvm_v2i32_ty], [llvm_v64i8_ty], [IntrNoMem, IntrWillReturn]>;
-class AIE2PI32V32I16 : DefaultAttrsIntrinsic<[llvm_i32_ty], [llvm_v32i16_ty], [IntrNoMem, IntrWillReturn]>;
-class AIE2PI32V16I32 : DefaultAttrsIntrinsic<[llvm_i32_ty], [llvm_v16i32_ty], [IntrNoMem, IntrWillReturn]>;
+class AIE2PV2I32V64I8 : DefaultAttrsIntrinsic<[llvm_v2i32_ty], [llvm_v64i8_ty], [IntrNoMem]>;
+class AIE2PI32V32I16 : DefaultAttrsIntrinsic<[llvm_i32_ty], [llvm_v32i16_ty], [IntrNoMem]>;
+class AIE2PI32V16I32 : DefaultAttrsIntrinsic<[llvm_i32_ty], [llvm_v16i32_ty], [IntrNoMem]>;
 
-class AIE2PV2I32V64I8V64I8I32 : DefaultAttrsIntrinsic<[llvm_v2i32_ty], [llvm_v64i8_ty, llvm_v64i8_ty, llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
-class AIE2PI32V32I16V32I16I32 : DefaultAttrsIntrinsic<[llvm_i32_ty], [llvm_v32i16_ty, llvm_v32i16_ty, llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
-class AIE2PI32V16I32V16I32I32 : DefaultAttrsIntrinsic<[llvm_i32_ty], [llvm_v16i32_ty, llvm_v16i32_ty, llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
-class AIE2PI32V32BF16V32BF16 : DefaultAttrsIntrinsic<[llvm_i32_ty], [llvm_v32bf16_ty, llvm_v32bf16_ty], [IntrNoMem, IntrWillReturn]>;
+class AIE2PV2I32V64I8V64I8I32 : DefaultAttrsIntrinsic<[llvm_v2i32_ty], [llvm_v64i8_ty, llvm_v64i8_ty, llvm_i32_ty], [IntrNoMem]>;
+class AIE2PI32V32I16V32I16I32 : DefaultAttrsIntrinsic<[llvm_i32_ty], [llvm_v32i16_ty, llvm_v32i16_ty, llvm_i32_ty], [IntrNoMem]>;
+class AIE2PI32V16I32V16I32I32 : DefaultAttrsIntrinsic<[llvm_i32_ty], [llvm_v16i32_ty, llvm_v16i32_ty, llvm_i32_ty], [IntrNoMem]>;
+class AIE2PI32V32BF16V32BF16 : DefaultAttrsIntrinsic<[llvm_i32_ty], [llvm_v32bf16_ty, llvm_v32bf16_ty], [IntrNoMem]>;
 
-class AIE2PV64I8I64V64I8V64I8I32 : DefaultAttrsIntrinsic<[llvm_v64i8_ty, llvm_v2i32_ty], [llvm_v64i8_ty, llvm_v64i8_ty, llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
-class AIE2PV32I16I32V32I16V32I16I32 : DefaultAttrsIntrinsic<[llvm_v32i16_ty, llvm_i32_ty], [llvm_v32i16_ty, llvm_v32i16_ty, llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
-class AIE2PV16I32I32V16I32V16I32I32 : DefaultAttrsIntrinsic<[llvm_v16i32_ty, llvm_i32_ty], [llvm_v16i32_ty, llvm_v16i32_ty, llvm_i32_ty], [IntrNoMem, IntrWillReturn]>;
-class AIE2PV32BF16I32V32BF16V32BF16I32 : DefaultAttrsIntrinsic<[llvm_v32bf16_ty, llvm_i32_ty], [llvm_v32bf16_ty, llvm_v32bf16_ty], [IntrNoMem, IntrWillReturn]>;
+class AIE2PV64I8I64V64I8V64I8I32 : DefaultAttrsIntrinsic<[llvm_v64i8_ty, llvm_v2i32_ty], [llvm_v64i8_ty, llvm_v64i8_ty, llvm_i32_ty], [IntrNoMem]>;
+class AIE2PV32I16I32V32I16V32I16I32 : DefaultAttrsIntrinsic<[llvm_v32i16_ty, llvm_i32_ty], [llvm_v32i16_ty, llvm_v32i16_ty, llvm_i32_ty], [IntrNoMem]>;
+class AIE2PV16I32I32V16I32V16I32I32 : DefaultAttrsIntrinsic<[llvm_v16i32_ty, llvm_i32_ty], [llvm_v16i32_ty, llvm_v16i32_ty, llvm_i32_ty], [IntrNoMem]>;
+class AIE2PV32BF16I32V32BF16V32BF16I32 : DefaultAttrsIntrinsic<[llvm_v32bf16_ty, llvm_i32_ty], [llvm_v32bf16_ty, llvm_v32bf16_ty], [IntrNoMem]>;
 
 // bfloat16 conversions
 class AIE2PV16BF16ToV16I : Intrinsic<[llvm_v16i32_ty],
       [llvm_v16bf16_ty, llvm_i32_ty],
-      [IntrReadMem, IntrWillReturn, IntrInaccessibleMemOnly]>;
+      [IntrReadMem, IntrInaccessibleMemOnly]>;
 
 def int_aie2p_ACC2048_add_conf : ClangBuiltin<"__builtin_aie2p_ACC2048_add_conf">, AIE2PADDACC2048ADD;
 def int_aie2p_ACC2048_accfloat_add_conf : ClangBuiltin<"__builtin_aie2p_ACC2048_accfloat_add_conf">, AIE2PADDACC2048BFADD;
@@ -371,22 +371,22 @@ def int_aie2p_I512_I512_ACC512_bf_negmul_conf : ClangBuiltin<"__builtin_aie2p_I5
 // BFP16 MAC MUL
 class AIE2PMUL_BFP16V64BFP16
       : Intrinsic<[llvm_v64i32_ty], [llvm_v64i8_ty, llvm_v8i8_ty, llvm_v64i8_ty, llvm_v8i8_ty, llvm_i32_ty],
-					 [IntrReadMem, IntrWillReturn, IntrInaccessibleMemOnly]>;
+					 [IntrReadMem, IntrInaccessibleMemOnly]>;
 class AIE2PMAC_BFP16V64BFP16
       : Intrinsic<[llvm_v64i32_ty], [llvm_v64i8_ty, llvm_v8i8_ty, llvm_v64i8_ty, llvm_v8i8_ty, llvm_v64i32_ty, llvm_i32_ty],
-					 [IntrReadMem, IntrWillReturn, IntrInaccessibleMemOnly]>;
+					 [IntrReadMem, IntrInaccessibleMemOnly]>;
 class AIE2PADDMAC_BFP16V64BFP16
       : Intrinsic<[llvm_v64i32_ty], [llvm_v64i8_ty, llvm_v8i8_ty, llvm_v64i8_ty, llvm_v8i8_ty, llvm_v64i32_ty, llvm_v64i32_ty, llvm_i32_ty],
-					 [IntrReadMem, IntrWillReturn, IntrInaccessibleMemOnly]>;
+					 [IntrReadMem, IntrInaccessibleMemOnly]>;
 class AIE2PMUL_BFP16V128BFP16
       : Intrinsic<[llvm_v64i32_ty], [llvm_v64i8_ty, llvm_v8i8_ty, llvm_v64i8_ty , llvm_v64i8_ty, llvm_v8i8_ty, llvm_v8i8_ty, llvm_i32_ty],
-					 [IntrReadMem, IntrWillReturn, IntrInaccessibleMemOnly]>;
+					 [IntrReadMem, IntrInaccessibleMemOnly]>;
 class AIE2PMAC_BFP16V128BFP16
       : Intrinsic<[llvm_v64i32_ty], [llvm_v64i8_ty, llvm_v8i8_ty, llvm_v64i8_ty , llvm_v64i8_ty, llvm_v8i8_ty, llvm_v8i8_ty, llvm_v64i32_ty, llvm_i32_ty],
-					 [IntrReadMem, IntrWillReturn, IntrInaccessibleMemOnly]>;
+					 [IntrReadMem, IntrInaccessibleMemOnly]>;
 class AIE2PADDMAC_BFP16V128BFP16
       : Intrinsic<[llvm_v64i32_ty], [llvm_v64i8_ty, llvm_v8i8_ty, llvm_v64i8_ty , llvm_v64i8_ty, llvm_v8i8_ty, llvm_v8i8_ty, llvm_v64i32_ty, llvm_v64i32_ty, llvm_i32_ty],
-					 [IntrReadMem, IntrWillReturn, IntrInaccessibleMemOnly]>;
+					 [IntrReadMem, IntrInaccessibleMemOnly]>;
 
 def int_aie2p_BFP576_BFP576_ACC2048_mul_conf : ClangBuiltin<"__builtin_aie2p_BFP576_BFP576_ACC2048_mul_conf">, AIE2PMUL_BFP16V64BFP16;
 def int_aie2p_BFP576_BFP576_ACC2048_negmul_conf : ClangBuiltin<"__builtin_aie2p_BFP576_BFP576_ACC2048_negmul_conf">, AIE2PMUL_BFP16V64BFP16;
@@ -571,11 +571,11 @@ def int_aie2p_vbcst_shuffle64 : ClangBuiltin<"__builtin_aie2p_vbcst_shuffle64">,
 
 
 // Streams
-class AIE2PV16I32I32I32 : DefaultAttrsIntrinsic<[llvm_v16i32_ty], [llvm_i32_ty], [IntrInaccessibleMemOnly, IntrWillReturn]>;
-class AIE2PV16Acc32I32I32 : DefaultAttrsIntrinsic<[llvm_v16i32_ty], [llvm_i32_ty], [IntrInaccessibleMemOnly, IntrWillReturn]>;
-class AIE2PV32Acc32I32 : DefaultAttrsIntrinsic<[llvm_v32i32_ty], [llvm_i32_ty], [IntrInaccessibleMemOnly, IntrWillReturn]>;
-class AIE2PvV16I32I32 : DefaultAttrsIntrinsic<[], [llvm_v16i32_ty, llvm_i32_ty], [IntrInaccessibleMemOnly, IntrWillReturn]>;
-class AIE2PvV8Acc64I32 : DefaultAttrsIntrinsic<[], [llvm_v8i64_ty, llvm_i32_ty], [IntrInaccessibleMemOnly, IntrWillReturn]>;
+class AIE2PV16I32I32I32 : DefaultAttrsIntrinsic<[llvm_v16i32_ty], [llvm_i32_ty], [IntrInaccessibleMemOnly]>;
+class AIE2PV16Acc32I32I32 : DefaultAttrsIntrinsic<[llvm_v16i32_ty], [llvm_i32_ty], [IntrInaccessibleMemOnly]>;
+class AIE2PV32Acc32I32 : DefaultAttrsIntrinsic<[llvm_v32i32_ty], [llvm_i32_ty], [IntrInaccessibleMemOnly]>;
+class AIE2PvV16I32I32 : DefaultAttrsIntrinsic<[], [llvm_v16i32_ty, llvm_i32_ty], [IntrInaccessibleMemOnly]>;
+class AIE2PvV8Acc64I32 : DefaultAttrsIntrinsic<[], [llvm_v8i64_ty, llvm_i32_ty], [IntrInaccessibleMemOnly]>;
 // Streams
 // Cascade stream read
 def int_aie2p_scd_read_vec : ClangBuiltin<"__builtin_aie2p_scd_read_vec">, AIE2PV16I32I32I32;
@@ -588,22 +588,22 @@ def int_aie2p_mcd_write_vec : ClangBuiltin<"__builtin_aie2p_mcd_write_vec">, AIE
 def int_aie2p_mcd_write_acc32 : ClangBuiltin<"__builtin_aie2p_mcd_write_acc32">, AIE2PvV8Acc64I32;
 
 // Scalar stream read
-class AIE2P_get_ss : DefaultAttrsIntrinsic<[llvm_i32_ty, llvm_i32_ty], [], [IntrHasSideEffects, IntrNoMem, IntrWillReturn]>;
+class AIE2P_get_ss : DefaultAttrsIntrinsic<[llvm_i32_ty, llvm_i32_ty], [], [IntrHasSideEffects, IntrNoMem]>;
 def int_aie2p_get_ss : AIE2P_get_ss;
 def int_aie2p_get_ss_nb : AIE2P_get_ss;
 
 // Scalar stream write with tlast
-class AIE2P_put_ms : DefaultAttrsIntrinsic<[], [llvm_i32_ty, llvm_i32_ty], [IntrHasSideEffects, IntrNoMem, IntrWillReturn]>;
+class AIE2P_put_ms : DefaultAttrsIntrinsic<[], [llvm_i32_ty, llvm_i32_ty], [IntrHasSideEffects, IntrNoMem]>;
 def int_aie2p_put_ms : ClangBuiltin<"__builtin_aie2p_put_ms">, AIE2P_put_ms;
-def int_aie2p_put_ms_nb : DefaultAttrsIntrinsic<[llvm_i32_ty], [llvm_i32_ty, llvm_i32_ty], [IntrHasSideEffects, IntrNoMem, IntrWillReturn]>;
+def int_aie2p_put_ms_nb : DefaultAttrsIntrinsic<[llvm_i32_ty], [llvm_i32_ty, llvm_i32_ty], [IntrHasSideEffects, IntrNoMem]>;
 // Read data into accumulator lane
-class AIE2PV64ACC32I32I32 : DefaultAttrsIntrinsic<[llvm_v64i32_ty], [llvm_i32_ty, llvm_i32_ty], [IntrHasSideEffects, IntrNoMem, IntrWillReturn]>;
-class AIE2PV32ACC32I32I32 : DefaultAttrsIntrinsic<[llvm_v32i32_ty], [llvm_i32_ty, llvm_i32_ty], [IntrHasSideEffects, IntrNoMem, IntrWillReturn]>;
+class AIE2PV64ACC32I32I32 : DefaultAttrsIntrinsic<[llvm_v64i32_ty], [llvm_i32_ty, llvm_i32_ty], [IntrHasSideEffects, IntrNoMem]>;
+class AIE2PV32ACC32I32I32 : DefaultAttrsIntrinsic<[llvm_v32i32_ty], [llvm_i32_ty, llvm_i32_ty], [IntrHasSideEffects, IntrNoMem]>;
 def int_aie2p_scd_expand_ACC1024 : ClangBuiltin<"__builtin_aie2p_scd_expand_ACC1024">, AIE2PV32ACC32I32I32;
 def int_aie2p_scd_ACC2048 : ClangBuiltin<"__builtin_aie2p_scd_ACC2048">, AIE2PV64ACC32I32I32;
 def int_aie2p_scd_expand_ACC2048 : ClangBuiltin<"__builtin_aie2p_scd_expand_ACC2048">, AIE2PV64ACC32I32I32;
-def int_aie2p_scd_expand_ACC1024_incr: DefaultAttrsIntrinsic<[llvm_v16i64_ty, llvm_i32_ty], [llvm_i32_ty, llvm_ptr_ty], [IntrHasSideEffects, IntrNoMem, IntrWillReturn]>;
-def int_aie2p_scd_expand_ACC2048_incr: DefaultAttrsIntrinsic<[llvm_v32i64_ty, llvm_i32_ty], [llvm_i32_ty, llvm_ptr_ty], [IntrHasSideEffects, IntrNoMem, IntrWillReturn]>;
+def int_aie2p_scd_expand_ACC1024_incr: DefaultAttrsIntrinsic<[llvm_v16i64_ty, llvm_i32_ty], [llvm_i32_ty, llvm_ptr_ty], [IntrHasSideEffects, IntrNoMem]>;
+def int_aie2p_scd_expand_ACC2048_incr: DefaultAttrsIntrinsic<[llvm_v32i64_ty, llvm_i32_ty], [llvm_i32_ty, llvm_ptr_ty], [IntrHasSideEffects, IntrNoMem]>;
 
 // Read/Write for Tile Memory Map
 def int_aie2p_read_tm : ClangBuiltin<"__builtin_aie2p_read_tm">, AIE2PReadTM;
@@ -623,73 +623,73 @@ def int_aie2p_divs : AIE2PDIVS;
 // BFP16 MAC MUL
 class AIE2PSHUFFLEBFP16
       : DefaultAttrsIntrinsic<[llvm_v64i8_ty, llvm_v8i8_ty], [llvm_v64i8_ty, llvm_v8i8_ty, llvm_v64i8_ty, llvm_v8i8_ty, llvm_i32_ty],
-					 [IntrNoMem, IntrWillReturn]>;
+					 [IntrNoMem]>;
 def int_aie2p_vshuffle_576_bfp16 :  AIE2PSHUFFLEBFP16;
 
 // PUSH
 class AIE2PFIFO_ST_PUSH_576_BFP16 : Intrinsic<[llvm_anyptr_ty, llvm_v32i32_ty, llvm_i32_ty],
      [llvm_anyptr_ty, llvm_v64i8_ty, llvm_v8i8_ty, llvm_v32i32_ty, llvm_i32_ty],
-     [IntrWriteMem, IntrArgMemOnly, IntrWillReturn]>;
+     [IntrWriteMem, IntrArgMemOnly]>;
 def int_aie2p_fifo_st_push_576_bfp16: AIE2PFIFO_ST_PUSH_576_BFP16;
 def int_aie2p_fifo_st_push_544_bfp16: AIE2PFIFO_ST_PUSH_576_BFP16;
 class AIE2PFIFO_ST_PUSH_512_BFP16 : Intrinsic<[llvm_anyptr_ty, llvm_v32i32_ty, llvm_i32_ty],
      [llvm_anyptr_ty, llvm_v16i32_ty, llvm_v32i32_ty, llvm_i32_ty],
-     [IntrWriteMem, IntrArgMemOnly, IntrWillReturn]>;
+     [IntrWriteMem, IntrArgMemOnly]>;
 def int_aie2p_fifo_st_push_512_bfp16: AIE2PFIFO_ST_PUSH_512_BFP16;
 
 // FLUSH normal
 class AIE2PFIFO_ST_FLUSH : Intrinsic<[llvm_anyptr_ty, llvm_v32i32_ty, llvm_i32_ty],
      [llvm_anyptr_ty, llvm_v32i32_ty, llvm_i32_ty],
-     [IntrWriteMem, IntrArgMemOnly, IntrWillReturn]>;
+     [IntrWriteMem, IntrArgMemOnly]>;
 def int_aie2p_fifo_st_flush: AIE2PFIFO_ST_FLUSH;
 def int_aie2p_fifo_st_flush_conv: AIE2PFIFO_ST_FLUSH;
 
 // FLUSH 1D
 class AIE2PFIFO_ST_FLUSH_1D : Intrinsic<[llvm_anyptr_ty, llvm_v32i32_ty, llvm_i32_ty],
      [llvm_anyptr_ty, llvm_v32i32_ty, llvm_i32_ty, llvm_i20_ty],
-     [IntrWriteMem, IntrArgMemOnly, IntrWillReturn]>;
+     [IntrWriteMem, IntrArgMemOnly]>;
 def int_aie2p_fifo_st_flush_1d: AIE2PFIFO_ST_FLUSH_1D;
 def int_aie2p_fifo_st_flush_1d_conv: AIE2PFIFO_ST_FLUSH_1D;
 
 // FLUSH 2D
 class AIE2PFIFO_ST_FLUSH_2D : Intrinsic<[llvm_anyptr_ty, llvm_v32i32_ty, llvm_i32_ty, llvm_i20_ty],
      [llvm_anyptr_ty, llvm_v32i32_ty, llvm_i32_ty, llvm_i20_ty, llvm_i20_ty, llvm_i20_ty, llvm_i20_ty],
-     [IntrWriteMem, IntrArgMemOnly, IntrWillReturn]>;
+     [IntrWriteMem, IntrArgMemOnly]>;
 def int_aie2p_fifo_st_flush_2d: AIE2PFIFO_ST_FLUSH_2D;
 def int_aie2p_fifo_st_flush_2d_conv: AIE2PFIFO_ST_FLUSH_2D;
 
 // FLUSH 3D
 class AIE2PFIFO_ST_FLUSH_3D : Intrinsic<[llvm_anyptr_ty, llvm_v32i32_ty, llvm_i32_ty, llvm_i20_ty, llvm_i20_ty],
      [llvm_anyptr_ty, llvm_v32i32_ty, llvm_i32_ty, llvm_i20_ty, llvm_i20_ty, llvm_i20_ty, llvm_i20_ty, llvm_i20_ty, llvm_i20_ty, llvm_i20_ty],
-     [IntrWriteMem, IntrArgMemOnly, IntrWillReturn]>;
+     [IntrWriteMem, IntrArgMemOnly]>;
 def int_aie2p_fifo_st_flush_3d: AIE2PFIFO_ST_FLUSH_3D;
 def int_aie2p_fifo_st_flush_3d_conv: AIE2PFIFO_ST_FLUSH_3D;
 
 // FILLX
 class AIE2PFIFO_LD_FILLX : Intrinsic<[llvm_anyptr_ty, llvm_v32i32_ty, llvm_i32_ty, llvm_v16i32_ty],
      [llvm_anyptr_ty, llvm_v32i32_ty, llvm_i32_ty, llvm_v16i32_ty, llvm_i32_ty],
-     [IntrReadMem, IntrWillReturn, IntrArgMemOnly, IntrWillReturn]>;
+     [IntrReadMem, IntrArgMemOnly]>;
 def int_aie2p_fifo_ld_fillx: AIE2PFIFO_LD_FILLX;
 
 // POPX
 class AIE2PFIFO_LD_POPX : Intrinsic<[llvm_v64i8_ty, llvm_anyptr_ty, llvm_v32i32_ty, llvm_i32_ty, llvm_v16i32_ty],
      [llvm_anyptr_ty, llvm_v32i32_ty, llvm_i32_ty, llvm_v16i32_ty, llvm_i32_ty],
-     [IntrReadMem, IntrWillReturn, IntrArgMemOnly, IntrWillReturn]>;
+     [IntrReadMem, IntrArgMemOnly]>;
 def int_aie2p_fifo_ld_popx: AIE2PFIFO_LD_POPX;
 
 // FILL
 class AIE2PFIFO_LD_FILL : Intrinsic<[llvm_anyptr_ty, llvm_v32i32_ty, llvm_i32_ty],
      [llvm_anyptr_ty, llvm_v32i32_ty, llvm_i32_ty],
-     [IntrReadMem, IntrWillReturn, IntrArgMemOnly, IntrWillReturn]>;
+     [IntrReadMem, IntrArgMemOnly]>;
 def int_aie2p_fifo_ld_fill: AIE2PFIFO_LD_FILL;
 
 // POP normal
 class AIE2PFIFO_LD_POPUnaligned : Intrinsic<[llvm_v64i8_ty, llvm_anyptr_ty, llvm_v32i32_ty, llvm_i32_ty],
      [llvm_anyptr_ty, llvm_v32i32_ty, llvm_i32_ty],
-     [IntrReadMem, IntrWillReturn, IntrArgMemOnly, IntrWillReturn]>;
+     [IntrReadMem, IntrArgMemOnly]>;
 class AIE2PFIFO_LD_POP_576_BFP16 : Intrinsic<[llvm_anyptr_ty, llvm_v32i32_ty, llvm_i32_ty, llvm_v64i8_ty, llvm_v8i8_ty],
      [llvm_anyptr_ty, llvm_v32i32_ty, llvm_i32_ty],
-     [IntrReadMem, IntrWillReturn, IntrArgMemOnly, IntrWillReturn]>;
+     [IntrReadMem, IntrArgMemOnly]>;
 def int_aie2p_fifo_ld_pop_unaligned: AIE2PFIFO_LD_POPUnaligned;
 def int_aie2p_fifo_ld_pop_576_bfp16: AIE2PFIFO_LD_POP_576_BFP16;
 def int_aie2p_fifo_ld_pop_544_bfp16: AIE2PFIFO_LD_POP_576_BFP16;
@@ -697,10 +697,10 @@ def int_aie2p_fifo_ld_pop_544_bfp16: AIE2PFIFO_LD_POP_576_BFP16;
 // POP 1D
 class AIE2PFIFO_LD_POPUnaligned1D : Intrinsic<[llvm_v64i8_ty, llvm_anyptr_ty, llvm_v32i32_ty, llvm_i32_ty],
      [llvm_anyptr_ty, llvm_v32i32_ty, llvm_i32_ty, llvm_i20_ty],
-     [IntrReadMem, IntrWillReturn, IntrArgMemOnly, IntrWillReturn]>;
+     [IntrReadMem, IntrArgMemOnly]>;
 class AIE2PFIFO_LD_POP_576_BFP161D : Intrinsic<[llvm_anyptr_ty, llvm_v32i32_ty, llvm_i32_ty, llvm_v64i8_ty, llvm_v8i8_ty],
      [llvm_anyptr_ty, llvm_v32i32_ty, llvm_i32_ty, llvm_i20_ty],
-     [IntrReadMem, IntrWillReturn, IntrArgMemOnly, IntrWillReturn]>;
+     [IntrReadMem, IntrArgMemOnly]>;
 def int_aie2p_fifo_ld_pop_1d_unaligned: AIE2PFIFO_LD_POPUnaligned1D;
 def int_aie2p_fifo_ld_pop_576_1d_bfp16: AIE2PFIFO_LD_POP_576_BFP161D;
 def int_aie2p_fifo_ld_pop_544_1d_bfp16: AIE2PFIFO_LD_POP_576_BFP161D;
@@ -708,10 +708,10 @@ def int_aie2p_fifo_ld_pop_544_1d_bfp16: AIE2PFIFO_LD_POP_576_BFP161D;
 // POP 2D
 class AIE2PFIFO_LD_POPUnaligned2D : Intrinsic<[llvm_v64i8_ty, llvm_anyptr_ty, llvm_v32i32_ty, llvm_i32_ty, llvm_i20_ty],
      [llvm_anyptr_ty, llvm_v32i32_ty, llvm_i32_ty, llvm_i20_ty, llvm_i20_ty, llvm_i20_ty, llvm_i20_ty],
-     [IntrReadMem, IntrWillReturn, IntrArgMemOnly, IntrWillReturn]>;
+     [IntrReadMem, IntrArgMemOnly]>;
 class AIE2PFIFO_LD_POP_576_BFP162D : Intrinsic<[llvm_anyptr_ty, llvm_v32i32_ty, llvm_i32_ty, llvm_i20_ty, llvm_v64i8_ty, llvm_v8i8_ty],
      [llvm_anyptr_ty, llvm_v32i32_ty, llvm_i32_ty, llvm_i20_ty, llvm_i20_ty, llvm_i20_ty, llvm_i20_ty],
-     [IntrReadMem, IntrWillReturn, IntrArgMemOnly, IntrWillReturn]>;
+     [IntrReadMem, IntrArgMemOnly]>;
 def int_aie2p_fifo_ld_pop_2d_unaligned: AIE2PFIFO_LD_POPUnaligned2D;
 def int_aie2p_fifo_ld_pop_576_2d_bfp16: AIE2PFIFO_LD_POP_576_BFP162D;
 def int_aie2p_fifo_ld_pop_544_2d_bfp16: AIE2PFIFO_LD_POP_576_BFP162D;
@@ -719,10 +719,10 @@ def int_aie2p_fifo_ld_pop_544_2d_bfp16: AIE2PFIFO_LD_POP_576_BFP162D;
 // POP 3D
 class AIE2PFIFO_LD_POPUnaligned3D : Intrinsic<[llvm_v64i8_ty, llvm_anyptr_ty, llvm_v32i32_ty, llvm_i32_ty, llvm_i20_ty, llvm_i20_ty],
      [llvm_anyptr_ty, llvm_v32i32_ty, llvm_i32_ty, llvm_i20_ty, llvm_i20_ty, llvm_i20_ty, llvm_i20_ty, llvm_i20_ty, llvm_i20_ty, llvm_i20_ty],
-     [IntrReadMem, IntrWillReturn, IntrArgMemOnly, IntrWillReturn]>;
+     [IntrReadMem, IntrArgMemOnly]>;
 class AIE2PFIFO_LD_POP_576_BFP163D : Intrinsic<[llvm_anyptr_ty, llvm_v32i32_ty, llvm_i32_ty, llvm_i20_ty, llvm_i20_ty, llvm_v64i8_ty, llvm_v8i8_ty],
      [llvm_anyptr_ty, llvm_v32i32_ty, llvm_i32_ty, llvm_i20_ty, llvm_i20_ty, llvm_i20_ty, llvm_i20_ty, llvm_i20_ty, llvm_i20_ty, llvm_i20_ty],
-     [IntrReadMem, IntrWillReturn, IntrArgMemOnly, IntrWillReturn]>;
+     [IntrReadMem, IntrArgMemOnly]>;
 def int_aie2p_fifo_ld_pop_3d_unaligned: AIE2PFIFO_LD_POPUnaligned3D;
 def int_aie2p_fifo_ld_pop_576_3d_bfp16: AIE2PFIFO_LD_POP_576_BFP163D;
 def int_aie2p_fifo_ld_pop_544_3d_bfp16: AIE2PFIFO_LD_POP_576_BFP163D;

--- a/llvm/test/CodeGen/AIE/opt/licm_promote_store_with_intrinsics_in_body.ll
+++ b/llvm/test/CodeGen/AIE/opt/licm_promote_store_with_intrinsics_in_body.ll
@@ -56,9 +56,10 @@ define void @promote_store_aie2_intrinsics(ptr noalias %param, ptr addrspace(5) 
 ; CHECK-NEXT:    [[TMP2:%.*]] = tail call <16 x i32> @llvm.aie2.vshuffle(<16 x i32> [[TMP1]], <16 x i32> zeroinitializer, i32 0)
 ; CHECK-NEXT:    store <16 x i32> [[TMP2]], ptr addrspace(5) [[PTR_INC]], align 64
 ; CHECK-NEXT:    [[INC]] = add i32 [[LOOP_CTR]], 1
-; CHECK-NEXT:    store i32 [[INC]], ptr [[COUNT2_I_I_I]], align 4, !alias.scope [[META3:![0-9]+]]
 ; CHECK-NEXT:    br i1 false, label %[[EXIT:.*]], label %[[FOR_BODY_I31_I]]
 ; CHECK:       [[EXIT]]:
+; CHECK-NEXT:    [[INC_LCSSA:%.*]] = phi i32 [ [[INC]], %[[FOR_BODY_I31_I]] ]
+; CHECK-NEXT:    store i32 [[INC_LCSSA]], ptr [[COUNT2_I_I_I]], align 4, !alias.scope [[META3:![0-9]+]]
 ; CHECK-NEXT:    ret void
 ;
 entry:
@@ -96,9 +97,10 @@ define void @promote_store_aie2p_intrinsics(ptr noalias %param, ptr addrspace(5)
 ; CHECK-NEXT:    [[TMP2:%.*]] = tail call <16 x i32> @llvm.aie2p.vshuffle(<16 x i32> [[TMP1]], <16 x i32> zeroinitializer, i32 0)
 ; CHECK-NEXT:    store <16 x i32> [[TMP2]], ptr addrspace(5) [[PTR_INC]], align 64
 ; CHECK-NEXT:    [[INC]] = add i32 [[LOOP_CTR]], 1
-; CHECK-NEXT:    store i32 [[INC]], ptr [[COUNT2_I_I_I]], align 4, !alias.scope [[META6:![0-9]+]]
 ; CHECK-NEXT:    br i1 false, label %[[EXIT:.*]], label %[[FOR_BODY_I31_I]]
 ; CHECK:       [[EXIT]]:
+; CHECK-NEXT:    [[INC_LCSSA:%.*]] = phi i32 [ [[INC]], %[[FOR_BODY_I31_I]] ]
+; CHECK-NEXT:    store i32 [[INC_LCSSA]], ptr [[COUNT2_I_I_I]], align 4, !alias.scope [[META6:![0-9]+]]
 ; CHECK-NEXT:    ret void
 ;
 entry:

--- a/llvm/test/CodeGen/AIE/opt/licm_promote_store_with_intrinsics_in_body.ll
+++ b/llvm/test/CodeGen/AIE/opt/licm_promote_store_with_intrinsics_in_body.ll
@@ -56,10 +56,9 @@ define void @promote_store_aie2_intrinsics(ptr noalias %param, ptr addrspace(5) 
 ; CHECK-NEXT:    [[TMP2:%.*]] = tail call <16 x i32> @llvm.aie2.vshuffle(<16 x i32> [[TMP1]], <16 x i32> zeroinitializer, i32 0)
 ; CHECK-NEXT:    store <16 x i32> [[TMP2]], ptr addrspace(5) [[PTR_INC]], align 64
 ; CHECK-NEXT:    [[INC]] = add i32 [[LOOP_CTR]], 1
+; CHECK-NEXT:    store i32 [[INC]], ptr [[COUNT2_I_I_I]], align 4, !alias.scope [[META3:![0-9]+]]
 ; CHECK-NEXT:    br i1 false, label %[[EXIT:.*]], label %[[FOR_BODY_I31_I]]
 ; CHECK:       [[EXIT]]:
-; CHECK-NEXT:    [[INC_LCSSA:%.*]] = phi i32 [ [[INC]], %[[FOR_BODY_I31_I]] ]
-; CHECK-NEXT:    store i32 [[INC_LCSSA]], ptr [[COUNT2_I_I_I]], align 4, !alias.scope [[META3:![0-9]+]]
 ; CHECK-NEXT:    ret void
 ;
 entry:
@@ -97,10 +96,9 @@ define void @promote_store_aie2p_intrinsics(ptr noalias %param, ptr addrspace(5)
 ; CHECK-NEXT:    [[TMP2:%.*]] = tail call <16 x i32> @llvm.aie2p.vshuffle(<16 x i32> [[TMP1]], <16 x i32> zeroinitializer, i32 0)
 ; CHECK-NEXT:    store <16 x i32> [[TMP2]], ptr addrspace(5) [[PTR_INC]], align 64
 ; CHECK-NEXT:    [[INC]] = add i32 [[LOOP_CTR]], 1
+; CHECK-NEXT:    store i32 [[INC]], ptr [[COUNT2_I_I_I]], align 4, !alias.scope [[META6:![0-9]+]]
 ; CHECK-NEXT:    br i1 false, label %[[EXIT:.*]], label %[[FOR_BODY_I31_I]]
 ; CHECK:       [[EXIT]]:
-; CHECK-NEXT:    [[INC_LCSSA:%.*]] = phi i32 [ [[INC]], %[[FOR_BODY_I31_I]] ]
-; CHECK-NEXT:    store i32 [[INC_LCSSA]], ptr [[COUNT2_I_I_I]], align 4, !alias.scope [[META6:![0-9]+]]
 ; CHECK-NEXT:    ret void
 ;
 entry:


### PR DESCRIPTION
Harmonize the Intrinsics attributes: Use `DefaultAttrsIntrinsic` for all AIE intrinsics.

<img width="4400" height="1800" alt="Core_Compute_Insn_Count" src="https://github.com/user-attachments/assets/6d2f44e8-4746-4297-9701-f739657c30eb" />

<img width="4400" height="1800" alt="Core_PMSize_absolute" src="https://github.com/user-attachments/assets/6f37a386-511e-47f0-a74f-f350c4671568" />

<img width="4400" height="1800" alt="Core_StackSize_absolute" src="https://github.com/user-attachments/assets/a451ae3e-5dd6-47f2-9b91-c4a9174edc28" />
