### PR TITLE
[AIE2P] Enable encoding tests run lines

### DIFF
--- a/llvm/test/CodeGen/AIE/aie2p/BinaryOutput/event.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/BinaryOutput/event.mir
@@ -3,11 +3,11 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2024-2025 Advanced Micro Devices, Inc. or its affiliates
 #
 # RUN: llc %llcflags --filetype=obj -o %t
 # RUN: llvm-objdump --triple=aie2p -dr --no-print-imm-hex %t | FileCheck %s
-# TODO: llc %llcflags --filetype=asm -o %t2
+# RUN: llc %llcflags --filetype=asm -o %t2
 # TODO: llvm-mc -triple aie2p -filetype=obj -o %t %t2
 # TODO: llvm-objdump --triple=aie2p -dr --no-print-imm-hex %t | FileCheck %s
 #

--- a/llvm/test/CodeGen/AIE/aie2p/BinaryOutput/inv.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/BinaryOutput/inv.mir
@@ -3,11 +3,11 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2024-2025 Advanced Micro Devices, Inc. or its affiliates
 #
 # RUN: llc %llcflags --filetype=obj -o %t
 # RUN: llvm-objdump --triple=aie2p -dr --no-print-imm-hex %t | FileCheck %s
-# TODO: llc %llcflags --filetype=asm -o %t2
+# RUN: llc %llcflags --filetype=asm -o %t2
 # TODO: llvm-mc -triple aie2p -filetype=obj -o %t %t2
 # TODO: llvm-objdump --triple=aie2p -dr --no-print-imm-hex %t | FileCheck %s
 # Change TODOs to RUN once there is AsmParser support

--- a/llvm/test/CodeGen/AIE/aie2p/BinaryOutput/invsqrt.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/BinaryOutput/invsqrt.mir
@@ -3,11 +3,11 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2024-2025 Advanced Micro Devices, Inc. or its affiliates
 #
 # RUN: llc %llcflags --filetype=obj -o %t
 # RUN: llvm-objdump --triple=aie2p -dr --no-print-imm-hex %t | FileCheck %s
-# TODO: llc %llcflags --filetype=asm -o %t2
+# RUN: llc %llcflags --filetype=asm -o %t2
 # TODO: llvm-mc -triple aie2p -filetype=obj -o %t %t2
 # TODO: llvm-objdump --triple=aie2p -dr --no-print-imm-hex %t | FileCheck %s
 # Change TODOs to RUN once there is AsmParser support

--- a/llvm/test/CodeGen/AIE/aie2p/BinaryOutput/mov.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/BinaryOutput/mov.mir
@@ -3,11 +3,11 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2024-2025 Advanced Micro Devices, Inc. or its affiliates
 #
 # RUN: llc %llcflags --filetype=obj -o %t
 # RUN: llvm-objdump --triple=aie2p -dr --no-print-imm-hex %t | FileCheck %s
-# TODO: llc %llcflags --filetype=asm -o %t2
+# RUN: llc %llcflags --filetype=asm -o %t2
 # TODO: llvm-mc -triple aie2p -filetype=obj -o %t %t2
 # TODO: llvm-objdump --triple=aie2p -dr --no-print-imm-hex %t | FileCheck %s
 # Change TODOs to RUN once there is AsmParser support

--- a/llvm/test/CodeGen/AIE/aie2p/BinaryOutput/sqrt.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/BinaryOutput/sqrt.mir
@@ -3,11 +3,11 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2024-2025 Advanced Micro Devices, Inc. or its affiliates
 #
 # RUN: llc %llcflags --filetype=obj -o %t
 # RUN: llvm-objdump --triple=aie2p -dr --no-print-imm-hex %t | FileCheck %s
-# TODO: llc %llcflags --filetype=asm -o %t2
+# RUN: llc %llcflags --filetype=asm -o %t2
 # TODO: llvm-mc -triple aie2p -filetype=obj -o %t %t2
 # TODO: llvm-objdump --triple=aie2p -dr --no-print-imm-hex %t | FileCheck %s
 # Change TODOs to RUN once there is AsmParser support

--- a/llvm/test/CodeGen/AIE/aie2p/BinaryOutput/vadd.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/BinaryOutput/vadd.mir
@@ -3,11 +3,11 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2024-2025 Advanced Micro Devices, Inc. or its affiliates
 #
 # RUN: llc %llcflags --filetype=obj -o %t
 # RUN: llvm-objdump --triple=aie2p -dr --no-print-imm-hex %t | FileCheck %s
-# TODO: llc %llcflags --filetype=asm -o %t2
+# RUN: llc %llcflags --filetype=asm -o %t2
 # TODO: llvm-mc -triple aie2p -filetype=obj -o %t %t2
 # TODO: llvm-objdump --triple=aie2p -dr --no-print-imm-hex %t | FileCheck %s
 # Change TODOs to RUN once there is AsmParser support

--- a/llvm/test/CodeGen/AIE/aie2p/BinaryOutput/vaddmac.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/BinaryOutput/vaddmac.mir
@@ -3,11 +3,11 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2024-2025 Advanced Micro Devices, Inc. or its affiliates
 #
 # RUN: llc %llcflags --filetype=obj -o %t
 # RUN: llvm-objdump --triple=aie2p -dr --no-print-imm-hex %t | FileCheck %s
