### PR TITLE
[AIEX]Refactor extract 128-bit subvector legalizer.

### DIFF
--- a/llvm/lib/Target/AIE/AIELegalizerHelper.cpp
+++ b/llvm/lib/Target/AIE/AIELegalizerHelper.cpp
@@ -772,25 +772,44 @@ bool AIELegalizerHelper::legalizeG_EXTRACT_VECTOR_ELT(LegalizerHelper &Helper,
       // Step 3: Select the correct mode for vshuffle. In AIE2P, Mode 8 maps
       // first 128-bits of src1 vector to lsb positions of output. Mode 9 maps
       // the second 128-bits to lsb positions of output.
+      auto GetShuffleModes = [&]() {
+        if (ST.isAIE2P())
+          return std::make_pair(/*Lo*/ 8, /*Hi*/ 9);
+        llvm_unreachable("vshuffle mode value needed for target.");
+      };
+      const auto [ModeLoValue, ModeHiValue] = GetShuffleModes();
+
       const Register ModeReg = MRI.createGenericVirtualRegister(S32);
       auto IdxVal = getIConstantVRegValWithLookThrough(IdxReg, MRI);
+      MachineInstrBuilder ShuffleOrCopyInstr;
       if (!IdxVal) {
-        const Register Mode8Reg = MIRBuilder.buildConstant(S32, 8).getReg(0);
-        const Register Mode9Reg = MIRBuilder.buildConstant(S32, 9).getReg(0);
-        MIRBuilder.buildSelect(ModeReg, IdxReg, Mode9Reg, Mode8Reg);
+        const Register ModeLoReg =
+            MIRBuilder.buildConstant(S32, ModeLoValue).getReg(0);
+        const Register ModeHiReg =
+            MIRBuilder.buildConstant(S32, ModeHiValue).getReg(0);
+        MIRBuilder.buildSelect(ModeReg, IdxReg, ModeHiReg, ModeLoReg);
+        // step 4: Create vshuffle.
+        ShuffleOrCopyInstr =
+            MIRBuilder.buildInstr(II->getGenericShuffleVectorOpcode(), {V64S8},
+                                  {RegSrcPadded, RegUndef, ModeReg});
       } else {
         const unsigned LaneIdx = IdxVal->Value.getZExtValue();
-        MIRBuilder.buildConstant(ModeReg, LaneIdx ? 9 : 8);
+        MIRBuilder.buildConstant(ModeReg, ModeHiValue);
+        // step 4: Create vshuffle. For LaneIdx 0, we don't have to use the
+        // shuffle, padded register itself is enough.
+        if (LaneIdx) {
+          ShuffleOrCopyInstr =
+              MIRBuilder.buildInstr(II->getGenericShuffleVectorOpcode(),
+                                    {V64S8}, {RegSrcPadded, RegUndef, ModeReg});
+        } else {
+          ShuffleOrCopyInstr = MIRBuilder.buildCopy({V64S8}, {RegSrcPadded});
+        }
       }
-      // step 4: Create vshuffle
-      auto ShuffleInstr =
-          MIRBuilder.buildInstr(II->getGenericShuffleVectorOpcode(), {V64S8},
-                                {RegSrcPadded, RegUndef, ModeReg});
 
       const unsigned UnpadOpc = II->getGenericUnpadVectorOpcode();
       // Finally, unpad the 512-bit result to 128-bit
       auto UnpadInstr =
-          MIRBuilder.buildInstr(UnpadOpc, {V16S8}, {ShuffleInstr});
+          MIRBuilder.buildInstr(UnpadOpc, {V16S8}, {ShuffleOrCopyInstr});
       MIRBuilder.buildBitcast(DstReg, {UnpadInstr});
       break;
     }

--- a/llvm/test/CodeGen/AIE/aie2p/GlobalIsel/legalize-extract-vector-elt.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/GlobalIsel/legalize-extract-vector-elt.mir
@@ -578,10 +578,8 @@ body:             |
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<2 x s128>) = COPY $wl0
     ; CHECK-NEXT: [[BITCAST:%[0-9]+]]:_(<32 x s8>) = G_BITCAST [[COPY]](<2 x s128>)
     ; CHECK-NEXT: [[AIE_PAD_VECTOR_UNDEF:%[0-9]+]]:_(<64 x s8>) = G_AIE_PAD_VECTOR_UNDEF [[BITCAST]](<32 x s8>)
-    ; CHECK-NEXT: [[DEF:%[0-9]+]]:_(<64 x s8>) = G_IMPLICIT_DEF
-    ; CHECK-NEXT: [[C:%[0-9]+]]:_(s32) = G_CONSTANT i32 8
-    ; CHECK-NEXT: [[AIE_SHUFFLE_VECTOR:%[0-9]+]]:_(<64 x s8>) = G_AIE_SHUFFLE_VECTOR [[AIE_PAD_VECTOR_UNDEF]], [[DEF]], [[C]](s32)
-    ; CHECK-NEXT: [[AIE_UNPAD_VECTOR:%[0-9]+]]:_(<16 x s8>) = G_AIE_UNPAD_VECTOR [[AIE_SHUFFLE_VECTOR]](<64 x s8>)
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(<64 x s8>) = COPY [[AIE_PAD_VECTOR_UNDEF]](<64 x s8>)
+    ; CHECK-NEXT: [[AIE_UNPAD_VECTOR:%[0-9]+]]:_(<16 x s8>) = G_AIE_UNPAD_VECTOR [[COPY1]](<64 x s8>)
     ; CHECK-NEXT: [[BITCAST1:%[0-9]+]]:_(s128) = G_BITCAST [[AIE_UNPAD_VECTOR]](<16 x s8>)
     ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[BITCAST1]](s128)
     %2:_(<2 x s128>) = COPY $wl0


### PR DESCRIPTION
Since shuffle modes are different for different AIE targets, refactored the use in legalizer. Also, extract subvector 128-bit doesn`t need a vshuffle, if we want to extract from idx 0 and known at compile time.