### PR TITLE
feat: allow tosa::TransposeOp and tosa::CastOp folders to fold when constant has multiple users.

### DIFF
--- a/mlir/lib/Dialect/Tosa/Transforms/TosaFolders.cpp
+++ b/mlir/lib/Dialect/Tosa/Transforms/TosaFolders.cpp
@@ -566,7 +566,8 @@ struct TosaFoldConstantTranspose
     if (inputValues.isSplat())
       return failure();
     // Make sure the input is a constant that has a single user.
-    if (!llvm::hasSingleElement(op.getInput1().getDefiningOp()->getUsers()))
+    if (!llvm::hasSingleElement(op.getInput1().getDefiningOp()->getUsers()) &&
+        foldSplatOrSingleUseOnly)
       return failure();
 
     DenseIntElementsAttr permAttr;
@@ -1005,7 +1006,8 @@ struct TosaFoldConstantCast : public TosaFoldConstantBase<CastOp> {
 
     // Only fold splat tensors and those used only once to avoid duplicating
     // them and increasing memory consumption.
-    if (!inputTensor.hasOneUse() && !isa<SplatElementsAttr>(elements)) {
+    if (!inputTensor.hasOneUse() && !isa<SplatElementsAttr>(elements) &&
+        foldSplatOrSingleUseOnly) {
       return rewriter.notifyMatchFailure(
           tosaCast, "Currently, casts will only be folded "
                     "if its input only has a single user or is a splat value.");

--- a/mlir/test/Dialect/Tosa/constant-cast-multi-user.mlir
+++ b/mlir/test/Dialect/Tosa/constant-cast-multi-user.mlir
@@ -1,0 +1,12 @@
+// RUN: mlir-opt --split-input-file --tosa-layerwise-constant-fold="fold-splat-or-single-use-only=0" %s | FileCheck %s
+// RUN: mlir-opt --split-input-file --tosa-layerwise-constant-fold="fold-splat-or-single-use-only=1" %s | FileCheck %s --check-prefix=ONLY-SINGLE-USE-CHECK
+
+// CHECK-LABEL: @cast_fold_f32_to_i1_multiple_users
+func.func @cast_fold_f32_to_i1_multiple_users() -> (tensor<3xf32>, tensor<3xi1>) {
+  // CHECK-DAG: "tosa.const"() <{value = dense<[1.200000e+01, 4.000000e+00, 5.000000e+00]> : tensor<3xf32>}>
+  // CHECK-DAG: "tosa.const"() <{value = dense<true> : tensor<3xi1>}>
+  %0 = "tosa.const"() {value = dense<[12.0, 4.0, 5.0]> : tensor<3xf32>} : () -> tensor<3xf32>
+  %1 = "tosa.cast"(%0) : (tensor<3xf32>) -> tensor<3xi1>
+  // ONLY-SINGLE-USE-CHECK: tosa.cast
+  return %0, %1 : tensor<3xf32>, tensor<3xi1>
+}

--- a/mlir/test/Dialect/Tosa/constant-transpose-multi-user.mlir
+++ b/mlir/test/Dialect/Tosa/constant-transpose-multi-user.mlir
@@ -1,0 +1,13 @@
+// RUN: mlir-opt --split-input-file --tosa-layerwise-constant-fold="fold-splat-or-single-use-only=0" %s | FileCheck %s
+// RUN: mlir-opt --split-input-file --tosa-layerwise-constant-fold="fold-splat-or-single-use-only=1" %s | FileCheck %s --check-prefix=ONLY-SINGLE-USE-CHECK
+
+// CHECK-LABEL: @transpose_bf16_multi_users
+func.func @transpose_bf16_multi_users() -> (tensor<2x3xbf16>, tensor<3x2xbf16>) {
+  %input = "tosa.const"() {value = dense<[[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]]> : tensor<2x3xbf16>} : () -> tensor<2x3xbf16>
+  %perms = "tosa.const"() {value = dense<[1, 0]> : tensor<2xi32>} : () -> tensor<2xi32>
+  // CHECK-DAG: "tosa.const"() <{value = dense<{{\[\[}}0.000000e+00, 1.000000e+00, 2.000000e+00], [3.000000e+00, 4.000000e+00, 5.000000e+00]]>
+  // CHECK-DAG: "tosa.const"() <{value = dense<{{\[\[}}0.000000e+00, 3.000000e+00], [1.000000e+00, 4.000000e+00], [2.000000e+00, 5.000000e+00]]>
+  %1 = "tosa.transpose"(%input, %perms) : (tensor<2x3xbf16>, tensor<2xi32>) -> tensor<3x2xbf16>
+  // ONLY-SINGLE-USE-CHECK: tosa.transpose
+  return %input, %1 : tensor<2x3xbf16>, tensor<3x2xbf16>
+}


### PR DESCRIPTION
This just aligns transpose and cast folders with the other ones w.r.t. multiple users.