### PR TITLE
[AIEX][NFC] Allow passing separate opcodes for loop setup start and end in ZOLSupport

### DIFF
--- a/llvm/lib/Target/AIE/AIE2InstrInfo.cpp
+++ b/llvm/lib/Target/AIE/AIE2InstrInfo.cpp
@@ -1446,7 +1446,8 @@ AIE2InstrInfo::getZOLSupport() const {
   Result.LoopStartOpcode = AIE2::LoopStart;
   Result.LoopEndOpcode = AIE2::PseudoLoopEnd;
   Result.SetLoopCountOpcode = AIE2::ADD_NC;
-  Result.SetAddressOpcode = AIE2::MOVXM_lng_cg;
+  Result.SetLoopStartOpcode = AIE2::MOVXM_lng_cg;
+  Result.SetLoopEndOpcode = AIE2::MOVXM_lng_cg;
   // We need at 112 bytes distance from the loop setup to the loop end label,
   // which requires 7 bundles of 16 bytes.
   Result.LoopSetupDistance = 7;

--- a/llvm/lib/Target/AIE/AIEBaseHardwareLoops.cpp
+++ b/llvm/lib/Target/AIE/AIEBaseHardwareLoops.cpp
@@ -413,18 +413,17 @@ void AIEBaseHardwareLoops::expandLoopStart(LowOverheadLoop &LoLoop) {
           TII->get(LoweringData->SetLoopCountOpcode), LoweringData->LCRegister)
       .addReg(Start->getOperand(0).getReg())
       .addImm(Start->getOperand(1).getImm());
+  auto LoopStart = BuildMI(*MBB, Start, Start->getDebugLoc(),
+                           TII->get(LoweringData->SetLoopStartOpcode));
+  if (LoweringData->LSRegister)
+    LoopStart.addDef(*LoweringData->LSRegister);
+  LoopStart.addMBB(LoLoop.LoopEnd->getOperand(1).getMBB());
 
-  BuildMI(*MBB, Start, Start->getDebugLoc(),
-          TII->get(LoweringData->SetAddressOpcode), LoweringData->LSRegister)
-      .addMBB(LoLoop.LoopEnd->getOperand(1).getMBB());
-  MachineInstrBuilder MIB;
-  MIB = BuildMI(*MBB, Start, Start->getDebugLoc(),
-                TII->get(LoweringData->SetAddressOpcode),
-                LoweringData->LERegister)
-            .addSym(LoLoop.LoopEnd->getOperand(0).getMCSymbol());
-  MachineInstr *MI = MIB.getInstr();
-  MI->getOperand(1).ChangeToMCSymbol(
-      LoLoop.LoopEnd->getOperand(0).getMCSymbol());
+  auto LoopEnd = BuildMI(*MBB, Start, Start->getDebugLoc(),
+                         TII->get(LoweringData->SetLoopEndOpcode));
+  if (LoweringData->LERegister)
+    LoopEnd.addDef(*LoweringData->LERegister);
+  LoopEnd.addSym(LoLoop.LoopEnd->getOperand(0).getMCSymbol());
 
   LoLoop.remove(LoLoop.Start);
 }

--- a/llvm/lib/Target/AIE/AIEBaseInstrInfo.cpp
+++ b/llvm/lib/Target/AIE/AIEBaseInstrInfo.cpp
@@ -361,9 +361,14 @@ bool AIEBaseInstrInfo::isZeroOverheadLoopSetupInstr(
   }
 
   return isZOLTripCountDef(MI) ||
-         (MI.getOpcode() == ZOLSupport->SetAddressOpcode &&
-          (MI.getOperand(0).getReg() == ZOLSupport->LSRegister ||
-           MI.getOperand(0).getReg() == ZOLSupport->LERegister));
+         ((MI.getOpcode() == ZOLSupport->SetLoopStartOpcode ||
+           MI.getOpcode() == ZOLSupport->SetLoopEndOpcode) &&
+          ((!ZOLSupport->LSRegister.has_value() &&
+            !ZOLSupport->LERegister.has_value()) ||
+           (ZOLSupport->LSRegister.has_value() &&
+            MI.getOperand(0).getReg() == *ZOLSupport->LSRegister) ||
+           (ZOLSupport->LERegister.has_value() &&
+            MI.getOperand(0).getReg() == *ZOLSupport->LERegister)));
 }
 
 void AIEBaseInstrInfo::adjustTripCount(MachineInstr &MI, int Adjustment) const {

--- a/llvm/lib/Target/AIE/AIEBaseInstrInfo.h
+++ b/llvm/lib/Target/AIE/AIEBaseInstrInfo.h
@@ -52,10 +52,11 @@ struct AIEBaseInstrInfo : public TargetInstrInfo {
     unsigned SetLoopCountOpcode;
     Register LCRegister;
 
-    // SetAddress takes an address and writes it to a loop register
-    unsigned SetAddressOpcode;
-    Register LSRegister;
-    Register LERegister;
+    // SetLoop{Start,End} takes an address and writes it to a loop register
+    unsigned SetLoopStartOpcode;
+    unsigned SetLoopEndOpcode;
+    std::optional<Register> LSRegister;
+    std::optional<Register> LERegister;
     // The distance between setup and the start of the loop, in units
     // of bundles.
     unsigned LoopSetupDistance;

--- a/llvm/lib/Target/AIE/aie2p/AIE2PInstrInfo.cpp
+++ b/llvm/lib/Target/AIE/aie2p/AIE2PInstrInfo.cpp
@@ -1781,7 +1781,8 @@ AIE2PInstrInfo::getZOLSupport() const {
   Result.LoopStartOpcode = AIE2P::LoopStart;
   Result.LoopEndOpcode = AIE2P::PseudoLoopEnd;
   Result.SetLoopCountOpcode = AIE2P::ADD_NC_mv_add_ri;
-  Result.SetAddressOpcode = AIE2P::MOVXM;
+  Result.SetLoopStartOpcode = AIE2P::MOVXM;
+  Result.SetLoopEndOpcode = AIE2P::MOVXM;
   // We need at 112 bytes distance from the loop setup to the loop end label,
   // which requires 7 bundles of 16 bytes.
   Result.LoopSetupDistance = 7;


### PR DESCRIPTION
Also make adding the physical register def operand to the instruction optional.