### PR TITLE
[AIEX][NFC] Refactor instruction selection to share common code across AIE targets

### DIFF
--- a/clang/lib/CodeGen/CGBuiltin.cpp
+++ b/clang/lib/CodeGen/CGBuiltin.cpp
@@ -24298,10 +24298,6 @@ Value *CodeGenFunction::EmitAIEBuiltinExpr(unsigned BuiltinID,
     Value *FifoAddr = nullptr;
     Value *PosAddr = nullptr;
     switch (BuiltinID) {
-    case AIE::BI__builtin_aie2p_fifo_st_flush:
-    case AIE::BI__builtin_aie2p_fifo_st_flush_conv:
-    case AIE::BI__builtin_aie2ps_fifo_st_flush:
-    case AIE::BI__builtin_aie2ps_fifo_st_flush_conv:
     case AIE::BI__builtin_aie2ps_fifo_st_push_BFP384:
     case AIE::BI__builtin_aie2ps_fifo_st_push_BFP640:
     case AIE::BI__builtin_aie2ps_fifo_st_push_BFP768: {
@@ -24309,20 +24305,10 @@ Value *CodeGenFunction::EmitAIEBuiltinExpr(unsigned BuiltinID,
       PosAddr = EmitLValue(E->getArg(2)).getPointer(*this);
       break;
     }
-    case AIE::BI__builtin_aie2p_fifo_st_push_512_bfp16:
-    case AIE::BI__builtin_aie2ps_fifo_st_push_512: {
-      FifoAddr = EmitLValue(E->getArg(2)).getPointer(*this);
-      PosAddr = EmitLValue(E->getArg(3)).getPointer(*this);
-      break;
-    }
-    case AIE::BI__builtin_aie2p_fifo_st_push_576_bfp16:
-    case AIE::BI__builtin_aie2p_fifo_st_push_544_bfp16: {
-      FifoAddr = EmitLValue(E->getArg(3)).getPointer(*this);
-      PosAddr = EmitLValue(E->getArg(4)).getPointer(*this);
-      break;
-    }
     default:
-      llvm_unreachable("Unexpected BuiltinID");
+      FifoAddr = EmitLValue(E->getArg(E->getNumArgs() - 2)).getPointer(*this);
+      PosAddr = EmitLValue(E->getArg(E->getNumArgs() - 1)).getPointer(*this);
+      break;
     }
 
     Builder.CreateDefaultAlignedStore(Fifo, FifoAddr);
@@ -24506,19 +24492,27 @@ Value *CodeGenFunction::EmitAIEBuiltinExpr(unsigned BuiltinID,
 
     insertImplicitCasts(Ops, *F->getFunctionType(), Builder);
     Value *Val = Builder.CreateCall(F, Ops);
+    unsigned ExtractValIter = 0;
 
-    Value *Vec = Builder.CreateExtractValue(Val, 0);
-    Value *Ptr = Builder.CreateExtractValue(Val, 1);
-    Value *Fifo = Builder.CreateExtractValue(Val, 2);
-    Value *Pos = Builder.CreateExtractValue(Val, 3);
+    Value *Vec = Builder.CreateExtractValue(Val, ExtractValIter++);
+    Value *Ptr = Builder.CreateExtractValue(Val, ExtractValIter++);
+    Value *Fifo = Builder.CreateExtractValue(Val, ExtractValIter++);
+    Value *Pos = Builder.CreateExtractValue(Val, ExtractValIter++);
     Value *PtrAddr = EmitLValue(E->getArg(0)).getPointer(*this);
     Value *FifoAddr = EmitLValue(E->getArg(1)).getPointer(*this);
     Value *PosAddr = EmitLValue(E->getArg(2)).getPointer(*this);
 
+    if (BuiltinID == AIE::BI__builtin_aie2p_fifo_ld_popx ||
+        BuiltinID == AIE::BI__builtin_aie2ps_fifo_ld_popx) {
+      Value *Extra = Builder.CreateExtractValue(Val, ExtractValIter++);
+      Value *ExtraAddr = EmitLValue(E->getArg(3)).getPointer(*this);
+      Builder.CreateDefaultAlignedStore(Extra, ExtraAddr);
+    }
+
     if (BuiltinID == AIE::BI__builtin_aie2p_fifo_ld_pop_2d_512_unaligned ||
         BuiltinID == AIE::BI__builtin_aie2ps_fifo_ld_pop_2d_512_unaligned) {
       Value *Count1 =
-          Builder.CreateZExt(Builder.CreateExtractValue(Val, 4),
+          Builder.CreateZExt(Builder.CreateExtractValue(Val, ExtractValIter++),
                              llvm::Type::getInt32Ty(getLLVMContext()));
       Value *Count1Addr = EmitLValue(E->getArg(5)).getPointer(*this);
       Builder.CreateDefaultAlignedStore(Count1, Count1Addr);
@@ -24527,24 +24521,17 @@ Value *CodeGenFunction::EmitAIEBuiltinExpr(unsigned BuiltinID,
                BuiltinID ==
                    AIE::BI__builtin_aie2ps_fifo_ld_pop_3d_512_unaligned) {
       Value *Count1 =
-          Builder.CreateZExt(Builder.CreateExtractValue(Val, 4),
+          Builder.CreateZExt(Builder.CreateExtractValue(Val, ExtractValIter++),
                              llvm::Type::getInt32Ty(getLLVMContext()));
       Value *Count1Addr =
           EmitLValue(E->getArg(E->getNumArgs() - 5)).getPointer(*this);
       Value *Count2 =
-          Builder.CreateZExt(Builder.CreateExtractValue(Val, 5),
+          Builder.CreateZExt(Builder.CreateExtractValue(Val, ExtractValIter++),
                              llvm::Type::getInt32Ty(getLLVMContext()));
       Value *Count2Addr =
           EmitLValue(E->getArg(E->getNumArgs() - 2)).getPointer(*this);
       Builder.CreateDefaultAlignedStore(Count1, Count1Addr);
       Builder.CreateDefaultAlignedStore(Count2, Count2Addr);
-    }
-
-    if (BuiltinID == AIE::BI__builtin_aie2p_fifo_ld_popx ||
-        BuiltinID == AIE::BI__builtin_aie2ps_fifo_ld_popx) {
-      Value *Extra = Builder.CreateExtractValue(Val, 4);
-      Value *ExtraAddr = EmitLValue(E->getArg(3)).getPointer(*this);
-      Builder.CreateDefaultAlignedStore(Extra, ExtraAddr);
     }
 
     Builder.CreateDefaultAlignedStore(Fifo, FifoAddr);

--- a/clang/test/CodeGen/aie/aie2p/aie2p-ldst.cpp
+++ b/clang/test/CodeGen/aie/aie2p/aie2p-ldst.cpp
@@ -10,15 +10,6 @@
 //===----------------------------------------------------------------------===//
 // RUN: %clang -O2 %s --target=aie2p -nostdlibinc -S -emit-llvm -o - | FileCheck %s
 
-// CHECK-LABEL: @_Z22test_pack_v32i8_v32i16Dv32_si(
-// CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[TMP0:%.*]] = tail call noundef <32 x i8> @llvm.aie2p.pack.I512.I8.I16(<32 x i16> [[V:%.*]], i32 [[SIGN:%.*]])
-// CHECK-NEXT:    ret <32 x i8> [[TMP0]]
-//
-v32int8 test_pack_v32i8_v32i16(v32int16 v, int sign) {
-  return pack(v, sign);
-}
-
 // CHECK-LABEL: @_Z24test_unpack_v32i16_v32i8Dv32_a(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[TMP0:%.*]] = tail call noundef <32 x i16> @llvm.aie2p.unpack.I512.I16.I8(<32 x i8> [[V:%.*]], i32 1)
@@ -63,25 +54,6 @@ v64uint8 test_pack_v64i8_v64i16(v64uint16 v, int sign) {
 v64uint16 test_unpack_v64i16_v64i8(v64uint8 v) {
   return unpack(v);
 }
-
-// CHECK-LABEL: @_Z23test_pack_v128i4_v128i8Dv128_hi(
-// CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[TMP0:%.*]] = tail call noundef <64 x i8> @llvm.aie2p.pack.I1024.I4.I8(<128 x i8> [[V:%.*]], i32 [[SIGN:%.*]])
-// CHECK-NEXT:    ret <64 x i8> [[TMP0]]
-//
-v128uint4 test_pack_v128i4_v128i8(v128uint8 v, int sign) {
-  return pack(v, sign);
-}
-
-// CHECK-LABEL: @_Z25test_unpack_v128i8_v128i4Dv64_DU8_(
-// CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[TMP0:%.*]] = tail call noundef <128 x i8> @llvm.aie2p.unpack.I1024.I8.I4(<64 x i8> [[V:%.*]], i32 0)
-// CHECK-NEXT:    ret <128 x i8> [[TMP0]]
-//
-v128uint8 test_unpack_v128i8_v128i4(v128uint4 v) {
-  return unpack(v);
-}
-
 
 // CHECK-LABEL: @_Z18test_fifo_st_resetRrPDv64_DB8_S0_R12fifo_state_t(
 // CHECK-NEXT:  entry:

--- a/llvm/lib/Target/AIE/AIE2InstrInfo.cpp
+++ b/llvm/lib/Target/AIE/AIE2InstrInfo.cpp
@@ -479,6 +479,9 @@ unsigned AIE2InstrInfo::getOpCode(MachineInstr &I) const {
 Register AIE2InstrInfo::getVaddSignControlRegister() const {
   return AIE2::crVaddSign;
 }
+Register AIE2InstrInfo::getUPSSignControlRegister() const {
+  return AIE2::crUPSSign;
+}
 
 // Implement CopyToReg/CopyFromReg
 void AIE2InstrInfo::copyPhysReg(MachineBasicBlock &MBB,

--- a/llvm/lib/Target/AIE/AIE2InstrInfo.h
+++ b/llvm/lib/Target/AIE/AIE2InstrInfo.h
@@ -99,6 +99,7 @@ public:
                            TypeSize Size) const override;
   unsigned getOpCode(MachineInstr &MI) const override;
   Register getVaddSignControlRegister() const override;
+  Register getUPSSignControlRegister() const override;
 
   virtual std::optional<ZOLSupport> getZOLSupport() const override;
   virtual std::optional<JNZDSupport> getJNZDSupport() const override;

--- a/llvm/lib/Target/AIE/AIE2InstructionSelector.cpp
+++ b/llvm/lib/Target/AIE/AIE2InstructionSelector.cpp
@@ -69,7 +69,6 @@ public:
   std::optional<AddressingModeInfo>
   getOrDefineAddressingRegister(MachineInstr &MemI,
                                 MachineRegisterInfo &MRI) final;
-  bool selectG_AIE_LOAD_UNPACK(MachineInstr &StoreI, MachineRegisterInfo &MRI);
   bool selectG_AIE_LOAD_UPS(MachineInstr &StoreI, MachineRegisterInfo &MRI,
                             std::optional<unsigned> crUPSModeVal) override;
   bool select512BitG_AIE_LOAD_UPS(MachineInstr &UPSI, LoadStoreOpcodes &LSO,
@@ -144,10 +143,10 @@ private:
                         bool Is32Lanes);
   bool canCombinePACK(MachineInstr &MemOp, MachineInstr &CombOp);
   bool canCombineUNPACKLoad(MachineInstr &MemOp, MachineInstr &CombOp,
-                            MachineRegisterInfo &MRI);
+                            MachineRegisterInfo &MRI) override;
   std::optional<LoadStoreOpcodes> getCombinedOpcodeUNPACKLoad(
       const MachineInstr &MemOp, const MachineInstr &CombOp,
-      std::optional<APInt> Immediate, MachineRegisterInfo &MRI);
+      std::optional<APInt> Immediate, bool IsSigned) override;
 
   // const AIE2TargetMachine &TM;
   const AIE2InstrInfo &TII;
@@ -627,7 +626,8 @@ bool AIE2InstructionSelector::selectVPACK(MachineInstr &I,
 std::optional<LoadStoreOpcodes>
 AIE2InstructionSelector::getCombinedOpcodeUNPACKLoad(
     const MachineInstr &MemOp, const MachineInstr &CombOp,
-    std::optional<APInt> Immediate, MachineRegisterInfo &MRI) {
+    std::optional<APInt> Immediate, bool IsSigned) {
+  const MachineRegisterInfo &MRI = MemOp.getMF()->getRegInfo();
 
   const bool NoImmediate = false;
   if (CombOp.getOpcode() != AIE2::G_INTRINSIC ||
@@ -719,79 +719,14 @@ AIE2InstructionSelector::getCombinedOpcodeUNPACKLoad(
 bool AIE2InstructionSelector::canCombineUNPACKLoad(MachineInstr &MemOp,
                                                    MachineInstr &CombOp,
                                                    MachineRegisterInfo &MRI) {
+  Register LoadResult = MemOp.defs().begin()->getReg();
+  if (MemOp.getParent() != CombOp.getParent() || !MRI.hasOneUse(LoadResult))
+    return false;
+
   const std::optional<APInt> NoImmediate = {};
-  return getCombinedOpcodeUNPACKLoad(MemOp, CombOp, NoImmediate, MRI)
+  const bool IsSigned = false;
+  return getCombinedOpcodeUNPACKLoad(MemOp, CombOp, NoImmediate, IsSigned)
       .has_value();
-}
-
-bool AIE2InstructionSelector::selectG_AIE_LOAD_UNPACK(
-    MachineInstr &UNPACKI, MachineRegisterInfo &MRI) {
-  Register LoadResult = UNPACKI.getOperand(2).getReg();
-  MachineInstr *LoadOp = getDefIgnoringCopiesAndBitcasts(LoadResult, MRI);
-  MachineInstr *InsertionPoint = &UNPACKI;
-
-  assert(LoadOp && "Expected SSA.");
-
-  // Do not try to combine if one of the load's defs is used by another
-  // instruction between the load and the VUNPACK or if there is a store
-  // between the load and the VUNPACK.
-  if (!canDelayMemOp(*LoadOp, UNPACKI, MRI)) {
-    // If we cannot delay the load, we can try to advance the combined
-    // instruction to the load's position.
-    if (canAdvanceOp(*LoadOp, UNPACKI, MRI))
-      InsertionPoint = LoadOp;
-    else
-      return false;
-  }
-
-  if (!canCombineUNPACKLoad(*LoadOp, UNPACKI, MRI) ||
-      LoadOp->getParent() != UNPACKI.getParent() || !MRI.hasOneUse(LoadResult))
-    return false;
-
-  std::optional<AddressingModeInfo> AMI =
-      getOrDefineAddressingRegister(*LoadOp, MRI);
-  if (!AMI)
-    return false;
-
-  std::optional<LoadStoreOpcodes> LSO = getCombinedOpcodeUNPACKLoad(
-      AMI->MemI, UNPACKI, AMI->ImmediateOffset, MRI);
-
-  assert(LSO && "Unexpected VLDB.UNPACK combine failure");
-
-  Register DstReg = UNPACKI.getOperand(0).getReg();
-  Register SignReg = UNPACKI.getOperand(3).getReg();
-
-  MIB.setInstr(*InsertionPoint);
-
-  auto NewInstr = MIB.buildInstr(LSO->ISelOpcode);
-
-  NewInstr.addDef(DstReg);
-
-  for (auto *Def = std::next(AMI->MemI.defs().begin());
-       Def != AMI->MemI.defs().end(); ++Def) {
-    NewInstr.addDef(Def->getReg());
-  }
-
-  addAddressingMode(NewInstr, *AMI, LSO->FitsImmediateRange, false, MRI);
-
-  NewInstr.cloneMemRefs(AMI->MemI);
-
-  auto ConstantSign = getIConstantVRegValWithLookThrough(SignReg, MRI);
-  if (!ConstantSign)
-    setUnsetCtrlRegister(MIB, *NewInstr, MRI, AIE2::crUnpackSign, SignReg);
-
-  UNPACKI.eraseFromParent();
-
-  // Erasing the load instruction breaks later on in the selection code. That is
-  // because we keep an iterator on erased instructions. This breaks while
-  // trying to eliminate a trivially dead instruction which requires access to
-  // its memory operands which have been erased, thus leading to a seg fault. To
-  // remedy this, we keep the load to be removed by the trivial dead code
-  // elimination and we make sure to assign a new virtual register definition to
-  // its live operands to respect SSA.
-  makeDeadMI(*LoadOp, MRI);
-
-  return constrainSelectedInstRegOperands(*NewInstr.getInstr(), TII, TRI, RBI);
 }
 
 std::optional<LoadStoreOpcodes>

--- a/llvm/lib/Target/AIE/AIE2InstructionSelector.cpp
+++ b/llvm/lib/Target/AIE/AIE2InstructionSelector.cpp
@@ -84,7 +84,8 @@ public:
   bool select512BitG_AIE_LOAD_STORE(MachineInstr &I, LoadStoreOpcodes &LSO,
                                     AddressingModeInfo &AMI,
                                     MachineRegisterInfo &MRI);
-  bool selectG_AIE_STORE_SRS(MachineInstr &StoreI, MachineRegisterInfo &MRI);
+  bool selectG_AIE_STORE_SRS(MachineInstr &StoreI,
+                             MachineRegisterInfo &MRI) override;
   bool select512BitG_AIE_STORE_SRS(LoadStoreOpcodes &LSO,
                                    AddressingModeInfo &AMI, Register SrcReg,
                                    Register ShftReg, Register SignReg,

--- a/llvm/lib/Target/AIE/AIE2InstructionSelector.cpp
+++ b/llvm/lib/Target/AIE/AIE2InstructionSelector.cpp
@@ -61,9 +61,7 @@ public:
   bool selectG_GLOBAL_VALUE(MachineInstr &I, MachineRegisterInfo &MRI);
   bool selectG_LOAD(MachineInstr &I, MachineRegisterInfo &MRI);
   bool selectG_STORE(MachineInstr &I, MachineRegisterInfo &MRI);
-  bool selectGetControlRegister(MachineInstr &I, MachineRegisterInfo &MRI);
   bool selectReadTM(MachineInstr &I, MachineRegisterInfo &MRI);
-  bool selectSetControlRegister(MachineInstr &I, MachineRegisterInfo &MRI);
   bool selectVEXTRACT(MachineInstr &I, MachineRegisterInfo &MRI);
   bool selectVSRS(MachineInstr &I, MachineRegisterInfo &MRI);
   bool selectVUNPACK(MachineInstr &I, MachineRegisterInfo &MRI);
@@ -2090,84 +2088,6 @@ Register AIE2InstructionSelector::createDSRegSequence(
                            MI->getOperand(13));
 
   return MI.getReg(0);
-}
-
-// Build Instruction to get control register
-bool AIE2InstructionSelector::selectGetControlRegister(
-    MachineInstr &I, MachineRegisterInfo &MRI) {
-
-  Register DstReg = I.getOperand(0).getReg();
-  // In this case of G_INTRINSIC operand 1 is target intrinsic
-  Register IdxReg = I.getOperand(2).getReg();
-  Register CtrlReg;
-
-  // Check if the argument is constant for register map index.
-  if (auto Idx = getIConstantVRegValWithLookThrough(IdxReg, MRI))
-    CtrlReg = TRI.getControlRegister(Idx->Value.getZExtValue());
-  else
-    llvm_unreachable("Expected const value for control register map index.");
-
-  if (!RBI.constrainGenericRegister(DstReg, AIE2::eRRegClass, MRI))
-    return false;
-
-  auto CopyInstr =
-      MIB.buildInstr(TargetOpcode::COPY, {DstReg}, {}).addReg(CtrlReg);
-  if (!selectCopy(*CopyInstr, MRI)) {
-    return false;
-  }
-  I.eraseFromParent();
-  return true;
-}
-
-// Build Instruction to set control register
-bool AIE2InstructionSelector::selectSetControlRegister(
-    MachineInstr &I, MachineRegisterInfo &MRI) {
-
-  Register IdxReg = I.getOperand(1).getReg();
-  Register SrcReg = I.getOperand(2).getReg();
-  Register CtrlReg;
-
-  // Check if the argument is constant for register map index.
-  if (auto Idx = getIConstantVRegValWithLookThrough(IdxReg, MRI))
-    CtrlReg = TRI.getControlRegister(Idx->Value.getZExtValue());
-  else
-    llvm_unreachable("Expected const value for control register map index.");
-
-  // Handle const input val for control regs.
-  if (auto Src = getIConstantVRegValWithLookThrough(SrcReg, MRI)) {
-    unsigned SrcConstVal = Src->Value.getZExtValue();
-    /* Modulo by width of control regs.
-       To constrain the max possible value in the register
-       according to register width.
-    */
-    switch (CtrlReg) {
-    case AIE2::crSat:
-      SrcConstVal = SrcConstVal % (1 << 2);
-      break;
-    case AIE2::crRnd:
-      SrcConstVal = SrcConstVal % (1 << 4);
-      break;
-    case AIE2::crF2FMask:
-    case AIE2::crF2IMask:
-    case AIE2::crFPMask:
-      SrcConstVal = SrcConstVal % (1 << 5);
-      break;
-    default:
-      break;
-    }
-
-    MachineInstrBuilder MI = setCtrlRegister(MIB, CtrlReg, SrcConstVal);
-    I.eraseFromParent();
-    return constrainSelectedInstRegOperands(*MI, TII, TRI, RBI);
-  }
-
-  auto CopyInstr =
-      MIB.buildInstr(TargetOpcode::COPY, {CtrlReg}, {}).addReg(SrcReg);
-  if (!selectCopy(*CopyInstr, MRI))
-    return false;
-
-  I.eraseFromParent();
-  return true;
 }
 
 bool AIE2InstructionSelector::selectWriteTM(MachineInstr &I,

--- a/llvm/lib/Target/AIE/AIE2InstructionSelector.cpp
+++ b/llvm/lib/Target/AIE/AIE2InstructionSelector.cpp
@@ -90,7 +90,8 @@ public:
                                    Register ShftReg, Register SignReg,
                                    bool ConstantSign, MachineRegisterInfo &MRI);
   bool selectG_AIE_STORE_CONV(MachineInstr &StoreI, MachineRegisterInfo &MRI);
-  bool selectG_AIE_STORE_PACK(MachineInstr &StoreI, MachineRegisterInfo &MRI);
+  bool selectG_AIE_STORE_PACK(MachineInstr &StoreI,
+                              MachineRegisterInfo &MRI) override;
   bool selectStartLoop(MachineInstr &I, MachineRegisterInfo &MRI);
 
   unsigned getSub256LoIdx() const override { return AIE2::sub_256_lo; }
@@ -139,9 +140,9 @@ private:
   bool canCombineSRSUPS(MachineInstr &MemOp, MachineInstr &CombOp);
   std::optional<LoadStoreOpcodes>
   getCombinedOpcodePACK(const MachineInstr &MemOp, const MachineInstr &CombOp,
-                        std::optional<APInt> Immediate, bool IsSigned,
-                        bool Is32Lanes);
-  bool canCombinePACK(MachineInstr &MemOp, MachineInstr &CombOp);
+                        std::optional<APInt> Immediate, bool IsSigned) override;
+  bool canCombinePACK(MachineInstr &MemOp, MachineInstr &CombOp,
+                      MachineRegisterInfo &MRI) override;
   bool canCombineUNPACKLoad(MachineInstr &MemOp, MachineInstr &CombOp,
                             MachineRegisterInfo &MRI) override;
   std::optional<LoadStoreOpcodes> getCombinedOpcodeUNPACKLoad(
@@ -2572,7 +2573,7 @@ LoadStoreOpcodes AIE2InstructionSelector::getLoadStoreOpcode(
 
 std::optional<LoadStoreOpcodes> AIE2InstructionSelector::getCombinedOpcodePACK(
     const MachineInstr &MemOp, const MachineInstr &CombOp,
-    std::optional<APInt> Immediate, bool IsSigned, bool Is32Lanes) {
+    std::optional<APInt> Immediate, bool IsSigned) {
   const bool AlwaysFitsImmediateRange = true;
 
   if (CombOp.getOpcode() != AIE2::G_INTRINSIC_W_SIDE_EFFECTS ||
@@ -2583,6 +2584,10 @@ std::optional<LoadStoreOpcodes> AIE2InstructionSelector::getCombinedOpcodePACK(
     return {};
 
   assert(getLoadStoreSize(MemOp) == 256 && "Unexpected VST.PACK size");
+
+  // Determine lane size from intrinsic type
+  bool Is32Lanes =
+      cast<GIntrinsic>(CombOp).getIntrinsicID() == Intrinsic::aie2_pack_I8_I16;
 
   unsigned ISelOpcode;
   bool FitsImmediateRange = false;
@@ -2723,13 +2728,13 @@ std::optional<LoadStoreOpcodes> AIE2InstructionSelector::getCombinedOpcodePACK(
 }
 
 bool AIE2InstructionSelector::canCombinePACK(MachineInstr &MemOp,
-                                             MachineInstr &CombOp) {
+                                             MachineInstr &CombOp,
+                                             MachineRegisterInfo &MRI) {
 
   std::optional<APInt> NoImmediate = {};
   bool IsSigned = true;
-  bool Is32Lanes = true;
 
-  return getCombinedOpcodePACK(MemOp, CombOp, NoImmediate, IsSigned, Is32Lanes)
+  return getCombinedOpcodePACK(MemOp, CombOp, NoImmediate, IsSigned)
       .has_value();
 }
 
@@ -2741,17 +2746,14 @@ bool AIE2InstructionSelector::selectG_AIE_STORE_PACK(MachineInstr &StoreI,
 
   assert(PackOp && "Expected SSA.");
 
-  if (!canCombinePACK(StoreI, *PackOp) ||
+  if (!canCombinePACK(StoreI, *PackOp, MRI) ||
       StoreI.getParent() != PackOp->getParent() || !MRI.hasOneUse(PackResult))
     return false;
 
-  std::optional<AddressingModeInfo> AMI =
+  std::optional<AddressingModeInfo> AddrModeInfo =
       getOrDefineAddressingRegister(StoreI, MRI);
-  if (!AMI)
+  if (!AddrModeInfo)
     return false;
-
-  bool Is32Lanes =
-      cast<GIntrinsic>(PackOp)->getIntrinsicID() == Intrinsic::aie2_pack_I8_I16;
 
   // Note: Operand 1 is the ID of the intrinsic
   Register SrcReg = PackOp->getOperand(2).getReg();
@@ -2761,12 +2763,12 @@ bool AIE2InstructionSelector::selectG_AIE_STORE_PACK(MachineInstr &StoreI,
   bool ConstantSign = false;
   if (auto SignVal = getIConstantVRegValWithLookThrough(SignReg, MRI)) {
     // SignVal = 1 for signed and 0 for dynamically signed
-    LSO = getCombinedOpcodePACK(StoreI, *PackOp, AMI->ImmediateOffset,
-                                SignVal.value().Value == 0x1, Is32Lanes);
+    LSO = getCombinedOpcodePACK(StoreI, *PackOp, AddrModeInfo->ImmediateOffset,
+                                SignVal.value().Value == 0x1);
     ConstantSign = true;
   } else {
-    LSO = getCombinedOpcodePACK(StoreI, *PackOp, AMI->ImmediateOffset, false,
-                                Is32Lanes);
+    LSO = getCombinedOpcodePACK(StoreI, *PackOp, AddrModeInfo->ImmediateOffset,
+                                false);
   }
 
   assert(LSO && "Unexpected VST.PACK combine failure");
@@ -2776,7 +2778,8 @@ bool AIE2InstructionSelector::selectG_AIE_STORE_PACK(MachineInstr &StoreI,
   for (auto Def : StoreI.defs())
     NewInstr.addDef(Def.getReg());
 
-  addAddressingMode(NewInstr, *AMI, LSO->FitsImmediateRange, false, MRI);
+  addAddressingMode(NewInstr, *AddrModeInfo, LSO->FitsImmediateRange, false,
+                    MRI);
 
   NewInstr.addUse(SrcReg);
 

--- a/llvm/lib/Target/AIE/AIE2InstructionSelector.cpp
+++ b/llvm/lib/Target/AIE/AIE2InstructionSelector.cpp
@@ -70,12 +70,12 @@ public:
   getOrDefineAddressingRegister(MachineInstr &MemI,
                                 MachineRegisterInfo &MRI) final;
   bool selectG_AIE_LOAD_UNPACK(MachineInstr &StoreI, MachineRegisterInfo &MRI);
-  bool selectG_AIE_LOAD_UPS(MachineInstr &StoreI, MachineRegisterInfo &MRI);
+  bool selectG_AIE_LOAD_UPS(MachineInstr &StoreI, MachineRegisterInfo &MRI,
+                            std::optional<unsigned> crUPSModeVal) override;
   bool select512BitG_AIE_LOAD_UPS(MachineInstr &UPSI, LoadStoreOpcodes &LSO,
                                   AddressingModeInfo &AMI, Register DstReg,
                                   Register ShftReg, Register SignReg,
                                   bool ConstantSign, MachineRegisterInfo &MRI);
-  bool selectVUPS(MachineInstr &I, MachineRegisterInfo &MRI);
   bool selectWriteTM(MachineInstr &I, MachineRegisterInfo &MRI);
   LoadStoreOpcodes getLoadStoreOpcode(const MachineInstr &I,
                                       const MachineRegisterInfo &MRI,
@@ -1835,8 +1835,9 @@ bool AIE2InstructionSelector::select512BitG_AIE_LOAD_UPS(
   }
 }
 
-bool AIE2InstructionSelector::selectG_AIE_LOAD_UPS(MachineInstr &UPSI,
-                                                   MachineRegisterInfo &MRI) {
+bool AIE2InstructionSelector::selectG_AIE_LOAD_UPS(
+    MachineInstr &UPSI, MachineRegisterInfo &MRI,
+    std::optional<unsigned> crUPSModeVal) {
 
   // First use is the G_INTRINSIC_W_SIDE_EFFECTS ID
   Register LoadResult = UPSI.getOperand(2).getReg();
@@ -1903,33 +1904,6 @@ bool AIE2InstructionSelector::selectG_AIE_LOAD_UPS(MachineInstr &UPSI,
   UPSI.eraseFromParent();
   AMI->MemI.eraseFromParent();
   return constrainSelectedInstRegOperands(*NewInstr.getInstr(), TII, TRI, RBI);
-}
-
-bool AIE2InstructionSelector::selectVUPS(MachineInstr &I,
-                                         MachineRegisterInfo &MRI) {
-  // First try to match UPS combine
-  if (selectG_AIE_LOAD_UPS(I, MRI))
-    return true;
-
-  Register DstReg = I.getOperand(0).getReg();
-  // In this case of G_INTRINSIC_W_SIDE_EFFECTS operand 1 is target intrinsic
-  Register SrcReg = I.getOperand(2).getReg();
-  Register ShftReg = I.getOperand(3).getReg();
-  Register SignReg = I.getOperand(4).getReg();
-
-  if (auto SignVal = getIConstantVRegValWithLookThrough(SignReg, MRI)) {
-    // Handle constant sign through instruction patterns
-    return selectImpl(I, *CoverageInfo);
-  }
-
-  unsigned OpCode = TII.getOpCode(I);
-  MachineInstrBuilder MI =
-      MIB.buildInstr(OpCode, {DstReg}, {}).addReg(SrcReg).addReg(ShftReg);
-
-  setUnsetCtrlRegister(MIB, *MI, MRI, AIE2::crUPSSign, SignReg);
-
-  I.eraseFromParent();
-  return constrainSelectedInstRegOperands(*MI, TII, TRI, RBI);
 }
 
 bool AIE2InstructionSelector::selectVSRS(MachineInstr &I,

--- a/llvm/lib/Target/AIE/AIE2RegisterInfo.cpp
+++ b/llvm/lib/Target/AIE/AIE2RegisterInfo.cpp
@@ -566,3 +566,7 @@ AIE2RegisterInfo::matchControlRegisterBitwidth(Register CtrlReg,
     llvm_unreachable("Unknown control register.");
   }
 }
+
+Register AIE2RegisterInfo::getUnpackSignCtrlReg() const {
+  return AIE2::crUnpackSign;
+}

--- a/llvm/lib/Target/AIE/AIE2RegisterInfo.cpp
+++ b/llvm/lib/Target/AIE/AIE2RegisterInfo.cpp
@@ -539,3 +539,22 @@ bool AIE2RegisterInfo::isVecOrAccRegClass(const TargetRegisterClass &RC) const {
 
   return false;
 }
+
+unsigned
+AIE2RegisterInfo::matchControlRegisterBitwidth(Register CtrlReg,
+                                               unsigned SrcConstVal) const {
+  // Modulo by width of control regs.  To constrain the max possible value in
+  // the register according to register width.
+  switch (CtrlReg) {
+  case AIE2::crSat:
+    return SrcConstVal % (1 << 2);
+  case AIE2::crRnd:
+    return SrcConstVal % (1 << 4);
+  case AIE2::crF2FMask:
+  case AIE2::crF2IMask:
+  case AIE2::crFPMask:
+    return SrcConstVal % (1 << 5);
+  default:
+    llvm_unreachable("Unknown control register.");
+  }
+}

--- a/llvm/lib/Target/AIE/AIE2RegisterInfo.cpp
+++ b/llvm/lib/Target/AIE/AIE2RegisterInfo.cpp
@@ -543,9 +543,17 @@ bool AIE2RegisterInfo::isVecOrAccRegClass(const TargetRegisterClass &RC) const {
 unsigned
 AIE2RegisterInfo::matchControlRegisterBitwidth(Register CtrlReg,
                                                unsigned SrcConstVal) const {
-  // Modulo by width of control regs.  To constrain the max possible value in
+  // Modulo by width of control regs. To constrain the max possible value in
   // the register according to register width.
   switch (CtrlReg) {
+  case AIE2::crVaddSign:
+  case AIE2::crMCDEn:
+  case AIE2::crPackSign:
+  case AIE2::crSCDEn:
+  case AIE2::crSRSSign:
+  case AIE2::crUPSSign:
+  case AIE2::crUnpackSign:
+    return SrcConstVal % (1 << 1);
   case AIE2::crSat:
     return SrcConstVal % (1 << 2);
   case AIE2::crRnd:

--- a/llvm/lib/Target/AIE/AIE2RegisterInfo.h
+++ b/llvm/lib/Target/AIE/AIE2RegisterInfo.h
@@ -70,7 +70,7 @@ struct AIE2RegisterInfo : public AIE2GenRegisterInfo {
       const MachineOperand &MO, const MachineRegisterInfo &MRI) const override;
 
   Register getStackPointerRegister() const override;
-  Register getControlRegister(unsigned Idx) const;
+  Register getControlRegister(unsigned Idx) const override;
 
   const TargetRegisterClass *
   getLargestLegalSuperClass(const TargetRegisterClass *RC,
@@ -101,6 +101,8 @@ struct AIE2RegisterInfo : public AIE2GenRegisterInfo {
   const TargetRegisterClass *getAddrCountRegClass() const override {
     return &AIE2::eDCRegClass;
   }
+  unsigned matchControlRegisterBitwidth(Register CtrlReg,
+                                        unsigned SrcConstVal) const override;
 };
 } // namespace llvm
 

--- a/llvm/lib/Target/AIE/AIE2RegisterInfo.h
+++ b/llvm/lib/Target/AIE/AIE2RegisterInfo.h
@@ -103,6 +103,8 @@ struct AIE2RegisterInfo : public AIE2GenRegisterInfo {
   }
   unsigned matchControlRegisterBitwidth(Register CtrlReg,
                                         unsigned SrcConstVal) const override;
+
+  Register getUnpackSignCtrlReg() const override;
 };
 } // namespace llvm
 

--- a/llvm/lib/Target/AIE/AIEBaseInstrInfo.h
+++ b/llvm/lib/Target/AIE/AIEBaseInstrInfo.h
@@ -213,6 +213,12 @@ struct AIEBaseInstrInfo : public TargetInstrInfo {
   virtual unsigned getMvSclMultiSlotPseudoOpcode() const {
     llvm_unreachable("Target didn't implement getMvSclOpcode");
   }
+  /// Return the opcode to set a status register with an immediate value.
+  /// Targets should override this to provide the correct opcode.
+  virtual unsigned getSetStatusRegisterOpcode() const {
+    // Fallback to multi-slot pseudo move if target doesn't override.
+    return getMvSclMultiSlotPseudoOpcode();
+  }
   /// Return the 3-address integer ADD opcode
   virtual unsigned getAddSclOpcode() const {
     llvm_unreachable("Target didn't implement getAddSclOpcode");

--- a/llvm/lib/Target/AIE/AIEBaseInstrInfo.h
+++ b/llvm/lib/Target/AIE/AIEBaseInstrInfo.h
@@ -397,6 +397,12 @@ struct AIEBaseInstrInfo : public TargetInstrInfo {
   virtual Register getVaddSignControlRegister() const {
     llvm_unreachable("Target didn't implement vaddSign control register");
   }
+  virtual Register getUPSModeControlRegister() const {
+    llvm_unreachable("Target didn't implement UPSMode control register");
+  }
+  virtual Register getUPSSignControlRegister() const {
+    llvm_unreachable("Target didn't implement UPSSign control register");
+  }
   // Opcodes related to hardware loop handling
   virtual bool isHardwareLoopDec(unsigned Opcode) const;
   virtual bool isHardwareLoopJNZ(unsigned Opcode) const;

--- a/llvm/lib/Target/AIE/AIEBaseInstructionSelector.cpp
+++ b/llvm/lib/Target/AIE/AIEBaseInstructionSelector.cpp
@@ -1077,6 +1077,38 @@ bool AIEBaseInstructionSelector::selectExtractI128(MachineInstr &I,
   return true;
 }
 
+// Build Instruction to set control register
+bool AIEBaseInstructionSelector::selectSetControlRegister(
+    MachineInstr &I, MachineRegisterInfo &MRI) {
+
+  const Register IdxReg = I.getOperand(1).getReg();
+  const Register SrcReg = I.getOperand(2).getReg();
+
+  // Check if the argument is constant for register map index.
+  const auto Idx = getIConstantVRegValWithLookThroughOrFail(
+      IdxReg, MRI, "Expected const value for control register map index.");
+
+  const Register CtrlReg = TRI.getControlRegister(Idx.Value.getZExtValue());
+
+  // Handle const input val for control regs.
+  if (const auto Src = getIConstantVRegValWithLookThrough(SrcReg, MRI)) {
+    const unsigned SrcConstVal =
+        TRI.matchControlRegisterBitwidth(CtrlReg, Src->Value.getZExtValue());
+
+    MachineInstrBuilder MI = setCtrlRegister(MIB, CtrlReg, SrcConstVal);
+    I.eraseFromParent();
+    return constrainSelectedInstRegOperands(*MI, TII, TRI, RBI);
+  }
+
+  auto CopyInstr =
+      MIB.buildInstr(TargetOpcode::COPY, {CtrlReg}, {}).addReg(SrcReg);
+  if (!selectCopy(*CopyInstr, MRI))
+    return false;
+
+  I.eraseFromParent();
+  return true;
+}
+
 bool AIEBaseInstructionSelector::selectG_AIE_UNPAD_VECTOR(
     MachineInstr &I, Register DstReg, Register SrcReg, MachineRegisterInfo &MRI,
     MachineFunction &MF) {
@@ -1128,6 +1160,33 @@ bool AIEBaseInstructionSelector::selectSetI128(MachineInstr &I,
   } else {
     llvm_unreachable("Expected 256 or 512 bit input vector");
   }
+
+  I.eraseFromParent();
+  return true;
+}
+
+// Build Instruction to get control register
+bool AIEBaseInstructionSelector::selectGetControlRegister(
+    MachineInstr &I, MachineRegisterInfo &MRI) {
+
+  const Register DstReg = I.getOperand(0).getReg();
+  // In this case of G_INTRINSIC operand 1 is target intrinsic
+  const Register IdxReg = I.getOperand(2).getReg();
+
+  // Check if the argument is constant for register map index.
+  const auto Idx = getIConstantVRegValWithLookThroughOrFail(
+      IdxReg, MRI, "Expected const value for control register map index.");
+
+  const Register CtrlReg = TRI.getControlRegister(Idx.Value.getZExtValue());
+  const MachineFunction &MF = *I.getParent()->getParent();
+
+  if (!RBI.constrainGenericRegister(DstReg, *TRI.getGPRRegClass(MF), MRI))
+    return false;
+
+  auto CopyInstr =
+      MIB.buildInstr(TargetOpcode::COPY, {DstReg}, {}).addReg(CtrlReg);
+  if (!selectCopy(*CopyInstr, MRI))
+    return false;
 
   I.eraseFromParent();
   return true;

--- a/llvm/lib/Target/AIE/AIEBaseInstructionSelector.cpp
+++ b/llvm/lib/Target/AIE/AIEBaseInstructionSelector.cpp
@@ -835,6 +835,80 @@ bool AIEBaseInstructionSelector::selectVCONV(MachineInstr &I,
   return selectImpl(I, *CoverageInfo);
 }
 
+bool AIEBaseInstructionSelector::selectG_AIE_LOAD_UNPACK(
+    MachineInstr &UNPACKI, MachineRegisterInfo &MRI) {
+  Register LoadResult = (std::next(UNPACKI.uses().begin()))->getReg();
+  MachineInstr *LoadOp = getDefIgnoringCopiesAndBitcasts(LoadResult, MRI);
+  if (!LoadOp)
+    return false;
+
+  // Should we build the instruction at load's position?
+  bool ShouldAdvanceOp = false;
+
+  // Do not try to combine if one of the load's defs is used by another
+  // instruction between the load and the VUNPACK or if there is a store
+  // between the load and the VUNPACK.
+  if (!canDelayMemOp(*LoadOp, UNPACKI, MRI)) {
+    // If we cannot delay the load, we can try to advance the combined
+    // instruction to the load's position.
+    if (canAdvanceOp(*LoadOp, UNPACKI, MRI))
+      ShouldAdvanceOp = true;
+    else
+      return false;
+  }
+
+  if (!canCombineUNPACKLoad(*LoadOp, UNPACKI, MRI))
+    return false;
+
+  std::optional<AddressingModeInfo> AddrModeInfo =
+      getOrDefineAddressingRegister(*LoadOp, MRI);
+  if (!AddrModeInfo)
+    return false;
+
+  Register DstReg = UNPACKI.getOperand(0).getReg();
+  // In this case of G_INTRINSIC operand 1 is target intrinsic
+  // In this case the operand 2 is the source register which is the loaded value
+  Register SignReg = UNPACKI.getOperand(3).getReg();
+
+  auto SignVal = getIConstantVRegValWithLookThrough(SignReg, MRI);
+  bool ConstantSign = SignVal.has_value();
+  std::optional<LoadStoreOpcodes> LSO = getCombinedOpcodeUNPACKLoad(
+      *LoadOp, UNPACKI, AddrModeInfo->ImmediateOffset,
+      ConstantSign ? SignVal.value().Value == 0x1 : false);
+
+  assert(LSO && "Unexpected VLDB.UNPACK combine failure");
+
+  if (ShouldAdvanceOp)
+    MIB.setInstr(*LoadOp);
+  else
+    MIB.setInstr(UNPACKI);
+
+  setUnpackSizeRegister(MIB, cast<GIntrinsic>(UNPACKI).getIntrinsicID());
+
+  auto NewInstr = MIB.buildInstr(LSO->ISelOpcode);
+
+  NewInstr.addDef(DstReg);
+
+  for (auto *Def = std::next(LoadOp->defs().begin());
+       Def != LoadOp->defs().end(); ++Def) {
+    NewInstr.addDef(Def->getReg());
+  }
+
+  addAddressingMode(NewInstr, *AddrModeInfo, LSO->FitsImmediateRange, false,
+                    MRI);
+
+  NewInstr.cloneMemRefs(*LoadOp);
+
+  if (!ConstantSign)
+    setUnsetCtrlRegister(MIB, *NewInstr, MRI, TRI.getUnpackSignCtrlReg(),
+                         SignReg);
+
+  UNPACKI.eraseFromParent();
+  makeDeadMI(*LoadOp, MRI);
+
+  return constrainSelectedInstRegOperands(*NewInstr.getInstr(), TII, TRI, RBI);
+}
+
 std::optional<AddressingModeInfo>
 AIEBaseInstructionSelector::getOrDefineAddressingRegister(
     MachineInstr &MemI, MachineRegisterInfo &MRI) {

--- a/llvm/lib/Target/AIE/AIEBaseInstructionSelector.cpp
+++ b/llvm/lib/Target/AIE/AIEBaseInstructionSelector.cpp
@@ -909,6 +909,75 @@ bool AIEBaseInstructionSelector::selectG_AIE_LOAD_UNPACK(
   return constrainSelectedInstRegOperands(*NewInstr.getInstr(), TII, TRI, RBI);
 }
 
+bool AIEBaseInstructionSelector::selectG_AIE_STORE_PACK(
+    MachineInstr &StoreI, MachineRegisterInfo &MRI) {
+
+  Register PackResult = (StoreI.uses().begin())->getReg();
+  MachineInstr *PackOp = getDefIgnoringCopiesAndBitcasts(PackResult, MRI);
+
+  if (!canCombinePACK(StoreI, *PackOp, MRI))
+    return false;
+
+  std::optional<AddressingModeInfo> AddrModeInfo =
+      getOrDefineAddressingRegister(StoreI, MRI);
+  if (!AddrModeInfo)
+    return false;
+
+  // Note: Operand 1 is the ID of the intrinsic
+  Register SrcReg = PackOp->getOperand(2).getReg();
+  Register SignReg = PackOp->getOperand(3).getReg();
+
+  unsigned MemOpLoadStoreSize = getLoadStoreSize(StoreI);
+  TypeSize SrcRegSize = MRI.getType(SrcReg).getSizeInBits();
+  assert(((MemOpLoadStoreSize == 256 && SrcRegSize == 512) ||
+          (MemOpLoadStoreSize == 512 && SrcRegSize == 1024)) &&
+         "Unexpected VST.PACK size");
+
+  auto SignVal = getIConstantVRegValWithLookThrough(SignReg, MRI);
+  bool ConstantSign = SignVal ? true : false;
+  // SignVal = 1 for signed and 0 for dynamically signed
+  std::optional<LoadStoreOpcodes> LSO = getCombinedOpcodePACK(
+      StoreI, *PackOp, AddrModeInfo->ImmediateOffset,
+      ConstantSign ? SignVal.value().Value == 0x1 : false);
+
+  assert(LSO && "Unexpected VST.PACK combine failure");
+
+  // Note: the output size (I8 or I4) is not encoded as part of the instruction,
+  // but it is read from the crPackSize register.
+  auto NewInstr = MIB.buildInstr(LSO->ISelOpcode);
+
+  for (auto Def : StoreI.defs())
+    NewInstr.addDef(Def.getReg());
+
+  NewInstr.addUse(SrcReg);
+
+  addAddressingMode(NewInstr, *AddrModeInfo, LSO->FitsImmediateRange, false,
+                    MRI);
+
+  NewInstr.cloneMemRefs(StoreI);
+
+  // Set the crPackSize before NewInstr
+  // Selects the size of the Pack instructions
+  // 0 – Destination is 4 bits
+  // 1 – Destination is 8 bits
+  Register PackSizeReg = TRI.getPackSizeCtrlReg();
+  if (PackSizeReg.isValid()) {
+    const bool Is8Bit =
+        isPackI8Intrinsic(cast<GIntrinsic>(PackOp)->getIntrinsicID());
+    auto Opcode = TII.getMvSclMultiSlotPseudoOpcode();
+    MIB.setInstr(*NewInstr);
+    MIB.buildInstr(Opcode, {PackSizeReg}, {}).addImm((unsigned)Is8Bit);
+  }
+
+  Register PackSignReg = TRI.getPackSignCtrlReg();
+  if (!ConstantSign && PackSignReg.isValid())
+    setUnsetCtrlRegister(MIB, *NewInstr, MRI, PackSignReg, SignReg);
+
+  StoreI.eraseFromParent();
+  makeDeadMI(*PackOp, MRI);
+  return constrainSelectedInstRegOperands(*NewInstr.getInstr(), TII, TRI, RBI);
+}
+
 std::optional<AddressingModeInfo>
 AIEBaseInstructionSelector::getOrDefineAddressingRegister(
     MachineInstr &MemI, MachineRegisterInfo &MRI) {

--- a/llvm/lib/Target/AIE/AIEBaseInstructionSelector.cpp
+++ b/llvm/lib/Target/AIE/AIEBaseInstructionSelector.cpp
@@ -1459,3 +1459,60 @@ bool AIEBaseInstructionSelector::selectVUPS(
   I.eraseFromParent();
   return constrainSelectedInstRegOperands(*MI, TII, TRI, RBI);
 }
+
+bool AIEBaseInstructionSelector::selectG_AIE_STORE_SRS(
+    MachineInstr &StoreI, MachineRegisterInfo &MRI) {
+  Register SrsResult = (StoreI.uses().begin())->getReg();
+  MachineInstr *SrsOp = getDefIgnoringCopiesAndBitcasts(SrsResult, MRI);
+
+  assert(SrsOp && "Expected SSA.");
+
+  if (!canCombineSRS(StoreI, *SrsOp, MRI))
+    return false;
+
+  std::optional<AddressingModeInfo> AddrModeInfo =
+      getOrDefineAddressingRegister(StoreI, MRI);
+  if (!AddrModeInfo)
+    return false;
+
+  // Note: Operand 1 is the ID of the intrinsic
+  Register SrcReg = SrsOp->getOperand(2).getReg();
+  Register ShftReg = SrsOp->getOperand(3).getReg();
+  Register SignReg = SrsOp->getOperand(4).getReg();
+
+  auto SignVal = getIConstantVRegValWithLookThrough(SignReg, MRI);
+  bool ConstantSign = SignVal.has_value();
+  // SignVal = 1 for signed and 0 for unsigned
+  std::optional<LoadStoreOpcodes> LSO =
+      getCombinedOpcodeSRS(StoreI, *SrsOp, AddrModeInfo->ImmediateOffset,
+                           ConstantSign ? SignVal->Value == 0x1 : false);
+
+  assert(LSO && "Unexpected VST.SRS combine failure");
+
+  // Set SRS mode control register if needed
+  MIB.setInstr(StoreI);
+  std::optional<unsigned> SRSMode =
+      getSRSModeForIntrinsic(cast<GIntrinsic>(SrsOp)->getIntrinsicID());
+  if (SRSMode)
+    setCtrlRegister(MIB, TRI.getSRSModeCtrlReg(), *SRSMode);
+
+  auto NewInstr = MIB.buildInstr(LSO->ISelOpcode);
+
+  for (auto Def : StoreI.defs())
+    NewInstr.addDef(Def.getReg());
+
+  NewInstr.addUse(SrcReg);
+  NewInstr.addUse(ShftReg);
+
+  addAddressingMode(NewInstr, *AddrModeInfo, LSO->FitsImmediateRange, false,
+                    MRI);
+
+  NewInstr.cloneMemRefs(StoreI);
+
+  if (!ConstantSign)
+    setUnsetCtrlRegister(MIB, *NewInstr, MRI, TRI.getSRSSignCtrlReg(), SignReg);
+
+  makeDeadMI(*SrsOp, MRI);
+  StoreI.eraseFromParent();
+  return constrainSelectedInstRegOperands(*NewInstr.getInstr(), TII, TRI, RBI);
+}

--- a/llvm/lib/Target/AIE/AIEBaseInstructionSelector.cpp
+++ b/llvm/lib/Target/AIE/AIEBaseInstructionSelector.cpp
@@ -1280,3 +1280,39 @@ bool AIEBaseInstructionSelector::selectGetStatusRegister(
   I.eraseFromParent();
   return true;
 }
+
+bool AIEBaseInstructionSelector::selectVUPS(
+    MachineInstr &I, MachineRegisterInfo &MRI,
+    std::optional<unsigned> crUPSModeVal) {
+  // First try to match UPS combine
+  if (selectG_AIE_LOAD_UPS(I, MRI, crUPSModeVal))
+    return true;
+
+  const Register DstReg = I.getOperand(0).getReg();
+  // In this case of G_INTRINSIC_W_SIDE_EFFECTS operand 1 is target intrinsic
+  const Register SrcReg = I.getOperand(2).getReg();
+  const Register ShftReg = I.getOperand(3).getReg();
+  const Register SignReg = I.getOperand(4).getReg();
+
+  if (crUPSModeVal.has_value()) {
+    // Selects the mode of the accumulator for UPS instructions
+    // 0 – 32-bit accumulator lane
+    // 1 – 64-bit accumulator lane
+    MIB.setInstr(I);
+    setCtrlRegister(MIB, TII.getUPSModeControlRegister(), *crUPSModeVal);
+  }
+
+  if (const auto SignVal = getIConstantVRegValWithLookThrough(SignReg, MRI)) {
+    // Handle constant sign through instruction patterns
+    return selectImpl(I, *CoverageInfo);
+  }
+
+  const unsigned OpCode = TII.getOpCode(I);
+  MachineInstrBuilder MI =
+      MIB.buildInstr(OpCode, {DstReg}, {}).addReg(SrcReg).addReg(ShftReg);
+
+  setUnsetCtrlRegister(MIB, *MI, MRI, TII.getUPSSignControlRegister(), SignReg);
+
+  I.eraseFromParent();
+  return constrainSelectedInstRegOperands(*MI, TII, TRI, RBI);
+}

--- a/llvm/lib/Target/AIE/AIEBaseInstructionSelector.cpp
+++ b/llvm/lib/Target/AIE/AIEBaseInstructionSelector.cpp
@@ -339,6 +339,12 @@ AIEBaseInstructionSelector::setCtrlRegister(MachineIRBuilder &MIB,
   return MIB.buildInstr(Opcode, {CRReg}, {}).addImm(Val);
 }
 
+MachineInstrBuilder AIEBaseInstructionSelector::setStatusRegister(
+    MachineIRBuilder &MIB, Register StatusReg, unsigned Val) {
+  auto Opcode = TII.getSetStatusRegisterOpcode();
+  return MIB.buildInstr(Opcode, {StatusReg}, {}).addImm(Val);
+}
+
 void AIEBaseInstructionSelector::addSplitMemOperands(
     MachineInstr &I, MachineInstrBuilder &Higher, MachineInstrBuilder &Lower,
     unsigned Offset, unsigned SplitFactor) {
@@ -1211,6 +1217,66 @@ bool AIEBaseInstructionSelector::selectG_AIE_PAD_VECTOR_UNDEF(
   constrainOperandRegClass(MF, TRI, MRI, TII, RBI, I, OutRC, DstReg);
   MIB.buildInstr(TargetOpcode::REG_SEQUENCE, {DstReg}, {SrcReg})
       .addImm(getSub256LoIdx());
+
+  I.eraseFromParent();
+  return true;
+}
+
+// Build Instruction to set status register
+bool AIEBaseInstructionSelector::selectSetStatusRegister(
+    MachineInstr &I, MachineRegisterInfo &MRI) {
+
+  const Register IdxReg = I.getOperand(1).getReg();
+  const Register SrcReg = I.getOperand(2).getReg();
+
+  // Check if the argument is constant for register map index.
+  const auto Idx = getIConstantVRegValWithLookThroughOrFail(
+      IdxReg, MRI, "Expected const value for status register map index.");
+
+  const Register StatusReg = TRI.getStatusRegister(Idx.Value.getZExtValue());
+
+  // Handle const input val for status regs.
+  if (const auto Src = getIConstantVRegValWithLookThrough(SrcReg, MRI)) {
+    const unsigned SrcConstVal =
+        TRI.matchStatusRegisterBitwidth(StatusReg, Src->Value.getZExtValue());
+
+    MachineInstrBuilder MI = setStatusRegister(MIB, StatusReg, SrcConstVal);
+    I.eraseFromParent();
+    return constrainSelectedInstRegOperands(*MI, TII, TRI, RBI);
+  }
+
+  auto CopyInstr =
+      MIB.buildInstr(TargetOpcode::COPY, {StatusReg}, {}).addReg(SrcReg);
+  if (!selectCopy(*CopyInstr, MRI))
+    return false;
+
+  I.eraseFromParent();
+  return true;
+}
+
+// Build Instruction to get status register
+bool AIEBaseInstructionSelector::selectGetStatusRegister(
+    MachineInstr &I, MachineRegisterInfo &MRI) {
+
+  const Register DstReg = I.getOperand(0).getReg();
+  // In this case of G_INTRINSIC operand 1 is target intrinsic
+  const Register IdxReg = I.getOperand(2).getReg();
+
+  // Check if the argument is constant for register map index.
+  const auto Idx = getIConstantVRegValWithLookThroughOrFail(
+      IdxReg, MRI, "Expected const value for status register map index.");
+
+  const Register StatusReg = TRI.getStatusRegister(Idx.Value.getZExtValue());
+  const MachineFunction &MF = *I.getParent()->getParent();
+
+  if (!RBI.constrainGenericRegister(DstReg, *TRI.getGPRRegClass(MF), MRI))
+    return false;
+
+  auto CopyInstr =
+      MIB.buildInstr(TargetOpcode::COPY, {DstReg}, {}).addReg(StatusReg);
+  if (!selectCopy(*CopyInstr, MRI))
+    return false;
+
   I.eraseFromParent();
   return true;
 }

--- a/llvm/lib/Target/AIE/AIEBaseInstructionSelector.cpp
+++ b/llvm/lib/Target/AIE/AIEBaseInstructionSelector.cpp
@@ -1516,3 +1516,113 @@ bool AIEBaseInstructionSelector::selectG_AIE_STORE_SRS(
   StoreI.eraseFromParent();
   return constrainSelectedInstRegOperands(*NewInstr.getInstr(), TII, TRI, RBI);
 }
+
+// FIFO Store selection helpers - shared implementation for AIE2P and AIE4
+bool AIEBaseInstructionSelector::selectVST_FIFO_Push(MachineInstr &I,
+                                                     MachineRegisterInfo &MRI) {
+  const unsigned Opcode = TII.getOpCode(I);
+  const Register PtrOut = I.getOperand(0).getReg();
+  const Register FifoOut = I.getOperand(1).getReg();
+  const Register AvailOut = I.getOperand(2).getReg();
+  const Register PtrIn = I.getOperand(4).getReg();
+  const Register VecIn = I.getOperand(5).getReg();
+  const Register FifoIn = I.getOperand(6).getReg();
+  const Register AvailIn = I.getOperand(7).getReg();
+
+  auto MI = MIB.buildInstr(Opcode, {FifoOut, PtrOut, AvailOut},
+                           {FifoIn, VecIn, PtrIn, AvailIn});
+  MI.cloneMemRefs(I);
+  I.eraseFromParent();
+  return constrainSelectedInstRegOperands(*MI, TII, TRI, RBI);
+}
+
+bool AIEBaseInstructionSelector::selectVST_FIFO_Flush(
+    MachineInstr &I, MachineRegisterInfo &MRI) {
+  const unsigned Opcode = TII.getOpCode(I);
+  const Register PtrOut = I.getOperand(0).getReg();
+  const Register FifoOut = I.getOperand(1).getReg();
+  const Register AvailOut = I.getOperand(2).getReg();
+  const Register PtrIn = I.getOperand(4).getReg();
+  const Register FifoIn = I.getOperand(5).getReg();
+  const Register AvailIn = I.getOperand(6).getReg();
+
+  auto MI = MIB.buildInstr(Opcode, {FifoOut, PtrOut, AvailOut},
+                           {FifoIn, PtrIn, AvailIn});
+  MI.cloneMemRefs(I);
+  I.eraseFromParent();
+  return constrainSelectedInstRegOperands(*MI, TII, TRI, RBI);
+}
+
+bool AIEBaseInstructionSelector::selectVST_FIFO_Flush1D(
+    MachineInstr &I, MachineRegisterInfo &MRI) {
+  const unsigned Opcode = TII.getOpCode(I);
+  const Register PtrOut = I.getOperand(0).getReg();
+  const Register FifoOut = I.getOperand(1).getReg();
+  const Register AvailOut = I.getOperand(2).getReg();
+  const Register PtrIn = I.getOperand(4).getReg();
+  const Register FifoIn = I.getOperand(5).getReg();
+  const Register AvailIn = I.getOperand(6).getReg();
+  const Register OffsetReg = I.getOperand(7).getReg();
+
+  auto MI = MIB.buildInstr(Opcode, {FifoOut, PtrOut, AvailOut},
+                           {FifoIn, PtrIn, AvailIn, OffsetReg});
+  MI.cloneMemRefs(I);
+  I.eraseFromParent();
+  return constrainSelectedInstRegOperands(*MI, TII, TRI, RBI);
+}
+
+bool AIEBaseInstructionSelector::selectVST_FIFO_Flush2D(
+    MachineInstr &I, MachineRegisterInfo &MRI) {
+  const unsigned Opcode = TII.getOpCode(I);
+  const Register PtrOut = I.getOperand(0).getReg();
+  const Register FifoOut = I.getOperand(1).getReg();
+  const Register AvailOut = I.getOperand(2).getReg();
+  const Register CountOut1Reg = I.getOperand(3).getReg();
+  const Register PtrIn = I.getOperand(5).getReg();
+  const Register FifoIn = I.getOperand(6).getReg();
+  const Register AvailIn = I.getOperand(7).getReg();
+  const Register OffsetReg = I.getOperand(8).getReg();
+  const Register SizeReg = I.getOperand(9).getReg();
+  const Register CountIn1Reg = I.getOperand(10).getReg();
+  const Register IncrReg = I.getOperand(11).getReg();
+
+  const Register DReg =
+      createDRegSequence(OffsetReg, IncrReg, SizeReg, CountIn1Reg, MRI);
+
+  auto MI = MIB.buildInstr(Opcode, {FifoOut, PtrOut, AvailOut, CountOut1Reg},
+                           {FifoIn, PtrIn, AvailIn, DReg});
+  MI.cloneMemRefs(I);
+  I.eraseFromParent();
+  return constrainSelectedInstRegOperands(*MI, TII, TRI, RBI);
+}
+
+bool AIEBaseInstructionSelector::selectVST_FIFO_Flush3D(
+    MachineInstr &I, MachineRegisterInfo &MRI) {
+  const unsigned Opcode = TII.getOpCode(I);
+  const Register PtrOut = I.getOperand(0).getReg();
+  const Register FifoOut = I.getOperand(1).getReg();
+  const Register AvailOut = I.getOperand(2).getReg();
+  const Register CountOut1Reg = I.getOperand(3).getReg();
+  const Register CountOut2Reg = I.getOperand(4).getReg();
+  const Register PtrIn = I.getOperand(6).getReg();
+  const Register FifoIn = I.getOperand(7).getReg();
+  const Register AvailIn = I.getOperand(8).getReg();
+  const Register OffsetReg = I.getOperand(9).getReg();
+  const Register Size1Reg = I.getOperand(10).getReg();
+  const Register CountIn1Reg = I.getOperand(11).getReg();
+  const Register Incr1Reg = I.getOperand(12).getReg();
+  const Register Size2Reg = I.getOperand(13).getReg();
+  const Register CountIn2Reg = I.getOperand(14).getReg();
+  const Register Incr2Reg = I.getOperand(15).getReg();
+
+  const Register DSReg =
+      createDSRegSequence(OffsetReg, Incr1Reg, Incr2Reg, Size1Reg, CountIn1Reg,
+                          Size2Reg, CountIn2Reg, MRI);
+
+  auto MI = MIB.buildInstr(
+      Opcode, {FifoOut, PtrOut, AvailOut, CountOut1Reg, CountOut2Reg},
+      {FifoIn, PtrIn, AvailIn, DSReg});
+  MI.cloneMemRefs(I);
+  I.eraseFromParent();
+  return constrainSelectedInstRegOperands(*MI, TII, TRI, RBI);
+}

--- a/llvm/lib/Target/AIE/AIEBaseInstructionSelector.h
+++ b/llvm/lib/Target/AIE/AIEBaseInstructionSelector.h
@@ -252,6 +252,29 @@ protected:
   virtual bool selectG_AIE_STORE_PACK(MachineInstr &StoreI,
                                       MachineRegisterInfo &MRI);
 
+  /// Shared implementation for G_AIE_STORE_SRS selection.
+  /// Returns true if SRS combine was successful.
+  virtual bool selectG_AIE_STORE_SRS(MachineInstr &StoreI,
+                                     MachineRegisterInfo &MRI);
+
+  /// Check if SRS combine is possible. Override in derived classes.
+  virtual bool canCombineSRS(MachineInstr &MemOp, MachineInstr &CombOp,
+                             MachineRegisterInfo &MRI) {
+    return false;
+  }
+
+  /// Get combined opcode for SRS store. Override in derived classes.
+  virtual std::optional<LoadStoreOpcodes>
+  getCombinedOpcodeSRS(const MachineInstr &MemOp, const MachineInstr &CombOp,
+                       std::optional<APInt> Immediate, bool IsSigned) {
+    return std::nullopt;
+  }
+
+  /// Get SRS mode (0 for 32-bit acc, 1 for 64-bit acc) based on intrinsic.
+  virtual std::optional<unsigned> getSRSModeForIntrinsic(Intrinsic::ID ID) {
+    return std::nullopt;
+  }
+
 protected:
   MachineIRBuilder MIB;
 

--- a/llvm/lib/Target/AIE/AIEBaseInstructionSelector.h
+++ b/llvm/lib/Target/AIE/AIEBaseInstructionSelector.h
@@ -224,6 +224,16 @@ protected:
                                     std::optional<unsigned> crUPSModeVal) {
     return false;
   }
+  virtual bool setUnpackSizeRegister(MachineIRBuilder &MIB,
+                                     Intrinsic::ID IntrinsicID) {
+    return false;
+  }
+  virtual bool canCombineUNPACKLoad(MachineInstr &MemOp, MachineInstr &CombOp,
+                                    MachineRegisterInfo &MRI) = 0;
+  virtual std::optional<LoadStoreOpcodes> getCombinedOpcodeUNPACKLoad(
+      const MachineInstr &MemOp, const MachineInstr &CombOp,
+      std::optional<APInt> Immediate, bool IsSigned) = 0;
+  bool selectG_AIE_LOAD_UNPACK(MachineInstr &UNPACKI, MachineRegisterInfo &MRI);
 
 protected:
   MachineIRBuilder MIB;

--- a/llvm/lib/Target/AIE/AIEBaseInstructionSelector.h
+++ b/llvm/lib/Target/AIE/AIEBaseInstructionSelector.h
@@ -235,6 +235,23 @@ protected:
       std::optional<APInt> Immediate, bool IsSigned) = 0;
   bool selectG_AIE_LOAD_UNPACK(MachineInstr &UNPACKI, MachineRegisterInfo &MRI);
 
+  // Virtual methods for PACK combine
+  virtual bool canCombinePACK(MachineInstr &MemOp, MachineInstr &CombOp,
+                              MachineRegisterInfo &MRI) {
+    return false;
+  }
+  virtual std::optional<LoadStoreOpcodes>
+  getCombinedOpcodePACK(const MachineInstr &MemOp, const MachineInstr &CombOp,
+                        std::optional<APInt> Immediate, bool IsSigned) {
+    return {};
+  }
+  /// Returns true if the intrinsic produces 8-bit output (vs 4-bit).
+  virtual bool isPackI8Intrinsic(Intrinsic::ID IntrinsicID) const {
+    llvm_unreachable("Target didn't implement isPackI8Intrinsic!");
+  }
+  virtual bool selectG_AIE_STORE_PACK(MachineInstr &StoreI,
+                                      MachineRegisterInfo &MRI);
+
 protected:
   MachineIRBuilder MIB;
 

--- a/llvm/lib/Target/AIE/AIEBaseInstructionSelector.h
+++ b/llvm/lib/Target/AIE/AIEBaseInstructionSelector.h
@@ -275,6 +275,13 @@ protected:
     return std::nullopt;
   }
 
+  // FIFO store selection helpers - common implementation for derived classes
+  bool selectVST_FIFO_Push(MachineInstr &I, MachineRegisterInfo &MRI);
+  bool selectVST_FIFO_Flush(MachineInstr &I, MachineRegisterInfo &MRI);
+  bool selectVST_FIFO_Flush1D(MachineInstr &I, MachineRegisterInfo &MRI);
+  bool selectVST_FIFO_Flush2D(MachineInstr &I, MachineRegisterInfo &MRI);
+  bool selectVST_FIFO_Flush3D(MachineInstr &I, MachineRegisterInfo &MRI);
+
 protected:
   MachineIRBuilder MIB;
 

--- a/llvm/lib/Target/AIE/AIEBaseInstructionSelector.h
+++ b/llvm/lib/Target/AIE/AIEBaseInstructionSelector.h
@@ -104,6 +104,8 @@ public:
                             unsigned DefaultCRVal = 0);
   MachineInstrBuilder setCtrlRegister(MachineIRBuilder &MIB, Register CRReg,
                                       unsigned Val);
+  MachineInstrBuilder setStatusRegister(MachineIRBuilder &MIB,
+                                        Register StatusReg, unsigned Val);
   AddressingModeInfo createAddressModeInfo(MachineInstr &MemI,
                                            MachineOperand &SrcDstOp,
                                            MachineOperand &PtrOp,
@@ -213,6 +215,8 @@ protected:
   bool selectStartLoop(MachineInstr &I, MachineRegisterInfo &MRI);
   bool selectSetControlRegister(MachineInstr &I, MachineRegisterInfo &MRI);
   bool selectGetControlRegister(MachineInstr &I, MachineRegisterInfo &MRI);
+  bool selectSetStatusRegister(MachineInstr &I, MachineRegisterInfo &MRI);
+  bool selectGetStatusRegister(MachineInstr &I, MachineRegisterInfo &MRI);
 
 protected:
   MachineIRBuilder MIB;

--- a/llvm/lib/Target/AIE/AIEBaseInstructionSelector.h
+++ b/llvm/lib/Target/AIE/AIEBaseInstructionSelector.h
@@ -211,6 +211,8 @@ protected:
   bool selectG_AIE_LOAD_CONV(MachineInstr &CONVI, MachineRegisterInfo &MRI);
   bool selectVCONV(MachineInstr &I, MachineRegisterInfo &MRI);
   bool selectStartLoop(MachineInstr &I, MachineRegisterInfo &MRI);
+  bool selectSetControlRegister(MachineInstr &I, MachineRegisterInfo &MRI);
+  bool selectGetControlRegister(MachineInstr &I, MachineRegisterInfo &MRI);
 
 protected:
   MachineIRBuilder MIB;
@@ -255,6 +257,19 @@ inline MachineMemOperand *getTileMemOperand(MachineInstr &I,
   const auto *MFI = MF->getInfo<AIEMachineFunctionInfo>();
   MachinePointerInfo PtrInfo = MachinePointerInfo(MFI->getTileMemory());
   return MF->getMachineMemOperand(PtrInfo, Mode, 4, Align(4));
+}
+
+/// Get a constant VReg value or call llvm_unreachable with the provided message
+/// \param VReg The virtual register to lookup
+/// \param MRI The machine register info
+/// \param ErrorMsg The error message to display if constant is not found
+/// \return The ValueAndVReg containing the constant value
+inline ValueAndVReg getIConstantVRegValWithLookThroughOrFail(
+    Register VReg, const MachineRegisterInfo &MRI, const char *ErrorMsg) {
+  auto Result = getIConstantVRegValWithLookThrough(VReg, MRI);
+  if (!Result)
+    llvm_unreachable(ErrorMsg);
+  return *Result;
 }
 
 } // namespace llvm

--- a/llvm/lib/Target/AIE/AIEBaseInstructionSelector.h
+++ b/llvm/lib/Target/AIE/AIEBaseInstructionSelector.h
@@ -217,6 +217,13 @@ protected:
   bool selectGetControlRegister(MachineInstr &I, MachineRegisterInfo &MRI);
   bool selectSetStatusRegister(MachineInstr &I, MachineRegisterInfo &MRI);
   bool selectGetStatusRegister(MachineInstr &I, MachineRegisterInfo &MRI);
+  bool selectVUPS(MachineInstr &I, MachineRegisterInfo &MRI,
+                  std::optional<unsigned> crUPSModeVal = std::nullopt);
+  virtual bool selectG_AIE_LOAD_UPS(MachineInstr &StoreI,
+                                    MachineRegisterInfo &MRI,
+                                    std::optional<unsigned> crUPSModeVal) {
+    return false;
+  }
 
 protected:
   MachineIRBuilder MIB;

--- a/llvm/lib/Target/AIE/AIEBaseRegisterInfo.h
+++ b/llvm/lib/Target/AIE/AIEBaseRegisterInfo.h
@@ -78,6 +78,11 @@ struct AIEBaseRegisterInfo : public TargetRegisterInfo {
     llvm_unreachable("Target didn't implement isReservedStickyReg!");
   }
 
+  /// Returns the control register used for UNPACK sign control
+  virtual Register getUnpackSignCtrlReg() const {
+    llvm_unreachable("Target didn't implement getUnpackSignCtrlReg!");
+  }
+
   /// Given a register bank and operand type, return the smallest register class
   /// that can hold a value on that bank.
   virtual const TargetRegisterClass &

--- a/llvm/lib/Target/AIE/AIEBaseRegisterInfo.h
+++ b/llvm/lib/Target/AIE/AIEBaseRegisterInfo.h
@@ -110,6 +110,14 @@ struct AIEBaseRegisterInfo : public TargetRegisterInfo {
                       unsigned SubReg, const TargetRegisterClass *DstRC,
                       unsigned DstSubReg, const TargetRegisterClass *NewRC,
                       LiveIntervals &LIS) const override;
+
+  virtual unsigned matchControlRegisterBitwidth(Register CtrlReg,
+                                                unsigned SrcConstVal) const {
+    llvm_unreachable("Target didn't implement matchControlRegisterBitwidth!");
+  }
+  virtual Register getControlRegister(unsigned Idx) const {
+    llvm_unreachable("Target didn't implement getControlRegister!");
+  }
 };
 
 template <int N, unsigned step> bool isEncodableAsNegativeInt(int Value) {

--- a/llvm/lib/Target/AIE/AIEBaseRegisterInfo.h
+++ b/llvm/lib/Target/AIE/AIEBaseRegisterInfo.h
@@ -83,6 +83,16 @@ struct AIEBaseRegisterInfo : public TargetRegisterInfo {
     llvm_unreachable("Target didn't implement getUnpackSignCtrlReg!");
   }
 
+  /// Returns the control register used for PACK sign control
+  virtual Register getPackSignCtrlReg() const {
+    llvm_unreachable("Target didn't implement getPackSignCtrlReg!");
+  }
+
+  /// Returns the control register used for PACK size control
+  virtual Register getPackSizeCtrlReg() const {
+    llvm_unreachable("Target didn't implement getPackSizeCtrlReg!");
+  }
+
   /// Given a register bank and operand type, return the smallest register class
   /// that can hold a value on that bank.
   virtual const TargetRegisterClass &

--- a/llvm/lib/Target/AIE/AIEBaseRegisterInfo.h
+++ b/llvm/lib/Target/AIE/AIEBaseRegisterInfo.h
@@ -93,6 +93,16 @@ struct AIEBaseRegisterInfo : public TargetRegisterInfo {
     llvm_unreachable("Target didn't implement getPackSizeCtrlReg!");
   }
 
+  /// Returns the control register used for SRS sign control
+  virtual Register getSRSSignCtrlReg() const {
+    llvm_unreachable("Target didn't implement getSRSSignCtrlReg!");
+  }
+
+  /// Returns the control register used for SRS mode control
+  virtual Register getSRSModeCtrlReg() const {
+    llvm_unreachable("Target didn't implement getSRSModeCtrlReg!");
+  }
+
   /// Given a register bank and operand type, return the smallest register class
   /// that can hold a value on that bank.
   virtual const TargetRegisterClass &

--- a/llvm/lib/Target/AIE/AIEBaseRegisterInfo.h
+++ b/llvm/lib/Target/AIE/AIEBaseRegisterInfo.h
@@ -118,6 +118,9 @@ struct AIEBaseRegisterInfo : public TargetRegisterInfo {
   virtual Register getControlRegister(unsigned Idx) const {
     llvm_unreachable("Target didn't implement getControlRegister!");
   }
+  virtual Register getStatusRegister(unsigned Idx) const {
+    llvm_unreachable("Target didn't implement getStatusRegister!");
+  }
 };
 
 template <int N, unsigned step> bool isEncodableAsNegativeInt(int Value) {

--- a/llvm/lib/Target/AIE/AIEBaseRegisterInfo.h
+++ b/llvm/lib/Target/AIE/AIEBaseRegisterInfo.h
@@ -121,6 +121,10 @@ struct AIEBaseRegisterInfo : public TargetRegisterInfo {
   virtual Register getStatusRegister(unsigned Idx) const {
     llvm_unreachable("Target didn't implement getStatusRegister!");
   }
+  virtual unsigned matchStatusRegisterBitwidth(Register StatusReg,
+                                               unsigned SrcConstVal) const {
+    llvm_unreachable("Target didn't implement matchStatusRegisterBitwidth!");
+  }
 };
 
 template <int N, unsigned step> bool isEncodableAsNegativeInt(int Value) {

--- a/llvm/lib/Target/AIE/aie2p/AIE2PInstrInfo.cpp
+++ b/llvm/lib/Target/AIE/aie2p/AIE2PInstrInfo.cpp
@@ -574,6 +574,12 @@ unsigned AIE2PInstrInfo::getOpCode(MachineInstr &I) const {
 Register AIE2PInstrInfo::getVaddSignControlRegister() const {
   return AIE2P::vaddSign0;
 }
+Register AIE2PInstrInfo::getUPSModeControlRegister() const {
+  return AIE2P::crUPSMode;
+}
+Register AIE2PInstrInfo::getUPSSignControlRegister() const {
+  return AIE2P::upsSign0;
+}
 
 // Implement CopyToReg/CopyFromReg
 void AIE2PInstrInfo::copyPhysReg(MachineBasicBlock &MBB,

--- a/llvm/lib/Target/AIE/aie2p/AIE2PInstrInfo.cpp
+++ b/llvm/lib/Target/AIE/aie2p/AIE2PInstrInfo.cpp
@@ -566,6 +566,25 @@ unsigned AIE2PInstrInfo::getOpCode(MachineInstr &I) const {
     return AIE2P::MOV_st_mMStream_tlast_reg;
   case Intrinsic::aie2p_put_ms_nb:
     return AIE2P::MOV_nb_st_mMStream_tlast_reg;
+  // FIFO store intrinsics
+  case Intrinsic::aie2p_fifo_st_push_512_bfp16:
+    return AIE2P::VST_PUSH_512;
+  case Intrinsic::aie2p_fifo_st_flush:
+    return AIE2P::VST_FLUSH_512_normal_flush;
+  case Intrinsic::aie2p_fifo_st_flush_conv:
+    return AIE2P::VST_FLUSH_512_CONV_normal_flush;
+  case Intrinsic::aie2p_fifo_st_flush_1d:
+    return AIE2P::VST_FLUSH_512_fifo_1d_flush;
+  case Intrinsic::aie2p_fifo_st_flush_1d_conv:
+    return AIE2P::VST_FLUSH_512_CONV_fifo_1d_flush;
+  case Intrinsic::aie2p_fifo_st_flush_2d:
+    return AIE2P::VST_FLUSH_512_2D;
+  case Intrinsic::aie2p_fifo_st_flush_2d_conv:
+    return AIE2P::VST_FLUSH_512_CONV_2D;
+  case Intrinsic::aie2p_fifo_st_flush_3d:
+    return AIE2P::VST_FLUSH_512_3D;
+  case Intrinsic::aie2p_fifo_st_flush_3d_conv:
+    return AIE2P::VST_FLUSH_512_CONV_3D;
   default:
     llvm_unreachable("Unexpected Intrinsic ID");
   }

--- a/llvm/lib/Target/AIE/aie2p/AIE2PInstrInfo.h
+++ b/llvm/lib/Target/AIE/aie2p/AIE2PInstrInfo.h
@@ -105,6 +105,8 @@ public:
   getStoreFlushConvOpcode(unsigned StoreFlushOpcode) const override;
   unsigned getOpCode(MachineInstr &MI) const override;
   Register getVaddSignControlRegister() const override;
+  Register getUPSModeControlRegister() const override;
+  Register getUPSSignControlRegister() const override;
 
   virtual std::optional<ZOLSupport> getZOLSupport() const override;
   virtual std::optional<JNZDSupport> getJNZDSupport() const override;

--- a/llvm/lib/Target/AIE/aie2p/AIE2PInstructionSelector.cpp
+++ b/llvm/lib/Target/AIE/aie2p/AIE2PInstructionSelector.cpp
@@ -47,10 +47,8 @@ public:
   bool selectG_GLOBAL_VALUE(MachineInstr &I, MachineRegisterInfo &MRI);
   bool selectVSRS(MachineInstr &I, MachineRegisterInfo &MRI,
                   unsigned crSRSModeVal);
-  bool selectVUPS(MachineInstr &I, MachineRegisterInfo &MRI,
-                  unsigned crUPSModeVal);
   bool selectG_AIE_LOAD_UPS(MachineInstr &StoreI, MachineRegisterInfo &MRI,
-                            unsigned crUPSModeVal);
+                            std::optional<unsigned> crUPSModeVal) override;
   bool selectVCONVbfp16(MachineInstr &I, MachineRegisterInfo &MRI);
   bool selectG_AIE_BROADCAST_VECTOR(MachineInstr &I, MachineRegisterInfo &MRI);
   bool selectG_CONCAT_VECTORS(MachineInstr &I, MachineRegisterInfo &MRI);
@@ -499,9 +497,9 @@ bool AIE2PInstructionSelector::selectVSRS(MachineInstr &I,
   return constrainSelectedInstRegOperands(*MI, TII, TRI, RBI);
 }
 
-bool AIE2PInstructionSelector::selectG_AIE_LOAD_UPS(MachineInstr &UPSI,
-                                                    MachineRegisterInfo &MRI,
-                                                    unsigned crUPSModeVal) {
+bool AIE2PInstructionSelector::selectG_AIE_LOAD_UPS(
+    MachineInstr &UPSI, MachineRegisterInfo &MRI,
+    std::optional<unsigned> crUPSModeVal) {
 
   // Operand 0 is the def, operand 1 is the intrinsic ID, operand 2 is the
   // source register (loaded value).
@@ -556,11 +554,13 @@ bool AIE2PInstructionSelector::selectG_AIE_LOAD_UPS(MachineInstr &UPSI,
            (DstRegSize != 1024 || DstRegSize != 2048))) &&
          "Unexpected VLDA.UPS size");
 
+  if (!crUPSModeVal.has_value())
+    return false;
   // Selects the mode of the accumulator for UPS instructions
   // 0 – 32-bit accumulator lane
   // 1 – 64-bit accumulator lane
   MIB.setInstr(*InsertionPoint);
-  setCtrlRegister(MIB, AIE2P::crUPSMode, crUPSModeVal);
+  setCtrlRegister(MIB, AIE2P::crUPSMode, *crUPSModeVal);
 
   auto NewInstr = MIB.buildInstr(LSO->ISelOpcode);
 
@@ -582,40 +582,6 @@ bool AIE2PInstructionSelector::selectG_AIE_LOAD_UPS(MachineInstr &UPSI,
   UPSI.eraseFromParent();
   makeDeadMI(*LoadOp, MRI);
   return constrainSelectedInstRegOperands(*NewInstr.getInstr(), TII, TRI, RBI);
-}
-
-bool AIE2PInstructionSelector::selectVUPS(MachineInstr &I,
-                                          MachineRegisterInfo &MRI,
-                                          unsigned crUPSModeVal) {
-  // First try to match UPS combine
-  if (selectG_AIE_LOAD_UPS(I, MRI, crUPSModeVal))
-    return true;
-
-  // TODO Match UPS combine
-  Register DstReg = I.getOperand(0).getReg();
-  // In this case of G_INTRINSIC_W_SIDE_EFFECTS operand 1 is target intrinsic
-  Register SrcReg = I.getOperand(2).getReg();
-  Register ShftReg = I.getOperand(3).getReg();
-  Register SignReg = I.getOperand(4).getReg();
-  // Selects the mode of the accumulator for UPS instructions
-  // 0 – 32-bit accumulator lane
-  // 1 – 64-bit accumulator lane
-  MIB.setInstr(I);
-  setCtrlRegister(MIB, AIE2P::crUPSMode, crUPSModeVal);
-
-  if (auto SignVal = getIConstantVRegValWithLookThrough(SignReg, MRI)) {
-    // Handle constant sign through instruction patterns
-    return selectImpl(I, *CoverageInfo);
-  }
-
-  unsigned OpCode = TII.getOpCode(I);
-  MachineInstrBuilder MI =
-      MIB.buildInstr(OpCode, {DstReg}, {}).addReg(SrcReg).addReg(ShftReg);
-
-  setUnsetCtrlRegister(MIB, *MI, MRI, AIE2P::upsSign0, SignReg);
-
-  I.eraseFromParent();
-  return constrainSelectedInstRegOperands(*MI, TII, TRI, RBI);
 }
 
 bool AIE2PInstructionSelector::selectVCONVbfp16(MachineInstr &I,

--- a/llvm/lib/Target/AIE/aie2p/AIE2PInstructionSelector.cpp
+++ b/llvm/lib/Target/AIE/aie2p/AIE2PInstructionSelector.cpp
@@ -92,7 +92,6 @@ public:
   bool selectG_LOAD(MachineInstr &I, MachineRegisterInfo &MRI);
   bool selectG_STORE(MachineInstr &I, MachineRegisterInfo &MRI);
   bool selectG_AIE_LOAD_STORE(MachineInstr &I, MachineRegisterInfo &MRI);
-  bool selectG_AIE_STORE_PACK(MachineInstr &StoreI, MachineRegisterInfo &MRI);
   bool selectG_AIE_STORE_SRS(MachineInstr &StoreI, MachineRegisterInfo &MRI);
   bool selectWideG_AIE_LOAD_STORE(MachineInstr &I, LoadStoreOpcodes &LSO,
                                   AddressingModeInfo &AMI,
@@ -144,9 +143,13 @@ private:
                      MachineRegisterInfo &MRI);
   std::optional<LoadStoreOpcodes>
   getCombinedOpcodePACK(const MachineInstr &MemOp, const MachineInstr &CombOp,
-                        std::optional<APInt> Immediate, bool IsSigned);
+                        std::optional<APInt> Immediate, bool IsSigned) override;
   bool canCombinePACK(MachineInstr &MemOp, MachineInstr &CombOp,
-                      MachineRegisterInfo &MRI);
+                      MachineRegisterInfo &MRI) override;
+  bool isPackI8Intrinsic(Intrinsic::ID IntrinsicID) const override {
+    return IntrinsicID == Intrinsic::aie2p_pack_I512_I8_I16 ||
+           IntrinsicID == Intrinsic::aie2p_pack_I1024_I8_I16;
+  }
   std::optional<LoadStoreOpcodes>
   getCombinedOpcodeSRS(const MachineInstr &MemOp, const MachineInstr &CombOp,
                        std::optional<APInt> Immediate, bool IsSigned);
@@ -2509,73 +2512,6 @@ bool AIE2PInstructionSelector::canCombinePACK(MachineInstr &MemOp,
 
   return getCombinedOpcodePACK(MemOp, CombOp, NoImmediate, IsSigned)
       .has_value();
-}
-
-bool AIE2PInstructionSelector::selectG_AIE_STORE_PACK(
-    MachineInstr &StoreI, MachineRegisterInfo &MRI) {
-
-  Register PackResult = (StoreI.uses().begin())->getReg();
-  MachineInstr *PackOp = getDefIgnoringCopiesAndBitcasts(PackResult, MRI);
-
-  if (!canCombinePACK(StoreI, *PackOp, MRI))
-    return false;
-
-  std::optional<AddressingModeInfo> AMI =
-      getOrDefineAddressingRegister(StoreI, MRI);
-  if (!AMI)
-    return false;
-
-  // Note: Operand 1 is the ID of the intrinsic
-  Register SrcReg = PackOp->getOperand(2).getReg();
-  Register SignReg = PackOp->getOperand(3).getReg();
-
-  unsigned MemOpLoadStoreSize = getLoadStoreSize(StoreI);
-  TypeSize SrcRegSize = MRI.getType(SrcReg).getSizeInBits();
-  assert(((MemOpLoadStoreSize == 256 && SrcRegSize == 512) ||
-          (MemOpLoadStoreSize == 512 && SrcRegSize == 1024)) &&
-         "Unexpected VST.PACK size");
-
-  auto SignVal = getIConstantVRegValWithLookThrough(SignReg, MRI);
-  bool ConstantSign = SignVal ? true : false;
-  // SignVal = 1 for signed and 0 for dynamically signed
-  std::optional<LoadStoreOpcodes> LSO = getCombinedOpcodePACK(
-      StoreI, *PackOp, AMI->ImmediateOffset,
-      ConstantSign ? SignVal.value().Value == 0x1 : false);
-
-  assert(LSO && "Unexpected VST.PACK combine failure");
-
-  // Note: the output size (I8 or I4) is not encoded as part of the instruction,
-  // but it is read from the crPackSize register.
-  auto NewInstr = MIB.buildInstr(LSO->ISelOpcode);
-
-  for (auto Def : StoreI.defs())
-    NewInstr.addDef(Def.getReg());
-
-  NewInstr.addUse(SrcReg);
-
-  addAddressingMode(NewInstr, *AMI, LSO->FitsImmediateRange, false, MRI);
-
-  NewInstr.cloneMemRefs(StoreI);
-
-  // Set the crPackSize before NewInstr
-  // Selects the size of the Pack instructions
-  // 0 – Destination is 4 bits
-  // 1 – Destination is 8 bits
-  const bool Is8Bit = cast<GIntrinsic>(PackOp)->getIntrinsicID() ==
-                          Intrinsic::aie2p_pack_I512_I8_I16 ||
-                      cast<GIntrinsic>(PackOp)->getIntrinsicID() ==
-                          Intrinsic::aie2p_pack_I1024_I8_I16;
-
-  auto Opcode = TII.getMvSclMultiSlotPseudoOpcode();
-  MIB.setInstr(*NewInstr);
-  MIB.buildInstr(Opcode, {AIE2P::crPackSize}, {}).addImm((unsigned)Is8Bit);
-
-  if (!ConstantSign)
-    setUnsetCtrlRegister(MIB, *NewInstr, MRI, AIE2P::packSign0, SignReg);
-
-  StoreI.eraseFromParent();
-  makeDeadMI(*PackOp, MRI);
-  return constrainSelectedInstRegOperands(*NewInstr.getInstr(), TII, TRI, RBI);
 }
 
 bool AIE2PInstructionSelector::canCombineSRS(MachineInstr &MemOp,

--- a/llvm/lib/Target/AIE/aie2p/AIE2PInstructionSelector.cpp
+++ b/llvm/lib/Target/AIE/aie2p/AIE2PInstructionSelector.cpp
@@ -152,13 +152,13 @@ private:
                        std::optional<APInt> Immediate, bool IsSigned);
   bool canCombineSRS(MachineInstr &MemOp, MachineInstr &CombOp,
                      MachineRegisterInfo &MRI);
-  bool selectG_AIE_LOAD_UNPACK(MachineInstr &UNPACKI, MachineRegisterInfo &MRI);
-  std::optional<LoadStoreOpcodes>
-  getCombinedOpcodeUNPACKLoad(const MachineInstr &MemOp,
-                              const MachineInstr &CombOp,
-                              std::optional<APInt> Immediate, bool IsSigned);
+  bool setUnpackSizeRegister(MachineIRBuilder &MIB,
+                             Intrinsic::ID IntrinsicID) override;
   bool canCombineUNPACKLoad(MachineInstr &MemOp, MachineInstr &CombOp,
-                            MachineRegisterInfo &MRI);
+                            MachineRegisterInfo &MRI) override;
+  std::optional<LoadStoreOpcodes> getCombinedOpcodeUNPACKLoad(
+      const MachineInstr &MemOp, const MachineInstr &CombOp,
+      std::optional<APInt> Immediate, bool IsSigned) override;
 
   const AIE2PInstrInfo &TII;
   const AIE2PRegisterInfo &TRI;
@@ -3045,6 +3045,26 @@ AIE2PInstructionSelector::getCombinedOpcodeUNPACKLoad(
   return {};
 }
 
+bool AIE2PInstructionSelector::setUnpackSizeRegister(
+    MachineIRBuilder &MIB, Intrinsic::ID IntrinsicID) {
+  // Selects the size of the UNPACK instructions based on source size
+  // 0 – Source is 4 bits
+  // 1 – Source is 8 bits
+  switch (IntrinsicID) {
+  case Intrinsic::aie2p_unpack_I512_I8_I4:
+  case Intrinsic::aie2p_unpack_I1024_I8_I4:
+    setCtrlRegister(MIB, AIE2P::crUnpackSize, 0);
+    break;
+  case Intrinsic::aie2p_unpack_I512_I16_I8:
+  case Intrinsic::aie2p_unpack_I1024_I16_I8:
+    setCtrlRegister(MIB, AIE2P::crUnpackSize, 1);
+    break;
+  default:
+    return false;
+  }
+  return true;
+}
+
 bool AIE2PInstructionSelector::canCombineUNPACKLoad(MachineInstr &MemOp,
                                                     MachineInstr &CombOp,
                                                     MachineRegisterInfo &MRI) {
@@ -3056,83 +3076,6 @@ bool AIE2PInstructionSelector::canCombineUNPACKLoad(MachineInstr &MemOp,
   const bool IsSigned = false;
   return getCombinedOpcodeUNPACKLoad(MemOp, CombOp, NoImmediate, IsSigned)
       .has_value();
-}
-
-bool AIE2PInstructionSelector::selectG_AIE_LOAD_UNPACK(
-    MachineInstr &UNPACKI, MachineRegisterInfo &MRI) {
-  Register LoadResult = UNPACKI.getOperand(2).getReg();
-  MachineInstr *LoadOp = getDefIgnoringCopiesAndBitcasts(LoadResult, MRI);
-  MachineInstr *InsertionPoint = &UNPACKI;
-
-  assert(LoadOp && "Expected SSA.");
-
-  // Do not try to combine if one of the load's defs is used by another
-  // instruction between the load and the VUNPACK or if there is a store
-  // between the load and the VUNPACK.
-  if (!canDelayMemOp(*LoadOp, UNPACKI, MRI)) {
-    // If we cannot delay the load, we can try to advance the combined
-    // instruction to the load's position.
-    if (canAdvanceOp(*LoadOp, UNPACKI, MRI))
-      InsertionPoint = LoadOp;
-    else
-      return false;
-  }
-
-  if (!canCombineUNPACKLoad(*LoadOp, UNPACKI, MRI))
-    return false;
-
-  std::optional<AddressingModeInfo> AMI =
-      getOrDefineAddressingRegister(*LoadOp, MRI);
-  if (!AMI)
-    return false;
-
-  Register DstReg = UNPACKI.getOperand(0).getReg();
-  // In this case of G_INTRINSIC operand 1 is target intrinsic
-  // In this case the operand 2 is the source register which is the loaded value
-  Register SignReg = UNPACKI.getOperand(3).getReg();
-
-  auto SignVal = getIConstantVRegValWithLookThrough(SignReg, MRI);
-  bool ConstantSign = SignVal ? true : false;
-  std::optional<LoadStoreOpcodes> LSO = getCombinedOpcodeUNPACKLoad(
-      *LoadOp, UNPACKI, AMI->ImmediateOffset,
-      ConstantSign ? SignVal.value().Value == 0x1 : false);
-
-  assert(LSO && "Unexpected VLDB.UNPACK combine failure");
-
-  MIB.setInstr(*InsertionPoint);
-  // Selects the size of the UNPACK instructions
-  // 0 – Source is 4 bits
-  // 1 – Source is 8 bits
-  switch (cast<GIntrinsic>(UNPACKI).getIntrinsicID()) {
-  case Intrinsic::aie2p_unpack_I512_I8_I4:
-  case Intrinsic::aie2p_unpack_I1024_I8_I4:
-    setCtrlRegister(MIB, AIE2P::crUnpackSize, 0);
-    break;
-  case Intrinsic::aie2p_unpack_I512_I16_I8:
-  case Intrinsic::aie2p_unpack_I1024_I16_I8:
-    setCtrlRegister(MIB, AIE2P::crUnpackSize, 1);
-  }
-
-  auto NewInstr = MIB.buildInstr(LSO->ISelOpcode);
-
-  NewInstr.addDef(DstReg);
-
-  for (auto *Def = std::next(LoadOp->defs().begin());
-       Def != LoadOp->defs().end(); ++Def) {
-    NewInstr.addDef(Def->getReg());
-  }
-
-  addAddressingMode(NewInstr, *AMI, LSO->FitsImmediateRange, false, MRI);
-
-  NewInstr.cloneMemRefs(*LoadOp);
-
-  if (!ConstantSign)
-    setUnsetCtrlRegister(MIB, *NewInstr, MRI, AIE2P::unpackSign0, SignReg);
-
-  UNPACKI.eraseFromParent();
-  makeDeadMI(*LoadOp, MRI);
-
-  return constrainSelectedInstRegOperands(*NewInstr.getInstr(), TII, TRI, RBI);
 }
 
 bool AIE2PInstructionSelector::selectG_AIE_BROADCAST_VECTOR(

--- a/llvm/lib/Target/AIE/aie2p/AIE2PInstructionSelector.cpp
+++ b/llvm/lib/Target/AIE/aie2p/AIE2PInstructionSelector.cpp
@@ -321,6 +321,10 @@ bool AIE2PInstructionSelector::select(MachineInstr &I) {
       return selectSetControlRegister(I, MRI);
     case Intrinsic::aie2p_get_ctrl_reg:
       return selectGetControlRegister(I, MRI);
+    case Intrinsic::aie2p_set_status_reg:
+      return selectSetStatusRegister(I, MRI);
+    case Intrinsic::aie2p_get_status_reg:
+      return selectGetStatusRegister(I, MRI);
     case Intrinsic::aie2p_I256_v16_acc32_srs:
     case Intrinsic::aie2p_I256_v32_acc32_srs:
     case Intrinsic::aie2p_I512_v32_acc32_srs:

--- a/llvm/lib/Target/AIE/aie2p/AIE2PInstructionSelector.cpp
+++ b/llvm/lib/Target/AIE/aie2p/AIE2PInstructionSelector.cpp
@@ -54,7 +54,7 @@ public:
   bool selectG_CONCAT_VECTORS(MachineInstr &I, MachineRegisterInfo &MRI);
   bool selectCascadeStreamInsn(MachineInstr &I, MachineRegisterInfo &MRI,
                                bool isWrite);
-  bool selectVST_FIFO(MachineInstr &I, MachineRegisterInfo &MRI);
+  bool selectVST_FIFO_BFP16(MachineInstr &I, MachineRegisterInfo &MRI);
   bool selectVST_FIFO_CONV(MachineInstr &StoreI, MachineRegisterInfo &MRI);
 
   static const char *getName() { return DEBUG_TYPE; }
@@ -381,16 +381,21 @@ bool AIE2PInstructionSelector::select(MachineInstr &I) {
       return selectVCONVbfp16(I, MRI);
     case Intrinsic::aie2p_fifo_st_push_576_bfp16:
     case Intrinsic::aie2p_fifo_st_push_544_bfp16:
+      return selectVST_FIFO_BFP16(I, MRI);
     case Intrinsic::aie2p_fifo_st_push_512_bfp16:
+      return selectVST_FIFO_Push(I, MRI);
     case Intrinsic::aie2p_fifo_st_flush:
     case Intrinsic::aie2p_fifo_st_flush_conv:
+      return selectVST_FIFO_Flush(I, MRI);
     case Intrinsic::aie2p_fifo_st_flush_1d:
     case Intrinsic::aie2p_fifo_st_flush_1d_conv:
+      return selectVST_FIFO_Flush1D(I, MRI);
     case Intrinsic::aie2p_fifo_st_flush_2d:
     case Intrinsic::aie2p_fifo_st_flush_2d_conv:
+      return selectVST_FIFO_Flush2D(I, MRI);
     case Intrinsic::aie2p_fifo_st_flush_3d:
     case Intrinsic::aie2p_fifo_st_flush_3d_conv:
-      return selectVST_FIFO(I, MRI);
+      return selectVST_FIFO_Flush3D(I, MRI);
     case Intrinsic::aie2p_fifo_ld_fill:
       return selectVLD_FIFO_FILL(I, MRI);
     case Intrinsic::aie2p_fifo_ld_fillx:
@@ -3800,35 +3805,6 @@ bool AIE2PInstructionSelector ::selectVSHUFFLE_BFP(MachineInstr &I,
   return constrainSelectedInstRegOperands(*MI, TII, TRI, RBI);
 }
 
-unsigned int getStoreFifoOpcode(MachineInstr &I) {
-  switch (cast<GIntrinsic>(I).getIntrinsicID()) {
-  case Intrinsic::aie2p_fifo_st_flush:
-    return AIE2P::VST_FLUSH_512_normal_flush;
-  case Intrinsic::aie2p_fifo_st_flush_1d:
-    return AIE2P::VST_FLUSH_512_fifo_1d_flush;
-  case Intrinsic::aie2p_fifo_st_flush_2d:
-    return AIE2P::VST_FLUSH_512_2D;
-  case Intrinsic::aie2p_fifo_st_flush_3d:
-    return AIE2P::VST_FLUSH_512_3D;
-  case Intrinsic::aie2p_fifo_st_flush_conv:
-    return AIE2P::VST_FLUSH_512_CONV_normal_flush;
-  case Intrinsic::aie2p_fifo_st_flush_1d_conv:
-    return AIE2P::VST_FLUSH_512_CONV_fifo_1d_flush;
-  case Intrinsic::aie2p_fifo_st_flush_2d_conv:
-    return AIE2P::VST_FLUSH_512_CONV_2D;
-  case Intrinsic::aie2p_fifo_st_flush_3d_conv:
-    return AIE2P::VST_FLUSH_512_CONV_3D;
-  case Intrinsic::aie2p_fifo_st_push_576_bfp16:
-    return AIE2P::VST_PUSH_576;
-  case Intrinsic::aie2p_fifo_st_push_544_bfp16:
-    return AIE2P::VST_PUSH_544;
-  case Intrinsic::aie2p_fifo_st_push_512_bfp16:
-    return AIE2P::VST_PUSH_512;
-  }
-  llvm_unreachable("Unreachable: Cannot get fifo store opcode from intrinsic");
-  return AIE2P::INSTRUCTION_LIST_END;
-}
-
 bool AIE2PInstructionSelector::selectVST_FIFO_CONV(MachineInstr &StoreI,
                                                    MachineRegisterInfo &MRI) {
   Register ConvResult = StoreI.getOperand(5).getReg();
@@ -3880,128 +3856,39 @@ bool AIE2PInstructionSelector::selectVST_FIFO_CONV(MachineInstr &StoreI,
   return constrainSelectedInstRegOperands(*NewInstr.getInstr(), TII, TRI, RBI);
 }
 
-bool AIE2PInstructionSelector::selectVST_FIFO(MachineInstr &I,
-                                              MachineRegisterInfo &MRI) {
-  auto IntrinsicID = cast<GIntrinsic>(I).getIntrinsicID();
-  MachineInstrBuilder MI;
-  Register PtrOut = I.getOperand(0).getReg();
-  Register FifoOut = I.getOperand(1).getReg();
-  Register AvailOut = I.getOperand(2).getReg();
-  switch (IntrinsicID) {
-  case Intrinsic::aie2p_fifo_st_push_512_bfp16: {
-    Register PtrIn = I.getOperand(4).getReg();
-    Register FifoIn = I.getOperand(6).getReg();
-    Register AvailIn = I.getOperand(7).getReg();
-    Register VecIn = I.getOperand(5).getReg();
+bool AIE2PInstructionSelector::selectVST_FIFO_BFP16(MachineInstr &I,
+                                                    MachineRegisterInfo &MRI) {
+  // First try to match CONV combine
+  if (selectVST_FIFO_CONV(I, MRI))
+    return true;
 
-    MI = MIB.buildInstr(getStoreFifoOpcode(I), {FifoOut, PtrOut, AvailOut},
-                        {FifoIn, VecIn, PtrIn, AvailIn});
+  const auto IntrinsicID = cast<GIntrinsic>(I).getIntrinsicID();
+  const unsigned Opcode =
+      (IntrinsicID == Intrinsic::aie2p_fifo_st_push_576_bfp16)
+          ? AIE2P::VST_PUSH_576
+          : AIE2P::VST_PUSH_544;
 
-    MI.cloneMemRefs(I);
-    I.eraseFromParent();
-    return constrainSelectedInstRegOperands(*MI, TII, TRI, RBI);
-  }
-  case Intrinsic::aie2p_fifo_st_push_544_bfp16:
-  case Intrinsic::aie2p_fifo_st_push_576_bfp16: {
-    // First try to match CONV combine
-    if (selectVST_FIFO_CONV(I, MRI))
-      return true;
+  const Register PtrOut = I.getOperand(0).getReg();
+  const Register FifoOut = I.getOperand(1).getReg();
+  const Register AvailOut = I.getOperand(2).getReg();
+  const Register PtrIn = I.getOperand(4).getReg();
+  const Register MantIn = I.getOperand(5).getReg();
+  const Register ExpIn = I.getOperand(6).getReg();
+  const Register FifoIn = I.getOperand(7).getReg();
+  const Register AvailIn = I.getOperand(8).getReg();
 
-    Register PtrIn = I.getOperand(4).getReg();
-    Register FifoIn = I.getOperand(7).getReg();
-    Register AvailIn = I.getOperand(8).getReg();
-    Register MantIn = I.getOperand(5).getReg();
-    Register ExpIn = I.getOperand(6).getReg();
+  const Register SrcReg = MRI.createVirtualRegister(&AIE2P::mEXaRegClass);
+  MIB.buildInstr(TargetOpcode::REG_SEQUENCE, {SrcReg}, {})
+      .addReg(MantIn)
+      .addImm(AIE2P::sub_bfp16_x)
+      .addReg(ExpIn)
+      .addImm(AIE2P::sub_bfp16_e);
 
-    Register SrcReg = MRI.createVirtualRegister(&AIE2P::mEXaRegClass);
-    MIB.buildInstr(TargetOpcode::REG_SEQUENCE, {SrcReg}, {})
-        .addReg(MantIn)
-        .addImm(AIE2P::sub_bfp16_x)
-        .addReg(ExpIn)
-        .addImm(AIE2P::sub_bfp16_e);
-    MI = MIB.buildInstr(getStoreFifoOpcode(I), {FifoOut, PtrOut, AvailOut},
-                        {FifoIn, SrcReg, PtrIn, AvailIn});
-
-    MI.cloneMemRefs(I);
-    I.eraseFromParent();
-    return constrainSelectedInstRegOperands(*MI, TII, TRI, RBI);
-  }
-  case Intrinsic::aie2p_fifo_st_flush_conv:
-  case Intrinsic::aie2p_fifo_st_flush: {
-    Register PtrIn = I.getOperand(4).getReg();
-    Register FifoIn = I.getOperand(5).getReg();
-    Register AvailIn = I.getOperand(6).getReg();
-    MI = MIB.buildInstr(getStoreFifoOpcode(I), {FifoOut, PtrOut, AvailOut},
-                        {FifoIn, PtrIn, AvailIn});
-
-    MI.cloneMemRefs(I);
-    I.eraseFromParent();
-    return constrainSelectedInstRegOperands(*MI, TII, TRI, RBI);
-  }
-  case Intrinsic::aie2p_fifo_st_flush_1d:
-  case Intrinsic::aie2p_fifo_st_flush_1d_conv: {
-    Register PtrIn = I.getOperand(4).getReg();
-    Register FifoIn = I.getOperand(5).getReg();
-    Register AvailIn = I.getOperand(6).getReg();
-    Register OffsetReg = I.getOperand(7).getReg();
-    MI = MIB.buildInstr(getStoreFifoOpcode(I), {FifoOut, PtrOut, AvailOut},
-                        {FifoIn, PtrIn, AvailIn, OffsetReg});
-    MI.cloneMemRefs(I);
-    I.eraseFromParent();
-    return constrainSelectedInstRegOperands(*MI, TII, TRI, RBI);
-  }
-  case Intrinsic::aie2p_fifo_st_flush_2d:
-  case Intrinsic::aie2p_fifo_st_flush_2d_conv: {
-    Register CountOut1Reg = I.getOperand(3).getReg();
-    Register PtrIn = I.getOperand(5).getReg();
-    Register FifoIn = I.getOperand(6).getReg();
-    Register AvailIn = I.getOperand(7).getReg();
-    Register OffsetReg = I.getOperand(8).getReg();
-    Register SizeReg = I.getOperand(9).getReg();
-    Register CountIn1Reg = I.getOperand(10).getReg();
-    Register IncrReg = I.getOperand(11).getReg();
-    Register DReg =
-        createDRegSequence(OffsetReg, IncrReg, SizeReg, CountIn1Reg, MRI);
-
-    MI = MIB.buildInstr(getStoreFifoOpcode(I),
-                        {FifoOut, PtrOut, AvailOut, CountOut1Reg},
-                        {FifoIn, PtrIn, AvailIn, DReg});
-
-    MI.cloneMemRefs(I);
-    I.eraseFromParent();
-    return constrainSelectedInstRegOperands(*MI, TII, TRI, RBI);
-  }
-  case Intrinsic::aie2p_fifo_st_flush_3d:
-  case Intrinsic::aie2p_fifo_st_flush_3d_conv: {
-    Register CountOut1Reg = I.getOperand(3).getReg();
-    Register CountOut2Reg = I.getOperand(4).getReg();
-
-    Register PtrIn = I.getOperand(6).getReg();
-    Register FifoIn = I.getOperand(7).getReg();
-    Register AvailIn = I.getOperand(8).getReg();
-    Register OffsetReg = I.getOperand(9).getReg();
-    Register Size1Reg = I.getOperand(10).getReg();
-    Register CountIn1Reg = I.getOperand(11).getReg();
-    Register Incr1Reg = I.getOperand(12).getReg();
-    Register Size2Reg = I.getOperand(13).getReg();
-    Register CountIn2Reg = I.getOperand(14).getReg();
-    Register Incr2Reg = I.getOperand(15).getReg();
-
-    Register DSReg =
-        createDSRegSequence(OffsetReg, Incr1Reg, Incr2Reg, Size1Reg,
-                            CountIn1Reg, Size2Reg, CountIn2Reg, MRI);
-
-    MI = MIB.buildInstr(getStoreFifoOpcode(I),
-                        {FifoOut, PtrOut, AvailOut, CountOut1Reg, CountOut2Reg},
-                        {FifoIn, PtrIn, AvailIn, DSReg});
-
-    MI.cloneMemRefs(I);
-    I.eraseFromParent();
-    return constrainSelectedInstRegOperands(*MI, TII, TRI, RBI);
-  }
-    return false;
-  }
-  return false;
+  auto MI = MIB.buildInstr(Opcode, {FifoOut, PtrOut, AvailOut},
+                           {FifoIn, SrcReg, PtrIn, AvailIn});
+  MI.cloneMemRefs(I);
+  I.eraseFromParent();
+  return constrainSelectedInstRegOperands(*MI, TII, TRI, RBI);
 }
 namespace llvm {
 InstructionSelector *

--- a/llvm/lib/Target/AIE/aie2p/AIE2PInstructionSelector.cpp
+++ b/llvm/lib/Target/AIE/aie2p/AIE2PInstructionSelector.cpp
@@ -92,7 +92,6 @@ public:
   bool selectG_LOAD(MachineInstr &I, MachineRegisterInfo &MRI);
   bool selectG_STORE(MachineInstr &I, MachineRegisterInfo &MRI);
   bool selectG_AIE_LOAD_STORE(MachineInstr &I, MachineRegisterInfo &MRI);
-  bool selectG_AIE_STORE_SRS(MachineInstr &StoreI, MachineRegisterInfo &MRI);
   bool selectWideG_AIE_LOAD_STORE(MachineInstr &I, LoadStoreOpcodes &LSO,
                                   AddressingModeInfo &AMI,
                                   MachineRegisterInfo &MRI);
@@ -152,9 +151,10 @@ private:
   }
   std::optional<LoadStoreOpcodes>
   getCombinedOpcodeSRS(const MachineInstr &MemOp, const MachineInstr &CombOp,
-                       std::optional<APInt> Immediate, bool IsSigned);
+                       std::optional<APInt> Immediate, bool IsSigned) override;
   bool canCombineSRS(MachineInstr &MemOp, MachineInstr &CombOp,
-                     MachineRegisterInfo &MRI);
+                     MachineRegisterInfo &MRI) override;
+  std::optional<unsigned> getSRSModeForIntrinsic(Intrinsic::ID ID) override;
   bool setUnpackSizeRegister(MachineIRBuilder &MIB,
                              Intrinsic::ID IntrinsicID) override;
   bool canCombineUNPACKLoad(MachineInstr &MemOp, MachineInstr &CombOp,
@@ -2527,83 +2527,25 @@ bool AIE2PInstructionSelector::canCombineSRS(MachineInstr &MemOp,
   return getCombinedOpcodeSRS(MemOp, CombOp, NoImmediate, IsSigned).has_value();
 }
 
-bool AIE2PInstructionSelector::selectG_AIE_STORE_SRS(MachineInstr &StoreI,
-                                                     MachineRegisterInfo &MRI) {
-
-  Register SrsResult = (StoreI.uses().begin())->getReg();
-  MachineInstr *SrsOp = getDefIgnoringCopiesAndBitcasts(SrsResult, MRI);
-
-  assert(SrsOp && "Expected SSA.");
-
-  if (!canCombineSRS(StoreI, *SrsOp, MRI))
-    return false;
-
-  std::optional<AddressingModeInfo> AMI =
-      getOrDefineAddressingRegister(StoreI, MRI);
-  if (!AMI)
-    return false;
-
-  // Note: Operand 1 is the ID of the intrinsic
-  Register SrcReg = SrsOp->getOperand(2).getReg();
-  Register ShftReg = SrsOp->getOperand(3).getReg();
-  Register SignReg = SrsOp->getOperand(4).getReg();
-
-  unsigned MemOpLoadStoreSize = getLoadStoreSize(StoreI);
-  TypeSize SrcRegSize = MRI.getType(SrcReg).getSizeInBits();
-  assert(((MemOpLoadStoreSize == 256 &&
-           (SrcRegSize == 512 || SrcRegSize == 1024)) ||
-          (MemOpLoadStoreSize == 512 &&
-           (SrcRegSize == 1024 || SrcRegSize == 2048))) &&
-         "Unexpected VST.SRS size");
-
-  auto SignVal = getIConstantVRegValWithLookThrough(SignReg, MRI);
-  bool ConstantSign = SignVal ? true : false;
-  // SignVal = 1 for signed and 0 for unsigned
-  std::optional<LoadStoreOpcodes> LSO =
-      getCombinedOpcodeSRS(StoreI, *SrsOp, AMI->ImmediateOffset,
-                           ConstantSign ? SignVal.value().Value == 0x1 : false);
-
-  assert(LSO && "Unexpected VST.SRS combine failure");
-
+std::optional<unsigned>
+AIE2PInstructionSelector::getSRSModeForIntrinsic(Intrinsic::ID ID) {
   // Selects the mode of the accumulator for SRS instructions
   // 0 – 32-bit accumulator lane
   // 1 – 64-bit accumulator lane
-  MIB.setInstr(StoreI);
-  switch (cast<GIntrinsic>(SrsOp)->getIntrinsicID()) {
+  switch (ID) {
   case Intrinsic::aie2p_I512_v64_acc32_srs:
   case Intrinsic::aie2p_I512_v32_acc32_srs:
   case Intrinsic::aie2p_I256_v16_acc32_srs:
   case Intrinsic::aie2p_I256_v32_acc32_srs:
-    MIB.buildInstr(AIE2P::MOV_scalar_imm11_pseudo, {AIE2P::crSRSMode}, {})
-        .addImm(0);
-    break;
+    return 0;
   case Intrinsic::aie2p_I512_v32_acc64_srs:
   case Intrinsic::aie2p_I512_v16_acc64_srs:
   case Intrinsic::aie2p_I256_v8_acc64_srs:
   case Intrinsic::aie2p_I256_v16_acc64_srs:
-    MIB.buildInstr(AIE2P::MOV_scalar_imm11_pseudo, {AIE2P::crSRSMode}, {})
-        .addImm(1);
-    break;
+    return 1;
+  default:
+    return std::nullopt;
   }
-
-  auto NewInstr = MIB.buildInstr(LSO->ISelOpcode);
-
-  for (auto Def : StoreI.defs())
-    NewInstr.addDef(Def.getReg());
-
-  NewInstr.addUse(SrcReg);
-  NewInstr.addUse(ShftReg);
-
-  addAddressingMode(NewInstr, *AMI, LSO->FitsImmediateRange, false, MRI);
-
-  NewInstr.cloneMemRefs(StoreI);
-
-  if (!ConstantSign)
-    setUnsetCtrlRegister(MIB, *NewInstr, MRI, AIE2P::srsSign0, SignReg);
-
-  makeDeadMI(*SrsOp, MRI);
-  StoreI.eraseFromParent();
-  return constrainSelectedInstRegOperands(*NewInstr.getInstr(), TII, TRI, RBI);
 }
 
 bool AIE2PInstructionSelector::selectVUNPACK(MachineInstr &I,

--- a/llvm/lib/Target/AIE/aie2p/AIE2PInstructionSelector.cpp
+++ b/llvm/lib/Target/AIE/aie2p/AIE2PInstructionSelector.cpp
@@ -45,8 +45,6 @@ public:
 
   bool select(MachineInstr &I) override;
   bool selectG_GLOBAL_VALUE(MachineInstr &I, MachineRegisterInfo &MRI);
-  bool selectSetControlRegister(MachineInstr &I, MachineRegisterInfo &MRI);
-  bool selectGetControlRegister(MachineInstr &I, MachineRegisterInfo &MRI);
   bool selectVSRS(MachineInstr &I, MachineRegisterInfo &MRI,
                   unsigned crSRSModeVal);
   bool selectVUPS(MachineInstr &I, MachineRegisterInfo &MRI,
@@ -467,90 +465,6 @@ bool AIE2PInstructionSelector::selectG_GLOBAL_VALUE(MachineInstr &I,
   I.setDesc(TII.get(AIE2P::MOVXM));
   I.getOperand(1).setTargetFlags(AIEII::MO_GLOBAL);
   return constrainSelectedInstRegOperands(I, TII, TRI, RBI);
-}
-
-// Build Instruction to get control register
-bool AIE2PInstructionSelector::selectGetControlRegister(
-    MachineInstr &I, MachineRegisterInfo &MRI) {
-
-  Register DstReg = I.getOperand(0).getReg();
-  // In this case of G_INTRINSIC operand 1 is target intrinsic
-  Register IdxReg = I.getOperand(2).getReg();
-  Register CtrlReg;
-
-  // Check if the argument is constant for register map index.
-  if (auto Idx = getIConstantVRegValWithLookThrough(IdxReg, MRI))
-    CtrlReg = TRI.getControlRegister(Idx->Value.getZExtValue());
-  else
-    llvm_unreachable("Expected const value for control register map index.");
-
-  if (!RBI.constrainGenericRegister(DstReg, AIE2P::eRRegClass, MRI))
-    return false;
-
-  auto CopyInstr =
-      MIB.buildInstr(TargetOpcode::COPY, {DstReg}, {}).addReg(CtrlReg);
-  if (!selectCopy(*CopyInstr, MRI)) {
-    return false;
-  }
-  I.eraseFromParent();
-  return true;
-}
-
-// Build Instruction to set control register
-bool AIE2PInstructionSelector::selectSetControlRegister(
-    MachineInstr &I, MachineRegisterInfo &MRI) {
-
-  Register IdxReg = I.getOperand(1).getReg();
-  Register SrcReg = I.getOperand(2).getReg();
-  Register CtrlReg;
-
-  // Check if the argument is constant for register map index.
-  if (auto Idx = getIConstantVRegValWithLookThrough(IdxReg, MRI))
-    CtrlReg = TRI.getControlRegister(Idx->Value.getZExtValue());
-  else
-    llvm_unreachable("Expected const value for control register map index.");
-
-  // Handle const input val for control regs.
-  if (auto Src = getIConstantVRegValWithLookThrough(SrcReg, MRI)) {
-    unsigned SrcConstVal = Src->Value.getZExtValue();
-    /* Modulo by width of control regs.
-       To constrain the max possible value in the register
-       according to register width.
-    */
-    switch (CtrlReg) {
-    case AIE2P::crSat:
-      SrcConstVal = SrcConstVal % (1 << 2);
-      break;
-    case AIE2P::crRnd:
-      SrcConstVal = SrcConstVal % (1 << 4);
-      break;
-    case AIE2P::crF2FMask:
-    case AIE2P::crF2IMask:
-    case AIE2P::crFPMask:
-    case AIE2P::crF2BMask:
-      SrcConstVal = SrcConstVal % (1 << 5);
-      break;
-    case AIE2P::crFPNlfMask:
-    case AIE2P::crFPCnvFx2FlMask:
-    case AIE2P::crFPCnvFl2FxMask:
-      SrcConstVal = SrcConstVal % (1 << 8);
-      break;
-    default:
-      break;
-    }
-
-    MachineInstrBuilder MI = setCtrlRegister(MIB, CtrlReg, SrcConstVal);
-    I.eraseFromParent();
-    return constrainSelectedInstRegOperands(*MI, TII, TRI, RBI);
-  }
-
-  auto CopyInstr =
-      MIB.buildInstr(TargetOpcode::COPY, {CtrlReg}, {}).addReg(SrcReg);
-  if (!selectCopy(*CopyInstr, MRI))
-    return false;
-
-  I.eraseFromParent();
-  return true;
 }
 
 bool AIE2PInstructionSelector::selectVSRS(MachineInstr &I,

--- a/llvm/lib/Target/AIE/aie2p/AIE2PRegisterInfo.cpp
+++ b/llvm/lib/Target/AIE/aie2p/AIE2PRegisterInfo.cpp
@@ -432,28 +432,32 @@ Register AIE2PRegisterInfo::getControlRegister(unsigned Idx) const {
       {21, AIE2P::crMCDEn},
       {22, AIE2P::crFPNlfMask},
       {23, AIE2P::crFPCnvFx2FlMask},
-      {24, AIE2P::crFPCnvFl2FxMask},
-      {25, AIE2P::srCarry},
-      {26, AIE2P::srSS0},
-      {27, AIE2P::srMS0},
-      {28, AIE2P::srSRS_of},
-      {29, AIE2P::srUPS_of},
-      {30, AIE2P::srSparse_of},
-      {31, AIE2P::srFifo_of},
-      {32, AIE2P::srFifo_uf},
-      {33, AIE2P::srFPFlags},
-      {34, AIE2P::srF2IFlags},
-      {35, AIE2P::srF2FFlags},
-      {36, AIE2P::srF2BFlags},
-      {37, AIE2P::srFPNlf},
-      {38, AIE2P::srFPCnvFx2Fl},
-      {39, AIE2P::srFPCnvFl2Fx}
+      {24, AIE2P::crFPCnvFl2FxMask}
 
   };
 
   if (ControlRegisterMap.find(Idx) != ControlRegisterMap.end())
     return ControlRegisterMap[Idx];
   llvm_unreachable("Unexpected key for control register.");
+}
+
+Register AIE2PRegisterInfo::getStatusRegister(unsigned Idx) const {
+  // Status Register Map. Keys based on encoding.
+  static std::unordered_map<unsigned, Register> StatusRegisterMap = {
+      {25, AIE2P::srCarry},     {26, AIE2P::srSS0},
+      {27, AIE2P::srMS0},       {28, AIE2P::srSRS_of},
+      {29, AIE2P::srUPS_of},    {30, AIE2P::srSparse_of},
+      {31, AIE2P::srFifo_of},   {32, AIE2P::srFifo_uf},
+      {33, AIE2P::srFPFlags},   {34, AIE2P::srF2IFlags},
+      {35, AIE2P::srF2FFlags},  {36, AIE2P::srF2BFlags},
+      {37, AIE2P::srFPNlf},     {38, AIE2P::srFPCnvFx2Fl},
+      {39, AIE2P::srFPCnvFl2Fx}
+
+  };
+
+  if (StatusRegisterMap.find(Idx) != StatusRegisterMap.end())
+    return StatusRegisterMap[Idx];
+  llvm_unreachable("Unexpected key for status register.");
 }
 
 const TargetRegisterClass *
@@ -654,9 +658,26 @@ bool AIE2PRegisterInfo::shouldCoalesce(
 unsigned
 AIE2PRegisterInfo::matchControlRegisterBitwidth(Register CtrlReg,
                                                 unsigned SrcConstVal) const {
-  // Modulo by width of control regs.  To constrain the max possible value in
+  // Modulo by width of control regs. To constrain the max possible value in
   // the register according to register width.
   switch (CtrlReg) {
+  case AIE2P::crSRSMode:
+  case AIE2P::crUPSMode:
+  case AIE2P::crUnpackSize:
+  case AIE2P::crPackSize:
+  case AIE2P::srsSign0:
+  case AIE2P::srsSign1:
+  case AIE2P::upsSign0:
+  case AIE2P::upsSign1:
+  case AIE2P::packSign0:
+  case AIE2P::packSign1:
+  case AIE2P::unpackSign0:
+  case AIE2P::unpackSign1:
+  case AIE2P::vaddSign0:
+  case AIE2P::vaddSign1:
+  case AIE2P::crSCDEn:
+  case AIE2P::crMCDEn:
+    return SrcConstVal % (1 << 1);
   case AIE2P::crSat:
     return SrcConstVal % (1 << 2);
   case AIE2P::crRnd:

--- a/llvm/lib/Target/AIE/aie2p/AIE2PRegisterInfo.cpp
+++ b/llvm/lib/Target/AIE/aie2p/AIE2PRegisterInfo.cpp
@@ -737,3 +737,11 @@ Register AIE2PRegisterInfo::getPackSignCtrlReg() const {
 Register AIE2PRegisterInfo::getPackSizeCtrlReg() const {
   return AIE2P::crPackSize;
 }
+
+Register AIE2PRegisterInfo::getSRSSignCtrlReg() const {
+  return AIE2P::srsSign0;
+}
+
+Register AIE2PRegisterInfo::getSRSModeCtrlReg() const {
+  return AIE2P::crSRSMode;
+}

--- a/llvm/lib/Target/AIE/aie2p/AIE2PRegisterInfo.cpp
+++ b/llvm/lib/Target/AIE/aie2p/AIE2PRegisterInfo.cpp
@@ -725,3 +725,7 @@ AIE2PRegisterInfo::matchStatusRegisterBitwidth(Register StatusReg,
     llvm_unreachable("Unknown status register.");
   }
 }
+
+Register AIE2PRegisterInfo::getUnpackSignCtrlReg() const {
+  return AIE2P::unpackSign0;
+}

--- a/llvm/lib/Target/AIE/aie2p/AIE2PRegisterInfo.cpp
+++ b/llvm/lib/Target/AIE/aie2p/AIE2PRegisterInfo.cpp
@@ -729,3 +729,11 @@ AIE2PRegisterInfo::matchStatusRegisterBitwidth(Register StatusReg,
 Register AIE2PRegisterInfo::getUnpackSignCtrlReg() const {
   return AIE2P::unpackSign0;
 }
+
+Register AIE2PRegisterInfo::getPackSignCtrlReg() const {
+  return AIE2P::packSign0;
+}
+
+Register AIE2PRegisterInfo::getPackSizeCtrlReg() const {
+  return AIE2P::crPackSize;
+}

--- a/llvm/lib/Target/AIE/aie2p/AIE2PRegisterInfo.cpp
+++ b/llvm/lib/Target/AIE/aie2p/AIE2PRegisterInfo.cpp
@@ -695,3 +695,33 @@ AIE2PRegisterInfo::matchControlRegisterBitwidth(Register CtrlReg,
     llvm_unreachable("Unknown control register.");
   }
 }
+
+unsigned
+AIE2PRegisterInfo::matchStatusRegisterBitwidth(Register StatusReg,
+                                               unsigned SrcConstVal) const {
+  // Modulo by width of status regs. To constrain the max possible value in
+  // the register according to register width.
+  switch (StatusReg) {
+  case AIE2P::srCarry:
+  case AIE2P::srSRS_of:
+  case AIE2P::srUPS_of:
+  case AIE2P::srSparse_of:
+  case AIE2P::srFifo_of:
+  case AIE2P::srFifo_uf:
+    return SrcConstVal % (1 << 1);
+  case AIE2P::srFPFlags:
+  case AIE2P::srF2IFlags:
+  case AIE2P::srF2FFlags:
+  case AIE2P::srF2BFlags:
+    return SrcConstVal % (1 << 5);
+  case AIE2P::srFPNlf:
+  case AIE2P::srFPCnvFx2Fl:
+  case AIE2P::srFPCnvFl2Fx:
+    return SrcConstVal % (1 << 8);
+  case AIE2P::srSS0:
+  case AIE2P::srMS0:
+    return SrcConstVal;
+  default:
+    llvm_unreachable("Unknown status register.");
+  }
+}

--- a/llvm/lib/Target/AIE/aie2p/AIE2PRegisterInfo.cpp
+++ b/llvm/lib/Target/AIE/aie2p/AIE2PRegisterInfo.cpp
@@ -650,3 +650,27 @@ bool AIE2PRegisterInfo::shouldCoalesce(
   return TargetRegisterInfo::shouldCoalesce(MI, SrcRC, SubReg, DstRC, DstSubReg,
                                             NewRC, LIS);
 }
+
+unsigned
+AIE2PRegisterInfo::matchControlRegisterBitwidth(Register CtrlReg,
+                                                unsigned SrcConstVal) const {
+  // Modulo by width of control regs.  To constrain the max possible value in
+  // the register according to register width.
+  switch (CtrlReg) {
+  case AIE2P::crSat:
+    return SrcConstVal % (1 << 2);
+  case AIE2P::crRnd:
+    return SrcConstVal % (1 << 4);
+  case AIE2P::crF2FMask:
+  case AIE2P::crF2IMask:
+  case AIE2P::crFPMask:
+  case AIE2P::crF2BMask:
+    return SrcConstVal % (1 << 5);
+  case AIE2P::crFPNlfMask:
+  case AIE2P::crFPCnvFx2FlMask:
+  case AIE2P::crFPCnvFl2FxMask:
+    return SrcConstVal % (1 << 8);
+  default:
+    llvm_unreachable("Unknown control register.");
+  }
+}

--- a/llvm/lib/Target/AIE/aie2p/AIE2PRegisterInfo.h
+++ b/llvm/lib/Target/AIE/aie2p/AIE2PRegisterInfo.h
@@ -116,6 +116,8 @@ struct AIE2PRegisterInfo : public AIE2PGenRegisterInfo {
                                         unsigned SrcConstVal) const override;
   unsigned matchStatusRegisterBitwidth(Register StatusReg,
                                        unsigned SrcConstVal) const override;
+
+  Register getUnpackSignCtrlReg() const override;
 };
 } // namespace llvm
 

--- a/llvm/lib/Target/AIE/aie2p/AIE2PRegisterInfo.h
+++ b/llvm/lib/Target/AIE/aie2p/AIE2PRegisterInfo.h
@@ -72,6 +72,7 @@ struct AIE2PRegisterInfo : public AIE2PGenRegisterInfo {
 
   Register getStackPointerRegister() const override;
   Register getControlRegister(unsigned Idx) const override;
+  Register getStatusRegister(unsigned Idx) const override;
 
   const TargetRegisterClass *
   getLargestLegalSuperClass(const TargetRegisterClass *RC,

--- a/llvm/lib/Target/AIE/aie2p/AIE2PRegisterInfo.h
+++ b/llvm/lib/Target/AIE/aie2p/AIE2PRegisterInfo.h
@@ -118,6 +118,8 @@ struct AIE2PRegisterInfo : public AIE2PGenRegisterInfo {
                                        unsigned SrcConstVal) const override;
 
   Register getUnpackSignCtrlReg() const override;
+  Register getPackSignCtrlReg() const override;
+  Register getPackSizeCtrlReg() const override;
 };
 } // namespace llvm
 

--- a/llvm/lib/Target/AIE/aie2p/AIE2PRegisterInfo.h
+++ b/llvm/lib/Target/AIE/aie2p/AIE2PRegisterInfo.h
@@ -71,7 +71,7 @@ struct AIE2PRegisterInfo : public AIE2PGenRegisterInfo {
       const MachineOperand &MO, const MachineRegisterInfo &MRI) const override;
 
   Register getStackPointerRegister() const override;
-  Register getControlRegister(unsigned Idx) const;
+  Register getControlRegister(unsigned Idx) const override;
 
   const TargetRegisterClass *
   getLargestLegalSuperClass(const TargetRegisterClass *RC,
@@ -110,6 +110,9 @@ struct AIE2PRegisterInfo : public AIE2PGenRegisterInfo {
                       unsigned SubReg, const TargetRegisterClass *DstRC,
                       unsigned DstSubReg, const TargetRegisterClass *NewRC,
                       LiveIntervals &LIS) const override;
+
+  unsigned matchControlRegisterBitwidth(Register CtrlReg,
+                                        unsigned SrcConstVal) const override;
 };
 } // namespace llvm
 

--- a/llvm/lib/Target/AIE/aie2p/AIE2PRegisterInfo.h
+++ b/llvm/lib/Target/AIE/aie2p/AIE2PRegisterInfo.h
@@ -114,6 +114,8 @@ struct AIE2PRegisterInfo : public AIE2PGenRegisterInfo {
 
   unsigned matchControlRegisterBitwidth(Register CtrlReg,
                                         unsigned SrcConstVal) const override;
+  unsigned matchStatusRegisterBitwidth(Register StatusReg,
+                                       unsigned SrcConstVal) const override;
 };
 } // namespace llvm
 

--- a/llvm/lib/Target/AIE/aie2p/AIE2PRegisterInfo.h
+++ b/llvm/lib/Target/AIE/aie2p/AIE2PRegisterInfo.h
@@ -120,6 +120,8 @@ struct AIE2PRegisterInfo : public AIE2PGenRegisterInfo {
   Register getUnpackSignCtrlReg() const override;
   Register getPackSignCtrlReg() const override;
   Register getPackSizeCtrlReg() const override;
+  Register getSRSSignCtrlReg() const override;
+  Register getSRSModeCtrlReg() const override;
 };
 } // namespace llvm
 

--- a/llvm/test/CodeGen/AIE/aie2p/GlobalIsel/inst-select-set-mode.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/GlobalIsel/inst-select-set-mode.mir
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2024-2025 Advanced Micro Devices, Inc. or its affiliates
 # RUN: llc -mtriple aie2p -run-pass=instruction-select %s -verify-machineinstrs -o - | FileCheck %s
 
 ---
@@ -326,6 +326,250 @@ body:             |
     ; CHECK-NEXT: PseudoRET implicit $lr, implicit $r0
     %1:gprregbank(s32) = G_CONSTANT i32 24
     %0:gprregbank(s32) = G_INTRINSIC_W_SIDE_EFFECTS intrinsic(@llvm.aie2p.get.ctrl.reg), %1:gprregbank(s32)
+    $r0 = COPY %0:gprregbank(s32)
+    PseudoRET implicit $lr, implicit $r0
+...
+
+---
+name:            set_srcarry
+alignment:       16
+legalized:       true
+regBankSelected: true
+body:             |
+  bb.1.entry:
+    liveins: $r0
+    ; CHECK-LABEL: name: set_srcarry
+    ; CHECK: liveins: $r0
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:er = COPY $r0
+    ; CHECK-NEXT: $srcarry = COPY [[COPY]]
+    ; CHECK-NEXT: PseudoRET implicit $lr
+    %0:gprregbank(s32) = COPY $r0
+    %1:gprregbank(s32) = G_CONSTANT i32 25
+    G_INTRINSIC_W_SIDE_EFFECTS intrinsic(@llvm.aie2p.set.status.reg), %1:gprregbank(s32), %0:gprregbank(s32)
+    PseudoRET implicit $lr
+...
+
+---
+name:            set_srss0
+alignment:       16
+legalized:       true
+regBankSelected: true
+body:             |
+  bb.1.entry:
+    ; CHECK-LABEL: name: set_srss0
+    ; CHECK: $srss0 = MOV_scalar_imm11_pseudo 1
+    ; CHECK-NEXT: PseudoRET implicit $lr
+    %0:gprregbank(s32) = G_CONSTANT i32 26
+    %1:gprregbank(s32) = G_CONSTANT i32 1
+    G_INTRINSIC_W_SIDE_EFFECTS intrinsic(@llvm.aie2p.set.status.reg), %0:gprregbank(s32), %1:gprregbank(s32)
+    PseudoRET implicit $lr
+...
+
+---
+name:            set_srms0
+alignment:       16
+legalized:       true
+regBankSelected: true
+body:             |
+  bb.1.entry:
+    ; CHECK-LABEL: name: set_srms0
+    ; CHECK: $srms0 = MOV_scalar_imm11_pseudo 0
+    ; CHECK-NEXT: PseudoRET implicit $lr
+    %0:gprregbank(s32) = G_CONSTANT i32 27
+    %1:gprregbank(s32) = G_CONSTANT i32 0
+    G_INTRINSIC_W_SIDE_EFFECTS intrinsic(@llvm.aie2p.set.status.reg), %0:gprregbank(s32), %1:gprregbank(s32)
+    PseudoRET implicit $lr
+...
+
+---
+name:            set_srsrs_of
+alignment:       16
+legalized:       true
+regBankSelected: true
+body:             |
+  bb.1.entry:
+    liveins: $r0
+    ; CHECK-LABEL: name: set_srsrs_of
+    ; CHECK: liveins: $r0
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:er = COPY $r0
+    ; CHECK-NEXT: $srsrs_of = COPY [[COPY]]
+    ; CHECK-NEXT: PseudoRET implicit $lr
+    %0:gprregbank(s32) = COPY $r0
+    %1:gprregbank(s32) = G_CONSTANT i32 28
+    G_INTRINSIC_W_SIDE_EFFECTS intrinsic(@llvm.aie2p.set.status.reg), %1:gprregbank(s32), %0:gprregbank(s32)
+    PseudoRET implicit $lr
+...
+
+---
+name:            set_srups_of
+alignment:       16
+legalized:       true
+regBankSelected: true
+body:             |
+  bb.1.entry:
+    ; CHECK-LABEL: name: set_srups_of
+    ; CHECK: $srups_of = MOV_scalar_imm11_pseudo 0
+    ; CHECK-NEXT: PseudoRET implicit $lr
+    %0:gprregbank(s32) = G_CONSTANT i32 8
+    %1:gprregbank(s32) = G_CONSTANT i32 29
+    G_INTRINSIC_W_SIDE_EFFECTS intrinsic(@llvm.aie2p.set.status.reg), %1:gprregbank(s32), %0:gprregbank(s32)
+    PseudoRET implicit $lr
+...
+
+---
+name:            set_srfpflags
+alignment:       16
+legalized:       true
+regBankSelected: true
+body:             |
+  bb.1.entry:
+    liveins: $r0
+    ; CHECK-LABEL: name: set_srfpflags
+    ; CHECK: liveins: $r0
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:er = COPY $r0
+    ; CHECK-NEXT: $srfpflags = COPY [[COPY]]
+    ; CHECK-NEXT: PseudoRET implicit $lr
+    %0:gprregbank(s32) = COPY $r0
+    %1:gprregbank(s32) = G_CONSTANT i32 33
+    G_INTRINSIC_W_SIDE_EFFECTS intrinsic(@llvm.aie2p.set.status.reg), %1:gprregbank(s32), %0:gprregbank(s32)
+    PseudoRET implicit $lr
+...
+
+---
+name:            get_srcarry
+alignment:       16
+legalized:       true
+regBankSelected: true
+body:             |
+  bb.1.entry:
+    ; CHECK-LABEL: name: get_srcarry
+    ; CHECK: [[COPY:%[0-9]+]]:er = COPY $srcarry
+    ; CHECK-NEXT: $r0 = COPY [[COPY]]
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit $r0
+    %1:gprregbank(s32) = G_CONSTANT i32 25
+    %0:gprregbank(s32) = G_INTRINSIC_W_SIDE_EFFECTS intrinsic(@llvm.aie2p.get.status.reg), %1:gprregbank(s32)
+    $r0 = COPY %0:gprregbank(s32)
+    PseudoRET implicit $lr, implicit $r0
+...
+
+---
+name:            get_srss0
+alignment:       16
+legalized:       true
+regBankSelected: true
+body:             |
+  bb.1.entry:
+    ; CHECK-LABEL: name: get_srss0
+    ; CHECK: [[COPY:%[0-9]+]]:er = COPY $srss0
+    ; CHECK-NEXT: $r0 = COPY [[COPY]]
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit $r0
+    %1:gprregbank(s32) = G_CONSTANT i32 26
+    %0:gprregbank(s32) = G_INTRINSIC_W_SIDE_EFFECTS intrinsic(@llvm.aie2p.get.status.reg), %1:gprregbank(s32)
+    $r0 = COPY %0:gprregbank(s32)
+    PseudoRET implicit $lr, implicit $r0
+...
+
+---
+name:            get_srms0
+alignment:       16
+legalized:       true
+regBankSelected: true
+body:             |
+  bb.1.entry:
+    ; CHECK-LABEL: name: get_srms0
+    ; CHECK: [[COPY:%[0-9]+]]:er = COPY $srms0
+    ; CHECK-NEXT: $r0 = COPY [[COPY]]
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit $r0
+    %1:gprregbank(s32) = G_CONSTANT i32 27
+    %0:gprregbank(s32) = G_INTRINSIC_W_SIDE_EFFECTS intrinsic(@llvm.aie2p.get.status.reg), %1:gprregbank(s32)
+    $r0 = COPY %0:gprregbank(s32)
+    PseudoRET implicit $lr, implicit $r0
+...
+
+---
+name:            get_srsrs_of
+alignment:       16
+legalized:       true
+regBankSelected: true
+body:             |
+  bb.1.entry:
+    ; CHECK-LABEL: name: get_srsrs_of
+    ; CHECK: [[COPY:%[0-9]+]]:er = COPY $srsrs_of
+    ; CHECK-NEXT: $r0 = COPY [[COPY]]
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit $r0
+    %1:gprregbank(s32) = G_CONSTANT i32 28
+    %0:gprregbank(s32) = G_INTRINSIC_W_SIDE_EFFECTS intrinsic(@llvm.aie2p.get.status.reg), %1:gprregbank(s32)
+    $r0 = COPY %0:gprregbank(s32)
+    PseudoRET implicit $lr, implicit $r0
+...
+
+---
+name:            get_srups_of
+alignment:       16
+legalized:       true
+regBankSelected: true
+body:             |
+  bb.1.entry:
+    ; CHECK-LABEL: name: get_srups_of
+    ; CHECK: [[COPY:%[0-9]+]]:er = COPY $srups_of
+    ; CHECK-NEXT: $r0 = COPY [[COPY]]
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit $r0
+    %1:gprregbank(s32) = G_CONSTANT i32 29
+    %0:gprregbank(s32) = G_INTRINSIC_W_SIDE_EFFECTS intrinsic(@llvm.aie2p.get.status.reg), %1:gprregbank(s32)
+    $r0 = COPY %0:gprregbank(s32)
+    PseudoRET implicit $lr, implicit $r0
+...
+
+---
+name:            get_srfpflags
+alignment:       16
+legalized:       true
+regBankSelected: true
+body:             |
+  bb.1.entry:
+    ; CHECK-LABEL: name: get_srfpflags
+    ; CHECK: [[COPY:%[0-9]+]]:er = COPY $srfpflags
+    ; CHECK-NEXT: $r0 = COPY [[COPY]]
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit $r0
+    %1:gprregbank(s32) = G_CONSTANT i32 33
+    %0:gprregbank(s32) = G_INTRINSIC_W_SIDE_EFFECTS intrinsic(@llvm.aie2p.get.status.reg), %1:gprregbank(s32)
+    $r0 = COPY %0:gprregbank(s32)
+    PseudoRET implicit $lr, implicit $r0
+...
+
+---
+name:            get_srf2iflags
+alignment:       16
+legalized:       true
+regBankSelected: true
+body:             |
+  bb.1.entry:
+    ; CHECK-LABEL: name: get_srf2iflags
+    ; CHECK: [[COPY:%[0-9]+]]:er = COPY $srf2iflags
+    ; CHECK-NEXT: $r0 = COPY [[COPY]]
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit $r0
+    %1:gprregbank(s32) = G_CONSTANT i32 34
+    %0:gprregbank(s32) = G_INTRINSIC_W_SIDE_EFFECTS intrinsic(@llvm.aie2p.get.status.reg), %1:gprregbank(s32)
+    $r0 = COPY %0:gprregbank(s32)
+    PseudoRET implicit $lr, implicit $r0
+...
+
+---
+name:            get_srfpnlf
+alignment:       16
+legalized:       true
+regBankSelected: true
+body:             |
+  bb.1.entry:
+    ; CHECK-LABEL: name: get_srfpnlf
+    ; CHECK: [[COPY:%[0-9]+]]:er = COPY $srfpnlf
+    ; CHECK-NEXT: $r0 = COPY [[COPY]]
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit $r0
+    %1:gprregbank(s32) = G_CONSTANT i32 37
+    %0:gprregbank(s32) = G_INTRINSIC_W_SIDE_EFFECTS intrinsic(@llvm.aie2p.get.status.reg), %1:gprregbank(s32)
     $r0 = COPY %0:gprregbank(s32)
     PseudoRET implicit $lr, implicit $r0
 ...


### PR DESCRIPTION
Refactor instruction selection by moving common logic from
AIE2PInstructionSelector into AIEBaseInstructionSelector for:
- Set/GetControlRegister
- UPS
- LOAD_UNPACK
- STORE_PACK
- STORE_SRS

Also separates status registers from control registers, adds
AIE2P support for get/set_status_reg, and refactors CGBuiltins
for FIFO LD/ST.