-# TODO: llc %llcflags --filetype=asm -o %t2
+# RUN: llc %llcflags --filetype=asm -o %t2
 # TODO: llvm-mc -triple aie2p -filetype=obj -o %t %t2
 # TODO: llvm-objdump --triple=aie2p -dr --no-print-imm-hex %t | FileCheck %s
 # Change TODOs to RUN once there is AsmParser support

--- a/llvm/test/CodeGen/AIE/aie2p/BinaryOutput/vaddmsc.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/BinaryOutput/vaddmsc.mir
@@ -3,11 +3,11 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2024-2025 Advanced Micro Devices, Inc. or its affiliates
 #
 # RUN: llc %llcflags --filetype=obj -o %t
 # RUN: llvm-objdump --triple=aie2p -dr --no-print-imm-hex %t | FileCheck %s
-# TODO: llc %llcflags --filetype=asm -o %t2
+# RUN: llc %llcflags --filetype=asm -o %t2
 # TODO: llvm-mc -triple aie2p -filetype=obj -o %t %t2
 # TODO: llvm-objdump --triple=aie2p -dr --no-print-imm-hex %t | FileCheck %s
 # Change TODOs to RUN once there is AsmParser support

--- a/llvm/test/CodeGen/AIE/aie2p/BinaryOutput/vfloor.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/BinaryOutput/vfloor.mir
@@ -3,11 +3,11 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2024-2025 Advanced Micro Devices, Inc. or its affiliates
 #
 # RUN: llc %llcflags --filetype=obj -o %t
 # RUN: llvm-objdump --triple=aie2p -dr --no-print-imm-hex %t | FileCheck %s
-# TODO: llc %llcflags --filetype=asm -o %t2
+# RUN: llc %llcflags --filetype=asm -o %t2
 # TODO: llvm-mc -triple aie2p -filetype=obj -o %t %t2
 # TODO: llvm-objdump --triple=aie2p -dr --no-print-imm-hex %t | FileCheck %s
 # Change TODOs to RUN once there is AsmParser support

--- a/llvm/test/CodeGen/AIE/aie2p/BinaryOutput/vinsert.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/BinaryOutput/vinsert.mir
@@ -3,11 +3,11 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2024-2025 Advanced Micro Devices, Inc. or its affiliates
 #
 # RUN: llc %llcflags --filetype=obj -o %t
 # RUN: llvm-objdump --triple=aie2p -dr --no-print-imm-hex %t | FileCheck %s
-# TODO: llc %llcflags --filetype=asm -o %t2
+# RUN: llc %llcflags --filetype=asm -o %t2
 # TODO: llvm-mc -triple aie2p -filetype=obj -o %t %t2
 # TODO: llvm-objdump --triple=aie2p -dr --no-print-imm-hex %t | FileCheck %s
 # Change TODOs to RUN once there is AsmParser support

--- a/llvm/test/CodeGen/AIE/aie2p/BinaryOutput/vmov.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/BinaryOutput/vmov.mir
@@ -3,11 +3,11 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2024-2025 Advanced Micro Devices, Inc. or its affiliates
 #
 # RUN: llc %llcflags --filetype=obj -o %t
 # RUN: llvm-objdump --triple=aie2p -dr --no-print-imm-hex %t | FileCheck %s
-# TODO: llc %llcflags --filetype=asm -o %t2
+# RUN: llc %llcflags --filetype=asm -o %t2
 # TODO: llvm-mc -triple aie2p -filetype=obj -o %t %t2
 # TODO: llvm-objdump --triple=aie2p -dr --no-print-imm-hex %t | FileCheck %s
 # Change TODOs to RUN once there is AsmParser support

--- a/llvm/test/CodeGen/AIE/aie2p/BinaryOutput/vst.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/BinaryOutput/vst.mir
@@ -3,13 +3,13 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2024-2025 Advanced Micro Devices, Inc. or its affiliates
 #
 # RUN: llc %llcflags --filetype=obj -o %t
 # RUN: llvm-objdump --triple=aie2p -dr --no-print-imm-hex %t | FileCheck %s
-# TODO: llc %llcflags --filetype=asm -o %t2
-# TODO: llvm-mc -triple aie2p -filetype=obj -o %t %t2
-# TODO: llvm-objdump --triple=aie2p -dr --no-print-imm-hex %t | FileCheck %s
+# RUN: llc %llcflags --filetype=asm -o %t2
+# RUN: llvm-mc -triple aie2p -filetype=obj -o %t %t2
+# RUN: llvm-objdump --triple=aie2p -dr --no-print-imm-hex %t | FileCheck %s
 # Change TODOs to RUN once there is AsmParser support
 #
 # Test file automatically generated using generate_instr_info_test.py

--- a/llvm/test/CodeGen/AIE/aie2p/BinaryOutput/vsub.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/BinaryOutput/vsub.mir
@@ -3,11 +3,11 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2024-2025 Advanced Micro Devices, Inc. or its affiliates
 #
 # RUN: llc %llcflags --filetype=obj -o %t
 # RUN: llvm-objdump --triple=aie2p -dr --no-print-imm-hex %t | FileCheck %s
-# TODO: llc %llcflags --filetype=asm -o %t2
+# RUN: llc %llcflags --filetype=asm -o %t2
 # TODO: llvm-mc -triple aie2p -filetype=obj -o %t %t2
 # TODO: llvm-objdump --triple=aie2p -dr --no-print-imm-hex %t | FileCheck %s
 #


### PR DESCRIPTION
We had some run lines disabled in the encoding tests in AIE2P that are actually already passing. This PR simply activates them.