### PR TITLE
[AIE2P] Fix the 128-bit vector register calling convention

### DIFF
--- a/llvm/lib/Target/AIE/AIE2ISelLowering.cpp
+++ b/llvm/lib/Target/AIE/AIE2ISelLowering.cpp
@@ -40,11 +40,8 @@ AIE2TargetLowering::AIE2TargetLowering(const TargetMachine &TM,
           return TRI->isTypeLegalForClass(*RC, Ty);
         });
     // Add 128-bit RegClass as unavailable regclass for the 128-bit vector type
-    // as this RegClass is not supported natively. Make it also unavailable for
-    // the 128-bit integer type to prevent 64-bit promotion to 128-bit as these
-    // should be passed and returned in 32-bit register pairs.
-    if (RCIt != TRI->regclass_end() && !Ty.is128BitVector() &&
-        !(Ty.isScalarInteger() && Ty.getScalarSizeInBits() == 128)) {
+    // as this RegClass is not supported natively.
+    if (RCIt != TRI->regclass_end() && !Ty.is128BitVector()) {
       addRegisterClass(Ty, *RCIt);
     }
   }
@@ -73,23 +70,8 @@ MVT AIE2TargetLowering::getRegisterTypeForCallingConv(LLVMContext &Context,
   // compared to 256-bits vectors.
   if (VT.isSimple() && VT.is128BitVector())
     return VT.getSimpleVT();
-  // 128-bit integers aren't considered legal to prevent dafault legalization of
-  // 64-bit integers into 128-bit. However, for ABI compatibility reasons, we
-  // still want to keep those integers as is, because they are passed in mask
-  // registers.
-  if (VT.isScalarInteger() && VT.getScalarSizeInBits() == 128)
-    return VT.getSimpleVT();
 
   return AIEBaseTargetLowering::getRegisterTypeForCallingConv(Context, CC, VT);
-}
-
-unsigned AIE2TargetLowering::getNumRegistersForCallingConv(LLVMContext &Context,
-                                                           CallingConv::ID CC,
-                                                           EVT VT) const {
-  // See getRegisterTypeForCallingConv(): i128 is passed in a single register
-  if (VT.isScalarInteger() && VT.getScalarSizeInBits() == 128)
-    return 1;
-  return AIEBaseTargetLowering::getNumRegistersForCallingConv(Context, CC, VT);
 }
 
 // Returns true if type name matches with a sparse type name

--- a/llvm/lib/Target/AIE/AIE2ISelLowering.h
+++ b/llvm/lib/Target/AIE/AIE2ISelLowering.h
@@ -39,10 +39,6 @@ public:
   // I wonder why this isn't the default.
   bool isCheapToSpeculateCtlz(Type *) const override { return true; }
 
-  unsigned getNumRegistersForCallingConv(LLVMContext &Context,
-                                         CallingConv::ID CC,
-                                         EVT VT) const override;
-
   bool functionArgumentNeedsConsecutiveRegisters(
       Type *Ty, CallingConv::ID CallConv, bool isVarArg,
       const DataLayout &DL) const override;

