### PR TITLE
[AIEX] Add support for unsigned stepped immediates

### DIFF
--- a/llvm/lib/Target/AIE/AIEBaseInstrInfo.td
+++ b/llvm/lib/Target/AIE/AIEBaseInstrInfo.td
@@ -52,8 +52,10 @@ class immx1_negative <int n, ValueType vt> : Operand<vt>, ImmLeaf<vt, [{return i
 class immxstep <int n, int step, int fixedEncodedBits, ValueType vt = i32>
     : Operand<vt>, ImmLeaf<vt, [{return isInt<}] # n # [{+}] # fixedEncodedBits # [{>(Imm) && (Imm % }] # step # [{) == 0;}]> {
   bits<1> isNegative = false;
-  let DecoderMethod = "decodeSImmOperandXStep<" # n # ", "#step#", "# isNegative #">";
-  let EncoderMethod = "getSImmOpValueXStep<" # n # ", "#step#", /*offset=*/0, "# isNegative #">";
+  // Note: If isNegative is true, isUnsigned is ignored
+  bits<1> isUnsigned = false;
+  let DecoderMethod = "decodeSImmOperandXStep<" # n # ", "#step#", "# isNegative #", "# isUnsigned #">";
+  let EncoderMethod = "getSImmOpValueXStep<" # n # ", "#step#", /*offset=*/0, "# isNegative #", "# isUnsigned #">";
 }
 
 // A signed immediate with n+1 bits and the low-order 1 bits as 0.
@@ -130,6 +132,13 @@ class immx128 <int n, ValueType vt = i32> : immxstep<n, 128 /**step**/, 7 /**low
 class immx128_negative <int n> : immxstep<n, 128 /*step*/, 8 /**1 sign-bit + 7 lower-order bits as 0**/>
 {
   let isNegative = true;
+}
+
+// An unsigned immediate with n+7 bits and the low-order 7 bits as 0
+// This results in an n-bit encoded number
+class immx128_unsigned <int n, ValueType vt = i32> : immxstep<n, 128 /*step*/, 7 /**7 lower-order bits as 0**/, vt>
+{
+  let isUnsigned = true;
 }
 
 // A signed immediate which fits in n bits after being negated.

--- a/llvm/lib/Target/AIE/Disassembler/AIEBaseDisassembler.h
+++ b/llvm/lib/Target/AIE/Disassembler/AIEBaseDisassembler.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// (c) Copyright 2023-2024 Advanced Micro Devices, Inc. or its affiliates
+// (c) Copyright 2023-2025 Advanced Micro Devices, Inc. or its affiliates
 //
 //===----------------------------------------------------------------------===//
 //
@@ -77,23 +77,27 @@ static DecodeStatus decodeSImmOperandX1(MCInst &Inst, uint64_t Imm,
   return MCDisassembler::Success;
 }
 
-template <unsigned N, unsigned step, bool isNegative>
+template <unsigned N, unsigned step, bool isNegative, bool isUnsigned>
 static DecodeStatus decodeSImmOperandXStep(MCInst &Inst, uint64_t Imm,
                                            int64_t Address,
                                            const MCDisassembler *Decoder) {
   assert(isUInt<N>(Imm) && "Invalid immediate");
-  const unsigned fixedZeroBits = CTLog2<step>();
+  const unsigned FixedZeroBits = CTLog2<step>();
   if (isNegative)
     // Decode and sign extend a negative number encoded as fixed 1
     // <encoded_length bits> fixedZeroBits
     Inst.addOperand(MCOperand::createImm(
-        SignExtend64((Imm << fixedZeroBits) | 1 << (N + fixedZeroBits),
-                     N + 1 + fixedZeroBits)));
+        SignExtend64((Imm << FixedZeroBits) | 1 << (N + FixedZeroBits),
+                     N + 1 + FixedZeroBits)));
+  else if (isUnsigned)
+    // Decode an unsigned N+fixedZeroBits bit number encoded in N bits,
+    // with the LSBs as zero.
+    Inst.addOperand(MCOperand::createImm(Imm << FixedZeroBits));
   else
     // Decode and sign extend an N+fixedZeroBits bit number encoded in N bits,
     // with the LSBs as zero.
     Inst.addOperand(MCOperand::createImm(
-        SignExtend64(Imm << fixedZeroBits, N + fixedZeroBits)));
+        SignExtend64(Imm << FixedZeroBits, N + FixedZeroBits)));
   return MCDisassembler::Success;
 }
 } // namespace

--- a/llvm/lib/Target/AIE/MCTargetDesc/AIEBaseMCCodeEmitter.h
+++ b/llvm/lib/Target/AIE/MCTargetDesc/AIEBaseMCCodeEmitter.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// (c) Copyright 2023-2024 Advanced Micro Devices, Inc. or its affiliates
+// (c) Copyright 2023-2025 Advanced Micro Devices, Inc. or its affiliates
 //
 //===----------------------------------------------------------------------===//
 //
@@ -115,23 +115,33 @@ namespace {
 /// \param Fixups The fixups for the instruction
 /// \param STI The subtarget
 
-template <int N, unsigned step, int offset, bool isNegative>
+template <int N, unsigned step, int offset, bool isNegative, bool isUnsigned>
 void getSImmOpValueXStep(const MCInst &MI, unsigned OpNo, APInt &Op,
                          SmallVectorImpl<MCFixup> &Fixups,
                          const MCSubtargetInfo &STI) {
   const MCOperand &MO = MI.getOperand(OpNo);
-  const unsigned fixedZeroBits = CTLog2<step>();
+  const unsigned FixedZeroBits = CTLog2<step>();
 
   if (MO.isImm()) {
     constexpr int hexValue = step - 1;
     int64_t Imm = MO.getImm();
-    int64_t Min = isNegative ? minIntN(N + fixedZeroBits + 1)
-                             : minIntN(N + fixedZeroBits);
-    int64_t Max = isNegative ? -step : maxIntN(N + fixedZeroBits);
+    int64_t Min, Max;
+    if (isNegative) {
+      Min = minIntN(N + FixedZeroBits + 1);
+      // Note: step is unsigned; cast to signed before negating to avoid
+      // unsigned wraparound.
+      Max = -static_cast<int64_t>(step);
+    } else if (isUnsigned) {
+      Min = 0;
+      Max = maxUIntN(N + FixedZeroBits);
+    } else {
+      Min = minIntN(N + FixedZeroBits);
+      Max = maxIntN(N + FixedZeroBits);
+    }
     assert((Imm & hexValue) == 0 && "Value must be divisible by step!");
     assert(Imm >= Min && Imm <= Max &&
            "can not represent value in the given immediate type range!");
-    Imm >>= fixedZeroBits;
+    Imm >>= FixedZeroBits;
     Op = Imm;
   } else
     llvm_unreachable("Unhandled expression!");


### PR DESCRIPTION
Add support for unsigned stepped immediates in the encoding and decoding
infrastructure. This introduces:
- immx128_unsigned class for unsigned immediate operands
- isUnsigned flag for immxstep operands
- Updated encoder and decoder methods to handle unsigned immediates