### PR TITLE
[AIE2][AIE2P] Emit COPY in spilling through GPRs

### DIFF
--- a/llvm/lib/Target/AIE/AIE2InstrInfo.cpp
+++ b/llvm/lib/Target/AIE/AIE2InstrInfo.cpp
@@ -708,7 +708,7 @@ void AIE2InstrInfo::storeRegToStackSlot(MachineBasicBlock &MBB,
     // Can't spill these directly.  Need to bounce through a GPR.
     MachineRegisterInfo &MRI = MBB.getParent()->getRegInfo();
     Register ScratchReg = MRI.createVirtualRegister(&AIE2::eRRegClass);
-    BuildMI(MBB, I, DL, get(AIE2::MOV_mv_scl), ScratchReg)
+    BuildMI(MBB, I, DL, get(TargetOpcode::COPY), ScratchReg)
         .addReg(SrcReg, getKillRegState(IsKill));
     Opcode = AIE2::ST_dms_spill;
     SrcReg = ScratchReg;
@@ -786,7 +786,7 @@ void AIE2InstrInfo::loadRegFromStackSlot(
     BuildMI(MBB, I, DL, get(AIE2::LDA_dms_spill), Reg)
         .addFrameIndex(FI)
         .addMemOperand(CreateMMO(FI));
-    BuildMI(MBB, I, DL, get(AIE2::MOV_mv_scl), DstReg)
+    BuildMI(MBB, I, DL, get(TargetOpcode::COPY), DstReg)
         .addReg(Reg, getKillRegState(true));
     return;
   } else {

--- a/llvm/lib/Target/AIE/aie2p/AIE2PInstrInfo.cpp
+++ b/llvm/lib/Target/AIE/aie2p/AIE2PInstrInfo.cpp
@@ -980,7 +980,7 @@ void AIE2PInstrInfo::storeRegToStackSlot(MachineBasicBlock &MBB,
     // Can't spill these directly.  Need to bounce through a GPR.
     MachineRegisterInfo &MRI = MBB.getParent()->getRegInfo();
     Register ScratchReg = MRI.createVirtualRegister(&AIE2P::eRRegClass);
-    BuildMI(MBB, I, DL, get(AIE2P::MOV_alu_mv_mv_mv_scl), ScratchReg)
+    BuildMI(MBB, I, DL, get(TargetOpcode::COPY), ScratchReg)
         .addReg(SrcReg, getKillRegState(IsKill));
     Opcode = AIE2P::ST_R_SPILL;
     SrcReg = ScratchReg;
@@ -1065,7 +1065,7 @@ void AIE2PInstrInfo::loadRegFromStackSlot(
     BuildMI(MBB, I, DL, get(AIE2P::LDA_R_SPILL), Reg)
         .addFrameIndex(FI)
         .addMemOperand(CreateMMO(FI));
-    BuildMI(MBB, I, DL, get(AIE2P::MOV_alu_mv_mv_mv_scl), DstReg)
+    BuildMI(MBB, I, DL, get(TargetOpcode::COPY), DstReg)
         .addReg(Reg, getKillRegState(true));
     return;
   } else if (regClassMatches(AIE2P::spill_vec512_to_compositeRegClass, RC,

--- a/llvm/test/CodeGen/AIE/aie2/spill/spill-sreg-high-gpr-pressure.mir
+++ b/llvm/test/CodeGen/AIE/aie2/spill/spill-sreg-high-gpr-pressure.mir
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2023-2024 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2023-2025 Advanced Micro Devices, Inc. or its affiliates
 # RUN: llc -mtriple=aie2 --verify-machineinstrs --aie-reserved-gprs=31 -run-pass=greedy -run-pass=virtregrewriter %s -o - | FileCheck %s
 
 # We particularly focus on the spill_es_to_er when there is a high GPR and
@@ -27,7 +27,7 @@ body:             |
     ; CHECK-NEXT: ST_dms_spill $r1, %stack.0, implicit $sp :: (store (s32) into %stack.0)
     ; CHECK-NEXT: ST_dms_sts_idx_imm $r0, $p0, 0, implicit $s0
     ; CHECK-NEXT: renamable $r0 = LDA_dms_spill %stack.0, implicit $sp :: (load (s32) from %stack.0)
-    ; CHECK-NEXT: renamable $s0 = MOV_mv_scl killed renamable $r0
+    ; CHECK-NEXT: renamable $s0 = COPY killed renamable $r0
     ; CHECK-NEXT: renamable $cm0 = VUPS_S32_D16_mv_ups_x2c $x0, killed renamable $s0, implicit-def $srups_of, implicit $crsat, implicit $crupssign
     ; CHECK-NEXT: PseudoRET implicit $lr, implicit killed renamable $cm0, implicit $s1, implicit $s2, implicit $s3
     %0:spill_es_to_er = COPY $r1
@@ -51,11 +51,11 @@ body:             |
     ; CHECK-LABEL: name: spill_es_to_er_class
     ; CHECK: liveins: $s0
     ; CHECK-NEXT: {{  $}}
-    ; CHECK-NEXT: renamable $r0 = MOV_mv_scl $s0
+    ; CHECK-NEXT: renamable $r0 = COPY $s0
     ; CHECK-NEXT: ST_dms_spill killed renamable $r0, %stack.0, implicit $sp :: (store (s32) into %stack.0)
     ; CHECK-NEXT: PseudoJL 32, csr_aie2, implicit-def $lr
     ; CHECK-NEXT: renamable $r0 = LDA_dms_spill %stack.0, implicit $sp :: (load (s32) from %stack.0)
-    ; CHECK-NEXT: renamable $s0 = MOV_mv_scl killed renamable $r0
+    ; CHECK-NEXT: renamable $s0 = COPY killed renamable $r0
     ; CHECK-NEXT: PseudoRET implicit $lr, implicit killed renamable $s0
     %0:spill_es_to_er = COPY $s0
     PseudoJL 32, csr_aie2, implicit-def $lr

--- a/llvm/test/CodeGen/AIE/aie2/spill/spill-sreg.mir
+++ b/llvm/test/CodeGen/AIE/aie2/spill/spill-sreg.mir
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2023-2024 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2023-2025 Advanced Micro Devices, Inc. or its affiliates
 # RUN: llc -mtriple=aie2 --verify-machineinstrs -run-pass=greedy -run-pass=virtregrewriter %s -o - | FileCheck %s
 
 # There are 5 mSs (SHIFT) registers in use, one by %20, and 4 by the PseudoRET.
@@ -23,7 +23,6 @@ body:             |
     ; CHECK: liveins: $s0, $x0
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: renamable $r0 = MOVA_lda_cg 32
-    ; CHECK-NEXT: renamable $r0 = MOV_mv_scl killed renamable $r0
     ; CHECK-NEXT: ST_dms_spill killed renamable $r0, %stack.0, implicit $sp :: (store (s32) into %stack.0)
     ; CHECK-NEXT: renamable $r0 = MOVA_lda_cg 32
     ; CHECK-NEXT: renamable $s2 = COPY killed renamable $r0
@@ -33,7 +32,7 @@ body:             |
     ; CHECK-NEXT: renamable $s1 = COPY killed renamable $r0
     ; CHECK-NEXT: renamable $cm0 = VUPS_S32_D16_mv_ups_x2c $x0, $s0, implicit-def $srups_of, implicit $crsat, implicit $crupssign
     ; CHECK-NEXT: renamable $r0 = LDA_dms_spill %stack.0, implicit $sp :: (load (s32) from %stack.0)
-    ; CHECK-NEXT: renamable $s0 = MOV_mv_scl killed renamable $r0
+    ; CHECK-NEXT: renamable $s0 = COPY killed renamable $r0
     ; CHECK-NEXT: PseudoRET implicit $lr, implicit killed renamable $s0, implicit killed renamable $s2, implicit killed renamable $s3, implicit killed renamable $s1, implicit killed renamable $cm0
     %10:er = MOVA_lda_cg 32
     %0:mss = COPY %10
@@ -108,11 +107,11 @@ body:             |
     ; CHECK-LABEL: name: spill_to_mem_caller_saved
     ; CHECK: liveins: $s0
     ; CHECK-NEXT: {{  $}}
-    ; CHECK-NEXT: renamable $r0 = MOV_mv_scl $s0
+    ; CHECK-NEXT: renamable $r0 = COPY $s0
     ; CHECK-NEXT: ST_dms_spill killed renamable $r0, %stack.0, implicit $sp :: (store (s32) into %stack.0)
     ; CHECK-NEXT: PseudoJL 32, csr_aie2, implicit-def $lr
     ; CHECK-NEXT: renamable $r0 = LDA_dms_spill %stack.0, implicit $sp :: (load (s32) from %stack.0)
-    ; CHECK-NEXT: renamable $s0 = MOV_mv_scl killed renamable $r0
+    ; CHECK-NEXT: renamable $s0 = COPY killed renamable $r0
     ; CHECK-NEXT: PseudoRET implicit $lr, implicit killed renamable $s0
     %0:es = COPY $s0
     PseudoJL 32, csr_aie2, implicit-def $lr

--- a/llvm/test/CodeGen/AIE/aie2p/spill/spill-sreg-high-gpr-pressure.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/spill/spill-sreg-high-gpr-pressure.mir
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2024-2025 Advanced Micro Devices, Inc. or its affiliates
 # RUN: llc -mtriple=aie2p  --verify-machineinstrs --aie-reserved-gprs=31 -run-pass=greedy -run-pass=virtregrewriter %s -o - | FileCheck %s
 
 # We particularly focus on the spill_es_to_er when there is a high GPR and
@@ -27,7 +27,7 @@ body:             |
     ; CHECK-NEXT: ST_R_SPILL $r1, %stack.0, implicit $sp :: (store (s32) into %stack.0)
     ; CHECK-NEXT: ST_dms_sts_idx_imm $r0, $p0, 0, implicit $s0
     ; CHECK-NEXT: renamable $r0 = LDA_R_SPILL %stack.0, implicit $sp :: (load (s32) from %stack.0)
-    ; CHECK-NEXT: renamable $s0 = MOV_alu_mv_mv_mv_scl killed renamable $r0
+    ; CHECK-NEXT: renamable $s0 = COPY killed renamable $r0
     ; CHECK-NEXT: renamable $cml0 = VUPS_2x_mv_ups_x2c_upsSign0 $x0, killed renamable $s0, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0
     ; CHECK-NEXT: PseudoRET implicit $lr, implicit killed renamable $cml0, implicit $s1, implicit $s2, implicit $s3
     %0:spill_es_to_er = COPY $r1
@@ -51,11 +51,11 @@ body:             |
     ; CHECK-LABEL: name: spill_es_to_er_class
     ; CHECK: liveins: $s0
     ; CHECK-NEXT: {{  $}}
-    ; CHECK-NEXT: renamable $r0 = MOV_alu_mv_mv_mv_scl $s0
+    ; CHECK-NEXT: renamable $r0 = COPY $s0
     ; CHECK-NEXT: ST_R_SPILL killed renamable $r0, %stack.0, implicit $sp :: (store (s32) into %stack.0)
     ; CHECK-NEXT: PseudoJL 32, csr_aie2p, implicit-def $lr
     ; CHECK-NEXT: renamable $r0 = LDA_R_SPILL %stack.0, implicit $sp :: (load (s32) from %stack.0)
-    ; CHECK-NEXT: renamable $s0 = MOV_alu_mv_mv_mv_scl killed renamable $r0
+    ; CHECK-NEXT: renamable $s0 = COPY killed renamable $r0
     ; CHECK-NEXT: PseudoRET implicit $lr, implicit killed renamable $s0
     %0:spill_es_to_er = COPY $s0
     PseudoJL 32, csr_aie2p, implicit-def $lr

--- a/llvm/test/CodeGen/AIE/aie2p/spill/spill-sreg.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/spill/spill-sreg.mir
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2024-2025 Advanced Micro Devices, Inc. or its affiliates
 # RUN: llc -mtriple=aie2p --verify-machineinstrs -run-pass=greedy -run-pass=virtregrewriter %s -o - | FileCheck %s
 
 # There are 5 mSs (SHIFT) registers in use, one by %20, and 4 by the PseudoRET.
@@ -23,7 +23,6 @@ body:             |
     ; CHECK: liveins: $s0, $x0
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: renamable $r0 = MOVA 32
-    ; CHECK-NEXT: renamable $r0 = MOV_alu_mv_mv_mv_scl killed renamable $r0
     ; CHECK-NEXT: ST_R_SPILL killed renamable $r0, %stack.0, implicit $sp :: (store (s32) into %stack.0)
     ; CHECK-NEXT: renamable $r0 = MOVA 32
     ; CHECK-NEXT: renamable $s2 = COPY killed renamable $r0
@@ -33,7 +32,7 @@ body:             |
     ; CHECK-NEXT: renamable $s1 = COPY killed renamable $r0
     ; CHECK-NEXT: renamable $cml0 = VUPS_2x_mv_ups_x2c_upsSign0 $x0, $s0, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0
     ; CHECK-NEXT: renamable $r0 = LDA_R_SPILL %stack.0, implicit $sp :: (load (s32) from %stack.0)
-    ; CHECK-NEXT: renamable $s0 = MOV_alu_mv_mv_mv_scl killed renamable $r0
+    ; CHECK-NEXT: renamable $s0 = COPY killed renamable $r0
     ; CHECK-NEXT: PseudoRET implicit $lr, implicit killed renamable $s0, implicit killed renamable $s2, implicit killed renamable $s3, implicit killed renamable $s1, implicit killed renamable $cml0
     %10:er = MOVA 32
     %0:mss = COPY %10
@@ -108,11 +107,11 @@ body:             |
     ; CHECK-LABEL: name: spill_to_mem_caller_saved
     ; CHECK: liveins: $s0
     ; CHECK-NEXT: {{  $}}
-    ; CHECK-NEXT: renamable $r0 = MOV_alu_mv_mv_mv_scl $s0
+    ; CHECK-NEXT: renamable $r0 = COPY $s0
     ; CHECK-NEXT: ST_R_SPILL killed renamable $r0, %stack.0, implicit $sp :: (store (s32) into %stack.0)
     ; CHECK-NEXT: PseudoJL 32, csr_aie2p, implicit-def $lr
     ; CHECK-NEXT: renamable $r0 = LDA_R_SPILL %stack.0, implicit $sp :: (load (s32) from %stack.0)
-    ; CHECK-NEXT: renamable $s0 = MOV_alu_mv_mv_mv_scl killed renamable $r0
+    ; CHECK-NEXT: renamable $s0 = COPY killed renamable $r0
     ; CHECK-NEXT: PseudoRET implicit $lr, implicit killed renamable $s0
     %0:es = COPY $s0
     PseudoJL 32, csr_aie2p, implicit-def $lr


### PR DESCRIPTION
When we have to spill a register that does not support spilling directly, we need to bounce through another register that does support spilling.

Instead of using the target-specific move instruction to move the value into the register that does support spilling, we emit a COPY instruction to move the value.

This enables optimizations on the COPY instruction, such as removing it if it is redundant (see tests).

In our benchmarks this change has no QoR implications, so in practice this is mostly a clean-up.