--- a/llvm/lib/Target/AIE/aie2p/AIE2PCallingConv.td
+++ b/llvm/lib/Target/AIE/aie2p/AIE2PCallingConv.td
@@ -78,6 +78,9 @@ def AssignToVecCM : CCAssignToReg<[
 def AssignToVecDM : CCAssignToReg<[
   dm0,dm1,dm2,dm3,dm4]>;
 
+// Mask registers
+def AssignToVecQ : CCAssignToReg<[q0, q2, q1, q3]>;
+
 // Let's define the list of vector types in a single place.
 // TODO: bfloat and complex types are not yet supported.
 class VectorTypes {
@@ -129,6 +132,8 @@ def RetCC_AIE2P : CallingConv<[
   CCIfInReg<CCIfType<AIE2PVTypes.Acc1024Bits, AssignToVecCM>>,
   // 2048-bits accumulators go in DM regs
   CCIfInReg<CCIfType<AIE2PVTypes.Acc2048Bits, AssignToVecDM>>,
+  // 128-bits masks go in Q regs
+  CCIfType<[i128], AssignToVecQ>,
 ]>;
 
 //===----------------------------------------------------------------------===//
@@ -152,6 +157,7 @@ def CC_AIE2P_Stack : CallingConv<[
   CCIfType<AIE2PVTypes.V64Bits, CCAssignToStack<8, 4>>,
   // 128-bits vectors are 16-bytes aligned
   CCIfType<AIE2PVTypes.V128Bits, CCAssignToStack<16, 16>>,
+  CCIfType<[i128], CCAssignToStack<16, 16>>,
   // 256, 512 and 1024 bits vectors are 32-bytes aligned
   CCIfType<AIE2PVTypes.V256Bits, CCAssignToStack<32, 32>>,
   CCIfType<AIE2PVTypes.V512Bits, CCAssignToStack<64, 32>>,
@@ -203,6 +209,8 @@ def CC_AIE2P : CallingConv<[
   CCIfInReg<CCIfType<AIE2PVTypes.Acc1024Bits, AssignToVecCM>>,
   // 2048-bits accumulators go in DM regs
   CCIfInReg<CCIfType<AIE2PVTypes.Acc2048Bits, AssignToVecDM>>,
+  // 128-bits masks go in Q regs
+  CCIfType<[i128], AssignToVecQ>,
 
   // Couldn't pass in registers, must be on the stack
   CCDelegateTo<CC_AIE2P_Stack>

--- a/llvm/lib/Target/AIE/aie2p/AIE2PISelLowering.cpp
+++ b/llvm/lib/Target/AIE/aie2p/AIE2PISelLowering.cpp
@@ -15,6 +15,7 @@
 #include "AIE2PISelLowering.h"
 #include "AIEBaseSubtarget.h"
 #include "MCTargetDesc/aie2p/AIE2PMCTargetDesc.h"
+#include "llvm/CodeGen/TargetLowering.h"
 #include "llvm/IR/IntrinsicsAIE2P.h"
 
 using namespace llvm;
@@ -127,4 +128,35 @@ bool AIE2PTargetLowering::getTgtMemIntrinsic(IntrinsicInfo &Info,
     return true;
   }
   return false;
+}
+
+MVT AIE2PTargetLowering::getRegisterTypeForCallingConvAssignment(
+    LLVMContext &Context, CallingConv::ID CC, EVT VT) const {
+  // 128-bit vectors are passed in 256-bit W registers
+  if (VT.isSimple() && VT.is128BitVector())
+    return getRegisterType(VT.getSimpleVT());
+
+  return AIEBaseTargetLowering::getRegisterTypeForCallingConvAssignment(Context,
+                                                                        CC, VT);
+}
+
+MVT AIE2PTargetLowering::getRegisterTypeForCallingConv(LLVMContext &Context,
+                                                       CallingConv::ID CC,
+                                                       EVT VT) const {
+  // 128-bits registers aren't considered legal because AIE2P only has vector
+  // ops for 256+ bits vectors. However, for ABI compatibility reasons, we still
+  // want to keep those vectors as is, because they are passed differently
+  // compared to 256-bits vectors.
+  if (VT.isSimple() && VT.is128BitVector())
+    return VT.getSimpleVT();
+
+  return AIEBaseTargetLowering::getRegisterTypeForCallingConv(Context, CC, VT);
+}
+
+TargetLoweringBase::LegalizeTypeAction
+AIE2PTargetLowering::getPreferredVectorAction(MVT VT) const {
+  if (VT.is128BitVector())
+    return TypeWidenVector;
+
+  return TargetLoweringBase::getPreferredVectorAction(VT);
 }

--- a/llvm/lib/Target/AIE/aie2p/AIE2PISelLowering.h
+++ b/llvm/lib/Target/AIE/aie2p/AIE2PISelLowering.h
@@ -23,6 +23,14 @@ class AIE2PTargetLowering : public AIEBaseTargetLowering {
 public:
   explicit AIE2PTargetLowering(const TargetMachine &TM,
                                const AIEBaseSubtarget &STI);
+  MVT getRegisterTypeForCallingConvAssignment(LLVMContext &Context,
+                                              CallingConv::ID CC,
+                                              EVT VT) const override;
+  MVT getRegisterTypeForCallingConv(LLVMContext &Context, CallingConv::ID CC,
+                                    EVT VT) const override;
+  TargetLoweringBase::LegalizeTypeAction
+  getPreferredVectorAction(MVT VT) const override;
+
   bool functionArgumentNeedsConsecutiveRegisters(
       Type *Ty, CallingConv::ID CallConv, bool isVarArg,
       const DataLayout &DL) const override;

--- a/llvm/lib/Target/AIE/aie2p/AIE2PRegisterInfo.td
+++ b/llvm/lib/Target/AIE/aie2p/AIE2PRegisterInfo.td
@@ -189,8 +189,9 @@ class AIE2PRegisterClass <int size, int align, list<ValueType> regTypes, dag reg
   def mLm : AIE2PScalar64RegisterClass<(add eL)>;
   def mL8m : AIE2PScalar64RegisterClass<(add l8)>;
 
-  class AIE2PVector128RegisterClass<dag reglist> :
-      AIE2PRegisterClass<128, 128, [v16i8, v8i16, v8bf16, v4i32, v4f32], reglist> {
+  class AIE2PVector128RegisterClass<dag reglist>
+      : AIE2PRegisterClass<128, 128, [i128, v16i8, v8i16, v8bf16, v4i32, v4f32],
+                           reglist> {
     let hasCompleteDecoder = 0;
   }
 

--- a/llvm/test/CodeGen/AIE/aie2p/GlobalIsel/irtranslator-call-arguments-vect128.ll
+++ b/llvm/test/CodeGen/AIE/aie2p/GlobalIsel/irtranslator-call-arguments-vect128.ll
@@ -20,7 +20,7 @@ define void @call_v4int32() {
   ; CHECK: bb.1 (%ir-block.0):
   ; CHECK-NEXT:   [[C:%[0-9]+]]:_(s32) = G_CONSTANT i32 0
   ; CHECK-NEXT:   [[BUILD_VECTOR:%[0-9]+]]:_(<4 x s32>) = G_BUILD_VECTOR [[C]](s32), [[C]](s32), [[C]](s32), [[C]](s32)
-  ; CHECK-NEXT:   ADJCALLSTACKUP 64, 0, implicit-def $sp, implicit $sp
+  ; CHECK-NEXT:   ADJCALLSTACKUP 32, 0, implicit-def $sp, implicit $sp
   ; CHECK-NEXT:   [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32), [[UV2:%[0-9]+]]:_(s32), [[UV3:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[BUILD_VECTOR]](<4 x s32>)
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(s32) = G_IMPLICIT_DEF
   ; CHECK-NEXT:   [[BUILD_VECTOR1:%[0-9]+]]:_(<8 x s32>) = G_BUILD_VECTOR [[UV]](s32), [[UV1]](s32), [[UV2]](s32), [[UV3]](s32), [[DEF]](s32), [[DEF]](s32), [[DEF]](s32), [[DEF]](s32)
@@ -93,19 +93,13 @@ define void @call_v4int32() {
   ; CHECK-NEXT:   [[UV92:%[0-9]+]]:_(s32), [[UV93:%[0-9]+]]:_(s32), [[UV94:%[0-9]+]]:_(s32), [[UV95:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[BUILD_VECTOR]](<4 x s32>)
   ; CHECK-NEXT:   [[DEF23:%[0-9]+]]:_(s32) = G_IMPLICIT_DEF
   ; CHECK-NEXT:   [[BUILD_VECTOR24:%[0-9]+]]:_(<8 x s32>) = G_BUILD_VECTOR [[UV92]](s32), [[UV93]](s32), [[UV94]](s32), [[UV95]](s32), [[DEF23]](s32), [[DEF23]](s32), [[DEF23]](s32), [[DEF23]](s32)
-  ; CHECK-NEXT:   [[UV96:%[0-9]+]]:_(s32), [[UV97:%[0-9]+]]:_(s32), [[UV98:%[0-9]+]]:_(s32), [[UV99:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[BUILD_VECTOR]](<4 x s32>)
-  ; CHECK-NEXT:   [[DEF24:%[0-9]+]]:_(s32) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   [[BUILD_VECTOR25:%[0-9]+]]:_(<8 x s32>) = G_BUILD_VECTOR [[UV96]](s32), [[UV97]](s32), [[UV98]](s32), [[UV99]](s32), [[DEF24]](s32), [[DEF24]](s32), [[DEF24]](s32), [[DEF24]](s32)
   ; CHECK-NEXT:   [[COPY:%[0-9]+]]:_(p0) = COPY $sp
-  ; CHECK-NEXT:   [[C1:%[0-9]+]]:_(s20) = G_CONSTANT i20 -32
+  ; CHECK-NEXT:   [[C1:%[0-9]+]]:_(s20) = G_CONSTANT i20 -16
   ; CHECK-NEXT:   [[PTR_ADD:%[0-9]+]]:_(p0) = G_PTR_ADD [[COPY]], [[C1]](s20)
-  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR25]](<8 x s32>), [[PTR_ADD]](p0) :: (store (<8 x s32>) into stack - 32)
-  ; CHECK-NEXT:   [[UV100:%[0-9]+]]:_(s32), [[UV101:%[0-9]+]]:_(s32), [[UV102:%[0-9]+]]:_(s32), [[UV103:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[BUILD_VECTOR]](<4 x s32>)
-  ; CHECK-NEXT:   [[DEF25:%[0-9]+]]:_(s32) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   [[BUILD_VECTOR26:%[0-9]+]]:_(<8 x s32>) = G_BUILD_VECTOR [[UV100]](s32), [[UV101]](s32), [[UV102]](s32), [[UV103]](s32), [[DEF25]](s32), [[DEF25]](s32), [[DEF25]](s32), [[DEF25]](s32)
-  ; CHECK-NEXT:   [[C2:%[0-9]+]]:_(s20) = G_CONSTANT i20 -64
+  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<4 x s32>), [[PTR_ADD]](p0) :: (store (<4 x s32>) into stack - 16, basealign 32)
+  ; CHECK-NEXT:   [[C2:%[0-9]+]]:_(s20) = G_CONSTANT i20 -32
   ; CHECK-NEXT:   [[PTR_ADD1:%[0-9]+]]:_(p0) = G_PTR_ADD [[COPY]], [[C2]](s20)
-  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR26]](<8 x s32>), [[PTR_ADD1]](p0) :: (store (<8 x s32>) into stack - 64)
+  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<4 x s32>), [[PTR_ADD1]](p0) :: (store (<4 x s32>) into stack - 32)
   ; CHECK-NEXT:   $wl0 = COPY [[BUILD_VECTOR1]](<8 x s32>)
   ; CHECK-NEXT:   $wl2 = COPY [[BUILD_VECTOR2]](<8 x s32>)
   ; CHECK-NEXT:   $wl4 = COPY [[BUILD_VECTOR3]](<8 x s32>)
@@ -131,7 +125,7 @@ define void @call_v4int32() {
   ; CHECK-NEXT:   $wh9 = COPY [[BUILD_VECTOR23]](<8 x s32>)
   ; CHECK-NEXT:   $wh11 = COPY [[BUILD_VECTOR24]](<8 x s32>)
   ; CHECK-NEXT:   PseudoJL @callee_v4int32, csr_aie2p, implicit-def $lr, implicit $wl0, implicit $wl2, implicit $wl4, implicit $wl6, implicit $wl8, implicit $wl10, implicit $wl1, implicit $wl3, implicit $wl5, implicit $wl7, implicit $wl9, implicit $wl11, implicit $wh0, implicit $wh2, implicit $wh4, implicit $wh6, implicit $wh8, implicit $wh10, implicit $wh1, implicit $wh3, implicit $wh5, implicit $wh7, implicit $wh9, implicit $wh11
-  ; CHECK-NEXT:   ADJCALLSTACKDOWN 64, 0, implicit-def $sp, implicit $sp
+  ; CHECK-NEXT:   ADJCALLSTACKDOWN 32, 0, implicit-def $sp, implicit $sp
   ; CHECK-NEXT:   PseudoRET implicit $lr
   call void @callee_v4int32(<4 x i32> zeroinitializer, <4 x i32> zeroinitializer, <4 x i32> zeroinitializer, <4 x i32> zeroinitializer, <4 x i32> zeroinitializer, <4 x i32> zeroinitializer,
                             <4 x i32> zeroinitializer, <4 x i32> zeroinitializer, <4 x i32> zeroinitializer, <4 x i32> zeroinitializer, <4 x i32> zeroinitializer, <4 x i32> zeroinitializer,
@@ -151,66 +145,112 @@ define void @call_v8int16() {
   ; CHECK: bb.1 (%ir-block.0):
   ; CHECK-NEXT:   [[C:%[0-9]+]]:_(s16) = G_CONSTANT i16 0
   ; CHECK-NEXT:   [[BUILD_VECTOR:%[0-9]+]]:_(<8 x s16>) = G_BUILD_VECTOR [[C]](s16), [[C]](s16), [[C]](s16), [[C]](s16), [[C]](s16), [[C]](s16), [[C]](s16), [[C]](s16)
-  ; CHECK-NEXT:   ADJCALLSTACKUP 64, 0, implicit-def $sp, implicit $sp
-  ; CHECK-NEXT:   [[ANYEXT:%[0-9]+]]:_(<8 x s32>) = G_ANYEXT [[BUILD_VECTOR]](<8 x s16>)
-  ; CHECK-NEXT:   [[ANYEXT1:%[0-9]+]]:_(<8 x s32>) = G_ANYEXT [[BUILD_VECTOR]](<8 x s16>)
-  ; CHECK-NEXT:   [[ANYEXT2:%[0-9]+]]:_(<8 x s32>) = G_ANYEXT [[BUILD_VECTOR]](<8 x s16>)
-  ; CHECK-NEXT:   [[ANYEXT3:%[0-9]+]]:_(<8 x s32>) = G_ANYEXT [[BUILD_VECTOR]](<8 x s16>)
-  ; CHECK-NEXT:   [[ANYEXT4:%[0-9]+]]:_(<8 x s32>) = G_ANYEXT [[BUILD_VECTOR]](<8 x s16>)
-  ; CHECK-NEXT:   [[ANYEXT5:%[0-9]+]]:_(<8 x s32>) = G_ANYEXT [[BUILD_VECTOR]](<8 x s16>)
-  ; CHECK-NEXT:   [[ANYEXT6:%[0-9]+]]:_(<8 x s32>) = G_ANYEXT [[BUILD_VECTOR]](<8 x s16>)
-  ; CHECK-NEXT:   [[ANYEXT7:%[0-9]+]]:_(<8 x s32>) = G_ANYEXT [[BUILD_VECTOR]](<8 x s16>)
-  ; CHECK-NEXT:   [[ANYEXT8:%[0-9]+]]:_(<8 x s32>) = G_ANYEXT [[BUILD_VECTOR]](<8 x s16>)
-  ; CHECK-NEXT:   [[ANYEXT9:%[0-9]+]]:_(<8 x s32>) = G_ANYEXT [[BUILD_VECTOR]](<8 x s16>)
-  ; CHECK-NEXT:   [[ANYEXT10:%[0-9]+]]:_(<8 x s32>) = G_ANYEXT [[BUILD_VECTOR]](<8 x s16>)
-  ; CHECK-NEXT:   [[ANYEXT11:%[0-9]+]]:_(<8 x s32>) = G_ANYEXT [[BUILD_VECTOR]](<8 x s16>)
-  ; CHECK-NEXT:   [[ANYEXT12:%[0-9]+]]:_(<8 x s32>) = G_ANYEXT [[BUILD_VECTOR]](<8 x s16>)
-  ; CHECK-NEXT:   [[ANYEXT13:%[0-9]+]]:_(<8 x s32>) = G_ANYEXT [[BUILD_VECTOR]](<8 x s16>)
-  ; CHECK-NEXT:   [[ANYEXT14:%[0-9]+]]:_(<8 x s32>) = G_ANYEXT [[BUILD_VECTOR]](<8 x s16>)
-  ; CHECK-NEXT:   [[ANYEXT15:%[0-9]+]]:_(<8 x s32>) = G_ANYEXT [[BUILD_VECTOR]](<8 x s16>)
-  ; CHECK-NEXT:   [[ANYEXT16:%[0-9]+]]:_(<8 x s32>) = G_ANYEXT [[BUILD_VECTOR]](<8 x s16>)
-  ; CHECK-NEXT:   [[ANYEXT17:%[0-9]+]]:_(<8 x s32>) = G_ANYEXT [[BUILD_VECTOR]](<8 x s16>)
-  ; CHECK-NEXT:   [[ANYEXT18:%[0-9]+]]:_(<8 x s32>) = G_ANYEXT [[BUILD_VECTOR]](<8 x s16>)
-  ; CHECK-NEXT:   [[ANYEXT19:%[0-9]+]]:_(<8 x s32>) = G_ANYEXT [[BUILD_VECTOR]](<8 x s16>)
-  ; CHECK-NEXT:   [[ANYEXT20:%[0-9]+]]:_(<8 x s32>) = G_ANYEXT [[BUILD_VECTOR]](<8 x s16>)
-  ; CHECK-NEXT:   [[ANYEXT21:%[0-9]+]]:_(<8 x s32>) = G_ANYEXT [[BUILD_VECTOR]](<8 x s16>)
-  ; CHECK-NEXT:   [[ANYEXT22:%[0-9]+]]:_(<8 x s32>) = G_ANYEXT [[BUILD_VECTOR]](<8 x s16>)
-  ; CHECK-NEXT:   [[ANYEXT23:%[0-9]+]]:_(<8 x s32>) = G_ANYEXT [[BUILD_VECTOR]](<8 x s16>)
-  ; CHECK-NEXT:   [[ANYEXT24:%[0-9]+]]:_(<8 x s32>) = G_ANYEXT [[BUILD_VECTOR]](<8 x s16>)
+  ; CHECK-NEXT:   ADJCALLSTACKUP 32, 0, implicit-def $sp, implicit $sp
+  ; CHECK-NEXT:   [[UV:%[0-9]+]]:_(s16), [[UV1:%[0-9]+]]:_(s16), [[UV2:%[0-9]+]]:_(s16), [[UV3:%[0-9]+]]:_(s16), [[UV4:%[0-9]+]]:_(s16), [[UV5:%[0-9]+]]:_(s16), [[UV6:%[0-9]+]]:_(s16), [[UV7:%[0-9]+]]:_(s16) = G_UNMERGE_VALUES [[BUILD_VECTOR]](<8 x s16>)
+  ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(s16) = G_IMPLICIT_DEF
+  ; CHECK-NEXT:   [[BUILD_VECTOR1:%[0-9]+]]:_(<16 x s16>) = G_BUILD_VECTOR [[UV]](s16), [[UV1]](s16), [[UV2]](s16), [[UV3]](s16), [[UV4]](s16), [[UV5]](s16), [[UV6]](s16), [[UV7]](s16), [[DEF]](s16), [[DEF]](s16), [[DEF]](s16), [[DEF]](s16), [[DEF]](s16), [[DEF]](s16), [[DEF]](s16), [[DEF]](s16)
+  ; CHECK-NEXT:   [[UV8:%[0-9]+]]:_(s16), [[UV9:%[0-9]+]]:_(s16), [[UV10:%[0-9]+]]:_(s16), [[UV11:%[0-9]+]]:_(s16), [[UV12:%[0-9]+]]:_(s16), [[UV13:%[0-9]+]]:_(s16), [[UV14:%[0-9]+]]:_(s16), [[UV15:%[0-9]+]]:_(s16) = G_UNMERGE_VALUES [[BUILD_VECTOR]](<8 x s16>)
+  ; CHECK-NEXT:   [[DEF1:%[0-9]+]]:_(s16) = G_IMPLICIT_DEF
+  ; CHECK-NEXT:   [[BUILD_VECTOR2:%[0-9]+]]:_(<16 x s16>) = G_BUILD_VECTOR [[UV8]](s16), [[UV9]](s16), [[UV10]](s16), [[UV11]](s16), [[UV12]](s16), [[UV13]](s16), [[UV14]](s16), [[UV15]](s16), [[DEF1]](s16), [[DEF1]](s16), [[DEF1]](s16), [[DEF1]](s16), [[DEF1]](s16), [[DEF1]](s16), [[DEF1]](s16), [[DEF1]](s16)
+  ; CHECK-NEXT:   [[UV16:%[0-9]+]]:_(s16), [[UV17:%[0-9]+]]:_(s16), [[UV18:%[0-9]+]]:_(s16), [[UV19:%[0-9]+]]:_(s16), [[UV20:%[0-9]+]]:_(s16), [[UV21:%[0-9]+]]:_(s16), [[UV22:%[0-9]+]]:_(s16), [[UV23:%[0-9]+]]:_(s16) = G_UNMERGE_VALUES [[BUILD_VECTOR]](<8 x s16>)
+  ; CHECK-NEXT:   [[DEF2:%[0-9]+]]:_(s16) = G_IMPLICIT_DEF
+  ; CHECK-NEXT:   [[BUILD_VECTOR3:%[0-9]+]]:_(<16 x s16>) = G_BUILD_VECTOR [[UV16]](s16), [[UV17]](s16), [[UV18]](s16), [[UV19]](s16), [[UV20]](s16), [[UV21]](s16), [[UV22]](s16), [[UV23]](s16), [[DEF2]](s16), [[DEF2]](s16), [[DEF2]](s16), [[DEF2]](s16), [[DEF2]](s16), [[DEF2]](s16), [[DEF2]](s16), [[DEF2]](s16)
+  ; CHECK-NEXT:   [[UV24:%[0-9]+]]:_(s16), [[UV25:%[0-9]+]]:_(s16), [[UV26:%[0-9]+]]:_(s16), [[UV27:%[0-9]+]]:_(s16), [[UV28:%[0-9]+]]:_(s16), [[UV29:%[0-9]+]]:_(s16), [[UV30:%[0-9]+]]:_(s16), [[UV31:%[0-9]+]]:_(s16) = G_UNMERGE_VALUES [[BUILD_VECTOR]](<8 x s16>)
+  ; CHECK-NEXT:   [[DEF3:%[0-9]+]]:_(s16) = G_IMPLICIT_DEF
+  ; CHECK-NEXT:   [[BUILD_VECTOR4:%[0-9]+]]:_(<16 x s16>) = G_BUILD_VECTOR [[UV24]](s16), [[UV25]](s16), [[UV26]](s16), [[UV27]](s16), [[UV28]](s16), [[UV29]](s16), [[UV30]](s16), [[UV31]](s16), [[DEF3]](s16), [[DEF3]](s16), [[DEF3]](s16), [[DEF3]](s16), [[DEF3]](s16), [[DEF3]](s16), [[DEF3]](s16), [[DEF3]](s16)
+  ; CHECK-NEXT:   [[UV32:%[0-9]+]]:_(s16), [[UV33:%[0-9]+]]:_(s16), [[UV34:%[0-9]+]]:_(s16), [[UV35:%[0-9]+]]:_(s16), [[UV36:%[0-9]+]]:_(s16), [[UV37:%[0-9]+]]:_(s16), [[UV38:%[0-9]+]]:_(s16), [[UV39:%[0-9]+]]:_(s16) = G_UNMERGE_VALUES [[BUILD_VECTOR]](<8 x s16>)
+  ; CHECK-NEXT:   [[DEF4:%[0-9]+]]:_(s16) = G_IMPLICIT_DEF
+  ; CHECK-NEXT:   [[BUILD_VECTOR5:%[0-9]+]]:_(<16 x s16>) = G_BUILD_VECTOR [[UV32]](s16), [[UV33]](s16), [[UV34]](s16), [[UV35]](s16), [[UV36]](s16), [[UV37]](s16), [[UV38]](s16), [[UV39]](s16), [[DEF4]](s16), [[DEF4]](s16), [[DEF4]](s16), [[DEF4]](s16), [[DEF4]](s16), [[DEF4]](s16), [[DEF4]](s16), [[DEF4]](s16)
+  ; CHECK-NEXT:   [[UV40:%[0-9]+]]:_(s16), [[UV41:%[0-9]+]]:_(s16), [[UV42:%[0-9]+]]:_(s16), [[UV43:%[0-9]+]]:_(s16), [[UV44:%[0-9]+]]:_(s16), [[UV45:%[0-9]+]]:_(s16), [[UV46:%[0-9]+]]:_(s16), [[UV47:%[0-9]+]]:_(s16) = G_UNMERGE_VALUES [[BUILD_VECTOR]](<8 x s16>)
+  ; CHECK-NEXT:   [[DEF5:%[0-9]+]]:_(s16) = G_IMPLICIT_DEF
+  ; CHECK-NEXT:   [[BUILD_VECTOR6:%[0-9]+]]:_(<16 x s16>) = G_BUILD_VECTOR [[UV40]](s16), [[UV41]](s16), [[UV42]](s16), [[UV43]](s16), [[UV44]](s16), [[UV45]](s16), [[UV46]](s16), [[UV47]](s16), [[DEF5]](s16), [[DEF5]](s16), [[DEF5]](s16), [[DEF5]](s16), [[DEF5]](s16), [[DEF5]](s16), [[DEF5]](s16), [[DEF5]](s16)
+  ; CHECK-NEXT:   [[UV48:%[0-9]+]]:_(s16), [[UV49:%[0-9]+]]:_(s16), [[UV50:%[0-9]+]]:_(s16), [[UV51:%[0-9]+]]:_(s16), [[UV52:%[0-9]+]]:_(s16), [[UV53:%[0-9]+]]:_(s16), [[UV54:%[0-9]+]]:_(s16), [[UV55:%[0-9]+]]:_(s16) = G_UNMERGE_VALUES [[BUILD_VECTOR]](<8 x s16>)
+  ; CHECK-NEXT:   [[DEF6:%[0-9]+]]:_(s16) = G_IMPLICIT_DEF
+  ; CHECK-NEXT:   [[BUILD_VECTOR7:%[0-9]+]]:_(<16 x s16>) = G_BUILD_VECTOR [[UV48]](s16), [[UV49]](s16), [[UV50]](s16), [[UV51]](s16), [[UV52]](s16), [[UV53]](s16), [[UV54]](s16), [[UV55]](s16), [[DEF6]](s16), [[DEF6]](s16), [[DEF6]](s16), [[DEF6]](s16), [[DEF6]](s16), [[DEF6]](s16), [[DEF6]](s16), [[DEF6]](s16)
+  ; CHECK-NEXT:   [[UV56:%[0-9]+]]:_(s16), [[UV57:%[0-9]+]]:_(s16), [[UV58:%[0-9]+]]:_(s16), [[UV59:%[0-9]+]]:_(s16), [[UV60:%[0-9]+]]:_(s16), [[UV61:%[0-9]+]]:_(s16), [[UV62:%[0-9]+]]:_(s16), [[UV63:%[0-9]+]]:_(s16) = G_UNMERGE_VALUES [[BUILD_VECTOR]](<8 x s16>)
+  ; CHECK-NEXT:   [[DEF7:%[0-9]+]]:_(s16) = G_IMPLICIT_DEF
+  ; CHECK-NEXT:   [[BUILD_VECTOR8:%[0-9]+]]:_(<16 x s16>) = G_BUILD_VECTOR [[UV56]](s16), [[UV57]](s16), [[UV58]](s16), [[UV59]](s16), [[UV60]](s16), [[UV61]](s16), [[UV62]](s16), [[UV63]](s16), [[DEF7]](s16), [[DEF7]](s16), [[DEF7]](s16), [[DEF7]](s16), [[DEF7]](s16), [[DEF7]](s16), [[DEF7]](s16), [[DEF7]](s16)
+  ; CHECK-NEXT:   [[UV64:%[0-9]+]]:_(s16), [[UV65:%[0-9]+]]:_(s16), [[UV66:%[0-9]+]]:_(s16), [[UV67:%[0-9]+]]:_(s16), [[UV68:%[0-9]+]]:_(s16), [[UV69:%[0-9]+]]:_(s16), [[UV70:%[0-9]+]]:_(s16), [[UV71:%[0-9]+]]:_(s16) = G_UNMERGE_VALUES [[BUILD_VECTOR]](<8 x s16>)
+  ; CHECK-NEXT:   [[DEF8:%[0-9]+]]:_(s16) = G_IMPLICIT_DEF
+  ; CHECK-NEXT:   [[BUILD_VECTOR9:%[0-9]+]]:_(<16 x s16>) = G_BUILD_VECTOR [[UV64]](s16), [[UV65]](s16), [[UV66]](s16), [[UV67]](s16), [[UV68]](s16), [[UV69]](s16), [[UV70]](s16), [[UV71]](s16), [[DEF8]](s16), [[DEF8]](s16), [[DEF8]](s16), [[DEF8]](s16), [[DEF8]](s16), [[DEF8]](s16), [[DEF8]](s16), [[DEF8]](s16)
+  ; CHECK-NEXT:   [[UV72:%[0-9]+]]:_(s16), [[UV73:%[0-9]+]]:_(s16), [[UV74:%[0-9]+]]:_(s16), [[UV75:%[0-9]+]]:_(s16), [[UV76:%[0-9]+]]:_(s16), [[UV77:%[0-9]+]]:_(s16), [[UV78:%[0-9]+]]:_(s16), [[UV79:%[0-9]+]]:_(s16) = G_UNMERGE_VALUES [[BUILD_VECTOR]](<8 x s16>)
+  ; CHECK-NEXT:   [[DEF9:%[0-9]+]]:_(s16) = G_IMPLICIT_DEF
+  ; CHECK-NEXT:   [[BUILD_VECTOR10:%[0-9]+]]:_(<16 x s16>) = G_BUILD_VECTOR [[UV72]](s16), [[UV73]](s16), [[UV74]](s16), [[UV75]](s16), [[UV76]](s16), [[UV77]](s16), [[UV78]](s16), [[UV79]](s16), [[DEF9]](s16), [[DEF9]](s16), [[DEF9]](s16), [[DEF9]](s16), [[DEF9]](s16), [[DEF9]](s16), [[DEF9]](s16), [[DEF9]](s16)
+  ; CHECK-NEXT:   [[UV80:%[0-9]+]]:_(s16), [[UV81:%[0-9]+]]:_(s16), [[UV82:%[0-9]+]]:_(s16), [[UV83:%[0-9]+]]:_(s16), [[UV84:%[0-9]+]]:_(s16), [[UV85:%[0-9]+]]:_(s16), [[UV86:%[0-9]+]]:_(s16), [[UV87:%[0-9]+]]:_(s16) = G_UNMERGE_VALUES [[BUILD_VECTOR]](<8 x s16>)
+  ; CHECK-NEXT:   [[DEF10:%[0-9]+]]:_(s16) = G_IMPLICIT_DEF
+  ; CHECK-NEXT:   [[BUILD_VECTOR11:%[0-9]+]]:_(<16 x s16>) = G_BUILD_VECTOR [[UV80]](s16), [[UV81]](s16), [[UV82]](s16), [[UV83]](s16), [[UV84]](s16), [[UV85]](s16), [[UV86]](s16), [[UV87]](s16), [[DEF10]](s16), [[DEF10]](s16), [[DEF10]](s16), [[DEF10]](s16), [[DEF10]](s16), [[DEF10]](s16), [[DEF10]](s16), [[DEF10]](s16)
+  ; CHECK-NEXT:   [[UV88:%[0-9]+]]:_(s16), [[UV89:%[0-9]+]]:_(s16), [[UV90:%[0-9]+]]:_(s16), [[UV91:%[0-9]+]]:_(s16), [[UV92:%[0-9]+]]:_(s16), [[UV93:%[0-9]+]]:_(s16), [[UV94:%[0-9]+]]:_(s16), [[UV95:%[0-9]+]]:_(s16) = G_UNMERGE_VALUES [[BUILD_VECTOR]](<8 x s16>)
+  ; CHECK-NEXT:   [[DEF11:%[0-9]+]]:_(s16) = G_IMPLICIT_DEF
+  ; CHECK-NEXT:   [[BUILD_VECTOR12:%[0-9]+]]:_(<16 x s16>) = G_BUILD_VECTOR [[UV88]](s16), [[UV89]](s16), [[UV90]](s16), [[UV91]](s16), [[UV92]](s16), [[UV93]](s16), [[UV94]](s16), [[UV95]](s16), [[DEF11]](s16), [[DEF11]](s16), [[DEF11]](s16), [[DEF11]](s16), [[DEF11]](s16), [[DEF11]](s16), [[DEF11]](s16), [[DEF11]](s16)
+  ; CHECK-NEXT:   [[UV96:%[0-9]+]]:_(s16), [[UV97:%[0-9]+]]:_(s16), [[UV98:%[0-9]+]]:_(s16), [[UV99:%[0-9]+]]:_(s16), [[UV100:%[0-9]+]]:_(s16), [[UV101:%[0-9]+]]:_(s16), [[UV102:%[0-9]+]]:_(s16), [[UV103:%[0-9]+]]:_(s16) = G_UNMERGE_VALUES [[BUILD_VECTOR]](<8 x s16>)
+  ; CHECK-NEXT:   [[DEF12:%[0-9]+]]:_(s16) = G_IMPLICIT_DEF
+  ; CHECK-NEXT:   [[BUILD_VECTOR13:%[0-9]+]]:_(<16 x s16>) = G_BUILD_VECTOR [[UV96]](s16), [[UV97]](s16), [[UV98]](s16), [[UV99]](s16), [[UV100]](s16), [[UV101]](s16), [[UV102]](s16), [[UV103]](s16), [[DEF12]](s16), [[DEF12]](s16), [[DEF12]](s16), [[DEF12]](s16), [[DEF12]](s16), [[DEF12]](s16), [[DEF12]](s16), [[DEF12]](s16)
+  ; CHECK-NEXT:   [[UV104:%[0-9]+]]:_(s16), [[UV105:%[0-9]+]]:_(s16), [[UV106:%[0-9]+]]:_(s16), [[UV107:%[0-9]+]]:_(s16), [[UV108:%[0-9]+]]:_(s16), [[UV109:%[0-9]+]]:_(s16), [[UV110:%[0-9]+]]:_(s16), [[UV111:%[0-9]+]]:_(s16) = G_UNMERGE_VALUES [[BUILD_VECTOR]](<8 x s16>)
+  ; CHECK-NEXT:   [[DEF13:%[0-9]+]]:_(s16) = G_IMPLICIT_DEF
+  ; CHECK-NEXT:   [[BUILD_VECTOR14:%[0-9]+]]:_(<16 x s16>) = G_BUILD_VECTOR [[UV104]](s16), [[UV105]](s16), [[UV106]](s16), [[UV107]](s16), [[UV108]](s16), [[UV109]](s16), [[UV110]](s16), [[UV111]](s16), [[DEF13]](s16), [[DEF13]](s16), [[DEF13]](s16), [[DEF13]](s16), [[DEF13]](s16), [[DEF13]](s16), [[DEF13]](s16), [[DEF13]](s16)
+  ; CHECK-NEXT:   [[UV112:%[0-9]+]]:_(s16), [[UV113:%[0-9]+]]:_(s16), [[UV114:%[0-9]+]]:_(s16), [[UV115:%[0-9]+]]:_(s16), [[UV116:%[0-9]+]]:_(s16), [[UV117:%[0-9]+]]:_(s16), [[UV118:%[0-9]+]]:_(s16), [[UV119:%[0-9]+]]:_(s16) = G_UNMERGE_VALUES [[BUILD_VECTOR]](<8 x s16>)
+  ; CHECK-NEXT:   [[DEF14:%[0-9]+]]:_(s16) = G_IMPLICIT_DEF
+  ; CHECK-NEXT:   [[BUILD_VECTOR15:%[0-9]+]]:_(<16 x s16>) = G_BUILD_VECTOR [[UV112]](s16), [[UV113]](s16), [[UV114]](s16), [[UV115]](s16), [[UV116]](s16), [[UV117]](s16), [[UV118]](s16), [[UV119]](s16), [[DEF14]](s16), [[DEF14]](s16), [[DEF14]](s16), [[DEF14]](s16), [[DEF14]](s16), [[DEF14]](s16), [[DEF14]](s16), [[DEF14]](s16)
+  ; CHECK-NEXT:   [[UV120:%[0-9]+]]:_(s16), [[UV121:%[0-9]+]]:_(s16), [[UV122:%[0-9]+]]:_(s16), [[UV123:%[0-9]+]]:_(s16), [[UV124:%[0-9]+]]:_(s16), [[UV125:%[0-9]+]]:_(s16), [[UV126:%[0-9]+]]:_(s16), [[UV127:%[0-9]+]]:_(s16) = G_UNMERGE_VALUES [[BUILD_VECTOR]](<8 x s16>)
+  ; CHECK-NEXT:   [[DEF15:%[0-9]+]]:_(s16) = G_IMPLICIT_DEF
+  ; CHECK-NEXT:   [[BUILD_VECTOR16:%[0-9]+]]:_(<16 x s16>) = G_BUILD_VECTOR [[UV120]](s16), [[UV121]](s16), [[UV122]](s16), [[UV123]](s16), [[UV124]](s16), [[UV125]](s16), [[UV126]](s16), [[UV127]](s16), [[DEF15]](s16), [[DEF15]](s16), [[DEF15]](s16), [[DEF15]](s16), [[DEF15]](s16), [[DEF15]](s16), [[DEF15]](s16), [[DEF15]](s16)
+  ; CHECK-NEXT:   [[UV128:%[0-9]+]]:_(s16), [[UV129:%[0-9]+]]:_(s16), [[UV130:%[0-9]+]]:_(s16), [[UV131:%[0-9]+]]:_(s16), [[UV132:%[0-9]+]]:_(s16), [[UV133:%[0-9]+]]:_(s16), [[UV134:%[0-9]+]]:_(s16), [[UV135:%[0-9]+]]:_(s16) = G_UNMERGE_VALUES [[BUILD_VECTOR]](<8 x s16>)
+  ; CHECK-NEXT:   [[DEF16:%[0-9]+]]:_(s16) = G_IMPLICIT_DEF
+  ; CHECK-NEXT:   [[BUILD_VECTOR17:%[0-9]+]]:_(<16 x s16>) = G_BUILD_VECTOR [[UV128]](s16), [[UV129]](s16), [[UV130]](s16), [[UV131]](s16), [[UV132]](s16), [[UV133]](s16), [[UV134]](s16), [[UV135]](s16), [[DEF16]](s16), [[DEF16]](s16), [[DEF16]](s16), [[DEF16]](s16), [[DEF16]](s16), [[DEF16]](s16), [[DEF16]](s16), [[DEF16]](s16)
+  ; CHECK-NEXT:   [[UV136:%[0-9]+]]:_(s16), [[UV137:%[0-9]+]]:_(s16), [[UV138:%[0-9]+]]:_(s16), [[UV139:%[0-9]+]]:_(s16), [[UV140:%[0-9]+]]:_(s16), [[UV141:%[0-9]+]]:_(s16), [[UV142:%[0-9]+]]:_(s16), [[UV143:%[0-9]+]]:_(s16) = G_UNMERGE_VALUES [[BUILD_VECTOR]](<8 x s16>)
+  ; CHECK-NEXT:   [[DEF17:%[0-9]+]]:_(s16) = G_IMPLICIT_DEF
+  ; CHECK-NEXT:   [[BUILD_VECTOR18:%[0-9]+]]:_(<16 x s16>) = G_BUILD_VECTOR [[UV136]](s16), [[UV137]](s16), [[UV138]](s16), [[UV139]](s16), [[UV140]](s16), [[UV141]](s16), [[UV142]](s16), [[UV143]](s16), [[DEF17]](s16), [[DEF17]](s16), [[DEF17]](s16), [[DEF17]](s16), [[DEF17]](s16), [[DEF17]](s16), [[DEF17]](s16), [[DEF17]](s16)
+  ; CHECK-NEXT:   [[UV144:%[0-9]+]]:_(s16), [[UV145:%[0-9]+]]:_(s16), [[UV146:%[0-9]+]]:_(s16), [[UV147:%[0-9]+]]:_(s16), [[UV148:%[0-9]+]]:_(s16), [[UV149:%[0-9]+]]:_(s16), [[UV150:%[0-9]+]]:_(s16), [[UV151:%[0-9]+]]:_(s16) = G_UNMERGE_VALUES [[BUILD_VECTOR]](<8 x s16>)
+  ; CHECK-NEXT:   [[DEF18:%[0-9]+]]:_(s16) = G_IMPLICIT_DEF
+  ; CHECK-NEXT:   [[BUILD_VECTOR19:%[0-9]+]]:_(<16 x s16>) = G_BUILD_VECTOR [[UV144]](s16), [[UV145]](s16), [[UV146]](s16), [[UV147]](s16), [[UV148]](s16), [[UV149]](s16), [[UV150]](s16), [[UV151]](s16), [[DEF18]](s16), [[DEF18]](s16), [[DEF18]](s16), [[DEF18]](s16), [[DEF18]](s16), [[DEF18]](s16), [[DEF18]](s16), [[DEF18]](s16)
+  ; CHECK-NEXT:   [[UV152:%[0-9]+]]:_(s16), [[UV153:%[0-9]+]]:_(s16), [[UV154:%[0-9]+]]:_(s16), [[UV155:%[0-9]+]]:_(s16), [[UV156:%[0-9]+]]:_(s16), [[UV157:%[0-9]+]]:_(s16), [[UV158:%[0-9]+]]:_(s16), [[UV159:%[0-9]+]]:_(s16) = G_UNMERGE_VALUES [[BUILD_VECTOR]](<8 x s16>)
+  ; CHECK-NEXT:   [[DEF19:%[0-9]+]]:_(s16) = G_IMPLICIT_DEF
+  ; CHECK-NEXT:   [[BUILD_VECTOR20:%[0-9]+]]:_(<16 x s16>) = G_BUILD_VECTOR [[UV152]](s16), [[UV153]](s16), [[UV154]](s16), [[UV155]](s16), [[UV156]](s16), [[UV157]](s16), [[UV158]](s16), [[UV159]](s16), [[DEF19]](s16), [[DEF19]](s16), [[DEF19]](s16), [[DEF19]](s16), [[DEF19]](s16), [[DEF19]](s16), [[DEF19]](s16), [[DEF19]](s16)
+  ; CHECK-NEXT:   [[UV160:%[0-9]+]]:_(s16), [[UV161:%[0-9]+]]:_(s16), [[UV162:%[0-9]+]]:_(s16), [[UV163:%[0-9]+]]:_(s16), [[UV164:%[0-9]+]]:_(s16), [[UV165:%[0-9]+]]:_(s16), [[UV166:%[0-9]+]]:_(s16), [[UV167:%[0-9]+]]:_(s16) = G_UNMERGE_VALUES [[BUILD_VECTOR]](<8 x s16>)
+  ; CHECK-NEXT:   [[DEF20:%[0-9]+]]:_(s16) = G_IMPLICIT_DEF
+  ; CHECK-NEXT:   [[BUILD_VECTOR21:%[0-9]+]]:_(<16 x s16>) = G_BUILD_VECTOR [[UV160]](s16), [[UV161]](s16), [[UV162]](s16), [[UV163]](s16), [[UV164]](s16), [[UV165]](s16), [[UV166]](s16), [[UV167]](s16), [[DEF20]](s16), [[DEF20]](s16), [[DEF20]](s16), [[DEF20]](s16), [[DEF20]](s16), [[DEF20]](s16), [[DEF20]](s16), [[DEF20]](s16)
+  ; CHECK-NEXT:   [[UV168:%[0-9]+]]:_(s16), [[UV169:%[0-9]+]]:_(s16), [[UV170:%[0-9]+]]:_(s16), [[UV171:%[0-9]+]]:_(s16), [[UV172:%[0-9]+]]:_(s16), [[UV173:%[0-9]+]]:_(s16), [[UV174:%[0-9]+]]:_(s16), [[UV175:%[0-9]+]]:_(s16) = G_UNMERGE_VALUES [[BUILD_VECTOR]](<8 x s16>)
+  ; CHECK-NEXT:   [[DEF21:%[0-9]+]]:_(s16) = G_IMPLICIT_DEF
+  ; CHECK-NEXT:   [[BUILD_VECTOR22:%[0-9]+]]:_(<16 x s16>) = G_BUILD_VECTOR [[UV168]](s16), [[UV169]](s16), [[UV170]](s16), [[UV171]](s16), [[UV172]](s16), [[UV173]](s16), [[UV174]](s16), [[UV175]](s16), [[DEF21]](s16), [[DEF21]](s16), [[DEF21]](s16), [[DEF21]](s16), [[DEF21]](s16), [[DEF21]](s16), [[DEF21]](s16), [[DEF21]](s16)
+  ; CHECK-NEXT:   [[UV176:%[0-9]+]]:_(s16), [[UV177:%[0-9]+]]:_(s16), [[UV178:%[0-9]+]]:_(s16), [[UV179:%[0-9]+]]:_(s16), [[UV180:%[0-9]+]]:_(s16), [[UV181:%[0-9]+]]:_(s16), [[UV182:%[0-9]+]]:_(s16), [[UV183:%[0-9]+]]:_(s16) = G_UNMERGE_VALUES [[BUILD_VECTOR]](<8 x s16>)
+  ; CHECK-NEXT:   [[DEF22:%[0-9]+]]:_(s16) = G_IMPLICIT_DEF
+  ; CHECK-NEXT:   [[BUILD_VECTOR23:%[0-9]+]]:_(<16 x s16>) = G_BUILD_VECTOR [[UV176]](s16), [[UV177]](s16), [[UV178]](s16), [[UV179]](s16), [[UV180]](s16), [[UV181]](s16), [[UV182]](s16), [[UV183]](s16), [[DEF22]](s16), [[DEF22]](s16), [[DEF22]](s16), [[DEF22]](s16), [[DEF22]](s16), [[DEF22]](s16), [[DEF22]](s16), [[DEF22]](s16)
+  ; CHECK-NEXT:   [[UV184:%[0-9]+]]:_(s16), [[UV185:%[0-9]+]]:_(s16), [[UV186:%[0-9]+]]:_(s16), [[UV187:%[0-9]+]]:_(s16), [[UV188:%[0-9]+]]:_(s16), [[UV189:%[0-9]+]]:_(s16), [[UV190:%[0-9]+]]:_(s16), [[UV191:%[0-9]+]]:_(s16) = G_UNMERGE_VALUES [[BUILD_VECTOR]](<8 x s16>)
+  ; CHECK-NEXT:   [[DEF23:%[0-9]+]]:_(s16) = G_IMPLICIT_DEF
+  ; CHECK-NEXT:   [[BUILD_VECTOR24:%[0-9]+]]:_(<16 x s16>) = G_BUILD_VECTOR [[UV184]](s16), [[UV185]](s16), [[UV186]](s16), [[UV187]](s16), [[UV188]](s16), [[UV189]](s16), [[UV190]](s16), [[UV191]](s16), [[DEF23]](s16), [[DEF23]](s16), [[DEF23]](s16), [[DEF23]](s16), [[DEF23]](s16), [[DEF23]](s16), [[DEF23]](s16), [[DEF23]](s16)
   ; CHECK-NEXT:   [[COPY:%[0-9]+]]:_(p0) = COPY $sp
-  ; CHECK-NEXT:   [[C1:%[0-9]+]]:_(s20) = G_CONSTANT i20 -32
+  ; CHECK-NEXT:   [[C1:%[0-9]+]]:_(s20) = G_CONSTANT i20 -16
   ; CHECK-NEXT:   [[PTR_ADD:%[0-9]+]]:_(p0) = G_PTR_ADD [[COPY]], [[C1]](s20)
-  ; CHECK-NEXT:   G_STORE [[ANYEXT24]](<8 x s32>), [[PTR_ADD]](p0) :: (store (<8 x s32>) into stack - 32)
-  ; CHECK-NEXT:   [[ANYEXT25:%[0-9]+]]:_(<8 x s32>) = G_ANYEXT [[BUILD_VECTOR]](<8 x s16>)
-  ; CHECK-NEXT:   [[C2:%[0-9]+]]:_(s20) = G_CONSTANT i20 -64
+  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<8 x s16>), [[PTR_ADD]](p0) :: (store (<8 x s16>) into stack - 16, basealign 32)
+  ; CHECK-NEXT:   [[C2:%[0-9]+]]:_(s20) = G_CONSTANT i20 -32
   ; CHECK-NEXT:   [[PTR_ADD1:%[0-9]+]]:_(p0) = G_PTR_ADD [[COPY]], [[C2]](s20)
-  ; CHECK-NEXT:   G_STORE [[ANYEXT25]](<8 x s32>), [[PTR_ADD1]](p0) :: (store (<8 x s32>) into stack - 64)
-  ; CHECK-NEXT:   $wl0 = COPY [[ANYEXT]](<8 x s32>)
-  ; CHECK-NEXT:   $wl2 = COPY [[ANYEXT1]](<8 x s32>)
-  ; CHECK-NEXT:   $wl4 = COPY [[ANYEXT2]](<8 x s32>)
-  ; CHECK-NEXT:   $wl6 = COPY [[ANYEXT3]](<8 x s32>)
-  ; CHECK-NEXT:   $wl8 = COPY [[ANYEXT4]](<8 x s32>)
-  ; CHECK-NEXT:   $wl10 = COPY [[ANYEXT5]](<8 x s32>)
-  ; CHECK-NEXT:   $wl1 = COPY [[ANYEXT6]](<8 x s32>)
-  ; CHECK-NEXT:   $wl3 = COPY [[ANYEXT7]](<8 x s32>)
-  ; CHECK-NEXT:   $wl5 = COPY [[ANYEXT8]](<8 x s32>)
-  ; CHECK-NEXT:   $wl7 = COPY [[ANYEXT9]](<8 x s32>)
-  ; CHECK-NEXT:   $wl9 = COPY [[ANYEXT10]](<8 x s32>)
-  ; CHECK-NEXT:   $wl11 = COPY [[ANYEXT11]](<8 x s32>)
-  ; CHECK-NEXT:   $wh0 = COPY [[ANYEXT12]](<8 x s32>)
-  ; CHECK-NEXT:   $wh2 = COPY [[ANYEXT13]](<8 x s32>)
-  ; CHECK-NEXT:   $wh4 = COPY [[ANYEXT14]](<8 x s32>)
-  ; CHECK-NEXT:   $wh6 = COPY [[ANYEXT15]](<8 x s32>)
-  ; CHECK-NEXT:   $wh8 = COPY [[ANYEXT16]](<8 x s32>)
-  ; CHECK-NEXT:   $wh10 = COPY [[ANYEXT17]](<8 x s32>)
-  ; CHECK-NEXT:   $wh1 = COPY [[ANYEXT18]](<8 x s32>)
-  ; CHECK-NEXT:   $wh3 = COPY [[ANYEXT19]](<8 x s32>)
-  ; CHECK-NEXT:   $wh5 = COPY [[ANYEXT20]](<8 x s32>)
-  ; CHECK-NEXT:   $wh7 = COPY [[ANYEXT21]](<8 x s32>)
-  ; CHECK-NEXT:   $wh9 = COPY [[ANYEXT22]](<8 x s32>)
-  ; CHECK-NEXT:   $wh11 = COPY [[ANYEXT23]](<8 x s32>)
+  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<8 x s16>), [[PTR_ADD1]](p0) :: (store (<8 x s16>) into stack - 32)
+  ; CHECK-NEXT:   $wl0 = COPY [[BUILD_VECTOR1]](<16 x s16>)
+  ; CHECK-NEXT:   $wl2 = COPY [[BUILD_VECTOR2]](<16 x s16>)
+  ; CHECK-NEXT:   $wl4 = COPY [[BUILD_VECTOR3]](<16 x s16>)
+  ; CHECK-NEXT:   $wl6 = COPY [[BUILD_VECTOR4]](<16 x s16>)
+  ; CHECK-NEXT:   $wl8 = COPY [[BUILD_VECTOR5]](<16 x s16>)
+  ; CHECK-NEXT:   $wl10 = COPY [[BUILD_VECTOR6]](<16 x s16>)
+  ; CHECK-NEXT:   $wl1 = COPY [[BUILD_VECTOR7]](<16 x s16>)
+  ; CHECK-NEXT:   $wl3 = COPY [[BUILD_VECTOR8]](<16 x s16>)
+  ; CHECK-NEXT:   $wl5 = COPY [[BUILD_VECTOR9]](<16 x s16>)
+  ; CHECK-NEXT:   $wl7 = COPY [[BUILD_VECTOR10]](<16 x s16>)
+  ; CHECK-NEXT:   $wl9 = COPY [[BUILD_VECTOR11]](<16 x s16>)
+  ; CHECK-NEXT:   $wl11 = COPY [[BUILD_VECTOR12]](<16 x s16>)
+  ; CHECK-NEXT:   $wh0 = COPY [[BUILD_VECTOR13]](<16 x s16>)
+  ; CHECK-NEXT:   $wh2 = COPY [[BUILD_VECTOR14]](<16 x s16>)
+  ; CHECK-NEXT:   $wh4 = COPY [[BUILD_VECTOR15]](<16 x s16>)
+  ; CHECK-NEXT:   $wh6 = COPY [[BUILD_VECTOR16]](<16 x s16>)
+  ; CHECK-NEXT:   $wh8 = COPY [[BUILD_VECTOR17]](<16 x s16>)
+  ; CHECK-NEXT:   $wh10 = COPY [[BUILD_VECTOR18]](<16 x s16>)
+  ; CHECK-NEXT:   $wh1 = COPY [[BUILD_VECTOR19]](<16 x s16>)
+  ; CHECK-NEXT:   $wh3 = COPY [[BUILD_VECTOR20]](<16 x s16>)
+  ; CHECK-NEXT:   $wh5 = COPY [[BUILD_VECTOR21]](<16 x s16>)
+  ; CHECK-NEXT:   $wh7 = COPY [[BUILD_VECTOR22]](<16 x s16>)
+  ; CHECK-NEXT:   $wh9 = COPY [[BUILD_VECTOR23]](<16 x s16>)
+  ; CHECK-NEXT:   $wh11 = COPY [[BUILD_VECTOR24]](<16 x s16>)
   ; CHECK-NEXT:   PseudoJL @callee_v8int16, csr_aie2p, implicit-def $lr, implicit $wl0, implicit $wl2, implicit $wl4, implicit $wl6, implicit $wl8, implicit $wl10, implicit $wl1, implicit $wl3, implicit $wl5, implicit $wl7, implicit $wl9, implicit $wl11, implicit $wh0, implicit $wh2, implicit $wh4, implicit $wh6, implicit $wh8, implicit $wh10, implicit $wh1, implicit $wh3, implicit $wh5, implicit $wh7, implicit $wh9, implicit $wh11
-  ; CHECK-NEXT:   ADJCALLSTACKDOWN 64, 0, implicit-def $sp, implicit $sp
+  ; CHECK-NEXT:   ADJCALLSTACKDOWN 32, 0, implicit-def $sp, implicit $sp
   ; CHECK-NEXT:   PseudoRET implicit $lr
   call void @callee_v8int16(<8 x i16> zeroinitializer, <8 x i16> zeroinitializer, <8 x i16> zeroinitializer, <8 x i16> zeroinitializer, <8 x i16> zeroinitializer, <8 x i16> zeroinitializer,
                             <8 x i16> zeroinitializer, <8 x i16> zeroinitializer, <8 x i16> zeroinitializer, <8 x i16> zeroinitializer, <8 x i16> zeroinitializer, <8 x i16> zeroinitializer,
@@ -230,66 +270,112 @@ define void @call_v16int8() {
   ; CHECK: bb.1 (%ir-block.0):
   ; CHECK-NEXT:   [[C:%[0-9]+]]:_(s8) = G_CONSTANT i8 0
   ; CHECK-NEXT:   [[BUILD_VECTOR:%[0-9]+]]:_(<16 x s8>) = G_BUILD_VECTOR [[C]](s8), [[C]](s8), [[C]](s8), [[C]](s8), [[C]](s8), [[C]](s8), [[C]](s8), [[C]](s8), [[C]](s8), [[C]](s8), [[C]](s8), [[C]](s8), [[C]](s8), [[C]](s8), [[C]](s8), [[C]](s8)
-  ; CHECK-NEXT:   ADJCALLSTACKUP 64, 0, implicit-def $sp, implicit $sp
-  ; CHECK-NEXT:   [[ANYEXT:%[0-9]+]]:_(<16 x s16>) = G_ANYEXT [[BUILD_VECTOR]](<16 x s8>)
-  ; CHECK-NEXT:   [[ANYEXT1:%[0-9]+]]:_(<16 x s16>) = G_ANYEXT [[BUILD_VECTOR]](<16 x s8>)
-  ; CHECK-NEXT:   [[ANYEXT2:%[0-9]+]]:_(<16 x s16>) = G_ANYEXT [[BUILD_VECTOR]](<16 x s8>)
-  ; CHECK-NEXT:   [[ANYEXT3:%[0-9]+]]:_(<16 x s16>) = G_ANYEXT [[BUILD_VECTOR]](<16 x s8>)
-  ; CHECK-NEXT:   [[ANYEXT4:%[0-9]+]]:_(<16 x s16>) = G_ANYEXT [[BUILD_VECTOR]](<16 x s8>)
-  ; CHECK-NEXT:   [[ANYEXT5:%[0-9]+]]:_(<16 x s16>) = G_ANYEXT [[BUILD_VECTOR]](<16 x s8>)
-  ; CHECK-NEXT:   [[ANYEXT6:%[0-9]+]]:_(<16 x s16>) = G_ANYEXT [[BUILD_VECTOR]](<16 x s8>)
-  ; CHECK-NEXT:   [[ANYEXT7:%[0-9]+]]:_(<16 x s16>) = G_ANYEXT [[BUILD_VECTOR]](<16 x s8>)
-  ; CHECK-NEXT:   [[ANYEXT8:%[0-9]+]]:_(<16 x s16>) = G_ANYEXT [[BUILD_VECTOR]](<16 x s8>)
-  ; CHECK-NEXT:   [[ANYEXT9:%[0-9]+]]:_(<16 x s16>) = G_ANYEXT [[BUILD_VECTOR]](<16 x s8>)
-  ; CHECK-NEXT:   [[ANYEXT10:%[0-9]+]]:_(<16 x s16>) = G_ANYEXT [[BUILD_VECTOR]](<16 x s8>)
-  ; CHECK-NEXT:   [[ANYEXT11:%[0-9]+]]:_(<16 x s16>) = G_ANYEXT [[BUILD_VECTOR]](<16 x s8>)
-  ; CHECK-NEXT:   [[ANYEXT12:%[0-9]+]]:_(<16 x s16>) = G_ANYEXT [[BUILD_VECTOR]](<16 x s8>)
-  ; CHECK-NEXT:   [[ANYEXT13:%[0-9]+]]:_(<16 x s16>) = G_ANYEXT [[BUILD_VECTOR]](<16 x s8>)
-  ; CHECK-NEXT:   [[ANYEXT14:%[0-9]+]]:_(<16 x s16>) = G_ANYEXT [[BUILD_VECTOR]](<16 x s8>)
-  ; CHECK-NEXT:   [[ANYEXT15:%[0-9]+]]:_(<16 x s16>) = G_ANYEXT [[BUILD_VECTOR]](<16 x s8>)
-  ; CHECK-NEXT:   [[ANYEXT16:%[0-9]+]]:_(<16 x s16>) = G_ANYEXT [[BUILD_VECTOR]](<16 x s8>)
-  ; CHECK-NEXT:   [[ANYEXT17:%[0-9]+]]:_(<16 x s16>) = G_ANYEXT [[BUILD_VECTOR]](<16 x s8>)
-  ; CHECK-NEXT:   [[ANYEXT18:%[0-9]+]]:_(<16 x s16>) = G_ANYEXT [[BUILD_VECTOR]](<16 x s8>)
-  ; CHECK-NEXT:   [[ANYEXT19:%[0-9]+]]:_(<16 x s16>) = G_ANYEXT [[BUILD_VECTOR]](<16 x s8>)
-  ; CHECK-NEXT:   [[ANYEXT20:%[0-9]+]]:_(<16 x s16>) = G_ANYEXT [[BUILD_VECTOR]](<16 x s8>)
-  ; CHECK-NEXT:   [[ANYEXT21:%[0-9]+]]:_(<16 x s16>) = G_ANYEXT [[BUILD_VECTOR]](<16 x s8>)
-  ; CHECK-NEXT:   [[ANYEXT22:%[0-9]+]]:_(<16 x s16>) = G_ANYEXT [[BUILD_VECTOR]](<16 x s8>)
-  ; CHECK-NEXT:   [[ANYEXT23:%[0-9]+]]:_(<16 x s16>) = G_ANYEXT [[BUILD_VECTOR]](<16 x s8>)
-  ; CHECK-NEXT:   [[ANYEXT24:%[0-9]+]]:_(<16 x s16>) = G_ANYEXT [[BUILD_VECTOR]](<16 x s8>)
+  ; CHECK-NEXT:   ADJCALLSTACKUP 32, 0, implicit-def $sp, implicit $sp
+  ; CHECK-NEXT:   [[UV:%[0-9]+]]:_(s8), [[UV1:%[0-9]+]]:_(s8), [[UV2:%[0-9]+]]:_(s8), [[UV3:%[0-9]+]]:_(s8), [[UV4:%[0-9]+]]:_(s8), [[UV5:%[0-9]+]]:_(s8), [[UV6:%[0-9]+]]:_(s8), [[UV7:%[0-9]+]]:_(s8), [[UV8:%[0-9]+]]:_(s8), [[UV9:%[0-9]+]]:_(s8), [[UV10:%[0-9]+]]:_(s8), [[UV11:%[0-9]+]]:_(s8), [[UV12:%[0-9]+]]:_(s8), [[UV13:%[0-9]+]]:_(s8), [[UV14:%[0-9]+]]:_(s8), [[UV15:%[0-9]+]]:_(s8) = G_UNMERGE_VALUES [[BUILD_VECTOR]](<16 x s8>)
+  ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(s8) = G_IMPLICIT_DEF
+  ; CHECK-NEXT:   [[BUILD_VECTOR1:%[0-9]+]]:_(<32 x s8>) = G_BUILD_VECTOR [[UV]](s8), [[UV1]](s8), [[UV2]](s8), [[UV3]](s8), [[UV4]](s8), [[UV5]](s8), [[UV6]](s8), [[UV7]](s8), [[UV8]](s8), [[UV9]](s8), [[UV10]](s8), [[UV11]](s8), [[UV12]](s8), [[UV13]](s8), [[UV14]](s8), [[UV15]](s8), [[DEF]](s8), [[DEF]](s8), [[DEF]](s8), [[DEF]](s8), [[DEF]](s8), [[DEF]](s8), [[DEF]](s8), [[DEF]](s8), [[DEF]](s8), [[DEF]](s8), [[DEF]](s8), [[DEF]](s8), [[DEF]](s8), [[DEF]](s8), [[DEF]](s8), [[DEF]](s8)
+  ; CHECK-NEXT:   [[UV16:%[0-9]+]]:_(s8), [[UV17:%[0-9]+]]:_(s8), [[UV18:%[0-9]+]]:_(s8), [[UV19:%[0-9]+]]:_(s8), [[UV20:%[0-9]+]]:_(s8), [[UV21:%[0-9]+]]:_(s8), [[UV22:%[0-9]+]]:_(s8), [[UV23:%[0-9]+]]:_(s8), [[UV24:%[0-9]+]]:_(s8), [[UV25:%[0-9]+]]:_(s8), [[UV26:%[0-9]+]]:_(s8), [[UV27:%[0-9]+]]:_(s8), [[UV28:%[0-9]+]]:_(s8), [[UV29:%[0-9]+]]:_(s8), [[UV30:%[0-9]+]]:_(s8), [[UV31:%[0-9]+]]:_(s8) = G_UNMERGE_VALUES [[BUILD_VECTOR]](<16 x s8>)
+  ; CHECK-NEXT:   [[DEF1:%[0-9]+]]:_(s8) = G_IMPLICIT_DEF
+  ; CHECK-NEXT:   [[BUILD_VECTOR2:%[0-9]+]]:_(<32 x s8>) = G_BUILD_VECTOR [[UV16]](s8), [[UV17]](s8), [[UV18]](s8), [[UV19]](s8), [[UV20]](s8), [[UV21]](s8), [[UV22]](s8), [[UV23]](s8), [[UV24]](s8), [[UV25]](s8), [[UV26]](s8), [[UV27]](s8), [[UV28]](s8), [[UV29]](s8), [[UV30]](s8), [[UV31]](s8), [[DEF1]](s8), [[DEF1]](s8), [[DEF1]](s8), [[DEF1]](s8), [[DEF1]](s8), [[DEF1]](s8), [[DEF1]](s8), [[DEF1]](s8), [[DEF1]](s8), [[DEF1]](s8), [[DEF1]](s8), [[DEF1]](s8), [[DEF1]](s8), [[DEF1]](s8), [[DEF1]](s8), [[DEF1]](s8)
+  ; CHECK-NEXT:   [[UV32:%[0-9]+]]:_(s8), [[UV33:%[0-9]+]]:_(s8), [[UV34:%[0-9]+]]:_(s8), [[UV35:%[0-9]+]]:_(s8), [[UV36:%[0-9]+]]:_(s8), [[UV37:%[0-9]+]]:_(s8), [[UV38:%[0-9]+]]:_(s8), [[UV39:%[0-9]+]]:_(s8), [[UV40:%[0-9]+]]:_(s8), [[UV41:%[0-9]+]]:_(s8), [[UV42:%[0-9]+]]:_(s8), [[UV43:%[0-9]+]]:_(s8), [[UV44:%[0-9]+]]:_(s8), [[UV45:%[0-9]+]]:_(s8), [[UV46:%[0-9]+]]:_(s8), [[UV47:%[0-9]+]]:_(s8) = G_UNMERGE_VALUES [[BUILD_VECTOR]](<16 x s8>)
+  ; CHECK-NEXT:   [[DEF2:%[0-9]+]]:_(s8) = G_IMPLICIT_DEF
+  ; CHECK-NEXT:   [[BUILD_VECTOR3:%[0-9]+]]:_(<32 x s8>) = G_BUILD_VECTOR [[UV32]](s8), [[UV33]](s8), [[UV34]](s8), [[UV35]](s8), [[UV36]](s8), [[UV37]](s8), [[UV38]](s8), [[UV39]](s8), [[UV40]](s8), [[UV41]](s8), [[UV42]](s8), [[UV43]](s8), [[UV44]](s8), [[UV45]](s8), [[UV46]](s8), [[UV47]](s8), [[DEF2]](s8), [[DEF2]](s8), [[DEF2]](s8), [[DEF2]](s8), [[DEF2]](s8), [[DEF2]](s8), [[DEF2]](s8), [[DEF2]](s8), [[DEF2]](s8), [[DEF2]](s8), [[DEF2]](s8), [[DEF2]](s8), [[DEF2]](s8), [[DEF2]](s8), [[DEF2]](s8), [[DEF2]](s8)
+  ; CHECK-NEXT:   [[UV48:%[0-9]+]]:_(s8), [[UV49:%[0-9]+]]:_(s8), [[UV50:%[0-9]+]]:_(s8), [[UV51:%[0-9]+]]:_(s8), [[UV52:%[0-9]+]]:_(s8), [[UV53:%[0-9]+]]:_(s8), [[UV54:%[0-9]+]]:_(s8), [[UV55:%[0-9]+]]:_(s8), [[UV56:%[0-9]+]]:_(s8), [[UV57:%[0-9]+]]:_(s8), [[UV58:%[0-9]+]]:_(s8), [[UV59:%[0-9]+]]:_(s8), [[UV60:%[0-9]+]]:_(s8), [[UV61:%[0-9]+]]:_(s8), [[UV62:%[0-9]+]]:_(s8), [[UV63:%[0-9]+]]:_(s8) = G_UNMERGE_VALUES [[BUILD_VECTOR]](<16 x s8>)
+  ; CHECK-NEXT:   [[DEF3:%[0-9]+]]:_(s8) = G_IMPLICIT_DEF
+  ; CHECK-NEXT:   [[BUILD_VECTOR4:%[0-9]+]]:_(<32 x s8>) = G_BUILD_VECTOR [[UV48]](s8), [[UV49]](s8), [[UV50]](s8), [[UV51]](s8), [[UV52]](s8), [[UV53]](s8), [[UV54]](s8), [[UV55]](s8), [[UV56]](s8), [[UV57]](s8), [[UV58]](s8), [[UV59]](s8), [[UV60]](s8), [[UV61]](s8), [[UV62]](s8), [[UV63]](s8), [[DEF3]](s8), [[DEF3]](s8), [[DEF3]](s8), [[DEF3]](s8), [[DEF3]](s8), [[DEF3]](s8), [[DEF3]](s8), [[DEF3]](s8), [[DEF3]](s8), [[DEF3]](s8), [[DEF3]](s8), [[DEF3]](s8), [[DEF3]](s8), [[DEF3]](s8), [[DEF3]](s8), [[DEF3]](s8)
+  ; CHECK-NEXT:   [[UV64:%[0-9]+]]:_(s8), [[UV65:%[0-9]+]]:_(s8), [[UV66:%[0-9]+]]:_(s8), [[UV67:%[0-9]+]]:_(s8), [[UV68:%[0-9]+]]:_(s8), [[UV69:%[0-9]+]]:_(s8), [[UV70:%[0-9]+]]:_(s8), [[UV71:%[0-9]+]]:_(s8), [[UV72:%[0-9]+]]:_(s8), [[UV73:%[0-9]+]]:_(s8), [[UV74:%[0-9]+]]:_(s8), [[UV75:%[0-9]+]]:_(s8), [[UV76:%[0-9]+]]:_(s8), [[UV77:%[0-9]+]]:_(s8), [[UV78:%[0-9]+]]:_(s8), [[UV79:%[0-9]+]]:_(s8) = G_UNMERGE_VALUES [[BUILD_VECTOR]](<16 x s8>)
+  ; CHECK-NEXT:   [[DEF4:%[0-9]+]]:_(s8) = G_IMPLICIT_DEF
+  ; CHECK-NEXT:   [[BUILD_VECTOR5:%[0-9]+]]:_(<32 x s8>) = G_BUILD_VECTOR [[UV64]](s8), [[UV65]](s8), [[UV66]](s8), [[UV67]](s8), [[UV68]](s8), [[UV69]](s8), [[UV70]](s8), [[UV71]](s8), [[UV72]](s8), [[UV73]](s8), [[UV74]](s8), [[UV75]](s8), [[UV76]](s8), [[UV77]](s8), [[UV78]](s8), [[UV79]](s8), [[DEF4]](s8), [[DEF4]](s8), [[DEF4]](s8), [[DEF4]](s8), [[DEF4]](s8), [[DEF4]](s8), [[DEF4]](s8), [[DEF4]](s8), [[DEF4]](s8), [[DEF4]](s8), [[DEF4]](s8), [[DEF4]](s8), [[DEF4]](s8), [[DEF4]](s8), [[DEF4]](s8), [[DEF4]](s8)
+  ; CHECK-NEXT:   [[UV80:%[0-9]+]]:_(s8), [[UV81:%[0-9]+]]:_(s8), [[UV82:%[0-9]+]]:_(s8), [[UV83:%[0-9]+]]:_(s8), [[UV84:%[0-9]+]]:_(s8), [[UV85:%[0-9]+]]:_(s8), [[UV86:%[0-9]+]]:_(s8), [[UV87:%[0-9]+]]:_(s8), [[UV88:%[0-9]+]]:_(s8), [[UV89:%[0-9]+]]:_(s8), [[UV90:%[0-9]+]]:_(s8), [[UV91:%[0-9]+]]:_(s8), [[UV92:%[0-9]+]]:_(s8), [[UV93:%[0-9]+]]:_(s8), [[UV94:%[0-9]+]]:_(s8), [[UV95:%[0-9]+]]:_(s8) = G_UNMERGE_VALUES [[BUILD_VECTOR]](<16 x s8>)
+  ; CHECK-NEXT:   [[DEF5:%[0-9]+]]:_(s8) = G_IMPLICIT_DEF
+  ; CHECK-NEXT:   [[BUILD_VECTOR6:%[0-9]+]]:_(<32 x s8>) = G_BUILD_VECTOR [[UV80]](s8), [[UV81]](s8), [[UV82]](s8), [[UV83]](s8), [[UV84]](s8), [[UV85]](s8), [[UV86]](s8), [[UV87]](s8), [[UV88]](s8), [[UV89]](s8), [[UV90]](s8), [[UV91]](s8), [[UV92]](s8), [[UV93]](s8), [[UV94]](s8), [[UV95]](s8), [[DEF5]](s8), [[DEF5]](s8), [[DEF5]](s8), [[DEF5]](s8), [[DEF5]](s8), [[DEF5]](s8), [[DEF5]](s8), [[DEF5]](s8), [[DEF5]](s8), [[DEF5]](s8), [[DEF5]](s8), [[DEF5]](s8), [[DEF5]](s8), [[DEF5]](s8), [[DEF5]](s8), [[DEF5]](s8)
+  ; CHECK-NEXT:   [[UV96:%[0-9]+]]:_(s8), [[UV97:%[0-9]+]]:_(s8), [[UV98:%[0-9]+]]:_(s8), [[UV99:%[0-9]+]]:_(s8), [[UV100:%[0-9]+]]:_(s8), [[UV101:%[0-9]+]]:_(s8), [[UV102:%[0-9]+]]:_(s8), [[UV103:%[0-9]+]]:_(s8), [[UV104:%[0-9]+]]:_(s8), [[UV105:%[0-9]+]]:_(s8), [[UV106:%[0-9]+]]:_(s8), [[UV107:%[0-9]+]]:_(s8), [[UV108:%[0-9]+]]:_(s8), [[UV109:%[0-9]+]]:_(s8), [[UV110:%[0-9]+]]:_(s8), [[UV111:%[0-9]+]]:_(s8) = G_UNMERGE_VALUES [[BUILD_VECTOR]](<16 x s8>)
+  ; CHECK-NEXT:   [[DEF6:%[0-9]+]]:_(s8) = G_IMPLICIT_DEF
+  ; CHECK-NEXT:   [[BUILD_VECTOR7:%[0-9]+]]:_(<32 x s8>) = G_BUILD_VECTOR [[UV96]](s8), [[UV97]](s8), [[UV98]](s8), [[UV99]](s8), [[UV100]](s8), [[UV101]](s8), [[UV102]](s8), [[UV103]](s8), [[UV104]](s8), [[UV105]](s8), [[UV106]](s8), [[UV107]](s8), [[UV108]](s8), [[UV109]](s8), [[UV110]](s8), [[UV111]](s8), [[DEF6]](s8), [[DEF6]](s8), [[DEF6]](s8), [[DEF6]](s8), [[DEF6]](s8), [[DEF6]](s8), [[DEF6]](s8), [[DEF6]](s8), [[DEF6]](s8), [[DEF6]](s8), [[DEF6]](s8), [[DEF6]](s8), [[DEF6]](s8), [[DEF6]](s8), [[DEF6]](s8), [[DEF6]](s8)
+  ; CHECK-NEXT:   [[UV112:%[0-9]+]]:_(s8), [[UV113:%[0-9]+]]:_(s8), [[UV114:%[0-9]+]]:_(s8), [[UV115:%[0-9]+]]:_(s8), [[UV116:%[0-9]+]]:_(s8), [[UV117:%[0-9]+]]:_(s8), [[UV118:%[0-9]+]]:_(s8), [[UV119:%[0-9]+]]:_(s8), [[UV120:%[0-9]+]]:_(s8), [[UV121:%[0-9]+]]:_(s8), [[UV122:%[0-9]+]]:_(s8), [[UV123:%[0-9]+]]:_(s8), [[UV124:%[0-9]+]]:_(s8), [[UV125:%[0-9]+]]:_(s8), [[UV126:%[0-9]+]]:_(s8), [[UV127:%[0-9]+]]:_(s8) = G_UNMERGE_VALUES [[BUILD_VECTOR]](<16 x s8>)
+  ; CHECK-NEXT:   [[DEF7:%[0-9]+]]:_(s8) = G_IMPLICIT_DEF
+  ; CHECK-NEXT:   [[BUILD_VECTOR8:%[0-9]+]]:_(<32 x s8>) = G_BUILD_VECTOR [[UV112]](s8), [[UV113]](s8), [[UV114]](s8), [[UV115]](s8), [[UV116]](s8), [[UV117]](s8), [[UV118]](s8), [[UV119]](s8), [[UV120]](s8), [[UV121]](s8), [[UV122]](s8), [[UV123]](s8), [[UV124]](s8), [[UV125]](s8), [[UV126]](s8), [[UV127]](s8), [[DEF7]](s8), [[DEF7]](s8), [[DEF7]](s8), [[DEF7]](s8), [[DEF7]](s8), [[DEF7]](s8), [[DEF7]](s8), [[DEF7]](s8), [[DEF7]](s8), [[DEF7]](s8), [[DEF7]](s8), [[DEF7]](s8), [[DEF7]](s8), [[DEF7]](s8), [[DEF7]](s8), [[DEF7]](s8)
+  ; CHECK-NEXT:   [[UV128:%[0-9]+]]:_(s8), [[UV129:%[0-9]+]]:_(s8), [[UV130:%[0-9]+]]:_(s8), [[UV131:%[0-9]+]]:_(s8), [[UV132:%[0-9]+]]:_(s8), [[UV133:%[0-9]+]]:_(s8), [[UV134:%[0-9]+]]:_(s8), [[UV135:%[0-9]+]]:_(s8), [[UV136:%[0-9]+]]:_(s8), [[UV137:%[0-9]+]]:_(s8), [[UV138:%[0-9]+]]:_(s8), [[UV139:%[0-9]+]]:_(s8), [[UV140:%[0-9]+]]:_(s8), [[UV141:%[0-9]+]]:_(s8), [[UV142:%[0-9]+]]:_(s8), [[UV143:%[0-9]+]]:_(s8) = G_UNMERGE_VALUES [[BUILD_VECTOR]](<16 x s8>)
+  ; CHECK-NEXT:   [[DEF8:%[0-9]+]]:_(s8) = G_IMPLICIT_DEF
+  ; CHECK-NEXT:   [[BUILD_VECTOR9:%[0-9]+]]:_(<32 x s8>) = G_BUILD_VECTOR [[UV128]](s8), [[UV129]](s8), [[UV130]](s8), [[UV131]](s8), [[UV132]](s8), [[UV133]](s8), [[UV134]](s8), [[UV135]](s8), [[UV136]](s8), [[UV137]](s8), [[UV138]](s8), [[UV139]](s8), [[UV140]](s8), [[UV141]](s8), [[UV142]](s8), [[UV143]](s8), [[DEF8]](s8), [[DEF8]](s8), [[DEF8]](s8), [[DEF8]](s8), [[DEF8]](s8), [[DEF8]](s8), [[DEF8]](s8), [[DEF8]](s8), [[DEF8]](s8), [[DEF8]](s8), [[DEF8]](s8), [[DEF8]](s8), [[DEF8]](s8), [[DEF8]](s8), [[DEF8]](s8), [[DEF8]](s8)
+  ; CHECK-NEXT:   [[UV144:%[0-9]+]]:_(s8), [[UV145:%[0-9]+]]:_(s8), [[UV146:%[0-9]+]]:_(s8), [[UV147:%[0-9]+]]:_(s8), [[UV148:%[0-9]+]]:_(s8), [[UV149:%[0-9]+]]:_(s8), [[UV150:%[0-9]+]]:_(s8), [[UV151:%[0-9]+]]:_(s8), [[UV152:%[0-9]+]]:_(s8), [[UV153:%[0-9]+]]:_(s8), [[UV154:%[0-9]+]]:_(s8), [[UV155:%[0-9]+]]:_(s8), [[UV156:%[0-9]+]]:_(s8), [[UV157:%[0-9]+]]:_(s8), [[UV158:%[0-9]+]]:_(s8), [[UV159:%[0-9]+]]:_(s8) = G_UNMERGE_VALUES [[BUILD_VECTOR]](<16 x s8>)
+  ; CHECK-NEXT:   [[DEF9:%[0-9]+]]:_(s8) = G_IMPLICIT_DEF
+  ; CHECK-NEXT:   [[BUILD_VECTOR10:%[0-9]+]]:_(<32 x s8>) = G_BUILD_VECTOR [[UV144]](s8), [[UV145]](s8), [[UV146]](s8), [[UV147]](s8), [[UV148]](s8), [[UV149]](s8), [[UV150]](s8), [[UV151]](s8), [[UV152]](s8), [[UV153]](s8), [[UV154]](s8), [[UV155]](s8), [[UV156]](s8), [[UV157]](s8), [[UV158]](s8), [[UV159]](s8), [[DEF9]](s8), [[DEF9]](s8), [[DEF9]](s8), [[DEF9]](s8), [[DEF9]](s8), [[DEF9]](s8), [[DEF9]](s8), [[DEF9]](s8), [[DEF9]](s8), [[DEF9]](s8), [[DEF9]](s8), [[DEF9]](s8), [[DEF9]](s8), [[DEF9]](s8), [[DEF9]](s8), [[DEF9]](s8)
+  ; CHECK-NEXT:   [[UV160:%[0-9]+]]:_(s8), [[UV161:%[0-9]+]]:_(s8), [[UV162:%[0-9]+]]:_(s8), [[UV163:%[0-9]+]]:_(s8), [[UV164:%[0-9]+]]:_(s8), [[UV165:%[0-9]+]]:_(s8), [[UV166:%[0-9]+]]:_(s8), [[UV167:%[0-9]+]]:_(s8), [[UV168:%[0-9]+]]:_(s8), [[UV169:%[0-9]+]]:_(s8), [[UV170:%[0-9]+]]:_(s8), [[UV171:%[0-9]+]]:_(s8), [[UV172:%[0-9]+]]:_(s8), [[UV173:%[0-9]+]]:_(s8), [[UV174:%[0-9]+]]:_(s8), [[UV175:%[0-9]+]]:_(s8) = G_UNMERGE_VALUES [[BUILD_VECTOR]](<16 x s8>)
+  ; CHECK-NEXT:   [[DEF10:%[0-9]+]]:_(s8) = G_IMPLICIT_DEF
+  ; CHECK-NEXT:   [[BUILD_VECTOR11:%[0-9]+]]:_(<32 x s8>) = G_BUILD_VECTOR [[UV160]](s8), [[UV161]](s8), [[UV162]](s8), [[UV163]](s8), [[UV164]](s8), [[UV165]](s8), [[UV166]](s8), [[UV167]](s8), [[UV168]](s8), [[UV169]](s8), [[UV170]](s8), [[UV171]](s8), [[UV172]](s8), [[UV173]](s8), [[UV174]](s8), [[UV175]](s8), [[DEF10]](s8), [[DEF10]](s8), [[DEF10]](s8), [[DEF10]](s8), [[DEF10]](s8), [[DEF10]](s8), [[DEF10]](s8), [[DEF10]](s8), [[DEF10]](s8), [[DEF10]](s8), [[DEF10]](s8), [[DEF10]](s8), [[DEF10]](s8), [[DEF10]](s8), [[DEF10]](s8), [[DEF10]](s8)
+  ; CHECK-NEXT:   [[UV176:%[0-9]+]]:_(s8), [[UV177:%[0-9]+]]:_(s8), [[UV178:%[0-9]+]]:_(s8), [[UV179:%[0-9]+]]:_(s8), [[UV180:%[0-9]+]]:_(s8), [[UV181:%[0-9]+]]:_(s8), [[UV182:%[0-9]+]]:_(s8), [[UV183:%[0-9]+]]:_(s8), [[UV184:%[0-9]+]]:_(s8), [[UV185:%[0-9]+]]:_(s8), [[UV186:%[0-9]+]]:_(s8), [[UV187:%[0-9]+]]:_(s8), [[UV188:%[0-9]+]]:_(s8), [[UV189:%[0-9]+]]:_(s8), [[UV190:%[0-9]+]]:_(s8), [[UV191:%[0-9]+]]:_(s8) = G_UNMERGE_VALUES [[BUILD_VECTOR]](<16 x s8>)
+  ; CHECK-NEXT:   [[DEF11:%[0-9]+]]:_(s8) = G_IMPLICIT_DEF
+  ; CHECK-NEXT:   [[BUILD_VECTOR12:%[0-9]+]]:_(<32 x s8>) = G_BUILD_VECTOR [[UV176]](s8), [[UV177]](s8), [[UV178]](s8), [[UV179]](s8), [[UV180]](s8), [[UV181]](s8), [[UV182]](s8), [[UV183]](s8), [[UV184]](s8), [[UV185]](s8), [[UV186]](s8), [[UV187]](s8), [[UV188]](s8), [[UV189]](s8), [[UV190]](s8), [[UV191]](s8), [[DEF11]](s8), [[DEF11]](s8), [[DEF11]](s8), [[DEF11]](s8), [[DEF11]](s8), [[DEF11]](s8), [[DEF11]](s8), [[DEF11]](s8), [[DEF11]](s8), [[DEF11]](s8), [[DEF11]](s8), [[DEF11]](s8), [[DEF11]](s8), [[DEF11]](s8), [[DEF11]](s8), [[DEF11]](s8)
+  ; CHECK-NEXT:   [[UV192:%[0-9]+]]:_(s8), [[UV193:%[0-9]+]]:_(s8), [[UV194:%[0-9]+]]:_(s8), [[UV195:%[0-9]+]]:_(s8), [[UV196:%[0-9]+]]:_(s8), [[UV197:%[0-9]+]]:_(s8), [[UV198:%[0-9]+]]:_(s8), [[UV199:%[0-9]+]]:_(s8), [[UV200:%[0-9]+]]:_(s8), [[UV201:%[0-9]+]]:_(s8), [[UV202:%[0-9]+]]:_(s8), [[UV203:%[0-9]+]]:_(s8), [[UV204:%[0-9]+]]:_(s8), [[UV205:%[0-9]+]]:_(s8), [[UV206:%[0-9]+]]:_(s8), [[UV207:%[0-9]+]]:_(s8) = G_UNMERGE_VALUES [[BUILD_VECTOR]](<16 x s8>)
+  ; CHECK-NEXT:   [[DEF12:%[0-9]+]]:_(s8) = G_IMPLICIT_DEF
+  ; CHECK-NEXT:   [[BUILD_VECTOR13:%[0-9]+]]:_(<32 x s8>) = G_BUILD_VECTOR [[UV192]](s8), [[UV193]](s8), [[UV194]](s8), [[UV195]](s8), [[UV196]](s8), [[UV197]](s8), [[UV198]](s8), [[UV199]](s8), [[UV200]](s8), [[UV201]](s8), [[UV202]](s8), [[UV203]](s8), [[UV204]](s8), [[UV205]](s8), [[UV206]](s8), [[UV207]](s8), [[DEF12]](s8), [[DEF12]](s8), [[DEF12]](s8), [[DEF12]](s8), [[DEF12]](s8), [[DEF12]](s8), [[DEF12]](s8), [[DEF12]](s8), [[DEF12]](s8), [[DEF12]](s8), [[DEF12]](s8), [[DEF12]](s8), [[DEF12]](s8), [[DEF12]](s8), [[DEF12]](s8), [[DEF12]](s8)
+  ; CHECK-NEXT:   [[UV208:%[0-9]+]]:_(s8), [[UV209:%[0-9]+]]:_(s8), [[UV210:%[0-9]+]]:_(s8), [[UV211:%[0-9]+]]:_(s8), [[UV212:%[0-9]+]]:_(s8), [[UV213:%[0-9]+]]:_(s8), [[UV214:%[0-9]+]]:_(s8), [[UV215:%[0-9]+]]:_(s8), [[UV216:%[0-9]+]]:_(s8), [[UV217:%[0-9]+]]:_(s8), [[UV218:%[0-9]+]]:_(s8), [[UV219:%[0-9]+]]:_(s8), [[UV220:%[0-9]+]]:_(s8), [[UV221:%[0-9]+]]:_(s8), [[UV222:%[0-9]+]]:_(s8), [[UV223:%[0-9]+]]:_(s8) = G_UNMERGE_VALUES [[BUILD_VECTOR]](<16 x s8>)
+  ; CHECK-NEXT:   [[DEF13:%[0-9]+]]:_(s8) = G_IMPLICIT_DEF
+  ; CHECK-NEXT:   [[BUILD_VECTOR14:%[0-9]+]]:_(<32 x s8>) = G_BUILD_VECTOR [[UV208]](s8), [[UV209]](s8), [[UV210]](s8), [[UV211]](s8), [[UV212]](s8), [[UV213]](s8), [[UV214]](s8), [[UV215]](s8), [[UV216]](s8), [[UV217]](s8), [[UV218]](s8), [[UV219]](s8), [[UV220]](s8), [[UV221]](s8), [[UV222]](s8), [[UV223]](s8), [[DEF13]](s8), [[DEF13]](s8), [[DEF13]](s8), [[DEF13]](s8), [[DEF13]](s8), [[DEF13]](s8), [[DEF13]](s8), [[DEF13]](s8), [[DEF13]](s8), [[DEF13]](s8), [[DEF13]](s8), [[DEF13]](s8), [[DEF13]](s8), [[DEF13]](s8), [[DEF13]](s8), [[DEF13]](s8)
+  ; CHECK-NEXT:   [[UV224:%[0-9]+]]:_(s8), [[UV225:%[0-9]+]]:_(s8), [[UV226:%[0-9]+]]:_(s8), [[UV227:%[0-9]+]]:_(s8), [[UV228:%[0-9]+]]:_(s8), [[UV229:%[0-9]+]]:_(s8), [[UV230:%[0-9]+]]:_(s8), [[UV231:%[0-9]+]]:_(s8), [[UV232:%[0-9]+]]:_(s8), [[UV233:%[0-9]+]]:_(s8), [[UV234:%[0-9]+]]:_(s8), [[UV235:%[0-9]+]]:_(s8), [[UV236:%[0-9]+]]:_(s8), [[UV237:%[0-9]+]]:_(s8), [[UV238:%[0-9]+]]:_(s8), [[UV239:%[0-9]+]]:_(s8) = G_UNMERGE_VALUES [[BUILD_VECTOR]](<16 x s8>)
+  ; CHECK-NEXT:   [[DEF14:%[0-9]+]]:_(s8) = G_IMPLICIT_DEF
+  ; CHECK-NEXT:   [[BUILD_VECTOR15:%[0-9]+]]:_(<32 x s8>) = G_BUILD_VECTOR [[UV224]](s8), [[UV225]](s8), [[UV226]](s8), [[UV227]](s8), [[UV228]](s8), [[UV229]](s8), [[UV230]](s8), [[UV231]](s8), [[UV232]](s8), [[UV233]](s8), [[UV234]](s8), [[UV235]](s8), [[UV236]](s8), [[UV237]](s8), [[UV238]](s8), [[UV239]](s8), [[DEF14]](s8), [[DEF14]](s8), [[DEF14]](s8), [[DEF14]](s8), [[DEF14]](s8), [[DEF14]](s8), [[DEF14]](s8), [[DEF14]](s8), [[DEF14]](s8), [[DEF14]](s8), [[DEF14]](s8), [[DEF14]](s8), [[DEF14]](s8), [[DEF14]](s8), [[DEF14]](s8), [[DEF14]](s8)
+  ; CHECK-NEXT:   [[UV240:%[0-9]+]]:_(s8), [[UV241:%[0-9]+]]:_(s8), [[UV242:%[0-9]+]]:_(s8), [[UV243:%[0-9]+]]:_(s8), [[UV244:%[0-9]+]]:_(s8), [[UV245:%[0-9]+]]:_(s8), [[UV246:%[0-9]+]]:_(s8), [[UV247:%[0-9]+]]:_(s8), [[UV248:%[0-9]+]]:_(s8), [[UV249:%[0-9]+]]:_(s8), [[UV250:%[0-9]+]]:_(s8), [[UV251:%[0-9]+]]:_(s8), [[UV252:%[0-9]+]]:_(s8), [[UV253:%[0-9]+]]:_(s8), [[UV254:%[0-9]+]]:_(s8), [[UV255:%[0-9]+]]:_(s8) = G_UNMERGE_VALUES [[BUILD_VECTOR]](<16 x s8>)
+  ; CHECK-NEXT:   [[DEF15:%[0-9]+]]:_(s8) = G_IMPLICIT_DEF
+  ; CHECK-NEXT:   [[BUILD_VECTOR16:%[0-9]+]]:_(<32 x s8>) = G_BUILD_VECTOR [[UV240]](s8), [[UV241]](s8), [[UV242]](s8), [[UV243]](s8), [[UV244]](s8), [[UV245]](s8), [[UV246]](s8), [[UV247]](s8), [[UV248]](s8), [[UV249]](s8), [[UV250]](s8), [[UV251]](s8), [[UV252]](s8), [[UV253]](s8), [[UV254]](s8), [[UV255]](s8), [[DEF15]](s8), [[DEF15]](s8), [[DEF15]](s8), [[DEF15]](s8), [[DEF15]](s8), [[DEF15]](s8), [[DEF15]](s8), [[DEF15]](s8), [[DEF15]](s8), [[DEF15]](s8), [[DEF15]](s8), [[DEF15]](s8), [[DEF15]](s8), [[DEF15]](s8), [[DEF15]](s8), [[DEF15]](s8)
+  ; CHECK-NEXT:   [[UV256:%[0-9]+]]:_(s8), [[UV257:%[0-9]+]]:_(s8), [[UV258:%[0-9]+]]:_(s8), [[UV259:%[0-9]+]]:_(s8), [[UV260:%[0-9]+]]:_(s8), [[UV261:%[0-9]+]]:_(s8), [[UV262:%[0-9]+]]:_(s8), [[UV263:%[0-9]+]]:_(s8), [[UV264:%[0-9]+]]:_(s8), [[UV265:%[0-9]+]]:_(s8), [[UV266:%[0-9]+]]:_(s8), [[UV267:%[0-9]+]]:_(s8), [[UV268:%[0-9]+]]:_(s8), [[UV269:%[0-9]+]]:_(s8), [[UV270:%[0-9]+]]:_(s8), [[UV271:%[0-9]+]]:_(s8) = G_UNMERGE_VALUES [[BUILD_VECTOR]](<16 x s8>)
+  ; CHECK-NEXT:   [[DEF16:%[0-9]+]]:_(s8) = G_IMPLICIT_DEF
+  ; CHECK-NEXT:   [[BUILD_VECTOR17:%[0-9]+]]:_(<32 x s8>) = G_BUILD_VECTOR [[UV256]](s8), [[UV257]](s8), [[UV258]](s8), [[UV259]](s8), [[UV260]](s8), [[UV261]](s8), [[UV262]](s8), [[UV263]](s8), [[UV264]](s8), [[UV265]](s8), [[UV266]](s8), [[UV267]](s8), [[UV268]](s8), [[UV269]](s8), [[UV270]](s8), [[UV271]](s8), [[DEF16]](s8), [[DEF16]](s8), [[DEF16]](s8), [[DEF16]](s8), [[DEF16]](s8), [[DEF16]](s8), [[DEF16]](s8), [[DEF16]](s8), [[DEF16]](s8), [[DEF16]](s8), [[DEF16]](s8), [[DEF16]](s8), [[DEF16]](s8), [[DEF16]](s8), [[DEF16]](s8), [[DEF16]](s8)
+  ; CHECK-NEXT:   [[UV272:%[0-9]+]]:_(s8), [[UV273:%[0-9]+]]:_(s8), [[UV274:%[0-9]+]]:_(s8), [[UV275:%[0-9]+]]:_(s8), [[UV276:%[0-9]+]]:_(s8), [[UV277:%[0-9]+]]:_(s8), [[UV278:%[0-9]+]]:_(s8), [[UV279:%[0-9]+]]:_(s8), [[UV280:%[0-9]+]]:_(s8), [[UV281:%[0-9]+]]:_(s8), [[UV282:%[0-9]+]]:_(s8), [[UV283:%[0-9]+]]:_(s8), [[UV284:%[0-9]+]]:_(s8), [[UV285:%[0-9]+]]:_(s8), [[UV286:%[0-9]+]]:_(s8), [[UV287:%[0-9]+]]:_(s8) = G_UNMERGE_VALUES [[BUILD_VECTOR]](<16 x s8>)
+  ; CHECK-NEXT:   [[DEF17:%[0-9]+]]:_(s8) = G_IMPLICIT_DEF
+  ; CHECK-NEXT:   [[BUILD_VECTOR18:%[0-9]+]]:_(<32 x s8>) = G_BUILD_VECTOR [[UV272]](s8), [[UV273]](s8), [[UV274]](s8), [[UV275]](s8), [[UV276]](s8), [[UV277]](s8), [[UV278]](s8), [[UV279]](s8), [[UV280]](s8), [[UV281]](s8), [[UV282]](s8), [[UV283]](s8), [[UV284]](s8), [[UV285]](s8), [[UV286]](s8), [[UV287]](s8), [[DEF17]](s8), [[DEF17]](s8), [[DEF17]](s8), [[DEF17]](s8), [[DEF17]](s8), [[DEF17]](s8), [[DEF17]](s8), [[DEF17]](s8), [[DEF17]](s8), [[DEF17]](s8), [[DEF17]](s8), [[DEF17]](s8), [[DEF17]](s8), [[DEF17]](s8), [[DEF17]](s8), [[DEF17]](s8)
+  ; CHECK-NEXT:   [[UV288:%[0-9]+]]:_(s8), [[UV289:%[0-9]+]]:_(s8), [[UV290:%[0-9]+]]:_(s8), [[UV291:%[0-9]+]]:_(s8), [[UV292:%[0-9]+]]:_(s8), [[UV293:%[0-9]+]]:_(s8), [[UV294:%[0-9]+]]:_(s8), [[UV295:%[0-9]+]]:_(s8), [[UV296:%[0-9]+]]:_(s8), [[UV297:%[0-9]+]]:_(s8), [[UV298:%[0-9]+]]:_(s8), [[UV299:%[0-9]+]]:_(s8), [[UV300:%[0-9]+]]:_(s8), [[UV301:%[0-9]+]]:_(s8), [[UV302:%[0-9]+]]:_(s8), [[UV303:%[0-9]+]]:_(s8) = G_UNMERGE_VALUES [[BUILD_VECTOR]](<16 x s8>)
+  ; CHECK-NEXT:   [[DEF18:%[0-9]+]]:_(s8) = G_IMPLICIT_DEF
+  ; CHECK-NEXT:   [[BUILD_VECTOR19:%[0-9]+]]:_(<32 x s8>) = G_BUILD_VECTOR [[UV288]](s8), [[UV289]](s8), [[UV290]](s8), [[UV291]](s8), [[UV292]](s8), [[UV293]](s8), [[UV294]](s8), [[UV295]](s8), [[UV296]](s8), [[UV297]](s8), [[UV298]](s8), [[UV299]](s8), [[UV300]](s8), [[UV301]](s8), [[UV302]](s8), [[UV303]](s8), [[DEF18]](s8), [[DEF18]](s8), [[DEF18]](s8), [[DEF18]](s8), [[DEF18]](s8), [[DEF18]](s8), [[DEF18]](s8), [[DEF18]](s8), [[DEF18]](s8), [[DEF18]](s8), [[DEF18]](s8), [[DEF18]](s8), [[DEF18]](s8), [[DEF18]](s8), [[DEF18]](s8), [[DEF18]](s8)
+  ; CHECK-NEXT:   [[UV304:%[0-9]+]]:_(s8), [[UV305:%[0-9]+]]:_(s8), [[UV306:%[0-9]+]]:_(s8), [[UV307:%[0-9]+]]:_(s8), [[UV308:%[0-9]+]]:_(s8), [[UV309:%[0-9]+]]:_(s8), [[UV310:%[0-9]+]]:_(s8), [[UV311:%[0-9]+]]:_(s8), [[UV312:%[0-9]+]]:_(s8), [[UV313:%[0-9]+]]:_(s8), [[UV314:%[0-9]+]]:_(s8), [[UV315:%[0-9]+]]:_(s8), [[UV316:%[0-9]+]]:_(s8), [[UV317:%[0-9]+]]:_(s8), [[UV318:%[0-9]+]]:_(s8), [[UV319:%[0-9]+]]:_(s8) = G_UNMERGE_VALUES [[BUILD_VECTOR]](<16 x s8>)
+  ; CHECK-NEXT:   [[DEF19:%[0-9]+]]:_(s8) = G_IMPLICIT_DEF
+  ; CHECK-NEXT:   [[BUILD_VECTOR20:%[0-9]+]]:_(<32 x s8>) = G_BUILD_VECTOR [[UV304]](s8), [[UV305]](s8), [[UV306]](s8), [[UV307]](s8), [[UV308]](s8), [[UV309]](s8), [[UV310]](s8), [[UV311]](s8), [[UV312]](s8), [[UV313]](s8), [[UV314]](s8), [[UV315]](s8), [[UV316]](s8), [[UV317]](s8), [[UV318]](s8), [[UV319]](s8), [[DEF19]](s8), [[DEF19]](s8), [[DEF19]](s8), [[DEF19]](s8), [[DEF19]](s8), [[DEF19]](s8), [[DEF19]](s8), [[DEF19]](s8), [[DEF19]](s8), [[DEF19]](s8), [[DEF19]](s8), [[DEF19]](s8), [[DEF19]](s8), [[DEF19]](s8), [[DEF19]](s8), [[DEF19]](s8)
+  ; CHECK-NEXT:   [[UV320:%[0-9]+]]:_(s8), [[UV321:%[0-9]+]]:_(s8), [[UV322:%[0-9]+]]:_(s8), [[UV323:%[0-9]+]]:_(s8), [[UV324:%[0-9]+]]:_(s8), [[UV325:%[0-9]+]]:_(s8), [[UV326:%[0-9]+]]:_(s8), [[UV327:%[0-9]+]]:_(s8), [[UV328:%[0-9]+]]:_(s8), [[UV329:%[0-9]+]]:_(s8), [[UV330:%[0-9]+]]:_(s8), [[UV331:%[0-9]+]]:_(s8), [[UV332:%[0-9]+]]:_(s8), [[UV333:%[0-9]+]]:_(s8), [[UV334:%[0-9]+]]:_(s8), [[UV335:%[0-9]+]]:_(s8) = G_UNMERGE_VALUES [[BUILD_VECTOR]](<16 x s8>)
+  ; CHECK-NEXT:   [[DEF20:%[0-9]+]]:_(s8) = G_IMPLICIT_DEF
+  ; CHECK-NEXT:   [[BUILD_VECTOR21:%[0-9]+]]:_(<32 x s8>) = G_BUILD_VECTOR [[UV320]](s8), [[UV321]](s8), [[UV322]](s8), [[UV323]](s8), [[UV324]](s8), [[UV325]](s8), [[UV326]](s8), [[UV327]](s8), [[UV328]](s8), [[UV329]](s8), [[UV330]](s8), [[UV331]](s8), [[UV332]](s8), [[UV333]](s8), [[UV334]](s8), [[UV335]](s8), [[DEF20]](s8), [[DEF20]](s8), [[DEF20]](s8), [[DEF20]](s8), [[DEF20]](s8), [[DEF20]](s8), [[DEF20]](s8), [[DEF20]](s8), [[DEF20]](s8), [[DEF20]](s8), [[DEF20]](s8), [[DEF20]](s8), [[DEF20]](s8), [[DEF20]](s8), [[DEF20]](s8), [[DEF20]](s8)
+  ; CHECK-NEXT:   [[UV336:%[0-9]+]]:_(s8), [[UV337:%[0-9]+]]:_(s8), [[UV338:%[0-9]+]]:_(s8), [[UV339:%[0-9]+]]:_(s8), [[UV340:%[0-9]+]]:_(s8), [[UV341:%[0-9]+]]:_(s8), [[UV342:%[0-9]+]]:_(s8), [[UV343:%[0-9]+]]:_(s8), [[UV344:%[0-9]+]]:_(s8), [[UV345:%[0-9]+]]:_(s8), [[UV346:%[0-9]+]]:_(s8), [[UV347:%[0-9]+]]:_(s8), [[UV348:%[0-9]+]]:_(s8), [[UV349:%[0-9]+]]:_(s8), [[UV350:%[0-9]+]]:_(s8), [[UV351:%[0-9]+]]:_(s8) = G_UNMERGE_VALUES [[BUILD_VECTOR]](<16 x s8>)
+  ; CHECK-NEXT:   [[DEF21:%[0-9]+]]:_(s8) = G_IMPLICIT_DEF
+  ; CHECK-NEXT:   [[BUILD_VECTOR22:%[0-9]+]]:_(<32 x s8>) = G_BUILD_VECTOR [[UV336]](s8), [[UV337]](s8), [[UV338]](s8), [[UV339]](s8), [[UV340]](s8), [[UV341]](s8), [[UV342]](s8), [[UV343]](s8), [[UV344]](s8), [[UV345]](s8), [[UV346]](s8), [[UV347]](s8), [[UV348]](s8), [[UV349]](s8), [[UV350]](s8), [[UV351]](s8), [[DEF21]](s8), [[DEF21]](s8), [[DEF21]](s8), [[DEF21]](s8), [[DEF21]](s8), [[DEF21]](s8), [[DEF21]](s8), [[DEF21]](s8), [[DEF21]](s8), [[DEF21]](s8), [[DEF21]](s8), [[DEF21]](s8), [[DEF21]](s8), [[DEF21]](s8), [[DEF21]](s8), [[DEF21]](s8)
+  ; CHECK-NEXT:   [[UV352:%[0-9]+]]:_(s8), [[UV353:%[0-9]+]]:_(s8), [[UV354:%[0-9]+]]:_(s8), [[UV355:%[0-9]+]]:_(s8), [[UV356:%[0-9]+]]:_(s8), [[UV357:%[0-9]+]]:_(s8), [[UV358:%[0-9]+]]:_(s8), [[UV359:%[0-9]+]]:_(s8), [[UV360:%[0-9]+]]:_(s8), [[UV361:%[0-9]+]]:_(s8), [[UV362:%[0-9]+]]:_(s8), [[UV363:%[0-9]+]]:_(s8), [[UV364:%[0-9]+]]:_(s8), [[UV365:%[0-9]+]]:_(s8), [[UV366:%[0-9]+]]:_(s8), [[UV367:%[0-9]+]]:_(s8) = G_UNMERGE_VALUES [[BUILD_VECTOR]](<16 x s8>)
+  ; CHECK-NEXT:   [[DEF22:%[0-9]+]]:_(s8) = G_IMPLICIT_DEF
+  ; CHECK-NEXT:   [[BUILD_VECTOR23:%[0-9]+]]:_(<32 x s8>) = G_BUILD_VECTOR [[UV352]](s8), [[UV353]](s8), [[UV354]](s8), [[UV355]](s8), [[UV356]](s8), [[UV357]](s8), [[UV358]](s8), [[UV359]](s8), [[UV360]](s8), [[UV361]](s8), [[UV362]](s8), [[UV363]](s8), [[UV364]](s8), [[UV365]](s8), [[UV366]](s8), [[UV367]](s8), [[DEF22]](s8), [[DEF22]](s8), [[DEF22]](s8), [[DEF22]](s8), [[DEF22]](s8), [[DEF22]](s8), [[DEF22]](s8), [[DEF22]](s8), [[DEF22]](s8), [[DEF22]](s8), [[DEF22]](s8), [[DEF22]](s8), [[DEF22]](s8), [[DEF22]](s8), [[DEF22]](s8), [[DEF22]](s8)
+  ; CHECK-NEXT:   [[UV368:%[0-9]+]]:_(s8), [[UV369:%[0-9]+]]:_(s8), [[UV370:%[0-9]+]]:_(s8), [[UV371:%[0-9]+]]:_(s8), [[UV372:%[0-9]+]]:_(s8), [[UV373:%[0-9]+]]:_(s8), [[UV374:%[0-9]+]]:_(s8), [[UV375:%[0-9]+]]:_(s8), [[UV376:%[0-9]+]]:_(s8), [[UV377:%[0-9]+]]:_(s8), [[UV378:%[0-9]+]]:_(s8), [[UV379:%[0-9]+]]:_(s8), [[UV380:%[0-9]+]]:_(s8), [[UV381:%[0-9]+]]:_(s8), [[UV382:%[0-9]+]]:_(s8), [[UV383:%[0-9]+]]:_(s8) = G_UNMERGE_VALUES [[BUILD_VECTOR]](<16 x s8>)
+  ; CHECK-NEXT:   [[DEF23:%[0-9]+]]:_(s8) = G_IMPLICIT_DEF
+  ; CHECK-NEXT:   [[BUILD_VECTOR24:%[0-9]+]]:_(<32 x s8>) = G_BUILD_VECTOR [[UV368]](s8), [[UV369]](s8), [[UV370]](s8), [[UV371]](s8), [[UV372]](s8), [[UV373]](s8), [[UV374]](s8), [[UV375]](s8), [[UV376]](s8), [[UV377]](s8), [[UV378]](s8), [[UV379]](s8), [[UV380]](s8), [[UV381]](s8), [[UV382]](s8), [[UV383]](s8), [[DEF23]](s8), [[DEF23]](s8), [[DEF23]](s8), [[DEF23]](s8), [[DEF23]](s8), [[DEF23]](s8), [[DEF23]](s8), [[DEF23]](s8), [[DEF23]](s8), [[DEF23]](s8), [[DEF23]](s8), [[DEF23]](s8), [[DEF23]](s8), [[DEF23]](s8), [[DEF23]](s8), [[DEF23]](s8)
   ; CHECK-NEXT:   [[COPY:%[0-9]+]]:_(p0) = COPY $sp
-  ; CHECK-NEXT:   [[C1:%[0-9]+]]:_(s20) = G_CONSTANT i20 -32
+  ; CHECK-NEXT:   [[C1:%[0-9]+]]:_(s20) = G_CONSTANT i20 -16
   ; CHECK-NEXT:   [[PTR_ADD:%[0-9]+]]:_(p0) = G_PTR_ADD [[COPY]], [[C1]](s20)
-  ; CHECK-NEXT:   G_STORE [[ANYEXT24]](<16 x s16>), [[PTR_ADD]](p0) :: (store (<16 x s16>) into stack - 32)
-  ; CHECK-NEXT:   [[ANYEXT25:%[0-9]+]]:_(<16 x s16>) = G_ANYEXT [[BUILD_VECTOR]](<16 x s8>)
-  ; CHECK-NEXT:   [[C2:%[0-9]+]]:_(s20) = G_CONSTANT i20 -64
+  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<16 x s8>), [[PTR_ADD]](p0) :: (store (<16 x s8>) into stack - 16, basealign 32)
+  ; CHECK-NEXT:   [[C2:%[0-9]+]]:_(s20) = G_CONSTANT i20 -32
   ; CHECK-NEXT:   [[PTR_ADD1:%[0-9]+]]:_(p0) = G_PTR_ADD [[COPY]], [[C2]](s20)
-  ; CHECK-NEXT:   G_STORE [[ANYEXT25]](<16 x s16>), [[PTR_ADD1]](p0) :: (store (<16 x s16>) into stack - 64)
-  ; CHECK-NEXT:   $wl0 = COPY [[ANYEXT]](<16 x s16>)
-  ; CHECK-NEXT:   $wl2 = COPY [[ANYEXT1]](<16 x s16>)
-  ; CHECK-NEXT:   $wl4 = COPY [[ANYEXT2]](<16 x s16>)
-  ; CHECK-NEXT:   $wl6 = COPY [[ANYEXT3]](<16 x s16>)
-  ; CHECK-NEXT:   $wl8 = COPY [[ANYEXT4]](<16 x s16>)
-  ; CHECK-NEXT:   $wl10 = COPY [[ANYEXT5]](<16 x s16>)
-  ; CHECK-NEXT:   $wl1 = COPY [[ANYEXT6]](<16 x s16>)
-  ; CHECK-NEXT:   $wl3 = COPY [[ANYEXT7]](<16 x s16>)
-  ; CHECK-NEXT:   $wl5 = COPY [[ANYEXT8]](<16 x s16>)
-  ; CHECK-NEXT:   $wl7 = COPY [[ANYEXT9]](<16 x s16>)
-  ; CHECK-NEXT:   $wl9 = COPY [[ANYEXT10]](<16 x s16>)
-  ; CHECK-NEXT:   $wl11 = COPY [[ANYEXT11]](<16 x s16>)
-  ; CHECK-NEXT:   $wh0 = COPY [[ANYEXT12]](<16 x s16>)
-  ; CHECK-NEXT:   $wh2 = COPY [[ANYEXT13]](<16 x s16>)
-  ; CHECK-NEXT:   $wh4 = COPY [[ANYEXT14]](<16 x s16>)
-  ; CHECK-NEXT:   $wh6 = COPY [[ANYEXT15]](<16 x s16>)
-  ; CHECK-NEXT:   $wh8 = COPY [[ANYEXT16]](<16 x s16>)
-  ; CHECK-NEXT:   $wh10 = COPY [[ANYEXT17]](<16 x s16>)
-  ; CHECK-NEXT:   $wh1 = COPY [[ANYEXT18]](<16 x s16>)
-  ; CHECK-NEXT:   $wh3 = COPY [[ANYEXT19]](<16 x s16>)
-  ; CHECK-NEXT:   $wh5 = COPY [[ANYEXT20]](<16 x s16>)
-  ; CHECK-NEXT:   $wh7 = COPY [[ANYEXT21]](<16 x s16>)
-  ; CHECK-NEXT:   $wh9 = COPY [[ANYEXT22]](<16 x s16>)
-  ; CHECK-NEXT:   $wh11 = COPY [[ANYEXT23]](<16 x s16>)
+  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<16 x s8>), [[PTR_ADD1]](p0) :: (store (<16 x s8>) into stack - 32)
+  ; CHECK-NEXT:   $wl0 = COPY [[BUILD_VECTOR1]](<32 x s8>)
+  ; CHECK-NEXT:   $wl2 = COPY [[BUILD_VECTOR2]](<32 x s8>)
+  ; CHECK-NEXT:   $wl4 = COPY [[BUILD_VECTOR3]](<32 x s8>)
+  ; CHECK-NEXT:   $wl6 = COPY [[BUILD_VECTOR4]](<32 x s8>)
+  ; CHECK-NEXT:   $wl8 = COPY [[BUILD_VECTOR5]](<32 x s8>)
+  ; CHECK-NEXT:   $wl10 = COPY [[BUILD_VECTOR6]](<32 x s8>)
+  ; CHECK-NEXT:   $wl1 = COPY [[BUILD_VECTOR7]](<32 x s8>)
+  ; CHECK-NEXT:   $wl3 = COPY [[BUILD_VECTOR8]](<32 x s8>)
+  ; CHECK-NEXT:   $wl5 = COPY [[BUILD_VECTOR9]](<32 x s8>)
+  ; CHECK-NEXT:   $wl7 = COPY [[BUILD_VECTOR10]](<32 x s8>)
+  ; CHECK-NEXT:   $wl9 = COPY [[BUILD_VECTOR11]](<32 x s8>)
+  ; CHECK-NEXT:   $wl11 = COPY [[BUILD_VECTOR12]](<32 x s8>)
+  ; CHECK-NEXT:   $wh0 = COPY [[BUILD_VECTOR13]](<32 x s8>)
+  ; CHECK-NEXT:   $wh2 = COPY [[BUILD_VECTOR14]](<32 x s8>)
+  ; CHECK-NEXT:   $wh4 = COPY [[BUILD_VECTOR15]](<32 x s8>)
+  ; CHECK-NEXT:   $wh6 = COPY [[BUILD_VECTOR16]](<32 x s8>)
+  ; CHECK-NEXT:   $wh8 = COPY [[BUILD_VECTOR17]](<32 x s8>)
+  ; CHECK-NEXT:   $wh10 = COPY [[BUILD_VECTOR18]](<32 x s8>)
+  ; CHECK-NEXT:   $wh1 = COPY [[BUILD_VECTOR19]](<32 x s8>)
+  ; CHECK-NEXT:   $wh3 = COPY [[BUILD_VECTOR20]](<32 x s8>)
+  ; CHECK-NEXT:   $wh5 = COPY [[BUILD_VECTOR21]](<32 x s8>)
+  ; CHECK-NEXT:   $wh7 = COPY [[BUILD_VECTOR22]](<32 x s8>)
+  ; CHECK-NEXT:   $wh9 = COPY [[BUILD_VECTOR23]](<32 x s8>)
+  ; CHECK-NEXT:   $wh11 = COPY [[BUILD_VECTOR24]](<32 x s8>)
   ; CHECK-NEXT:   PseudoJL @callee_v16int8, csr_aie2p, implicit-def $lr, implicit $wl0, implicit $wl2, implicit $wl4, implicit $wl6, implicit $wl8, implicit $wl10, implicit $wl1, implicit $wl3, implicit $wl5, implicit $wl7, implicit $wl9, implicit $wl11, implicit $wh0, implicit $wh2, implicit $wh4, implicit $wh6, implicit $wh8, implicit $wh10, implicit $wh1, implicit $wh3, implicit $wh5, implicit $wh7, implicit $wh9, implicit $wh11
-  ; CHECK-NEXT:   ADJCALLSTACKDOWN 64, 0, implicit-def $sp, implicit $sp
+  ; CHECK-NEXT:   ADJCALLSTACKDOWN 32, 0, implicit-def $sp, implicit $sp
   ; CHECK-NEXT:   PseudoRET implicit $lr
   call void @callee_v16int8(<16 x i8> zeroinitializer, <16 x i8> zeroinitializer, <16 x i8> zeroinitializer, <16 x i8> zeroinitializer, <16 x i8> zeroinitializer, <16 x i8> zeroinitializer,
                             <16 x i8> zeroinitializer, <16 x i8> zeroinitializer, <16 x i8> zeroinitializer, <16 x i8> zeroinitializer, <16 x i8> zeroinitializer, <16 x i8> zeroinitializer,
@@ -309,7 +395,7 @@ define void @call_v4float() {
   ; CHECK: bb.1 (%ir-block.0):
   ; CHECK-NEXT:   [[C:%[0-9]+]]:_(s32) = G_FCONSTANT float 0.000000e+00
   ; CHECK-NEXT:   [[BUILD_VECTOR:%[0-9]+]]:_(<4 x s32>) = G_BUILD_VECTOR [[C]](s32), [[C]](s32), [[C]](s32), [[C]](s32)
-  ; CHECK-NEXT:   ADJCALLSTACKUP 64, 0, implicit-def $sp, implicit $sp
+  ; CHECK-NEXT:   ADJCALLSTACKUP 32, 0, implicit-def $sp, implicit $sp
   ; CHECK-NEXT:   [[UV:%[0-9]+]]:_(s32), [[UV1:%[0-9]+]]:_(s32), [[UV2:%[0-9]+]]:_(s32), [[UV3:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[BUILD_VECTOR]](<4 x s32>)
   ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(s32) = G_IMPLICIT_DEF
   ; CHECK-NEXT:   [[BUILD_VECTOR1:%[0-9]+]]:_(<8 x s32>) = G_BUILD_VECTOR [[UV]](s32), [[UV1]](s32), [[UV2]](s32), [[UV3]](s32), [[DEF]](s32), [[DEF]](s32), [[DEF]](s32), [[DEF]](s32)
@@ -382,19 +468,13 @@ define void @call_v4float() {
   ; CHECK-NEXT:   [[UV92:%[0-9]+]]:_(s32), [[UV93:%[0-9]+]]:_(s32), [[UV94:%[0-9]+]]:_(s32), [[UV95:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[BUILD_VECTOR]](<4 x s32>)
   ; CHECK-NEXT:   [[DEF23:%[0-9]+]]:_(s32) = G_IMPLICIT_DEF
   ; CHECK-NEXT:   [[BUILD_VECTOR24:%[0-9]+]]:_(<8 x s32>) = G_BUILD_VECTOR [[UV92]](s32), [[UV93]](s32), [[UV94]](s32), [[UV95]](s32), [[DEF23]](s32), [[DEF23]](s32), [[DEF23]](s32), [[DEF23]](s32)
-  ; CHECK-NEXT:   [[UV96:%[0-9]+]]:_(s32), [[UV97:%[0-9]+]]:_(s32), [[UV98:%[0-9]+]]:_(s32), [[UV99:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[BUILD_VECTOR]](<4 x s32>)
-  ; CHECK-NEXT:   [[DEF24:%[0-9]+]]:_(s32) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   [[BUILD_VECTOR25:%[0-9]+]]:_(<8 x s32>) = G_BUILD_VECTOR [[UV96]](s32), [[UV97]](s32), [[UV98]](s32), [[UV99]](s32), [[DEF24]](s32), [[DEF24]](s32), [[DEF24]](s32), [[DEF24]](s32)
   ; CHECK-NEXT:   [[COPY:%[0-9]+]]:_(p0) = COPY $sp
-  ; CHECK-NEXT:   [[C1:%[0-9]+]]:_(s20) = G_CONSTANT i20 -32
+  ; CHECK-NEXT:   [[C1:%[0-9]+]]:_(s20) = G_CONSTANT i20 -16
   ; CHECK-NEXT:   [[PTR_ADD:%[0-9]+]]:_(p0) = G_PTR_ADD [[COPY]], [[C1]](s20)
-  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR25]](<8 x s32>), [[PTR_ADD]](p0) :: (store (<8 x s32>) into stack - 32)
-  ; CHECK-NEXT:   [[UV100:%[0-9]+]]:_(s32), [[UV101:%[0-9]+]]:_(s32), [[UV102:%[0-9]+]]:_(s32), [[UV103:%[0-9]+]]:_(s32) = G_UNMERGE_VALUES [[BUILD_VECTOR]](<4 x s32>)
-  ; CHECK-NEXT:   [[DEF25:%[0-9]+]]:_(s32) = G_IMPLICIT_DEF
-  ; CHECK-NEXT:   [[BUILD_VECTOR26:%[0-9]+]]:_(<8 x s32>) = G_BUILD_VECTOR [[UV100]](s32), [[UV101]](s32), [[UV102]](s32), [[UV103]](s32), [[DEF25]](s32), [[DEF25]](s32), [[DEF25]](s32), [[DEF25]](s32)
-  ; CHECK-NEXT:   [[C2:%[0-9]+]]:_(s20) = G_CONSTANT i20 -64
+  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<4 x s32>), [[PTR_ADD]](p0) :: (store (<4 x s32>) into stack - 16, basealign 32)
+  ; CHECK-NEXT:   [[C2:%[0-9]+]]:_(s20) = G_CONSTANT i20 -32
   ; CHECK-NEXT:   [[PTR_ADD1:%[0-9]+]]:_(p0) = G_PTR_ADD [[COPY]], [[C2]](s20)
-  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR26]](<8 x s32>), [[PTR_ADD1]](p0) :: (store (<8 x s32>) into stack - 64)
+  ; CHECK-NEXT:   G_STORE [[BUILD_VECTOR]](<4 x s32>), [[PTR_ADD1]](p0) :: (store (<4 x s32>) into stack - 32)
   ; CHECK-NEXT:   $wl0 = COPY [[BUILD_VECTOR1]](<8 x s32>)
   ; CHECK-NEXT:   $wl2 = COPY [[BUILD_VECTOR2]](<8 x s32>)
   ; CHECK-NEXT:   $wl4 = COPY [[BUILD_VECTOR3]](<8 x s32>)
@@ -420,7 +500,7 @@ define void @call_v4float() {
   ; CHECK-NEXT:   $wh9 = COPY [[BUILD_VECTOR23]](<8 x s32>)
   ; CHECK-NEXT:   $wh11 = COPY [[BUILD_VECTOR24]](<8 x s32>)
   ; CHECK-NEXT:   PseudoJL @callee_v4float, csr_aie2p, implicit-def $lr, implicit $wl0, implicit $wl2, implicit $wl4, implicit $wl6, implicit $wl8, implicit $wl10, implicit $wl1, implicit $wl3, implicit $wl5, implicit $wl7, implicit $wl9, implicit $wl11, implicit $wh0, implicit $wh2, implicit $wh4, implicit $wh6, implicit $wh8, implicit $wh10, implicit $wh1, implicit $wh3, implicit $wh5, implicit $wh7, implicit $wh9, implicit $wh11
-  ; CHECK-NEXT:   ADJCALLSTACKDOWN 64, 0, implicit-def $sp, implicit $sp
+  ; CHECK-NEXT:   ADJCALLSTACKDOWN 32, 0, implicit-def $sp, implicit $sp
   ; CHECK-NEXT:   PseudoRET implicit $lr
   call void @callee_v4float(<4 x float> zeroinitializer, <4 x float> zeroinitializer, <4 x float> zeroinitializer, <4 x float> zeroinitializer, <4 x float> zeroinitializer, <4 x float> zeroinitializer,
                             <4 x float> zeroinitializer, <4 x float> zeroinitializer, <4 x float> zeroinitializer, <4 x float> zeroinitializer, <4 x float> zeroinitializer, <4 x float> zeroinitializer,

--- a/llvm/test/CodeGen/AIE/aie2p/GlobalIsel/irtranslator-call-arguments.ll
+++ b/llvm/test/CodeGen/AIE/aie2p/GlobalIsel/irtranslator-call-arguments.ll
@@ -65,6 +65,20 @@ define void @test_call_i64() {
   ret void
 }
 
+declare void @callee_i128(i128 %a)
+define void @test_call_i128() {
+  ; CHECK-LABEL: name: test_call_i128
+  ; CHECK: bb.1 (%ir-block.0):
+  ; CHECK-NEXT:   [[C:%[0-9]+]]:_(s128) = G_CONSTANT i128 0
+  ; CHECK-NEXT:   ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
+  ; CHECK-NEXT:   $q0 = COPY [[C]](s128)
+  ; CHECK-NEXT:   PseudoJL @callee_i128, csr_aie2p, implicit-def $lr, implicit $q0
+  ; CHECK-NEXT:   ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
+  ; CHECK-NEXT:   PseudoRET implicit $lr
+  call void @callee_i128(i128 0)
+  ret void
+}
+
 declare void @take_i1(i1)
 define void @test_abi_exts_call_i1(i1* %addr) {
   ; CHECK-LABEL: name: test_abi_exts_call_i1

--- a/llvm/test/CodeGen/AIE/aie2p/GlobalIsel/irtranslator-call-return-values-vect128.ll
+++ b/llvm/test/CodeGen/AIE/aie2p/GlobalIsel/irtranslator-call-return-values-vect128.ll
@@ -30,8 +30,8 @@ define void @call_v8int16() {
   ; CHECK: bb.1 (%ir-block.0):
   ; CHECK-NEXT:   ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
   ; CHECK-NEXT:   PseudoJL @callee_v8int16, csr_aie2p, implicit-def $lr, implicit-def $wl0
-  ; CHECK-NEXT:   [[COPY:%[0-9]+]]:_(<8 x s32>) = COPY $wl0
-  ; CHECK-NEXT:   [[TRUNC:%[0-9]+]]:_(<8 x s16>) = G_TRUNC [[COPY]](<8 x s32>)
+  ; CHECK-NEXT:   [[COPY:%[0-9]+]]:_(<16 x s16>) = COPY $wl0
+  ; CHECK-NEXT:   [[UV:%[0-9]+]]:_(<8 x s16>), [[UV1:%[0-9]+]]:_(<8 x s16>) = G_UNMERGE_VALUES [[COPY]](<16 x s16>)
   ; CHECK-NEXT:   ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
   ; CHECK-NEXT:   PseudoRET implicit $lr
   %res = call <8 x i16> @callee_v8int16()
@@ -44,8 +44,8 @@ define void @call_v16int8() {
   ; CHECK: bb.1 (%ir-block.0):
   ; CHECK-NEXT:   ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
   ; CHECK-NEXT:   PseudoJL @callee_v16int8, csr_aie2p, implicit-def $lr, implicit-def $wl0
-  ; CHECK-NEXT:   [[COPY:%[0-9]+]]:_(<16 x s16>) = COPY $wl0
-  ; CHECK-NEXT:   [[TRUNC:%[0-9]+]]:_(<16 x s8>) = G_TRUNC [[COPY]](<16 x s16>)
+  ; CHECK-NEXT:   [[COPY:%[0-9]+]]:_(<32 x s8>) = COPY $wl0
+  ; CHECK-NEXT:   [[UV:%[0-9]+]]:_(<16 x s8>), [[UV1:%[0-9]+]]:_(<16 x s8>) = G_UNMERGE_VALUES [[COPY]](<32 x s8>)
   ; CHECK-NEXT:   ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
   ; CHECK-NEXT:   PseudoRET implicit $lr
   %res = call <16 x i8> @callee_v16int8()

--- a/llvm/test/CodeGen/AIE/aie2p/GlobalIsel/irtranslator-call-return-values.ll
+++ b/llvm/test/CodeGen/AIE/aie2p/GlobalIsel/irtranslator-call-return-values.ll
@@ -37,6 +37,19 @@ define void @test_call_i64() {
   ret void
 }
 
+declare i128 @callee_i128()
+define void @test_call_i128() {
+  ; CHECK-LABEL: name: test_call_i128
+  ; CHECK: bb.1 (%ir-block.0):
+  ; CHECK-NEXT:   ADJCALLSTACKUP 0, 0, implicit-def $sp, implicit $sp
+  ; CHECK-NEXT:   PseudoJL @callee_i128, csr_aie2p, implicit-def $lr, implicit-def $q0
+  ; CHECK-NEXT:   [[COPY:%[0-9]+]]:_(s128) = COPY $q0
+  ; CHECK-NEXT:   ADJCALLSTACKDOWN 0, 0, implicit-def $sp, implicit $sp
+  ; CHECK-NEXT:   PseudoRET implicit $lr
+  %res = call i128 @callee_i128()
+  ret void
+}
+
 declare i1 @callee_i1()
 define void @test_call_i1() {
   ; CHECK-LABEL: name: test_call_i1

--- a/llvm/test/CodeGen/AIE/aie2p/GlobalIsel/irtranslator-formal-arguments-vect128.ll
+++ b/llvm/test/CodeGen/AIE/aie2p/GlobalIsel/irtranslator-formal-arguments-vect128.ll
@@ -13,10 +13,10 @@
 define void @callee_v4int32(<4 x i32>, <4 x i32>, <4 x i32>, <4 x i32>, <4 x i32>, <4 x i32>,
   ; CHECK-LABEL: name: callee_v4int32
   ; CHECK: fixedStack:
-  ; CHECK-NEXT:   - { id: 0, type: default, offset: -64, size: 32, alignment: 64, stack-id: default, 
+  ; CHECK-NEXT:   - { id: 0, type: default, offset: -32, size: 16, alignment: 32, stack-id: default, 
   ; CHECK-NEXT:       isImmutable: true, isAliased: false, callee-saved-register: '', callee-saved-restored: true, 
   ; CHECK-NEXT:       debug-info-variable: '', debug-info-expression: '', debug-info-location: '' }
-  ; CHECK-NEXT:   - { id: 1, type: default, offset: -32, size: 32, alignment: 32, stack-id: default, 
+  ; CHECK-NEXT:   - { id: 1, type: default, offset: -16, size: 16, alignment: 16, stack-id: default, 
   ; CHECK-NEXT:       isImmutable: true, isAliased: false, callee-saved-register: '', callee-saved-restored: true, 
   ; CHECK-NEXT:       debug-info-variable: '', debug-info-expression: '', debug-info-location: '' }
   ; CHECK: bb.1 (%ir-block.26):
@@ -71,11 +71,9 @@ define void @callee_v4int32(<4 x i32>, <4 x i32>, <4 x i32>, <4 x i32>, <4 x i32
   ; CHECK-NEXT:   [[COPY23:%[0-9]+]]:_(<8 x s32>) = COPY $wh11
   ; CHECK-NEXT:   [[UV46:%[0-9]+]]:_(<4 x s32>), [[UV47:%[0-9]+]]:_(<4 x s32>) = G_UNMERGE_VALUES [[COPY23]](<8 x s32>)
   ; CHECK-NEXT:   [[FRAME_INDEX:%[0-9]+]]:_(p0) = G_FRAME_INDEX %fixed-stack.1
-  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(<8 x s32>) = G_LOAD [[FRAME_INDEX]](p0) :: (invariant load (<8 x s32>) from %fixed-stack.1)
-  ; CHECK-NEXT:   [[UV48:%[0-9]+]]:_(<4 x s32>), [[UV49:%[0-9]+]]:_(<4 x s32>) = G_UNMERGE_VALUES [[LOAD]](<8 x s32>)
+  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(<4 x s32>) = G_LOAD [[FRAME_INDEX]](p0) :: (invariant load (<4 x s32>) from %fixed-stack.1)
   ; CHECK-NEXT:   [[FRAME_INDEX1:%[0-9]+]]:_(p0) = G_FRAME_INDEX %fixed-stack.0
-  ; CHECK-NEXT:   [[LOAD1:%[0-9]+]]:_(<8 x s32>) = G_LOAD [[FRAME_INDEX1]](p0) :: (invariant load (<8 x s32>) from %fixed-stack.0, align 64)
-  ; CHECK-NEXT:   [[UV50:%[0-9]+]]:_(<4 x s32>), [[UV51:%[0-9]+]]:_(<4 x s32>) = G_UNMERGE_VALUES [[LOAD1]](<8 x s32>)
+  ; CHECK-NEXT:   [[LOAD1:%[0-9]+]]:_(<4 x s32>) = G_LOAD [[FRAME_INDEX1]](p0) :: (invariant load (<4 x s32>) from %fixed-stack.0, align 32)
   ; CHECK-NEXT:   PseudoRET implicit $lr
                              <4 x i32>, <4 x i32>, <4 x i32>, <4 x i32>, <4 x i32>, <4 x i32>,
                              <4 x i32>, <4 x i32>, <4 x i32>, <4 x i32>, <4 x i32>, <4 x i32>,
@@ -87,69 +85,67 @@ define void @callee_v4int32(<4 x i32>, <4 x i32>, <4 x i32>, <4 x i32>, <4 x i32
 define void @callee_v8int16(<8 x i16>, <8 x i16>, <8 x i16>, <8 x i16>, <8 x i16>, <8 x i16>,
   ; CHECK-LABEL: name: callee_v8int16
   ; CHECK: fixedStack:
-  ; CHECK-NEXT:   - { id: 0, type: default, offset: -64, size: 32, alignment: 64, stack-id: default, 
+  ; CHECK-NEXT:   - { id: 0, type: default, offset: -32, size: 16, alignment: 32, stack-id: default, 
   ; CHECK-NEXT:       isImmutable: true, isAliased: false, callee-saved-register: '', callee-saved-restored: true, 
   ; CHECK-NEXT:       debug-info-variable: '', debug-info-expression: '', debug-info-location: '' }
-  ; CHECK-NEXT:   - { id: 1, type: default, offset: -32, size: 32, alignment: 32, stack-id: default, 
+  ; CHECK-NEXT:   - { id: 1, type: default, offset: -16, size: 16, alignment: 16, stack-id: default, 
   ; CHECK-NEXT:       isImmutable: true, isAliased: false, callee-saved-register: '', callee-saved-restored: true, 
   ; CHECK-NEXT:       debug-info-variable: '', debug-info-expression: '', debug-info-location: '' }
   ; CHECK: bb.1 (%ir-block.26):
   ; CHECK-NEXT:   liveins: $wh0, $wh1, $wh2, $wh3, $wh4, $wh5, $wh6, $wh7, $wh8, $wh9, $wh10, $wh11, $wl0, $wl1, $wl2, $wl3, $wl4, $wl5, $wl6, $wl7, $wl8, $wl9, $wl10, $wl11
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT:   [[COPY:%[0-9]+]]:_(<8 x s32>) = COPY $wl0
-  ; CHECK-NEXT:   [[TRUNC:%[0-9]+]]:_(<8 x s16>) = G_TRUNC [[COPY]](<8 x s32>)
-  ; CHECK-NEXT:   [[COPY1:%[0-9]+]]:_(<8 x s32>) = COPY $wl2
-  ; CHECK-NEXT:   [[TRUNC1:%[0-9]+]]:_(<8 x s16>) = G_TRUNC [[COPY1]](<8 x s32>)
-  ; CHECK-NEXT:   [[COPY2:%[0-9]+]]:_(<8 x s32>) = COPY $wl4
-  ; CHECK-NEXT:   [[TRUNC2:%[0-9]+]]:_(<8 x s16>) = G_TRUNC [[COPY2]](<8 x s32>)
-  ; CHECK-NEXT:   [[COPY3:%[0-9]+]]:_(<8 x s32>) = COPY $wl6
-  ; CHECK-NEXT:   [[TRUNC3:%[0-9]+]]:_(<8 x s16>) = G_TRUNC [[COPY3]](<8 x s32>)
-  ; CHECK-NEXT:   [[COPY4:%[0-9]+]]:_(<8 x s32>) = COPY $wl8
-  ; CHECK-NEXT:   [[TRUNC4:%[0-9]+]]:_(<8 x s16>) = G_TRUNC [[COPY4]](<8 x s32>)
-  ; CHECK-NEXT:   [[COPY5:%[0-9]+]]:_(<8 x s32>) = COPY $wl10
-  ; CHECK-NEXT:   [[TRUNC5:%[0-9]+]]:_(<8 x s16>) = G_TRUNC [[COPY5]](<8 x s32>)
-  ; CHECK-NEXT:   [[COPY6:%[0-9]+]]:_(<8 x s32>) = COPY $wl1
-  ; CHECK-NEXT:   [[TRUNC6:%[0-9]+]]:_(<8 x s16>) = G_TRUNC [[COPY6]](<8 x s32>)
-  ; CHECK-NEXT:   [[COPY7:%[0-9]+]]:_(<8 x s32>) = COPY $wl3
-  ; CHECK-NEXT:   [[TRUNC7:%[0-9]+]]:_(<8 x s16>) = G_TRUNC [[COPY7]](<8 x s32>)
-  ; CHECK-NEXT:   [[COPY8:%[0-9]+]]:_(<8 x s32>) = COPY $wl5
-  ; CHECK-NEXT:   [[TRUNC8:%[0-9]+]]:_(<8 x s16>) = G_TRUNC [[COPY8]](<8 x s32>)
-  ; CHECK-NEXT:   [[COPY9:%[0-9]+]]:_(<8 x s32>) = COPY $wl7
-  ; CHECK-NEXT:   [[TRUNC9:%[0-9]+]]:_(<8 x s16>) = G_TRUNC [[COPY9]](<8 x s32>)
-  ; CHECK-NEXT:   [[COPY10:%[0-9]+]]:_(<8 x s32>) = COPY $wl9
-  ; CHECK-NEXT:   [[TRUNC10:%[0-9]+]]:_(<8 x s16>) = G_TRUNC [[COPY10]](<8 x s32>)
-  ; CHECK-NEXT:   [[COPY11:%[0-9]+]]:_(<8 x s32>) = COPY $wl11
-  ; CHECK-NEXT:   [[TRUNC11:%[0-9]+]]:_(<8 x s16>) = G_TRUNC [[COPY11]](<8 x s32>)
-  ; CHECK-NEXT:   [[COPY12:%[0-9]+]]:_(<8 x s32>) = COPY $wh0
-  ; CHECK-NEXT:   [[TRUNC12:%[0-9]+]]:_(<8 x s16>) = G_TRUNC [[COPY12]](<8 x s32>)
-  ; CHECK-NEXT:   [[COPY13:%[0-9]+]]:_(<8 x s32>) = COPY $wh2
-  ; CHECK-NEXT:   [[TRUNC13:%[0-9]+]]:_(<8 x s16>) = G_TRUNC [[COPY13]](<8 x s32>)
-  ; CHECK-NEXT:   [[COPY14:%[0-9]+]]:_(<8 x s32>) = COPY $wh4
-  ; CHECK-NEXT:   [[TRUNC14:%[0-9]+]]:_(<8 x s16>) = G_TRUNC [[COPY14]](<8 x s32>)
-  ; CHECK-NEXT:   [[COPY15:%[0-9]+]]:_(<8 x s32>) = COPY $wh6
-  ; CHECK-NEXT:   [[TRUNC15:%[0-9]+]]:_(<8 x s16>) = G_TRUNC [[COPY15]](<8 x s32>)
-  ; CHECK-NEXT:   [[COPY16:%[0-9]+]]:_(<8 x s32>) = COPY $wh8
-  ; CHECK-NEXT:   [[TRUNC16:%[0-9]+]]:_(<8 x s16>) = G_TRUNC [[COPY16]](<8 x s32>)
-  ; CHECK-NEXT:   [[COPY17:%[0-9]+]]:_(<8 x s32>) = COPY $wh10
-  ; CHECK-NEXT:   [[TRUNC17:%[0-9]+]]:_(<8 x s16>) = G_TRUNC [[COPY17]](<8 x s32>)
-  ; CHECK-NEXT:   [[COPY18:%[0-9]+]]:_(<8 x s32>) = COPY $wh1
-  ; CHECK-NEXT:   [[TRUNC18:%[0-9]+]]:_(<8 x s16>) = G_TRUNC [[COPY18]](<8 x s32>)
-  ; CHECK-NEXT:   [[COPY19:%[0-9]+]]:_(<8 x s32>) = COPY $wh3
-  ; CHECK-NEXT:   [[TRUNC19:%[0-9]+]]:_(<8 x s16>) = G_TRUNC [[COPY19]](<8 x s32>)
-  ; CHECK-NEXT:   [[COPY20:%[0-9]+]]:_(<8 x s32>) = COPY $wh5
-  ; CHECK-NEXT:   [[TRUNC20:%[0-9]+]]:_(<8 x s16>) = G_TRUNC [[COPY20]](<8 x s32>)
-  ; CHECK-NEXT:   [[COPY21:%[0-9]+]]:_(<8 x s32>) = COPY $wh7
-  ; CHECK-NEXT:   [[TRUNC21:%[0-9]+]]:_(<8 x s16>) = G_TRUNC [[COPY21]](<8 x s32>)
-  ; CHECK-NEXT:   [[COPY22:%[0-9]+]]:_(<8 x s32>) = COPY $wh9
-  ; CHECK-NEXT:   [[TRUNC22:%[0-9]+]]:_(<8 x s16>) = G_TRUNC [[COPY22]](<8 x s32>)
-  ; CHECK-NEXT:   [[COPY23:%[0-9]+]]:_(<8 x s32>) = COPY $wh11
-  ; CHECK-NEXT:   [[TRUNC23:%[0-9]+]]:_(<8 x s16>) = G_TRUNC [[COPY23]](<8 x s32>)
+  ; CHECK-NEXT:   [[COPY:%[0-9]+]]:_(<16 x s16>) = COPY $wl0
+  ; CHECK-NEXT:   [[UV:%[0-9]+]]:_(<8 x s16>), [[UV1:%[0-9]+]]:_(<8 x s16>) = G_UNMERGE_VALUES [[COPY]](<16 x s16>)
+  ; CHECK-NEXT:   [[COPY1:%[0-9]+]]:_(<16 x s16>) = COPY $wl2
+  ; CHECK-NEXT:   [[UV2:%[0-9]+]]:_(<8 x s16>), [[UV3:%[0-9]+]]:_(<8 x s16>) = G_UNMERGE_VALUES [[COPY1]](<16 x s16>)
+  ; CHECK-NEXT:   [[COPY2:%[0-9]+]]:_(<16 x s16>) = COPY $wl4
+  ; CHECK-NEXT:   [[UV4:%[0-9]+]]:_(<8 x s16>), [[UV5:%[0-9]+]]:_(<8 x s16>) = G_UNMERGE_VALUES [[COPY2]](<16 x s16>)
+  ; CHECK-NEXT:   [[COPY3:%[0-9]+]]:_(<16 x s16>) = COPY $wl6
+  ; CHECK-NEXT:   [[UV6:%[0-9]+]]:_(<8 x s16>), [[UV7:%[0-9]+]]:_(<8 x s16>) = G_UNMERGE_VALUES [[COPY3]](<16 x s16>)
+  ; CHECK-NEXT:   [[COPY4:%[0-9]+]]:_(<16 x s16>) = COPY $wl8
+  ; CHECK-NEXT:   [[UV8:%[0-9]+]]:_(<8 x s16>), [[UV9:%[0-9]+]]:_(<8 x s16>) = G_UNMERGE_VALUES [[COPY4]](<16 x s16>)
+  ; CHECK-NEXT:   [[COPY5:%[0-9]+]]:_(<16 x s16>) = COPY $wl10
+  ; CHECK-NEXT:   [[UV10:%[0-9]+]]:_(<8 x s16>), [[UV11:%[0-9]+]]:_(<8 x s16>) = G_UNMERGE_VALUES [[COPY5]](<16 x s16>)
+  ; CHECK-NEXT:   [[COPY6:%[0-9]+]]:_(<16 x s16>) = COPY $wl1
+  ; CHECK-NEXT:   [[UV12:%[0-9]+]]:_(<8 x s16>), [[UV13:%[0-9]+]]:_(<8 x s16>) = G_UNMERGE_VALUES [[COPY6]](<16 x s16>)
+  ; CHECK-NEXT:   [[COPY7:%[0-9]+]]:_(<16 x s16>) = COPY $wl3
+  ; CHECK-NEXT:   [[UV14:%[0-9]+]]:_(<8 x s16>), [[UV15:%[0-9]+]]:_(<8 x s16>) = G_UNMERGE_VALUES [[COPY7]](<16 x s16>)
+  ; CHECK-NEXT:   [[COPY8:%[0-9]+]]:_(<16 x s16>) = COPY $wl5
+  ; CHECK-NEXT:   [[UV16:%[0-9]+]]:_(<8 x s16>), [[UV17:%[0-9]+]]:_(<8 x s16>) = G_UNMERGE_VALUES [[COPY8]](<16 x s16>)
+  ; CHECK-NEXT:   [[COPY9:%[0-9]+]]:_(<16 x s16>) = COPY $wl7
+  ; CHECK-NEXT:   [[UV18:%[0-9]+]]:_(<8 x s16>), [[UV19:%[0-9]+]]:_(<8 x s16>) = G_UNMERGE_VALUES [[COPY9]](<16 x s16>)
+  ; CHECK-NEXT:   [[COPY10:%[0-9]+]]:_(<16 x s16>) = COPY $wl9
+  ; CHECK-NEXT:   [[UV20:%[0-9]+]]:_(<8 x s16>), [[UV21:%[0-9]+]]:_(<8 x s16>) = G_UNMERGE_VALUES [[COPY10]](<16 x s16>)
+  ; CHECK-NEXT:   [[COPY11:%[0-9]+]]:_(<16 x s16>) = COPY $wl11
+  ; CHECK-NEXT:   [[UV22:%[0-9]+]]:_(<8 x s16>), [[UV23:%[0-9]+]]:_(<8 x s16>) = G_UNMERGE_VALUES [[COPY11]](<16 x s16>)
+  ; CHECK-NEXT:   [[COPY12:%[0-9]+]]:_(<16 x s16>) = COPY $wh0
+  ; CHECK-NEXT:   [[UV24:%[0-9]+]]:_(<8 x s16>), [[UV25:%[0-9]+]]:_(<8 x s16>) = G_UNMERGE_VALUES [[COPY12]](<16 x s16>)
+  ; CHECK-NEXT:   [[COPY13:%[0-9]+]]:_(<16 x s16>) = COPY $wh2
+  ; CHECK-NEXT:   [[UV26:%[0-9]+]]:_(<8 x s16>), [[UV27:%[0-9]+]]:_(<8 x s16>) = G_UNMERGE_VALUES [[COPY13]](<16 x s16>)
+  ; CHECK-NEXT:   [[COPY14:%[0-9]+]]:_(<16 x s16>) = COPY $wh4
+  ; CHECK-NEXT:   [[UV28:%[0-9]+]]:_(<8 x s16>), [[UV29:%[0-9]+]]:_(<8 x s16>) = G_UNMERGE_VALUES [[COPY14]](<16 x s16>)
+  ; CHECK-NEXT:   [[COPY15:%[0-9]+]]:_(<16 x s16>) = COPY $wh6
+  ; CHECK-NEXT:   [[UV30:%[0-9]+]]:_(<8 x s16>), [[UV31:%[0-9]+]]:_(<8 x s16>) = G_UNMERGE_VALUES [[COPY15]](<16 x s16>)
+  ; CHECK-NEXT:   [[COPY16:%[0-9]+]]:_(<16 x s16>) = COPY $wh8
+  ; CHECK-NEXT:   [[UV32:%[0-9]+]]:_(<8 x s16>), [[UV33:%[0-9]+]]:_(<8 x s16>) = G_UNMERGE_VALUES [[COPY16]](<16 x s16>)
+  ; CHECK-NEXT:   [[COPY17:%[0-9]+]]:_(<16 x s16>) = COPY $wh10
+  ; CHECK-NEXT:   [[UV34:%[0-9]+]]:_(<8 x s16>), [[UV35:%[0-9]+]]:_(<8 x s16>) = G_UNMERGE_VALUES [[COPY17]](<16 x s16>)
+  ; CHECK-NEXT:   [[COPY18:%[0-9]+]]:_(<16 x s16>) = COPY $wh1
+  ; CHECK-NEXT:   [[UV36:%[0-9]+]]:_(<8 x s16>), [[UV37:%[0-9]+]]:_(<8 x s16>) = G_UNMERGE_VALUES [[COPY18]](<16 x s16>)
+  ; CHECK-NEXT:   [[COPY19:%[0-9]+]]:_(<16 x s16>) = COPY $wh3
+  ; CHECK-NEXT:   [[UV38:%[0-9]+]]:_(<8 x s16>), [[UV39:%[0-9]+]]:_(<8 x s16>) = G_UNMERGE_VALUES [[COPY19]](<16 x s16>)
+  ; CHECK-NEXT:   [[COPY20:%[0-9]+]]:_(<16 x s16>) = COPY $wh5
+  ; CHECK-NEXT:   [[UV40:%[0-9]+]]:_(<8 x s16>), [[UV41:%[0-9]+]]:_(<8 x s16>) = G_UNMERGE_VALUES [[COPY20]](<16 x s16>)
+  ; CHECK-NEXT:   [[COPY21:%[0-9]+]]:_(<16 x s16>) = COPY $wh7
+  ; CHECK-NEXT:   [[UV42:%[0-9]+]]:_(<8 x s16>), [[UV43:%[0-9]+]]:_(<8 x s16>) = G_UNMERGE_VALUES [[COPY21]](<16 x s16>)
+  ; CHECK-NEXT:   [[COPY22:%[0-9]+]]:_(<16 x s16>) = COPY $wh9
+  ; CHECK-NEXT:   [[UV44:%[0-9]+]]:_(<8 x s16>), [[UV45:%[0-9]+]]:_(<8 x s16>) = G_UNMERGE_VALUES [[COPY22]](<16 x s16>)
+  ; CHECK-NEXT:   [[COPY23:%[0-9]+]]:_(<16 x s16>) = COPY $wh11
+  ; CHECK-NEXT:   [[UV46:%[0-9]+]]:_(<8 x s16>), [[UV47:%[0-9]+]]:_(<8 x s16>) = G_UNMERGE_VALUES [[COPY23]](<16 x s16>)
   ; CHECK-NEXT:   [[FRAME_INDEX:%[0-9]+]]:_(p0) = G_FRAME_INDEX %fixed-stack.1
-  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(<8 x s32>) = G_LOAD [[FRAME_INDEX]](p0) :: (invariant load (<8 x s32>) from %fixed-stack.1)
-  ; CHECK-NEXT:   [[TRUNC24:%[0-9]+]]:_(<8 x s16>) = G_TRUNC [[LOAD]](<8 x s32>)
+  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(<8 x s16>) = G_LOAD [[FRAME_INDEX]](p0) :: (invariant load (<8 x s16>) from %fixed-stack.1)
   ; CHECK-NEXT:   [[FRAME_INDEX1:%[0-9]+]]:_(p0) = G_FRAME_INDEX %fixed-stack.0
-  ; CHECK-NEXT:   [[LOAD1:%[0-9]+]]:_(<8 x s32>) = G_LOAD [[FRAME_INDEX1]](p0) :: (invariant load (<8 x s32>) from %fixed-stack.0, align 64)
-  ; CHECK-NEXT:   [[TRUNC25:%[0-9]+]]:_(<8 x s16>) = G_TRUNC [[LOAD1]](<8 x s32>)
+  ; CHECK-NEXT:   [[LOAD1:%[0-9]+]]:_(<8 x s16>) = G_LOAD [[FRAME_INDEX1]](p0) :: (invariant load (<8 x s16>) from %fixed-stack.0, align 32)
   ; CHECK-NEXT:   PseudoRET implicit $lr
                              <8 x i16>, <8 x i16>, <8 x i16>, <8 x i16>, <8 x i16>, <8 x i16>,
                              <8 x i16>, <8 x i16>, <8 x i16>, <8 x i16>, <8 x i16>, <8 x i16>,
@@ -161,69 +157,67 @@ define void @callee_v8int16(<8 x i16>, <8 x i16>, <8 x i16>, <8 x i16>, <8 x i16
 define void @callee_v16int8(<16 x i8>, <16 x i8>, <16 x i8>, <16 x i8>, <16 x i8>, <16 x i8>,
   ; CHECK-LABEL: name: callee_v16int8
   ; CHECK: fixedStack:
-  ; CHECK-NEXT:   - { id: 0, type: default, offset: -64, size: 32, alignment: 64, stack-id: default, 
+  ; CHECK-NEXT:   - { id: 0, type: default, offset: -32, size: 16, alignment: 32, stack-id: default, 
   ; CHECK-NEXT:       isImmutable: true, isAliased: false, callee-saved-register: '', callee-saved-restored: true, 
   ; CHECK-NEXT:       debug-info-variable: '', debug-info-expression: '', debug-info-location: '' }
-  ; CHECK-NEXT:   - { id: 1, type: default, offset: -32, size: 32, alignment: 32, stack-id: default, 
+  ; CHECK-NEXT:   - { id: 1, type: default, offset: -16, size: 16, alignment: 16, stack-id: default, 
   ; CHECK-NEXT:       isImmutable: true, isAliased: false, callee-saved-register: '', callee-saved-restored: true, 
   ; CHECK-NEXT:       debug-info-variable: '', debug-info-expression: '', debug-info-location: '' }
   ; CHECK: bb.1 (%ir-block.26):
   ; CHECK-NEXT:   liveins: $wh0, $wh1, $wh2, $wh3, $wh4, $wh5, $wh6, $wh7, $wh8, $wh9, $wh10, $wh11, $wl0, $wl1, $wl2, $wl3, $wl4, $wl5, $wl6, $wl7, $wl8, $wl9, $wl10, $wl11
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT:   [[COPY:%[0-9]+]]:_(<16 x s16>) = COPY $wl0
-  ; CHECK-NEXT:   [[TRUNC:%[0-9]+]]:_(<16 x s8>) = G_TRUNC [[COPY]](<16 x s16>)
-  ; CHECK-NEXT:   [[COPY1:%[0-9]+]]:_(<16 x s16>) = COPY $wl2
-  ; CHECK-NEXT:   [[TRUNC1:%[0-9]+]]:_(<16 x s8>) = G_TRUNC [[COPY1]](<16 x s16>)
-  ; CHECK-NEXT:   [[COPY2:%[0-9]+]]:_(<16 x s16>) = COPY $wl4
-  ; CHECK-NEXT:   [[TRUNC2:%[0-9]+]]:_(<16 x s8>) = G_TRUNC [[COPY2]](<16 x s16>)
-  ; CHECK-NEXT:   [[COPY3:%[0-9]+]]:_(<16 x s16>) = COPY $wl6
-  ; CHECK-NEXT:   [[TRUNC3:%[0-9]+]]:_(<16 x s8>) = G_TRUNC [[COPY3]](<16 x s16>)
-  ; CHECK-NEXT:   [[COPY4:%[0-9]+]]:_(<16 x s16>) = COPY $wl8
-  ; CHECK-NEXT:   [[TRUNC4:%[0-9]+]]:_(<16 x s8>) = G_TRUNC [[COPY4]](<16 x s16>)
-  ; CHECK-NEXT:   [[COPY5:%[0-9]+]]:_(<16 x s16>) = COPY $wl10
-  ; CHECK-NEXT:   [[TRUNC5:%[0-9]+]]:_(<16 x s8>) = G_TRUNC [[COPY5]](<16 x s16>)
-  ; CHECK-NEXT:   [[COPY6:%[0-9]+]]:_(<16 x s16>) = COPY $wl1
-  ; CHECK-NEXT:   [[TRUNC6:%[0-9]+]]:_(<16 x s8>) = G_TRUNC [[COPY6]](<16 x s16>)
-  ; CHECK-NEXT:   [[COPY7:%[0-9]+]]:_(<16 x s16>) = COPY $wl3
-  ; CHECK-NEXT:   [[TRUNC7:%[0-9]+]]:_(<16 x s8>) = G_TRUNC [[COPY7]](<16 x s16>)
-  ; CHECK-NEXT:   [[COPY8:%[0-9]+]]:_(<16 x s16>) = COPY $wl5
-  ; CHECK-NEXT:   [[TRUNC8:%[0-9]+]]:_(<16 x s8>) = G_TRUNC [[COPY8]](<16 x s16>)
-  ; CHECK-NEXT:   [[COPY9:%[0-9]+]]:_(<16 x s16>) = COPY $wl7
-  ; CHECK-NEXT:   [[TRUNC9:%[0-9]+]]:_(<16 x s8>) = G_TRUNC [[COPY9]](<16 x s16>)
-  ; CHECK-NEXT:   [[COPY10:%[0-9]+]]:_(<16 x s16>) = COPY $wl9
-  ; CHECK-NEXT:   [[TRUNC10:%[0-9]+]]:_(<16 x s8>) = G_TRUNC [[COPY10]](<16 x s16>)
-  ; CHECK-NEXT:   [[COPY11:%[0-9]+]]:_(<16 x s16>) = COPY $wl11
-  ; CHECK-NEXT:   [[TRUNC11:%[0-9]+]]:_(<16 x s8>) = G_TRUNC [[COPY11]](<16 x s16>)
-  ; CHECK-NEXT:   [[COPY12:%[0-9]+]]:_(<16 x s16>) = COPY $wh0
-  ; CHECK-NEXT:   [[TRUNC12:%[0-9]+]]:_(<16 x s8>) = G_TRUNC [[COPY12]](<16 x s16>)
-  ; CHECK-NEXT:   [[COPY13:%[0-9]+]]:_(<16 x s16>) = COPY $wh2
-  ; CHECK-NEXT:   [[TRUNC13:%[0-9]+]]:_(<16 x s8>) = G_TRUNC [[COPY13]](<16 x s16>)
-  ; CHECK-NEXT:   [[COPY14:%[0-9]+]]:_(<16 x s16>) = COPY $wh4
-  ; CHECK-NEXT:   [[TRUNC14:%[0-9]+]]:_(<16 x s8>) = G_TRUNC [[COPY14]](<16 x s16>)
-  ; CHECK-NEXT:   [[COPY15:%[0-9]+]]:_(<16 x s16>) = COPY $wh6
-  ; CHECK-NEXT:   [[TRUNC15:%[0-9]+]]:_(<16 x s8>) = G_TRUNC [[COPY15]](<16 x s16>)
-  ; CHECK-NEXT:   [[COPY16:%[0-9]+]]:_(<16 x s16>) = COPY $wh8
-  ; CHECK-NEXT:   [[TRUNC16:%[0-9]+]]:_(<16 x s8>) = G_TRUNC [[COPY16]](<16 x s16>)
-  ; CHECK-NEXT:   [[COPY17:%[0-9]+]]:_(<16 x s16>) = COPY $wh10
-  ; CHECK-NEXT:   [[TRUNC17:%[0-9]+]]:_(<16 x s8>) = G_TRUNC [[COPY17]](<16 x s16>)
-  ; CHECK-NEXT:   [[COPY18:%[0-9]+]]:_(<16 x s16>) = COPY $wh1
-  ; CHECK-NEXT:   [[TRUNC18:%[0-9]+]]:_(<16 x s8>) = G_TRUNC [[COPY18]](<16 x s16>)
-  ; CHECK-NEXT:   [[COPY19:%[0-9]+]]:_(<16 x s16>) = COPY $wh3
-  ; CHECK-NEXT:   [[TRUNC19:%[0-9]+]]:_(<16 x s8>) = G_TRUNC [[COPY19]](<16 x s16>)
-  ; CHECK-NEXT:   [[COPY20:%[0-9]+]]:_(<16 x s16>) = COPY $wh5
-  ; CHECK-NEXT:   [[TRUNC20:%[0-9]+]]:_(<16 x s8>) = G_TRUNC [[COPY20]](<16 x s16>)
-  ; CHECK-NEXT:   [[COPY21:%[0-9]+]]:_(<16 x s16>) = COPY $wh7
-  ; CHECK-NEXT:   [[TRUNC21:%[0-9]+]]:_(<16 x s8>) = G_TRUNC [[COPY21]](<16 x s16>)
-  ; CHECK-NEXT:   [[COPY22:%[0-9]+]]:_(<16 x s16>) = COPY $wh9
-  ; CHECK-NEXT:   [[TRUNC22:%[0-9]+]]:_(<16 x s8>) = G_TRUNC [[COPY22]](<16 x s16>)
-  ; CHECK-NEXT:   [[COPY23:%[0-9]+]]:_(<16 x s16>) = COPY $wh11
-  ; CHECK-NEXT:   [[TRUNC23:%[0-9]+]]:_(<16 x s8>) = G_TRUNC [[COPY23]](<16 x s16>)
+  ; CHECK-NEXT:   [[COPY:%[0-9]+]]:_(<32 x s8>) = COPY $wl0
+  ; CHECK-NEXT:   [[UV:%[0-9]+]]:_(<16 x s8>), [[UV1:%[0-9]+]]:_(<16 x s8>) = G_UNMERGE_VALUES [[COPY]](<32 x s8>)
+  ; CHECK-NEXT:   [[COPY1:%[0-9]+]]:_(<32 x s8>) = COPY $wl2
+  ; CHECK-NEXT:   [[UV2:%[0-9]+]]:_(<16 x s8>), [[UV3:%[0-9]+]]:_(<16 x s8>) = G_UNMERGE_VALUES [[COPY1]](<32 x s8>)
+  ; CHECK-NEXT:   [[COPY2:%[0-9]+]]:_(<32 x s8>) = COPY $wl4
+  ; CHECK-NEXT:   [[UV4:%[0-9]+]]:_(<16 x s8>), [[UV5:%[0-9]+]]:_(<16 x s8>) = G_UNMERGE_VALUES [[COPY2]](<32 x s8>)
+  ; CHECK-NEXT:   [[COPY3:%[0-9]+]]:_(<32 x s8>) = COPY $wl6
+  ; CHECK-NEXT:   [[UV6:%[0-9]+]]:_(<16 x s8>), [[UV7:%[0-9]+]]:_(<16 x s8>) = G_UNMERGE_VALUES [[COPY3]](<32 x s8>)
+  ; CHECK-NEXT:   [[COPY4:%[0-9]+]]:_(<32 x s8>) = COPY $wl8
+  ; CHECK-NEXT:   [[UV8:%[0-9]+]]:_(<16 x s8>), [[UV9:%[0-9]+]]:_(<16 x s8>) = G_UNMERGE_VALUES [[COPY4]](<32 x s8>)
+  ; CHECK-NEXT:   [[COPY5:%[0-9]+]]:_(<32 x s8>) = COPY $wl10
+  ; CHECK-NEXT:   [[UV10:%[0-9]+]]:_(<16 x s8>), [[UV11:%[0-9]+]]:_(<16 x s8>) = G_UNMERGE_VALUES [[COPY5]](<32 x s8>)
+  ; CHECK-NEXT:   [[COPY6:%[0-9]+]]:_(<32 x s8>) = COPY $wl1
+  ; CHECK-NEXT:   [[UV12:%[0-9]+]]:_(<16 x s8>), [[UV13:%[0-9]+]]:_(<16 x s8>) = G_UNMERGE_VALUES [[COPY6]](<32 x s8>)
+  ; CHECK-NEXT:   [[COPY7:%[0-9]+]]:_(<32 x s8>) = COPY $wl3
+  ; CHECK-NEXT:   [[UV14:%[0-9]+]]:_(<16 x s8>), [[UV15:%[0-9]+]]:_(<16 x s8>) = G_UNMERGE_VALUES [[COPY7]](<32 x s8>)
+  ; CHECK-NEXT:   [[COPY8:%[0-9]+]]:_(<32 x s8>) = COPY $wl5
+  ; CHECK-NEXT:   [[UV16:%[0-9]+]]:_(<16 x s8>), [[UV17:%[0-9]+]]:_(<16 x s8>) = G_UNMERGE_VALUES [[COPY8]](<32 x s8>)
+  ; CHECK-NEXT:   [[COPY9:%[0-9]+]]:_(<32 x s8>) = COPY $wl7
+  ; CHECK-NEXT:   [[UV18:%[0-9]+]]:_(<16 x s8>), [[UV19:%[0-9]+]]:_(<16 x s8>) = G_UNMERGE_VALUES [[COPY9]](<32 x s8>)
+  ; CHECK-NEXT:   [[COPY10:%[0-9]+]]:_(<32 x s8>) = COPY $wl9
+  ; CHECK-NEXT:   [[UV20:%[0-9]+]]:_(<16 x s8>), [[UV21:%[0-9]+]]:_(<16 x s8>) = G_UNMERGE_VALUES [[COPY10]](<32 x s8>)
+  ; CHECK-NEXT:   [[COPY11:%[0-9]+]]:_(<32 x s8>) = COPY $wl11
+  ; CHECK-NEXT:   [[UV22:%[0-9]+]]:_(<16 x s8>), [[UV23:%[0-9]+]]:_(<16 x s8>) = G_UNMERGE_VALUES [[COPY11]](<32 x s8>)
+  ; CHECK-NEXT:   [[COPY12:%[0-9]+]]:_(<32 x s8>) = COPY $wh0
+  ; CHECK-NEXT:   [[UV24:%[0-9]+]]:_(<16 x s8>), [[UV25:%[0-9]+]]:_(<16 x s8>) = G_UNMERGE_VALUES [[COPY12]](<32 x s8>)
+  ; CHECK-NEXT:   [[COPY13:%[0-9]+]]:_(<32 x s8>) = COPY $wh2
+  ; CHECK-NEXT:   [[UV26:%[0-9]+]]:_(<16 x s8>), [[UV27:%[0-9]+]]:_(<16 x s8>) = G_UNMERGE_VALUES [[COPY13]](<32 x s8>)
+  ; CHECK-NEXT:   [[COPY14:%[0-9]+]]:_(<32 x s8>) = COPY $wh4
+  ; CHECK-NEXT:   [[UV28:%[0-9]+]]:_(<16 x s8>), [[UV29:%[0-9]+]]:_(<16 x s8>) = G_UNMERGE_VALUES [[COPY14]](<32 x s8>)
+  ; CHECK-NEXT:   [[COPY15:%[0-9]+]]:_(<32 x s8>) = COPY $wh6
+  ; CHECK-NEXT:   [[UV30:%[0-9]+]]:_(<16 x s8>), [[UV31:%[0-9]+]]:_(<16 x s8>) = G_UNMERGE_VALUES [[COPY15]](<32 x s8>)
+  ; CHECK-NEXT:   [[COPY16:%[0-9]+]]:_(<32 x s8>) = COPY $wh8
+  ; CHECK-NEXT:   [[UV32:%[0-9]+]]:_(<16 x s8>), [[UV33:%[0-9]+]]:_(<16 x s8>) = G_UNMERGE_VALUES [[COPY16]](<32 x s8>)
+  ; CHECK-NEXT:   [[COPY17:%[0-9]+]]:_(<32 x s8>) = COPY $wh10
+  ; CHECK-NEXT:   [[UV34:%[0-9]+]]:_(<16 x s8>), [[UV35:%[0-9]+]]:_(<16 x s8>) = G_UNMERGE_VALUES [[COPY17]](<32 x s8>)
+  ; CHECK-NEXT:   [[COPY18:%[0-9]+]]:_(<32 x s8>) = COPY $wh1
+  ; CHECK-NEXT:   [[UV36:%[0-9]+]]:_(<16 x s8>), [[UV37:%[0-9]+]]:_(<16 x s8>) = G_UNMERGE_VALUES [[COPY18]](<32 x s8>)
+  ; CHECK-NEXT:   [[COPY19:%[0-9]+]]:_(<32 x s8>) = COPY $wh3
+  ; CHECK-NEXT:   [[UV38:%[0-9]+]]:_(<16 x s8>), [[UV39:%[0-9]+]]:_(<16 x s8>) = G_UNMERGE_VALUES [[COPY19]](<32 x s8>)
+  ; CHECK-NEXT:   [[COPY20:%[0-9]+]]:_(<32 x s8>) = COPY $wh5
+  ; CHECK-NEXT:   [[UV40:%[0-9]+]]:_(<16 x s8>), [[UV41:%[0-9]+]]:_(<16 x s8>) = G_UNMERGE_VALUES [[COPY20]](<32 x s8>)
+  ; CHECK-NEXT:   [[COPY21:%[0-9]+]]:_(<32 x s8>) = COPY $wh7
+  ; CHECK-NEXT:   [[UV42:%[0-9]+]]:_(<16 x s8>), [[UV43:%[0-9]+]]:_(<16 x s8>) = G_UNMERGE_VALUES [[COPY21]](<32 x s8>)
+  ; CHECK-NEXT:   [[COPY22:%[0-9]+]]:_(<32 x s8>) = COPY $wh9
+  ; CHECK-NEXT:   [[UV44:%[0-9]+]]:_(<16 x s8>), [[UV45:%[0-9]+]]:_(<16 x s8>) = G_UNMERGE_VALUES [[COPY22]](<32 x s8>)
+  ; CHECK-NEXT:   [[COPY23:%[0-9]+]]:_(<32 x s8>) = COPY $wh11
+  ; CHECK-NEXT:   [[UV46:%[0-9]+]]:_(<16 x s8>), [[UV47:%[0-9]+]]:_(<16 x s8>) = G_UNMERGE_VALUES [[COPY23]](<32 x s8>)
   ; CHECK-NEXT:   [[FRAME_INDEX:%[0-9]+]]:_(p0) = G_FRAME_INDEX %fixed-stack.1
-  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(<16 x s16>) = G_LOAD [[FRAME_INDEX]](p0) :: (invariant load (<16 x s16>) from %fixed-stack.1)
-  ; CHECK-NEXT:   [[TRUNC24:%[0-9]+]]:_(<16 x s8>) = G_TRUNC [[LOAD]](<16 x s16>)
+  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(<16 x s8>) = G_LOAD [[FRAME_INDEX]](p0) :: (invariant load (<16 x s8>) from %fixed-stack.1)
   ; CHECK-NEXT:   [[FRAME_INDEX1:%[0-9]+]]:_(p0) = G_FRAME_INDEX %fixed-stack.0
-  ; CHECK-NEXT:   [[LOAD1:%[0-9]+]]:_(<16 x s16>) = G_LOAD [[FRAME_INDEX1]](p0) :: (invariant load (<16 x s16>) from %fixed-stack.0, align 64)
-  ; CHECK-NEXT:   [[TRUNC25:%[0-9]+]]:_(<16 x s8>) = G_TRUNC [[LOAD1]](<16 x s16>)
+  ; CHECK-NEXT:   [[LOAD1:%[0-9]+]]:_(<16 x s8>) = G_LOAD [[FRAME_INDEX1]](p0) :: (invariant load (<16 x s8>) from %fixed-stack.0, align 32)
   ; CHECK-NEXT:   PseudoRET implicit $lr
                              <16 x i8>, <16 x i8>, <16 x i8>, <16 x i8>, <16 x i8>, <16 x i8>,
                              <16 x i8>, <16 x i8>, <16 x i8>, <16 x i8>, <16 x i8>, <16 x i8>,
@@ -235,10 +229,10 @@ define void @callee_v16int8(<16 x i8>, <16 x i8>, <16 x i8>, <16 x i8>, <16 x i8
 define void @callee_v4float(<4 x float>, <4 x float>, <4 x float>, <4 x float>, <4 x float>, <4 x float>,
   ; CHECK-LABEL: name: callee_v4float
   ; CHECK: fixedStack:
-  ; CHECK-NEXT:   - { id: 0, type: default, offset: -64, size: 32, alignment: 64, stack-id: default, 
+  ; CHECK-NEXT:   - { id: 0, type: default, offset: -32, size: 16, alignment: 32, stack-id: default, 
   ; CHECK-NEXT:       isImmutable: true, isAliased: false, callee-saved-register: '', callee-saved-restored: true, 
   ; CHECK-NEXT:       debug-info-variable: '', debug-info-expression: '', debug-info-location: '' }
-  ; CHECK-NEXT:   - { id: 1, type: default, offset: -32, size: 32, alignment: 32, stack-id: default, 
+  ; CHECK-NEXT:   - { id: 1, type: default, offset: -16, size: 16, alignment: 16, stack-id: default, 
   ; CHECK-NEXT:       isImmutable: true, isAliased: false, callee-saved-register: '', callee-saved-restored: true, 
   ; CHECK-NEXT:       debug-info-variable: '', debug-info-expression: '', debug-info-location: '' }
   ; CHECK: bb.1 (%ir-block.26):
@@ -293,11 +287,9 @@ define void @callee_v4float(<4 x float>, <4 x float>, <4 x float>, <4 x float>, 
   ; CHECK-NEXT:   [[COPY23:%[0-9]+]]:_(<8 x s32>) = COPY $wh11
   ; CHECK-NEXT:   [[UV46:%[0-9]+]]:_(<4 x s32>), [[UV47:%[0-9]+]]:_(<4 x s32>) = G_UNMERGE_VALUES [[COPY23]](<8 x s32>)
   ; CHECK-NEXT:   [[FRAME_INDEX:%[0-9]+]]:_(p0) = G_FRAME_INDEX %fixed-stack.1
-  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(<8 x s32>) = G_LOAD [[FRAME_INDEX]](p0) :: (invariant load (<8 x s32>) from %fixed-stack.1)
-  ; CHECK-NEXT:   [[UV48:%[0-9]+]]:_(<4 x s32>), [[UV49:%[0-9]+]]:_(<4 x s32>) = G_UNMERGE_VALUES [[LOAD]](<8 x s32>)
+  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(<4 x s32>) = G_LOAD [[FRAME_INDEX]](p0) :: (invariant load (<4 x s32>) from %fixed-stack.1)
   ; CHECK-NEXT:   [[FRAME_INDEX1:%[0-9]+]]:_(p0) = G_FRAME_INDEX %fixed-stack.0
-  ; CHECK-NEXT:   [[LOAD1:%[0-9]+]]:_(<8 x s32>) = G_LOAD [[FRAME_INDEX1]](p0) :: (invariant load (<8 x s32>) from %fixed-stack.0, align 64)
-  ; CHECK-NEXT:   [[UV50:%[0-9]+]]:_(<4 x s32>), [[UV51:%[0-9]+]]:_(<4 x s32>) = G_UNMERGE_VALUES [[LOAD1]](<8 x s32>)
+  ; CHECK-NEXT:   [[LOAD1:%[0-9]+]]:_(<4 x s32>) = G_LOAD [[FRAME_INDEX1]](p0) :: (invariant load (<4 x s32>) from %fixed-stack.0, align 32)
   ; CHECK-NEXT:   PseudoRET implicit $lr
                              <4 x float>, <4 x float>, <4 x float>, <4 x float>, <4 x float>, <4 x float>,
                              <4 x float>, <4 x float>, <4 x float>, <4 x float>, <4 x float>, <4 x float>,

--- a/llvm/test/CodeGen/AIE/aie2p/GlobalIsel/irtranslator-formal-arguments.ll
+++ b/llvm/test/CodeGen/AIE/aie2p/GlobalIsel/irtranslator-formal-arguments.ll
@@ -56,17 +56,44 @@ define void @test_arg_i64(i64 %a) {
   ret void
 }
 
-; Sparse vectors are not implemetned
-;define void @test_arg_i128([3 x i128] %b, i128 %a) {
-;  store i128 %a, i128* @g_ptr_128
-;  ret void
-;}
+define void @test_arg_i128([3 x i128] %b, i128 %a) {
+  ; CHECK-LABEL: name: test_arg_i128
+  ; CHECK: fixedStack:
+  ; CHECK: bb.1 (%ir-block.0):
+  ; CHECK-NEXT:   liveins: $q0, $q1, $q2, $q3
+  ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT:   [[COPY:%[0-9]+]]:_(s128) = COPY $q0
+  ; CHECK-NEXT:   [[COPY1:%[0-9]+]]:_(s128) = COPY $q2
+  ; CHECK-NEXT:   [[COPY2:%[0-9]+]]:_(s128) = COPY $q1
+  ; CHECK-NEXT:   [[COPY3:%[0-9]+]]:_(s128) = COPY $q3
+  ; CHECK-NEXT:   [[GV:%[0-9]+]]:_(p0) = G_GLOBAL_VALUE @g_ptr_128
+  ; CHECK-NEXT:   G_STORE [[COPY3]](s128), [[GV]](p0) :: (store (s128) into @g_ptr_128, align 4)
+  ; CHECK-NEXT:   PseudoRET implicit $lr
+ store i128 %a, i128* @g_ptr_128
+ ret void
+}
 
-; Sparse vectors are not implemetned
-;define void @test_arg_i128_stack([4 x i128] %a, i128 %stack) {
-;  store i128 %stack, i128* @g_ptr_128
-;  ret void
-;}
+define void @test_arg_i128_stack([4 x i128] %a, i128 %stack) {
+  ; CHECK-LABEL: name: test_arg_i128_stack
+  ; CHECK: fixedStack:
+  ; CHECK-NEXT:   - { id: 0, type: default, offset: -16, size: 16, alignment: 16, stack-id: default,
+  ; CHECK-NEXT:       isImmutable: true, isAliased: false, callee-saved-register: '', callee-saved-restored: true,
+  ; CHECK-NEXT:       debug-info-variable: '', debug-info-expression: '', debug-info-location: '' }
+  ; CHECK: bb.1 (%ir-block.0):
+  ; CHECK-NEXT:   liveins: $q0, $q1, $q2, $q3
+  ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT:   [[COPY:%[0-9]+]]:_(s128) = COPY $q0
+  ; CHECK-NEXT:   [[COPY1:%[0-9]+]]:_(s128) = COPY $q2
+  ; CHECK-NEXT:   [[COPY2:%[0-9]+]]:_(s128) = COPY $q1
+  ; CHECK-NEXT:   [[COPY3:%[0-9]+]]:_(s128) = COPY $q3
+  ; CHECK-NEXT:   [[FRAME_INDEX:%[0-9]+]]:_(p0) = G_FRAME_INDEX %fixed-stack.0
+  ; CHECK-NEXT:   [[LOAD:%[0-9]+]]:_(s128) = G_LOAD [[FRAME_INDEX]](p0) :: (invariant load (s128) from %fixed-stack.0)
+  ; CHECK-NEXT:   [[GV:%[0-9]+]]:_(p0) = G_GLOBAL_VALUE @g_ptr_128
+  ; CHECK-NEXT:   G_STORE [[LOAD]](s128), [[GV]](p0) :: (store (s128) into @g_ptr_128, align 4)
+  ; CHECK-NEXT:   PseudoRET implicit $lr
+ store i128 %stack, i128* @g_ptr_128
+ ret void
+}
 
 define void @test_arg_i1(i1 %a) {
   ; CHECK-LABEL: name: test_arg_i1

--- a/llvm/test/CodeGen/AIE/aie2p/GlobalIsel/irtranslator-ret.ll
+++ b/llvm/test/CodeGen/AIE/aie2p/GlobalIsel/irtranslator-ret.ll
@@ -41,6 +41,15 @@ define i64 @test_ret_i64() {
   ret i64 0
 }
 
+define i128 @test_ret_i128() {
+  ; CHECK-LABEL: name: test_ret_i128
+  ; CHECK: bb.1 (%ir-block.0):
+  ; CHECK-NEXT:   [[C:%[0-9]+]]:_(s128) = G_CONSTANT i128 0
+  ; CHECK-NEXT:   $q0 = COPY [[C]](s128)
+  ; CHECK-NEXT:   PseudoRET implicit $lr, implicit $q0
+  ret i128 0
+}
+
 define i1 @test_ret_i1() {
   ; CHECK-LABEL: name: test_ret_i1
   ; CHECK: bb.1 (%ir-block.0):

--- a/llvm/test/CodeGen/AIE/aie2p/GlobalIsel/irtranslator-return-vect128.ll
+++ b/llvm/test/CodeGen/AIE/aie2p/GlobalIsel/irtranslator-return-vect128.ll
@@ -28,8 +28,10 @@ define <8 x i16> @callee_v8int16() {
   ; CHECK: bb.1 (%ir-block.0):
   ; CHECK-NEXT:   [[C:%[0-9]+]]:_(s16) = G_CONSTANT i16 0
   ; CHECK-NEXT:   [[BUILD_VECTOR:%[0-9]+]]:_(<8 x s16>) = G_BUILD_VECTOR [[C]](s16), [[C]](s16), [[C]](s16), [[C]](s16), [[C]](s16), [[C]](s16), [[C]](s16), [[C]](s16)
-  ; CHECK-NEXT:   [[ANYEXT:%[0-9]+]]:_(<8 x s32>) = G_ANYEXT [[BUILD_VECTOR]](<8 x s16>)
-  ; CHECK-NEXT:   $wl0 = COPY [[ANYEXT]](<8 x s32>)
+  ; CHECK-NEXT:   [[UV:%[0-9]+]]:_(s16), [[UV1:%[0-9]+]]:_(s16), [[UV2:%[0-9]+]]:_(s16), [[UV3:%[0-9]+]]:_(s16), [[UV4:%[0-9]+]]:_(s16), [[UV5:%[0-9]+]]:_(s16), [[UV6:%[0-9]+]]:_(s16), [[UV7:%[0-9]+]]:_(s16) = G_UNMERGE_VALUES [[BUILD_VECTOR]](<8 x s16>)
+  ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(s16) = G_IMPLICIT_DEF
+  ; CHECK-NEXT:   [[BUILD_VECTOR1:%[0-9]+]]:_(<16 x s16>) = G_BUILD_VECTOR [[UV]](s16), [[UV1]](s16), [[UV2]](s16), [[UV3]](s16), [[UV4]](s16), [[UV5]](s16), [[UV6]](s16), [[UV7]](s16), [[DEF]](s16), [[DEF]](s16), [[DEF]](s16), [[DEF]](s16), [[DEF]](s16), [[DEF]](s16), [[DEF]](s16), [[DEF]](s16)
+  ; CHECK-NEXT:   $wl0 = COPY [[BUILD_VECTOR1]](<16 x s16>)
   ; CHECK-NEXT:   PseudoRET implicit $lr, implicit $wl0
   ret <8 x i16> zeroinitializer
 }
@@ -39,8 +41,10 @@ define <16 x i8> @callee_v16int8() {
   ; CHECK: bb.1 (%ir-block.0):
   ; CHECK-NEXT:   [[C:%[0-9]+]]:_(s8) = G_CONSTANT i8 0
   ; CHECK-NEXT:   [[BUILD_VECTOR:%[0-9]+]]:_(<16 x s8>) = G_BUILD_VECTOR [[C]](s8), [[C]](s8), [[C]](s8), [[C]](s8), [[C]](s8), [[C]](s8), [[C]](s8), [[C]](s8), [[C]](s8), [[C]](s8), [[C]](s8), [[C]](s8), [[C]](s8), [[C]](s8), [[C]](s8), [[C]](s8)
-  ; CHECK-NEXT:   [[ANYEXT:%[0-9]+]]:_(<16 x s16>) = G_ANYEXT [[BUILD_VECTOR]](<16 x s8>)
-  ; CHECK-NEXT:   $wl0 = COPY [[ANYEXT]](<16 x s16>)
+  ; CHECK-NEXT:   [[UV:%[0-9]+]]:_(s8), [[UV1:%[0-9]+]]:_(s8), [[UV2:%[0-9]+]]:_(s8), [[UV3:%[0-9]+]]:_(s8), [[UV4:%[0-9]+]]:_(s8), [[UV5:%[0-9]+]]:_(s8), [[UV6:%[0-9]+]]:_(s8), [[UV7:%[0-9]+]]:_(s8), [[UV8:%[0-9]+]]:_(s8), [[UV9:%[0-9]+]]:_(s8), [[UV10:%[0-9]+]]:_(s8), [[UV11:%[0-9]+]]:_(s8), [[UV12:%[0-9]+]]:_(s8), [[UV13:%[0-9]+]]:_(s8), [[UV14:%[0-9]+]]:_(s8), [[UV15:%[0-9]+]]:_(s8) = G_UNMERGE_VALUES [[BUILD_VECTOR]](<16 x s8>)
+  ; CHECK-NEXT:   [[DEF:%[0-9]+]]:_(s8) = G_IMPLICIT_DEF
+  ; CHECK-NEXT:   [[BUILD_VECTOR1:%[0-9]+]]:_(<32 x s8>) = G_BUILD_VECTOR [[UV]](s8), [[UV1]](s8), [[UV2]](s8), [[UV3]](s8), [[UV4]](s8), [[UV5]](s8), [[UV6]](s8), [[UV7]](s8), [[UV8]](s8), [[UV9]](s8), [[UV10]](s8), [[UV11]](s8), [[UV12]](s8), [[UV13]](s8), [[UV14]](s8), [[UV15]](s8), [[DEF]](s8), [[DEF]](s8), [[DEF]](s8), [[DEF]](s8), [[DEF]](s8), [[DEF]](s8), [[DEF]](s8), [[DEF]](s8), [[DEF]](s8), [[DEF]](s8), [[DEF]](s8), [[DEF]](s8), [[DEF]](s8), [[DEF]](s8), [[DEF]](s8), [[DEF]](s8)
+  ; CHECK-NEXT:   $wl0 = COPY [[BUILD_VECTOR1]](<32 x s8>)
   ; CHECK-NEXT:   PseudoRET implicit $lr, implicit $wl0
   ret <16 x i8> zeroinitializer
 }

--- a/llvm/test/CodeGen/AIE/aie2p/load-store-aligned.ll
+++ b/llvm/test/CodeGen/AIE/aie2p/load-store-aligned.ll
@@ -15,29 +15,25 @@ target triple = "aie2p"
 define dso_local void @test_load_store_aligned(<8 x i16> noundef %a, <4 x i32> noundef %b, <16 x i8> noundef %c, <16 x i16> noundef %d, <8 x i32> noundef %e, <4 x i64> inreg noundef %f, <8 x i64> inreg noundef %g, <16 x i32> noundef %h) #0 {
 ; CHECK-LABEL: test_load_store_aligned:
 ; CHECK:       // %bb.0: // %entry
-; CHECK-NEXT:    mova r0, #2; nopx
+; CHECK-NEXT:    nopx ; vmov q0, wl0
 ; CHECK-NEXT:    paddxm [sp], #768
 ; CHECK-NEXT:    vmov x1, bmll0
-; CHECK-NEXT:    vshuffle x0, x0, x0, r0
-; CHECK-NEXT:    mova r0, #0
 ; CHECK-NEXT:    vst wl6, [sp, #-704]
 ; CHECK-NEXT:    vst wl8, [sp, #-640]
 ; CHECK-NEXT:    vst bmll1, [sp, #-512]
 ; CHECK-NEXT:    vst x10, [sp, #-448]
-; CHECK-NEXT:    vmov q0, wl0
-; CHECK-NEXT:    vshuffle x4, x4, x4, r0
-; CHECK-NEXT:    vst wl1, [sp, #-576]
-; CHECK-NEXT:    vlda bmll0, [sp, #-512]
-; CHECK-NEXT:    vmov q0, wl2
 ; CHECK-NEXT:    vmov wh0, q0
+; CHECK-NEXT:    vst wl1, [sp, #-576]
+; CHECK-NEXT:    vmov q0, wl2
+; CHECK-NEXT:    vlda bmll0, [sp, #-512]
 ; CHECK-NEXT:    vmov wh2, q0
 ; CHECK-NEXT:    vmov q0, wl4
 ; CHECK-NEXT:    vst.128 wh0, [sp, #-768]
 ; CHECK-NEXT:    vlda.128 wh0, [sp, #-768]
 ; CHECK-NEXT:    vmov wh4, q0
 ; CHECK-NEXT:    vst.128 wh2, [sp, #-752]
-; CHECK-NEXT:    vst bmll0, [sp, #-128]
 ; CHECK-NEXT:    vst.128 wh4, [sp, #-736]
+; CHECK-NEXT:    vst bmll0, [sp, #-128]
 ; CHECK-NEXT:    vlda.128 wh0, [sp, #-752]
 ; CHECK-NEXT:    vlda.128 wh0, [sp, #-736]
 ; CHECK-NEXT:    vlda wh0, [sp, #-704]

--- a/llvm/test/CodeGen/AIE/aie2p/load-store-unaligned.ll
+++ b/llvm/test/CodeGen/AIE/aie2p/load-store-unaligned.ll
@@ -15,7 +15,7 @@ target triple = "aie2p"
 define dso_local void @test_load_store_unaligned(<8 x i16> noundef %a, <4 x i32> noundef %b, <16 x i8> noundef %c, <16 x i16> noundef %d, <8 x i32> noundef %e, <4 x i64> inreg noundef %f, <8 x i64> inreg noundef %g, <16 x i32> noundef %h) #0 {
 ; CHECK-LABEL: test_load_store_unaligned:
 ; CHECK:       // %bb.0: // %entry
-; CHECK-NEXT:    mova m0, #-560; nopb ; nopx
+; CHECK-NEXT:    mova m0, #-560; nopb ; nops ; nopxm ; nopv
 ; CHECK-NEXT:    paddxm [sp], #576
 ; CHECK-NEXT:    mov p0, sp
 ; CHECK-NEXT:    mov p2, sp
@@ -69,119 +69,119 @@ define dso_local void @test_load_store_unaligned(<8 x i16> noundef %a, <4 x i32>
 ; CHECK-NEXT:    mov r24, p0
 ; CHECK-NEXT:    mov p0, r17
 ; CHECK-NEXT:    st.s16 r0, [p0, #0]
-; CHECK-NEXT:    nop
-; CHECK-NEXT:    nop
-; CHECK-NEXT:    nop
-; CHECK-NEXT:    vextract.32 r0, x0, #0, vaddsign1
+; CHECK-NEXT:    vmov q1, wl0
+; CHECK-NEXT:    vmov q2, wl2
+; CHECK-NEXT:    vmov wl2, q1
+; CHECK-NEXT:    vextract.16 r0, x2, #0, vaddsign1
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    st.s16 r1, [p0, #2]
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
-; CHECK-NEXT:    vextract.32 r1, x0, #1, vaddsign1
+; CHECK-NEXT:    vextract.16 r1, x2, #1, vaddsign1
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    st.s16 r2, [p0, #4]
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
-; CHECK-NEXT:    vextract.32 r2, x0, #2, vaddsign1
+; CHECK-NEXT:    vextract.16 r2, x2, #2, vaddsign1
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    st.s16 r3, [p0, #6]
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
-; CHECK-NEXT:    vextract.32 r3, x0, #3, vaddsign1
+; CHECK-NEXT:    vextract.16 r3, x2, #3, vaddsign1
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    st.s16 r4, [p0, #8]
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
-; CHECK-NEXT:    vextract.32 r4, x0, #4, vaddsign1
+; CHECK-NEXT:    vextract.16 r4, x2, #4, vaddsign1
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    st.s16 r5, [p0, #10]
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
-; CHECK-NEXT:    vextract.32 r5, x0, #5, vaddsign1
+; CHECK-NEXT:    vextract.16 r5, x2, #5, vaddsign1
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    st.s16 r6, [p0, #12]
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
-; CHECK-NEXT:    vextract.32 r6, x0, #6, vaddsign1
+; CHECK-NEXT:    vextract.16 r6, x2, #6, vaddsign1
 ; CHECK-NEXT:    nop
-; CHECK-NEXT:    vmov q0, wl2
+; CHECK-NEXT:    vextract.16 r7, x2, #7, vaddsign1
 ; CHECK-NEXT:    st.s16 r7, [p0, #14]
-; CHECK-NEXT:    vextract.32 r7, x0, #7, vaddsign1
-; CHECK-NEXT:    vmov wl0, q0
+; CHECK-NEXT:    vmov wl2, q2
 ; CHECK-NEXT:    mov r29, p0
-; CHECK-NEXT:    vextract.32 r0, x0, #0, vaddsign1
-; CHECK-NEXT:    vextract.32 r1, x0, #1, vaddsign1
+; CHECK-NEXT:    vextract.32 r0, x2, #0, vaddsign1
+; CHECK-NEXT:    vextract.32 r1, x2, #1, vaddsign1
 ; CHECK-NEXT:    mov p0, r16
-; CHECK-NEXT:    st r1, [p0, #4]
+; CHECK-NEXT:    vextract.32 r2, x2, #2, vaddsign1
 ; CHECK-NEXT:    st r0, [p0, #0]
-; CHECK-NEXT:    st.s8 r0, [p2, #0]
-; CHECK-NEXT:    nop
-; CHECK-NEXT:    nop
-; CHECK-NEXT:    nop
-; CHECK-NEXT:    vextract.16 r0, x4, #0, vaddsign1
-; CHECK-NEXT:    vextract.32 r2, x0, #2, vaddsign1
-; CHECK-NEXT:    nop
+; CHECK-NEXT:    st r1, [p0, #4]
 ; CHECK-NEXT:    st r2, [p0, #8]
+; CHECK-NEXT:    st.s8 r0, [p2, #0]
+; CHECK-NEXT:    vmov q0, wl4
+; CHECK-NEXT:    vextract.32 r3, x2, #3, vaddsign1
+; CHECK-NEXT:    vmov wl2, q0
+; CHECK-NEXT:    vextract.8 r0, x2, #0, vaddsign1
+; CHECK-NEXT:    nop
+; CHECK-NEXT:    nop
+; CHECK-NEXT:    st r3, [p0, #12]
 ; CHECK-NEXT:    st.s8 r1, [p2, #1]
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
-; CHECK-NEXT:    vextract.16 r1, x4, #1, vaddsign1
-; CHECK-NEXT:    vextract.32 r3, x0, #3, vaddsign1
+; CHECK-NEXT:    vextract.8 r1, x2, #1, vaddsign1
 ; CHECK-NEXT:    nop
-; CHECK-NEXT:    st r3, [p0, #12]
+; CHECK-NEXT:    nop
 ; CHECK-NEXT:    st.s8 r2, [p2, #2]
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
-; CHECK-NEXT:    vextract.16 r2, x4, #2, vaddsign1
+; CHECK-NEXT:    vextract.8 r2, x2, #2, vaddsign1
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    st.s8 r3, [p2, #3]
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
-; CHECK-NEXT:    vextract.16 r3, x4, #3, vaddsign1
+; CHECK-NEXT:    vextract.8 r3, x2, #3, vaddsign1
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    st.s8 r4, [p2, #4]
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
-; CHECK-NEXT:    vextract.16 r4, x4, #4, vaddsign1
+; CHECK-NEXT:    vextract.8 r4, x2, #4, vaddsign1
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    st.s8 r5, [p2, #5]
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
-; CHECK-NEXT:    vextract.16 r5, x4, #5, vaddsign1
+; CHECK-NEXT:    vextract.8 r5, x2, #5, vaddsign1
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    st.s8 r6, [p2, #6]
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
-; CHECK-NEXT:    vextract.16 r6, x4, #6, vaddsign1
+; CHECK-NEXT:    vextract.8 r6, x2, #6, vaddsign1
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    st.s8 r7, [p2, #7]
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
-; CHECK-NEXT:    vextract.16 r7, x4, #7, vaddsign1
+; CHECK-NEXT:    vextract.8 r7, x2, #7, vaddsign1
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    mova dj0, #8
 ; CHECK-NEXT:    st r8, [sp, #-564] // 4-byte Folded Spill
@@ -189,56 +189,56 @@ define dso_local void @test_load_store_unaligned(<8 x i16> noundef %a, <4 x i32>
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
-; CHECK-NEXT:    vextract.16 r16, x4, #8, vaddsign1
+; CHECK-NEXT:    vextract.8 r16, x2, #8, vaddsign1
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    mova dj0, #9
 ; CHECK-NEXT:    st.s8 r17, [p2, dj0]
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
-; CHECK-NEXT:    vextract.16 r17, x4, #9, vaddsign1
+; CHECK-NEXT:    vextract.8 r17, x2, #9, vaddsign1
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    mova dj2, #10
 ; CHECK-NEXT:    st.s8 r18, [p2, dj2]
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
-; CHECK-NEXT:    vextract.16 r18, x4, #10, vaddsign1
+; CHECK-NEXT:    vextract.8 r18, x2, #10, vaddsign1
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    mova dj0, #11
 ; CHECK-NEXT:    st.s8 r19, [p2, dj0]
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
-; CHECK-NEXT:    vextract.16 r19, x4, #11, vaddsign1
+; CHECK-NEXT:    vextract.8 r19, x2, #11, vaddsign1
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    mova dj1, #12
 ; CHECK-NEXT:    st.s8 r20, [p2, dj1]
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
-; CHECK-NEXT:    vextract.16 r20, x4, #12, vaddsign1
+; CHECK-NEXT:    vextract.8 r20, x2, #12, vaddsign1
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    mova dj0, #13
 ; CHECK-NEXT:    st.s8 r21, [p2, dj0]
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
-; CHECK-NEXT:    vextract.16 r21, x4, #13, vaddsign1
+; CHECK-NEXT:    vextract.8 r21, x2, #13, vaddsign1
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    mova dj3, #14
 ; CHECK-NEXT:    st.s8 r22, [p2, dj3]
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
-; CHECK-NEXT:    vextract.16 r22, x4, #14, vaddsign1
+; CHECK-NEXT:    vextract.8 r22, x2, #14, vaddsign1
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    mova dj0, #15
 ; CHECK-NEXT:    st.s8 r23, [p2, dj0]
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
-; CHECK-NEXT:    vextract.16 r23, x4, #15, vaddsign1
+; CHECK-NEXT:    vextract.8 r23, x2, #15, vaddsign1
 ; CHECK-NEXT:    mov p3, sp
 ; CHECK-NEXT:    padda [p3], #-512
 ; CHECK-NEXT:    st.s16 r0, [p3, #0]
@@ -307,7 +307,7 @@ define dso_local void @test_load_store_unaligned(<8 x i16> noundef %a, <4 x i32>
 ; CHECK-NEXT:    mova dj6, #40
 ; CHECK-NEXT:    mova dj0, #18
 ; CHECK-NEXT:    st.s16 r17, [p3, dj0]
-; CHECK-NEXT:    vmov x2, bmll0
+; CHECK-NEXT:    vmov x0, bmll0
 ; CHECK-NEXT:    mov p1, sp
 ; CHECK-NEXT:    vextract.16 r17, x6, #9, vaddsign1
 ; CHECK-NEXT:    vextract.32 r2, x8, #2, vaddsign1
@@ -316,16 +316,16 @@ define dso_local void @test_load_store_unaligned(<8 x i16> noundef %a, <4 x i32>
 ; CHECK-NEXT:    st r2, [p0, #8]
 ; CHECK-NEXT:    st r3, [p0, #12]
 ; CHECK-NEXT:    st.s16 r18, [p3, dj0]
-; CHECK-NEXT:    vmov bmll0, x2
+; CHECK-NEXT:    vmov bmll0, x0
 ; CHECK-NEXT:    padda [p1], #-448
-; CHECK-NEXT:    vmov x0, bmll0
+; CHECK-NEXT:    vmov x2, bmll0
 ; CHECK-NEXT:    vextract.16 r18, x6, #10, vaddsign1
-; CHECK-NEXT:    vextract.64 r1:r0, x0, #0, vaddsign1
+; CHECK-NEXT:    vextract.64 r1:r0, x2, #0, vaddsign1
 ; CHECK-NEXT:    mova dj0, #22
 ; CHECK-NEXT:    st r1, [p1, #4]
 ; CHECK-NEXT:    st.s16 r19, [p3, dj0]
 ; CHECK-NEXT:    mova dj7, #44
-; CHECK-NEXT:    vmov bmll0, x2
+; CHECK-NEXT:    mov r31, p0
 ; CHECK-NEXT:    vextract.16 r19, x6, #11, vaddsign1
 ; CHECK-NEXT:    vextract.32 r4, x8, #4, vaddsign1
 ; CHECK-NEXT:    vextract.32 r5, x8, #5, vaddsign1
@@ -333,11 +333,11 @@ define dso_local void @test_load_store_unaligned(<8 x i16> noundef %a, <4 x i32>
 ; CHECK-NEXT:    st r4, [p0, #16]
 ; CHECK-NEXT:    st r5, [p0, #20]
 ; CHECK-NEXT:    st.s16 r20, [p3, dj0]
-; CHECK-NEXT:    mov r31, p0
+; CHECK-NEXT:    vmov bmll0, x0
 ; CHECK-NEXT:    mova dj2, #60
 ; CHECK-NEXT:    vextract.16 r20, x6, #12, vaddsign1
-; CHECK-NEXT:    vmov x0, bmll0
-; CHECK-NEXT:    vextract.64 r3:r2, x0, #1, vaddsign1
+; CHECK-NEXT:    vmov x2, bmll0
+; CHECK-NEXT:    vextract.64 r3:r2, x2, #1, vaddsign1
 ; CHECK-NEXT:    mova dj0, #26
 ; CHECK-NEXT:    st r2, [p1, #8]
 ; CHECK-NEXT:    st r3, [p1, #12]
@@ -351,11 +351,11 @@ define dso_local void @test_load_store_unaligned(<8 x i16> noundef %a, <4 x i32>
 ; CHECK-NEXT:    st r6, [p0, #24]
 ; CHECK-NEXT:    st r7, [p0, #28]
 ; CHECK-NEXT:    st.s16 r22, [p3, dj0]
-; CHECK-NEXT:    vmov bmll0, x2
+; CHECK-NEXT:    vmov bmll0, x0
 ; CHECK-NEXT:    vextract.16 r22, x6, #14, vaddsign1
-; CHECK-NEXT:    vmov x0, bmll0
-; CHECK-NEXT:    vmov bmll0, x2
-; CHECK-NEXT:    vextract.64 r5:r4, x0, #2, vaddsign1
+; CHECK-NEXT:    vmov x2, bmll0
+; CHECK-NEXT:    vmov bmll0, x0
+; CHECK-NEXT:    vextract.64 r5:r4, x2, #2, vaddsign1
 ; CHECK-NEXT:    mova dj0, #30
 ; CHECK-NEXT:    st r4, [p1, #16]
 ; CHECK-NEXT:    st r5, [p1, #20]

--- a/llvm/test/CodeGen/AIE/extractelement.ll
+++ b/llvm/test/CodeGen/AIE/extractelement.ll
@@ -66,10 +66,10 @@ define signext i8 @extract_v16i8_signext(<16 x i8> %v) nounwind {
 ;
 ; AIE2P-LABEL: extract_v16i8_signext:
 ; AIE2P:       // %bb.0:
-; AIE2P-NEXT:    nopa ; nopb ; nops ; ret lr; nopm ; nopv
+; AIE2P-NEXT:    ret lr
 ; AIE2P-NEXT:    nop // Delay Slot 5
-; AIE2P-NEXT:    mova r0, #0 // Delay Slot 4
-; AIE2P-NEXT:    vshuffle x0, x0, x0, r0 // Delay Slot 3
+; AIE2P-NEXT:    nop // Delay Slot 4
+; AIE2P-NEXT:    nop // Delay Slot 3
 ; AIE2P-NEXT:    vextract.8 r0, x0, #0, vaddsign1 // Delay Slot 2
 ; AIE2P-NEXT:    nop // Delay Slot 1
   %1 = extractelement <16 x i8> %v, i32 0
@@ -88,10 +88,10 @@ define zeroext i8 @extract_v16i8_zeroext(<16 x i8> %v) nounwind {
 ;
 ; AIE2P-LABEL: extract_v16i8_zeroext:
 ; AIE2P:       // %bb.0:
-; AIE2P-NEXT:    nopa ; nopb ; nops ; ret lr; nopm ; nopv
+; AIE2P-NEXT:    ret lr
 ; AIE2P-NEXT:    nop // Delay Slot 5
-; AIE2P-NEXT:    mova r0, #0 // Delay Slot 4
-; AIE2P-NEXT:    vshuffle x0, x0, x0, r0 // Delay Slot 3
+; AIE2P-NEXT:    nop // Delay Slot 4
+; AIE2P-NEXT:    nop // Delay Slot 3
 ; AIE2P-NEXT:    vextract.8 r0, x0, #0, vaddsign0 // Delay Slot 2
 ; AIE2P-NEXT:    nop // Delay Slot 1
   %1 = extractelement <16 x i8> %v, i32 0
@@ -110,10 +110,10 @@ define zeroext i8 @extract_v16i8_dyn(<16 x i8> %v, i32 %idx) nounwind {
 ;
 ; AIE2P-LABEL: extract_v16i8_dyn:
 ; AIE2P:       // %bb.0:
-; AIE2P-NEXT:    nopa ; nopb ; nops ; ret lr; nopm ; nopv
+; AIE2P-NEXT:    ret lr
 ; AIE2P-NEXT:    nop // Delay Slot 5
-; AIE2P-NEXT:    mova r0, #0 // Delay Slot 4
-; AIE2P-NEXT:    vshuffle x0, x0, x0, r0 // Delay Slot 3
+; AIE2P-NEXT:    nop // Delay Slot 4
+; AIE2P-NEXT:    nop // Delay Slot 3
 ; AIE2P-NEXT:    vextract.8 r0, x0, r1, vaddsign0 // Delay Slot 2
 ; AIE2P-NEXT:    nop // Delay Slot 1
   %1 = extractelement <16 x i8> %v, i32 %idx
@@ -132,10 +132,10 @@ define signext i16 @extract_v8i16_signext(<8 x i16> %v) nounwind {
 ;
 ; AIE2P-LABEL: extract_v8i16_signext:
 ; AIE2P:       // %bb.0:
-; AIE2P-NEXT:    nopa ; nopb ; nops ; ret lr; nopm ; nopv
+; AIE2P-NEXT:    ret lr
 ; AIE2P-NEXT:    nop // Delay Slot 5
-; AIE2P-NEXT:    mova r0, #2 // Delay Slot 4
-; AIE2P-NEXT:    vshuffle x0, x0, x0, r0 // Delay Slot 3
+; AIE2P-NEXT:    nop // Delay Slot 4
+; AIE2P-NEXT:    nop // Delay Slot 3
 ; AIE2P-NEXT:    vextract.16 r0, x0, #0, vaddsign1 // Delay Slot 2
 ; AIE2P-NEXT:    nop // Delay Slot 1
   %1 = extractelement <8 x i16> %v, i32 0
@@ -154,10 +154,10 @@ define zeroext i16 @extract_v8i16_zeroext(<8 x i16> %v) nounwind {
 ;
 ; AIE2P-LABEL: extract_v8i16_zeroext:
 ; AIE2P:       // %bb.0:
-; AIE2P-NEXT:    nopa ; nopb ; nops ; ret lr; nopm ; nopv
+; AIE2P-NEXT:    ret lr
 ; AIE2P-NEXT:    nop // Delay Slot 5
-; AIE2P-NEXT:    mova r0, #2 // Delay Slot 4
-; AIE2P-NEXT:    vshuffle x0, x0, x0, r0 // Delay Slot 3
+; AIE2P-NEXT:    nop // Delay Slot 4
+; AIE2P-NEXT:    nop // Delay Slot 3
 ; AIE2P-NEXT:    vextract.16 r0, x0, #0, vaddsign0 // Delay Slot 2
 ; AIE2P-NEXT:    nop // Delay Slot 1
   %1 = extractelement <8 x i16> %v, i32 0
@@ -176,10 +176,10 @@ define signext i16 @extract_v8i16_dyn(<8 x i16> %v, i32 %idx) nounwind {
 ;
 ; AIE2P-LABEL: extract_v8i16_dyn:
 ; AIE2P:       // %bb.0:
-; AIE2P-NEXT:    nopa ; nopb ; nops ; ret lr; nopm ; nopv
+; AIE2P-NEXT:    ret lr
 ; AIE2P-NEXT:    nop // Delay Slot 5
-; AIE2P-NEXT:    mova r0, #2 // Delay Slot 4
-; AIE2P-NEXT:    vshuffle x0, x0, x0, r0 // Delay Slot 3
+; AIE2P-NEXT:    nop // Delay Slot 4
+; AIE2P-NEXT:    nop // Delay Slot 3
 ; AIE2P-NEXT:    vextract.16 r0, x0, r1, vaddsign1 // Delay Slot 2
 ; AIE2P-NEXT:    nop // Delay Slot 1
   %1 = extractelement <8 x i16> %v, i32 %idx


### PR DESCRIPTION
128-bit vector types should be passed in the LSB of the 256-bit 'w' registers, similar to AIE2. However, we were promoting the 128-bit vector type to a 256-bit vector type at the call site and truncating back in the callee.