### PR TITLE
Martien.ubsanfix

### DIFF
--- a/llvm/utils/TableGen/CodeGenFormat.cpp
+++ b/llvm/utils/TableGen/CodeGenFormat.cpp
@@ -1112,11 +1112,9 @@ void TGTargetSlots::finalizeSlots() {
 
   // Give an ID for each slot
   int SlotID = 0;
-  for (RecordSlot &Slot : Slots)
-    if (Slot.second.isDefaultSlot())
-      Slot.second.setNumSlot(-1);
-    else
-      Slot.second.setNumSlot(SlotID++);
+  for (auto &[_, Slot] : Slots)
+    if (!Slot.isDefaultSlot())
+      Slot.setNumSlot(SlotID++);
 
   // Sort the slot container by ID
   std::sort(Slots.begin(), Slots.end(),

--- a/llvm/utils/TableGen/CodeGenFormat.h
+++ b/llvm/utils/TableGen/CodeGenFormat.h
@@ -279,7 +279,7 @@ class TGTargetSlot {
   bool Artificial = false;
   // Unique number attributed (in the pool) for the slot.
   // It is used to generate a unique "SlotSet".
-  int NumSlot;
+  int NumSlot = -1;
 
   // The Slot bits for this slot. These are the pristine bits that correspond
   // to the slots a format accommodates.

--- a/llvm/utils/TableGen/CodeGenFormat.h
+++ b/llvm/utils/TableGen/CodeGenFormat.h
@@ -377,6 +377,7 @@ public:
 
 private:
   void setNumSlot(int SlotID) {
+    assert(SlotID >= 0);
     NumSlot = SlotID;
     const uint64_t Base = 1;
     SlotBits = Base << SlotID;


### PR DESCRIPTION
As reported by @konstantinschwarz. When setting the SlotID, we also computed the slotset, leading to a negative shift count for the default slot, which has ID=-1. 