### PR TITLE
[AIEX] Disable hasCompleteDecoder for all instructions and registers

### DIFF
--- a/llvm/lib/Target/AIE/AIE2GenFixupInstrInfo.td
+++ b/llvm/lib/Target/AIE/AIE2GenFixupInstrInfo.td
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// (c) Copyright 2023-2024 Advanced Micro Devices, Inc. or its affiliates
+// (c) Copyright 2023-2025 Advanced Micro Devices, Inc. or its affiliates
 //
 //===----------------------------------------------------------------------===//
 
@@ -450,14 +450,7 @@ let hasSideEffects = false, mayLoad = true, mayStore = false in {
 
 // 3.3 VLD.UNPACK – Vector Loads with unpacking
 
-// VLDB.UNPACK uses mXs register class which doesn't have a power-of-2 number of registers.
-// PADDB uses an immediate value seperated with a fixed {0b11} field. This field coincides with
-// mXs register field in VLDB.UNPACK. Because of this, it could happen that we try to decode a
-// PADDB instruction as VLDB.UNPACK assuming that the latter has a complete decoder.
-// To avoid this, we set hasCompleteDecoder to false in VLDB.UNPACK instructions.
-// Setting hasCompleteDecoder to false in the mXs register class is not enough because
-// VLDB.2D.UNPACK and VLDB.3D.UNPACK instructions have custom decoder methods
-let hasSideEffects = false, mayLoad = true, mayStore = false, hasCompleteDecoder= false in {
+let hasSideEffects = false, mayLoad = true, mayStore = false in {
   let Itinerary = II_VLDB_UNPACK in {
     class VLDB_ag_idx_dmw_ldb_unpack<bits<1> sgn, bits<1> sz, string opcodestr> :
         AIE2_dmw_ldb_unpack_inst_ldb<sgn, sz, (outs mXs:$dst), (ins eP:$ptr, eDJ:$dj), opcodestr, "$dst, [$ptr, $dj]">;
@@ -517,7 +510,7 @@ let hasSideEffects = false, mayLoad = true, mayStore = false, hasCompleteDecoder
       }
     }
 
-} // hasSideEffects = false, mayLoad = true, mayStore = false, hasCompleteDecoder= false
+} // hasSideEffects = false, mayLoad = true, mayStore = false
 
 // 3.10 VST - Vector Stores
 let hasSideEffects = false, mayLoad = false, mayStore = true in {

--- a/llvm/lib/Target/AIE/AIE2GenRegisterInfo.td
+++ b/llvm/lib/Target/AIE/AIE2GenRegisterInfo.td
@@ -15,6 +15,8 @@
 //===----------------------------------------------------------------------===//
 //* Automatically generated file, do not edit! *
 
+include "AIEBaseRegisterInfo.td"
+
 let Namespace = "AIE2" in {
 
   class AIE2Reg<string n> : Register<n> {
@@ -27,13 +29,11 @@ let Namespace = "AIE2" in {
   }
 
 class AIE2RegisterClass <int size, int align, list<ValueType> regTypes, dag reglist, RegAltNameIndex idx = NoRegAltName> :
-               RegisterClass<"AIE2", regTypes, /*alignment*/size, reglist, idx> {
+               AIEBaseRegisterClass<"AIE2", regTypes, /*alignment*/size, reglist, idx> {
   dag Regs = reglist;
   let RegInfos = RegInfoByHwMode<
       [DefaultMode],
       [RegInfo</*size*/size, /*spill size*/size, /*spill alignment*/align>]>;
-  let DecodeZeroBitOperand = true;
-  let hasCompleteDecoder = false;
 }
 
   class AIE2ScalarRegisterClass<dag reglist, RegAltNameIndex idx = NoRegAltName>
@@ -68,7 +68,7 @@ class AIE2RegisterClass <int size, int align, list<ValueType> regTypes, dag regl
       AIE2RegisterClass<1024, 256, [v16i64], reglist>;
 
 class AIE220BitRegisterClass <dag reglist, RegAltNameIndex idx = NoRegAltName> :
-                 RegisterClass<"AIE2", [i20], /*alignment*/ 32, reglist, idx> {
+                 AIEBaseRegisterClass<"AIE2", [i20], /*alignment*/ 32, reglist, idx> {
   dag Regs = reglist;
   let RegInfos = RegInfoByHwMode<
       [DefaultMode],
@@ -76,7 +76,7 @@ class AIE220BitRegisterClass <dag reglist, RegAltNameIndex idx = NoRegAltName> :
 }
 
 class AIE2Dim2DRegisterClass <dag reglist, RegAltNameIndex idx = NoRegAltName> :
-                 RegisterClass<"AIE2", [i20], /*alignment*/ 32, reglist, idx> {
+                 AIEBaseRegisterClass<"AIE2", [i20], /*alignment*/ 32, reglist, idx> {
   dag Regs = reglist;
   let RegInfos = RegInfoByHwMode<
       [DefaultMode],
@@ -84,7 +84,7 @@ class AIE2Dim2DRegisterClass <dag reglist, RegAltNameIndex idx = NoRegAltName> :
 }
 
 class AIE2Dim3DRegisterClass <dag reglist, RegAltNameIndex idx = NoRegAltName> :
-                 RegisterClass<"AIE2", [i20], /*alignment*/ 32, reglist, idx> {
+                 AIEBaseRegisterClass<"AIE2", [i20], /*alignment*/ 32, reglist, idx> {
   dag Regs = reglist;
   let RegInfos = RegInfoByHwMode<
       [DefaultMode],

--- a/llvm/lib/Target/AIE/AIE2GenRegisterInfo.td
+++ b/llvm/lib/Target/AIE/AIE2GenRegisterInfo.td
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// (c) Copyright 2023-2024 Advanced Micro Devices, Inc. or its affiliates
+// (c) Copyright 2023-2025 Advanced Micro Devices, Inc. or its affiliates
 //
 //===----------------------------------------------------------------------===//
 //
@@ -33,6 +33,7 @@ class AIE2RegisterClass <int size, int align, list<ValueType> regTypes, dag regl
       [DefaultMode],
       [RegInfo</*size*/size, /*spill size*/size, /*spill alignment*/align>]>;
   let DecodeZeroBitOperand = true;
+  let hasCompleteDecoder = false;
 }
 
   class AIE2ScalarRegisterClass<dag reglist, RegAltNameIndex idx = NoRegAltName>
@@ -45,38 +46,26 @@ class AIE2RegisterClass <int size, int align, list<ValueType> regTypes, dag regl
                           idx>;
 
   class AIE2Vector128RegisterClass<dag reglist> :
-      AIE2RegisterClass<128, 128, [v16i8, v8i16, v8bf16, v4i32, v4f32, i128], reglist> {
-    let hasCompleteDecoder = 0;
-  }
+      AIE2RegisterClass<128, 128, [v16i8, v8i16, v8bf16, v4i32, v4f32, i128], reglist>;
 
   class AIE2Vector256RegisterClass<dag reglist> :
-      AIE2RegisterClass<256, 256, [v32i8, v16i16, v16bf16, v8f32, v8i32], reglist> {
-    let hasCompleteDecoder = 0;
-  }
+      AIE2RegisterClass<256, 256, [v32i8, v16i16, v16bf16, v8f32, v8i32], reglist>;
 
   class AIE2Vector512RegisterClass<dag reglist> :
-      AIE2RegisterClass<512, 256, [v64i8, v32i16, v32bf16, v16i32, v16f32], reglist> {
-    let hasCompleteDecoder = 0;
-  }
+      AIE2RegisterClass<512, 256, [v64i8, v32i16, v32bf16, v16i32, v16f32], reglist>;
 
   class AIE2Vector1024RegisterClass<dag reglist> :
 
       AIE2RegisterClass<1024, 256, [v128i8, v64i16, v64bf16, v32i32, v32f32], reglist>;
 
   class AIE2Acc256RegisterClass<dag reglist> :
-      AIE2RegisterClass<256, 256, [v4i64], reglist> {
-    let hasCompleteDecoder = 0;
-  }
+      AIE2RegisterClass<256, 256, [v4i64], reglist>;
 
   class AIE2Acc512RegisterClass<dag reglist> :
-      AIE2RegisterClass<512, 256, [v8i64, v16f32], reglist> {
-    let hasCompleteDecoder = 0;
-  }
+      AIE2RegisterClass<512, 256, [v8i64, v16f32], reglist>;
 
   class AIE2Acc1024RegisterClass<dag reglist> :
-      AIE2RegisterClass<1024, 256, [v16i64], reglist> {
-    let hasCompleteDecoder = 0;
-  }
+      AIE2RegisterClass<1024, 256, [v16i64], reglist>;
 
 class AIE220BitRegisterClass <dag reglist, RegAltNameIndex idx = NoRegAltName> :
                  RegisterClass<"AIE2", [i20], /*alignment*/ 32, reglist, idx> {

--- a/llvm/lib/Target/AIE/AIE2PRegOperandDef.td
+++ b/llvm/lib/Target/AIE/AIE2PRegOperandDef.td
@@ -4,71 +4,66 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+// (c) Copyright 2024-2025 Advanced Micro Devices, Inc. or its affiliates
 //
 //===----------------------------------------------------------------------===//
 //* Automatically generated file, do not edit! *
 
-class AIE2PRegisterOperand<RegisterClass c> : RegisterOperand<c> {
-  let EncoderMethod = "get" # c # OpValue;
-  let hasCompleteDecoder = false;
-}
-
-def OP_mWa : AIE2PRegisterOperand<mWa>;
-def OP_mXm : AIE2PRegisterOperand<mXm>;
-def OP_mCMm : AIE2PRegisterOperand<mCMm>;
-def OP_mQEXsm : AIE2PRegisterOperand<mQEXsm>;
-def OP_mEs : AIE2PRegisterOperand<mEs>;
-def OP_mAguSrc : AIE2PRegisterOperand<mAguSrc>;
-def OP_mQXsb : AIE2PRegisterOperand<mQXsb>;
-def OP_mEhm : AIE2PRegisterOperand<mEhm>;
-def OP_mLdaScl : AIE2PRegisterOperand<mLdaScl>;
-def OP_mQQsm : AIE2PRegisterOperand<mQQsm>;
-def OP_mWs : AIE2PRegisterOperand<mWs>;
-def OP_mXw : AIE2PRegisterOperand<mXw>;
-def OP_mAguDst : AIE2PRegisterOperand<mAguDst>;
-def OP_mEXm : AIE2PRegisterOperand<mEXm>;
-def OP_mQXsa : AIE2PRegisterOperand<mQXsa>;
-def OP_mDm : AIE2PRegisterOperand<mDm>;
-def OP_mQQss : AIE2PRegisterOperand<mQQss>;
-def OP_mQXsm : AIE2PRegisterOperand<mQXsm>;
-def OP_mShflBMDst : AIE2PRegisterOperand<mShflBMDst>;
-def OP_mBMm : AIE2PRegisterOperand<mBMm>;
-def OP_mMvBMXDst : AIE2PRegisterOperand<mMvBMXDst>;
-def OP_mShflXDst : AIE2PRegisterOperand<mShflXDst>;
-def OP_mMvSclDst : AIE2PRegisterOperand<mMvSclDst>;
-def OP_mMcdXSrc : AIE2PRegisterOperand<mMcdXSrc>;
-def OP_mEXn : AIE2PRegisterOperand<mEXn>;
-def OP_mMvSclDstCg : AIE2PRegisterOperand<mMvSclDstCg>;
-def OP_mSclMS : AIE2PRegisterOperand<mSclMS>;
-def OP_mXn : AIE2PRegisterOperand<mXn>;
-def OP_mBMSm : AIE2PRegisterOperand<mBMSm>;
-def OP_mXv : AIE2PRegisterOperand<mXv>;
-def OP_mWb : AIE2PRegisterOperand<mWb>;
-def OP_mMvBMXSrc : AIE2PRegisterOperand<mMvBMXSrc>;
-def OP_mAluCg : AIE2PRegisterOperand<mAluCg>;
-def OP_mEXw : AIE2PRegisterOperand<mEXw>;
-def OP_mXs : AIE2PRegisterOperand<mXs>;
-def OP_mEXs : AIE2PRegisterOperand<mEXs>;
-def OP_mCMs : AIE2PRegisterOperand<mCMs>;
-def OP_mFifoHLReg : AIE2PRegisterOperand<mFifoHLReg>;
-def OP_mSRm : AIE2PRegisterOperand<mSRm>;
-def OP_mElm : AIE2PRegisterOperand<mElm>;
-def OP_mQEXsw : AIE2PRegisterOperand<mQEXsw>;
-def OP_mQQsa : AIE2PRegisterOperand<mQQsa>;
-def OP_mEXv : AIE2PRegisterOperand<mEXv>;
-def OP_mXa : AIE2PRegisterOperand<mXa>;
-def OP_mWm : AIE2PRegisterOperand<mWm>;
-def OP_mMvSclSrc : AIE2PRegisterOperand<mMvSclSrc>;
-def OP_mQEXsa : AIE2PRegisterOperand<mQEXsa>;
-def OP_mCRm : AIE2PRegisterOperand<mCRm>;
-def OP_mSclSt : AIE2PRegisterOperand<mSclSt>;
-def OP_mMcdBMSrc : AIE2PRegisterOperand<mMcdBMSrc>;
-def OP_mQXsw : AIE2PRegisterOperand<mQXsw>;
-def OP_mEXa : AIE2PRegisterOperand<mEXa>;
-def OP_mQEXsb : AIE2PRegisterOperand<mQEXsb>;
-def OP_mLdaCg : AIE2PRegisterOperand<mLdaCg>;
-def OP_mFl2FxSrc_W : AIE2PRegisterOperand<mFl2FxSrc_W>;
-def OP_mXb : AIE2PRegisterOperand<mXb>;
-def OP_mBMs : AIE2PRegisterOperand<mBMs>;
-def OP_mEXb : AIE2PRegisterOperand<mEXb>;
+def OP_mWa : AIEBaseRegisterOperand<mWa>;
+def OP_mXm : AIEBaseRegisterOperand<mXm>;
+def OP_mCMm : AIEBaseRegisterOperand<mCMm>;
+def OP_mQEXsm : AIEBaseRegisterOperand<mQEXsm>;
+def OP_mEs : AIEBaseRegisterOperand<mEs>;
+def OP_mAguSrc : AIEBaseRegisterOperand<mAguSrc>;
+def OP_mQXsb : AIEBaseRegisterOperand<mQXsb>;
+def OP_mEhm : AIEBaseRegisterOperand<mEhm>;
+def OP_mLdaScl : AIEBaseRegisterOperand<mLdaScl>;
+def OP_mQQsm : AIEBaseRegisterOperand<mQQsm>;
+def OP_mWs : AIEBaseRegisterOperand<mWs>;
+def OP_mXw : AIEBaseRegisterOperand<mXw>;
+def OP_mAguDst : AIEBaseRegisterOperand<mAguDst>;
+def OP_mEXm : AIEBaseRegisterOperand<mEXm>;
+def OP_mQXsa : AIEBaseRegisterOperand<mQXsa>;
+def OP_mDm : AIEBaseRegisterOperand<mDm>;
+def OP_mQQss : AIEBaseRegisterOperand<mQQss>;
+def OP_mQXsm : AIEBaseRegisterOperand<mQXsm>;
+def OP_mShflBMDst : AIEBaseRegisterOperand<mShflBMDst>;
+def OP_mBMm : AIEBaseRegisterOperand<mBMm>;
+def OP_mMvBMXDst : AIEBaseRegisterOperand<mMvBMXDst>;
+def OP_mShflXDst : AIEBaseRegisterOperand<mShflXDst>;
+def OP_mMvSclDst : AIEBaseRegisterOperand<mMvSclDst>;
+def OP_mMcdXSrc : AIEBaseRegisterOperand<mMcdXSrc>;
+def OP_mEXn : AIEBaseRegisterOperand<mEXn>;
+def OP_mMvSclDstCg : AIEBaseRegisterOperand<mMvSclDstCg>;
+def OP_mSclMS : AIEBaseRegisterOperand<mSclMS>;
+def OP_mXn : AIEBaseRegisterOperand<mXn>;
+def OP_mBMSm : AIEBaseRegisterOperand<mBMSm>;
+def OP_mXv : AIEBaseRegisterOperand<mXv>;
+def OP_mWb : AIEBaseRegisterOperand<mWb>;
+def OP_mMvBMXSrc : AIEBaseRegisterOperand<mMvBMXSrc>;
+def OP_mAluCg : AIEBaseRegisterOperand<mAluCg>;
+def OP_mEXw : AIEBaseRegisterOperand<mEXw>;
+def OP_mXs : AIEBaseRegisterOperand<mXs>;
+def OP_mEXs : AIEBaseRegisterOperand<mEXs>;
+def OP_mCMs : AIEBaseRegisterOperand<mCMs>;
+def OP_mFifoHLReg : AIEBaseRegisterOperand<mFifoHLReg>;
+def OP_mSRm : AIEBaseRegisterOperand<mSRm>;
+def OP_mElm : AIEBaseRegisterOperand<mElm>;
+def OP_mQEXsw : AIEBaseRegisterOperand<mQEXsw>;
+def OP_mQQsa : AIEBaseRegisterOperand<mQQsa>;
+def OP_mEXv : AIEBaseRegisterOperand<mEXv>;
+def OP_mXa : AIEBaseRegisterOperand<mXa>;
+def OP_mWm : AIEBaseRegisterOperand<mWm>;
+def OP_mMvSclSrc : AIEBaseRegisterOperand<mMvSclSrc>;
+def OP_mQEXsa : AIEBaseRegisterOperand<mQEXsa>;
+def OP_mCRm : AIEBaseRegisterOperand<mCRm>;
+def OP_mSclSt : AIEBaseRegisterOperand<mSclSt>;
+def OP_mMcdBMSrc : AIEBaseRegisterOperand<mMcdBMSrc>;
+def OP_mQXsw : AIEBaseRegisterOperand<mQXsw>;
+def OP_mEXa : AIEBaseRegisterOperand<mEXa>;
+def OP_mQEXsb : AIEBaseRegisterOperand<mQEXsb>;
+def OP_mLdaCg : AIEBaseRegisterOperand<mLdaCg>;
+def OP_mFl2FxSrc_W : AIEBaseRegisterOperand<mFl2FxSrc_W>;
+def OP_mXb : AIEBaseRegisterOperand<mXb>;
+def OP_mBMs : AIEBaseRegisterOperand<mBMs>;
+def OP_mEXb : AIEBaseRegisterOperand<mEXb>;

--- a/llvm/lib/Target/AIE/AIE2RegOperandDef.td
+++ b/llvm/lib/Target/AIE/AIE2RegOperandDef.td
@@ -7,36 +7,32 @@
 // (c) Copyright 2023-2025 Advanced Micro Devices, Inc. or its affiliates
 //
 //===----------------------------------------------------------------------===//
-class AIE2RegisterOperand<RegisterClass c> : RegisterOperand<c> {
-  let EncoderMethod = "get" # c # OpValue;
-  let hasCompleteDecoder = false;
-}
- def OP_mDm : AIE2RegisterOperand<mDm>;
+ def OP_mDm : AIEBaseRegisterOperand<mDm>;
  def OP_mMvSclDst_and_eR : RegisterOperand<eR> {
   let EncoderMethod = "getmMvSclDstOpValue";
  }
- def OP_mAluCg : AIE2RegisterOperand<mAluCg>;
- def OP_mMvSclDst : AIE2RegisterOperand<mMvSclDst>;
- def OP_mMvSclDstCg : AIE2RegisterOperand<mMvSclDstCg>;
- def OP_mMvSclSrc : AIE2RegisterOperand<mMvSclSrc>;
- def OP_mLdaScl : AIE2RegisterOperand<mLdaScl>;
- def OP_mSclSt : AIE2RegisterOperand<mSclSt>;
- def OP_mSclMS : AIE2RegisterOperand<mSclMS>;
- def OP_mLdaCg : AIE2RegisterOperand<mLdaCg>;
- def OP_mWm_1  : AIE2RegisterOperand<mWm_1>;
+ def OP_mAluCg : AIEBaseRegisterOperand<mAluCg>;
+ def OP_mMvSclDst : AIEBaseRegisterOperand<mMvSclDst>;
+ def OP_mMvSclDstCg : AIEBaseRegisterOperand<mMvSclDstCg>;
+ def OP_mMvSclSrc : AIEBaseRegisterOperand<mMvSclSrc>;
+ def OP_mLdaScl : AIEBaseRegisterOperand<mLdaScl>;
+ def OP_mSclSt : AIEBaseRegisterOperand<mSclSt>;
+ def OP_mSclMS : AIEBaseRegisterOperand<mSclMS>;
+ def OP_mLdaCg : AIEBaseRegisterOperand<mLdaCg>;
+ def OP_mWm_1  : AIEBaseRegisterOperand<mWm_1>;
 
  // VMOV Operands
- def OP_mMvAMWQSrc : AIE2RegisterOperand<mMvAMWQSrc>;
- def OP_mMvAMWQDst : AIE2RegisterOperand<mMvAMWQDst>;
- def OP_mMvBMXSrc : AIE2RegisterOperand<mMvBMXSrc>;
- def OP_mMvBMXDst : AIE2RegisterOperand<mMvBMXDst>;
- def OP_mMcdSrc : AIE2RegisterOperand<mMvBMXDst>;
- def OP_mScdDst : AIE2RegisterOperand<mMvBMXDst>;
+ def OP_mMvAMWQSrc : AIEBaseRegisterOperand<mMvAMWQSrc>;
+ def OP_mMvAMWQDst : AIEBaseRegisterOperand<mMvAMWQDst>;
+ def OP_mMvBMXSrc : AIEBaseRegisterOperand<mMvBMXSrc>;
+ def OP_mMvBMXDst : AIEBaseRegisterOperand<mMvBMXDst>;
+ def OP_mMcdSrc : AIEBaseRegisterOperand<mMvBMXDst>;
+ def OP_mScdDst : AIEBaseRegisterOperand<mMvBMXDst>;
 
  // VSHUFFLE Operands
- def OP_mShflDst : AIE2RegisterOperand<mShflDst>;
+ def OP_mShflDst : AIEBaseRegisterOperand<mShflDst>;
 
- def OP_mRS4m : AIE2RegisterOperand<eRS4>;
+ def OP_mRS4m : AIEBaseRegisterOperand<eRS4>;
 
 // VLDB.SPARSE Operands
-def OP_mQXHLb : AIE2RegisterOperand<mQXHLb>;
+def OP_mQXHLb : AIEBaseRegisterOperand<mQXHLb>;

--- a/llvm/lib/Target/AIE/AIE2RegOperandDef.td
+++ b/llvm/lib/Target/AIE/AIE2RegOperandDef.td
@@ -4,11 +4,12 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// (c) Copyright 2023-2024 Advanced Micro Devices, Inc. or its affiliates
+// (c) Copyright 2023-2025 Advanced Micro Devices, Inc. or its affiliates
 //
 //===----------------------------------------------------------------------===//
 class AIE2RegisterOperand<RegisterClass c> : RegisterOperand<c> {
   let EncoderMethod = "get" # c # OpValue;
+  let hasCompleteDecoder = false;
 }
  def OP_mDm : AIE2RegisterOperand<mDm>;
  def OP_mMvSclDst_and_eR : RegisterOperand<eR> {

--- a/llvm/lib/Target/AIE/AIEBaseInstrFormats.td
+++ b/llvm/lib/Target/AIE/AIEBaseInstrFormats.td
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// (c) Copyright 2023-2024 Advanced Micro Devices, Inc. or its affiliates
+// (c) Copyright 2023-2025 Advanced Micro Devices, Inc. or its affiliates
 //
 //===----------------------------------------------------------------------===//
 //
@@ -25,6 +25,8 @@ class AIEBaseInst<dag outs, dag ins, list<dag> pattern, string opcodestr, string
   // A scratchpad of bits that is used in the encoding to say "these bits do not
   // matter for encoding or decoding".
   field bits<32> dontcare = 0;
+
+  let hasCompleteDecoder = false;
 }
 
 // Attributes for Pseudo instructions

--- a/llvm/lib/Target/AIE/AIEBaseRegisterInfo.td
+++ b/llvm/lib/Target/AIE/AIEBaseRegisterInfo.td
@@ -1,0 +1,39 @@
+//===-- AIEBaseRegisterInfo.td - Base Register Info for AIE -*- tablegen -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2025 Advanced Micro Devices, Inc. or its affiliates
+//
+//===----------------------------------------------------------------------===//
+//
+// This file contains a generic utility class for AIE register classes
+//
+//===----------------------------------------------------------------------===//
+
+// Base class for all AIE register classes across all targets
+// This centralizes common decoder properties that should be applied to all
+// register classes in the AIE targets.
+class AIEBaseRegisterClass<string namespace, list<ValueType> regTypes, int alignment,
+                    dag regList, RegAltNameIndex idx = NoRegAltName> :
+            RegisterClass<namespace, regTypes, alignment, regList, idx> {
+  // Enable decoding of zero-bit operands
+  bit DecodeZeroBitOperand = true;
+  
+  // Disable complete decoder for all register classes to avoid decoder
+  // conflicts between instructions with overlapping encodings
+  bit hasCompleteDecoder = false;
+}
+
+// Base class for all AIE register operands across all targets
+// This centralizes common decoder properties for register operands.
+class AIEBaseRegisterOperand<RegisterClass c> : RegisterOperand<c> {
+  // Set encoder method based on register class name
+  let EncoderMethod = "get" # c # OpValue;
+  
+  // Disable complete decoder for all register operands to avoid decoder
+  // conflicts between instructions with overlapping encodings
+  let hasCompleteDecoder = false;
+}
+

--- a/llvm/lib/Target/AIE/aie1/AIE1InstrInfo.td
+++ b/llvm/lib/Target/AIE/aie1/AIE1InstrInfo.td
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// (c) Copyright 2023-2024 Advanced Micro Devices, Inc. or its affiliates
+// (c) Copyright 2023-2025 Advanced Micro Devices, Inc. or its affiliates
 //
 //===----------------------------------------------------------------------===//
 //
@@ -95,6 +95,7 @@ def immfp32    : ImmLeaf<f32, [{return true;}] >;
 // per-registerClass basis by default.)
 class AIERegisterOperand<RegisterClass c> : RegisterOperand<c> {
   let EncoderMethod = "get" # c # OpValue;
+  let hasCompleteDecoder = false;
 }
 
 // WARNING: These register classes contain registers of different

--- a/llvm/lib/Target/AIE/aie1/AIE1InstrInfo.td
+++ b/llvm/lib/Target/AIE/aie1/AIE1InstrInfo.td
@@ -93,48 +93,44 @@ def immfp32    : ImmLeaf<f32, [{return true;}] >;
 // code to encode registers correctly on a per-registerClass basis.
 // (Note that decoding in the disassembler is done on a
 // per-registerClass basis by default.)
-class AIERegisterOperand<RegisterClass c> : RegisterOperand<c> {
-  let EncoderMethod = "get" # c # OpValue;
-  let hasCompleteDecoder = false;
-}
 
 // WARNING: These register classes contain registers of different
 // sizes!  This case is not well handled in LLVM and can silently
 // cause miscompilations if a 20-bit (PTR) register is chosen to store
 // a value that doesn't fit!  Codegen patterns should use the
 // more specialized *_GPR and *_PTR register classes below.
-def OP_mMvScl   : AIERegisterOperand<mMvScl>;
-def OP_mSclSt   : AIERegisterOperand<mSclSt>;
-def OP_mLdaScl  : AIERegisterOperand<mLdaScl>;
+def OP_mMvScl   : AIEBaseRegisterOperand<mMvScl>;
+def OP_mSclSt   : AIEBaseRegisterOperand<mSclSt>;
+def OP_mLdaScl  : AIEBaseRegisterOperand<mLdaScl>;
 
 let EncoderMethod = "get" # mMvScl # OpValue in {
-def OP_mMvScl_GPR   : AIERegisterOperand<mRCm>;
-def OP_mMvScl_PTR   : AIERegisterOperand<PTRMODCSCB>;
+def OP_mMvScl_GPR   : AIEBaseRegisterOperand<mRCm>;
+def OP_mMvScl_PTR   : AIEBaseRegisterOperand<PTRMODCSCB>;
 }
 let EncoderMethod = "get" # mSclSt # OpValue in {
-def OP_mSclSt_GPR   : AIERegisterOperand<mRCm>;
-def OP_mSclSt_PTR   : AIERegisterOperand<mSclSt_PTR>;
-def OP_mSclSt_MOD   : AIERegisterOperand<MOD>;
+def OP_mSclSt_GPR   : AIEBaseRegisterOperand<mRCm>;
+def OP_mSclSt_PTR   : AIEBaseRegisterOperand<mSclSt_PTR>;
+def OP_mSclSt_MOD   : AIEBaseRegisterOperand<MOD>;
 }
 let EncoderMethod = "get" # mLdaScl # OpValue in {
-def OP_mLdaScl_GPR   : AIERegisterOperand<mRCm>;
-def OP_mLdaScl_PTR   : AIERegisterOperand<PTRMODCSCB>;
-def OP_mLdaScl_MOD   : AIERegisterOperand<MOD>;
+def OP_mLdaScl_GPR   : AIEBaseRegisterOperand<mRCm>;
+def OP_mLdaScl_PTR   : AIEBaseRegisterOperand<PTRMODCSCB>;
+def OP_mLdaScl_MOD   : AIEBaseRegisterOperand<MOD>;
 }
 
-def OP_mLdbScl  : AIERegisterOperand<mLdbScl>;
-def OP_mAluCg12 : AIERegisterOperand<mAluCg12>;
-def OP_mMv0Cg20 : AIERegisterOperand<mMv0Cg20>;
-def OP_mRCm     : AIERegisterOperand<mRCm>;
-def OP_mWAv    : AIERegisterOperand<mWAv>;
-def OP_mWABv   : AIERegisterOperand<mWABv>;
-def OP_mWABDv   : AIERegisterOperand<mWABDv>;
-def OP_mWBDv    : AIERegisterOperand<mWBDv>;
-def OP_mWCDv    : AIERegisterOperand<mWCDv>;
-def OP_mXABv    : AIERegisterOperand<mXABv>;
-def OP_mXCDv    : AIERegisterOperand<mXCDv>;
+def OP_mLdbScl  : AIEBaseRegisterOperand<mLdbScl>;
+def OP_mAluCg12 : AIEBaseRegisterOperand<mAluCg12>;
+def OP_mMv0Cg20 : AIEBaseRegisterOperand<mMv0Cg20>;
+def OP_mRCm     : AIEBaseRegisterOperand<mRCm>;
+def OP_mWAv    : AIEBaseRegisterOperand<mWAv>;
+def OP_mWABv   : AIEBaseRegisterOperand<mWABv>;
+def OP_mWABDv   : AIEBaseRegisterOperand<mWABDv>;
+def OP_mWBDv    : AIEBaseRegisterOperand<mWBDv>;
+def OP_mWCDv    : AIEBaseRegisterOperand<mWCDv>;
+def OP_mXABv    : AIEBaseRegisterOperand<mXABv>;
+def OP_mXCDv    : AIEBaseRegisterOperand<mXCDv>;
 //mVn, mVs, mVm, mVa
-def OP_mVn      : AIERegisterOperand<mVn>;
+def OP_mVn      : AIEBaseRegisterOperand<mVn>;
 
 // Extract least significant 20 bits from an immediate value.
 def LO20 : SDNodeXForm<imm, [{

--- a/llvm/lib/Target/AIE/aie1/AIE1RegisterInfo.td
+++ b/llvm/lib/Target/AIE/aie1/AIE1RegisterInfo.td
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// (c) Copyright 2023-2024 Advanced Micro Devices, Inc. or its affiliates
+// (c) Copyright 2023-2025 Advanced Micro Devices, Inc. or its affiliates
 //
 //===----------------------------------------------------------------------===//
 
@@ -207,6 +207,7 @@ class AIERegisterClass <int size, list<ValueType> regTypes, dag reglist, RegAltN
   let RegInfos = RegInfoByHwMode<
       [DefaultMode],
       [RegInfo</*size*/size, /*spill size*/size, /*spill alignment*/size>]>;
+  let hasCompleteDecoder = false;
 }
 class AIEScalarRegisterClass <dag reglist, RegAltNameIndex idx = NoRegAltName> :
 		AIERegisterClass<32, [v8i1, v16i1, i20, i32, f32], reglist, idx>;

--- a/llvm/lib/Target/AIE/aie1/AIE1RegisterInfo.td
+++ b/llvm/lib/Target/AIE/aie1/AIE1RegisterInfo.td
@@ -12,6 +12,8 @@
 //  Declarations that describe the AIEngine register files
 //===----------------------------------------------------------------------===//
 
+include "AIEBaseRegisterInfo.td"
+
 let Namespace = "AIE" in {
 
 class AIEReg<string n> : Register<n> {
@@ -201,19 +203,17 @@ let SubRegIndices = [sub_32_lo, sub_32_hi], CoveredBySubRegs = 1 in {
 // We have lots of different register classes, representing register
 // restrictions for different instructions
 class AIERegisterClass <int size, list<ValueType> regTypes, dag reglist, RegAltNameIndex idx = NoRegAltName> :
-		RegisterClass<"AIE", regTypes, /*alignment*/size, reglist, idx> {
+		AIEBaseRegisterClass<"AIE", regTypes, /*alignment*/size, reglist, idx> {
   dag Regs = reglist;
-  let DecodeZeroBitOperand = true;
   let RegInfos = RegInfoByHwMode<
       [DefaultMode],
       [RegInfo</*size*/size, /*spill size*/size, /*spill alignment*/size>]>;
-  let hasCompleteDecoder = false;
 }
 class AIEScalarRegisterClass <dag reglist, RegAltNameIndex idx = NoRegAltName> :
 		AIERegisterClass<32, [v8i1, v16i1, i20, i32, f32], reglist, idx>;
 
 class AIEPointerRegisterClass <dag reglist, RegAltNameIndex idx = NoRegAltName> :
-		  RegisterClass<"AIE", [i20], /*alignment*/ 32, reglist, idx> {
+		  AIEBaseRegisterClass<"AIE", [i20], /*alignment*/ 32, reglist, idx> {
   dag Regs = reglist;
   let RegInfos = RegInfoByHwMode<
       [DefaultMode],

--- a/llvm/lib/Target/AIE/aie2p/AIE2PGenInstrInfo.td
+++ b/llvm/lib/Target/AIE/aie2p/AIE2PGenInstrInfo.td
@@ -8034,7 +8034,7 @@ bits<5> dst;
 let ldb = {ptr, mod, 0b100, dst, 0b000};
 }
 
-let Itinerary = II_VLDB_2D_UNPACK_dmw_ldb_unpack_unpackSign0, DecoderMethod = "DecodeDmw_ldb_unpack_2D", hasCompleteDecoder = false, mayLoad = true, Uses = [crUnpackSize, unpackSign0], Constraints = "$ptr_out = $ptr" in
+let Itinerary = II_VLDB_2D_UNPACK_dmw_ldb_unpack_unpackSign0, DecoderMethod = "DecodeDmw_ldb_unpack_2D", mayLoad = true, Uses = [crUnpackSize, unpackSign0], Constraints = "$ptr_out = $ptr" in
 def VLDB_2D_UNPACK_dmw_ldb_unpack_unpackSign0 : AIE2P_inst_ldb_instr32 <(outs OP_mXb:$dst, eP:$ptr_out, eDC:$dc), (ins eP:$ptr, eD:$mod), "vldb.2d.unpack", " $dst, unpacksign0, [$ptr], $mod">, AIE_HasTiedSubregister{
 // id: me__instr128_or__ldb__dmw_ldb_unpack__agub_dmw__nrm__agub_dmw__normal__agub_dmw__pstm_2d__mPb__mDb__unpackSign0
 bits<3> ptr;
@@ -8044,7 +8044,7 @@ bits<4> dst;
 let ldb = {ptr, mod, 0b100, dst, 0b0, 0b010};
 }
 
-let Itinerary = II_VLDB_2D_UNPACK_dmw_ldb_unpack_unpackSign1, DecoderMethod = "DecodeDmw_ldb_unpack_2D", hasCompleteDecoder = false, mayLoad = true, Uses = [crUnpackSize, unpackSign1], Constraints = "$ptr_out = $ptr" in
+let Itinerary = II_VLDB_2D_UNPACK_dmw_ldb_unpack_unpackSign1, DecoderMethod = "DecodeDmw_ldb_unpack_2D", mayLoad = true, Uses = [crUnpackSize, unpackSign1], Constraints = "$ptr_out = $ptr" in
 def VLDB_2D_UNPACK_dmw_ldb_unpack_unpackSign1 : AIE2P_inst_ldb_instr32 <(outs OP_mXb:$dst, eP:$ptr_out, eDC:$dc), (ins eP:$ptr, eD:$mod), "vldb.2d.unpack", " $dst, unpacksign1, [$ptr], $mod">, AIE_HasTiedSubregister{
 // id: me__instr128_or__ldb__dmw_ldb_unpack__agub_dmw__nrm__agub_dmw__normal__agub_dmw__pstm_2d__mPb__mDb__unpackSign1
 bits<3> ptr;
@@ -8054,7 +8054,7 @@ bits<4> dst;
 let ldb = {ptr, mod, 0b100, dst, 0b1, 0b010};
 }
 
-let Itinerary = II_VLDB_2D_UNPACK_dmx_ldb_unpack_unpackSign0, DecoderMethod = "DecodeDmx_ldb_unpack_2D", hasCompleteDecoder = false, mayLoad = true, Uses = [crUnpackSize, unpackSign0], Constraints = "$ptr_out = $ptr" in
+let Itinerary = II_VLDB_2D_UNPACK_dmx_ldb_unpack_unpackSign0, DecoderMethod = "DecodeDmx_ldb_unpack_2D", mayLoad = true, Uses = [crUnpackSize, unpackSign0], Constraints = "$ptr_out = $ptr" in
 def VLDB_2D_UNPACK_dmx_ldb_unpack_unpackSign0 : AIE2P_inst_ldb_instr32 <(outs eY:$dst, eP:$ptr_out, eDC:$dc), (ins eP:$ptr, eD:$mod), "vldb.2d.unpack", " $dst, unpacksign0, [$ptr], $mod">, AIE_HasTiedSubregister{
 // id: me__instr128_or__ldb__dmx_ldb_unpack__agub_dmx__nrm__agub_dmx__normal__agub_dmx__pstm_2d__mPb__mDb__mYb__unpackSign0
 bits<3> ptr;
@@ -8064,7 +8064,7 @@ bits<3> dst;
 let ldb = {ptr, mod, 0b100, dst, dontcare{1}, 0b0, 0b011};
 }
 
-let Itinerary = II_VLDB_2D_UNPACK_dmx_ldb_unpack_unpackSign1, DecoderMethod = "DecodeDmx_ldb_unpack_2D", hasCompleteDecoder = false, mayLoad = true, Uses = [crUnpackSize, unpackSign1], Constraints = "$ptr_out = $ptr" in
+let Itinerary = II_VLDB_2D_UNPACK_dmx_ldb_unpack_unpackSign1, DecoderMethod = "DecodeDmx_ldb_unpack_2D", mayLoad = true, Uses = [crUnpackSize, unpackSign1], Constraints = "$ptr_out = $ptr" in
 def VLDB_2D_UNPACK_dmx_ldb_unpack_unpackSign1 : AIE2P_inst_ldb_instr32 <(outs eY:$dst, eP:$ptr_out, eDC:$dc), (ins eP:$ptr, eD:$mod), "vldb.2d.unpack", " $dst, unpacksign1, [$ptr], $mod">, AIE_HasTiedSubregister{
 // id: me__instr128_or__ldb__dmx_ldb_unpack__agub_dmx__nrm__agub_dmx__normal__agub_dmx__pstm_2d__mPb__mDb__mYb__unpackSign1
 bits<3> ptr;
@@ -8104,7 +8104,7 @@ bits<5> dst;
 let ldb = {ptr, dontcare{1}, mod, 0b110, dst, 0b000};
 }
 
-let Itinerary = II_VLDB_3D_UNPACK_dmw_ldb_unpack_unpackSign0, DecoderMethod = "DecodeDmw_ldb_unpack_3D", hasCompleteDecoder = false, mayLoad = true, Uses = [crUnpackSize, unpackSign0], Constraints = "$ptr_out = $ptr" in
+let Itinerary = II_VLDB_3D_UNPACK_dmw_ldb_unpack_unpackSign0, DecoderMethod = "DecodeDmw_ldb_unpack_3D", mayLoad = true, Uses = [crUnpackSize, unpackSign0], Constraints = "$ptr_out = $ptr" in
 def VLDB_3D_UNPACK_dmw_ldb_unpack_unpackSign0 : AIE2P_inst_ldb_instr32 <(outs OP_mXb:$dst, eP:$ptr_out, eDCL:$dcl, eDCH:$dch), (ins eP:$ptr, eDS:$mod), "vldb.3d.unpack", " $dst, unpacksign0, [$ptr], $mod">, AIE_HasTiedSubregister{
 // id: me__instr128_or__ldb__dmw_ldb_unpack__agub_dmw__nrm__agub_dmw__normal__agub_dmw__pstm_3d__mPb__mDSb__unpackSign0
 bits<3> ptr;
@@ -8114,7 +8114,7 @@ bits<4> dst;
 let ldb = {ptr, dontcare{1}, mod, 0b110, dst, 0b0, 0b010};
 }
 
-let Itinerary = II_VLDB_3D_UNPACK_dmw_ldb_unpack_unpackSign1, DecoderMethod = "DecodeDmw_ldb_unpack_3D", hasCompleteDecoder = false, mayLoad = true, Uses = [crUnpackSize, unpackSign1], Constraints = "$ptr_out = $ptr" in
+let Itinerary = II_VLDB_3D_UNPACK_dmw_ldb_unpack_unpackSign1, DecoderMethod = "DecodeDmw_ldb_unpack_3D", mayLoad = true, Uses = [crUnpackSize, unpackSign1], Constraints = "$ptr_out = $ptr" in
 def VLDB_3D_UNPACK_dmw_ldb_unpack_unpackSign1 : AIE2P_inst_ldb_instr32 <(outs OP_mXb:$dst, eP:$ptr_out, eDCL:$dcl, eDCH:$dch), (ins eP:$ptr, eDS:$mod), "vldb.3d.unpack", " $dst, unpacksign1, [$ptr], $mod">, AIE_HasTiedSubregister{
 // id: me__instr128_or__ldb__dmw_ldb_unpack__agub_dmw__nrm__agub_dmw__normal__agub_dmw__pstm_3d__mPb__mDSb__unpackSign1
 bits<3> ptr;
@@ -8124,7 +8124,7 @@ bits<4> dst;
 let ldb = {ptr, dontcare{1}, mod, 0b110, dst, 0b1, 0b010};
 }
 
-let Itinerary = II_VLDB_3D_UNPACK_dmx_ldb_unpack_unpackSign0, DecoderMethod = "DecodeDmx_ldb_unpack_3D", hasCompleteDecoder = false, mayLoad = true, Uses = [crUnpackSize, unpackSign0], Constraints = "$ptr_out = $ptr" in
+let Itinerary = II_VLDB_3D_UNPACK_dmx_ldb_unpack_unpackSign0, DecoderMethod = "DecodeDmx_ldb_unpack_3D", mayLoad = true, Uses = [crUnpackSize, unpackSign0], Constraints = "$ptr_out = $ptr" in
 def VLDB_3D_UNPACK_dmx_ldb_unpack_unpackSign0 : AIE2P_inst_ldb_instr32 <(outs eY:$dst, eP:$ptr_out, eDCL:$dcl, eDCH:$dch), (ins eP:$ptr, eDS:$mod), "vldb.3d.unpack", " $dst, unpacksign0, [$ptr], $mod">, AIE_HasTiedSubregister{
 // id: me__instr128_or__ldb__dmx_ldb_unpack__agub_dmx__nrm__agub_dmx__normal__agub_dmx__pstm_3d__mPb__mDSb__mYb__unpackSign0
 bits<3> ptr;
@@ -8134,7 +8134,7 @@ bits<3> dst;
 let ldb = {ptr, dontcare{1}, mod, 0b110, dst, dontcare{1}, 0b0, 0b011};
 }
 
-let Itinerary = II_VLDB_3D_UNPACK_dmx_ldb_unpack_unpackSign1, DecoderMethod = "DecodeDmx_ldb_unpack_3D", hasCompleteDecoder = false, mayLoad = true, Uses = [crUnpackSize, unpackSign1], Constraints = "$ptr_out = $ptr" in
+let Itinerary = II_VLDB_3D_UNPACK_dmx_ldb_unpack_unpackSign1, DecoderMethod = "DecodeDmx_ldb_unpack_3D", mayLoad = true, Uses = [crUnpackSize, unpackSign1], Constraints = "$ptr_out = $ptr" in
 def VLDB_3D_UNPACK_dmx_ldb_unpack_unpackSign1 : AIE2P_inst_ldb_instr32 <(outs eY:$dst, eP:$ptr_out, eDCL:$dcl, eDCH:$dch), (ins eP:$ptr, eDS:$mod), "vldb.3d.unpack", " $dst, unpacksign1, [$ptr], $mod">, AIE_HasTiedSubregister{
 // id: me__instr128_or__ldb__dmx_ldb_unpack__agub_dmx__nrm__agub_dmx__normal__agub_dmx__pstm_3d__mPb__mDSb__mYb__unpackSign1
 bits<3> ptr;
@@ -8438,7 +8438,7 @@ bits<2> dst;
 let ldb = {0b01, ptr, dontcare{3-1}, 0b110, dst, dontcare{2-1}, 0b0101};
 }
 
-let Itinerary = II_VLDB_UNPACK_dmw_ldb_unpack_idx_unpackSign0, hasCompleteDecoder = false, mayLoad = true, Uses = [crUnpackSize, unpackSign0] in
+let Itinerary = II_VLDB_UNPACK_dmw_ldb_unpack_idx_unpackSign0, mayLoad = true, Uses = [crUnpackSize, unpackSign0] in
 def VLDB_UNPACK_dmw_ldb_unpack_idx_unpackSign0 : AIE2P_inst_ldb_instr32 <(outs OP_mXb:$dst), (ins eP:$ptr, eDJ:$dj), "vldb.unpack", " $dst, unpacksign0, [$ptr, $dj]">{
 // id: me__instr128_or__ldb__dmw_ldb_unpack__agub_dmw__nrm__agub_dmw__normal__agub_dmw__idx__mPb__mDJb__unpackSign0
 bits<3> ptr;
@@ -8448,7 +8448,7 @@ bits<4> dst;
 let ldb = {ptr, dj, 0b000, dst, 0b0, 0b010};
 }
 
-let Itinerary = II_VLDB_UNPACK_dmw_ldb_unpack_idx_unpackSign1, hasCompleteDecoder = false, mayLoad = true, Uses = [crUnpackSize, unpackSign1] in
+let Itinerary = II_VLDB_UNPACK_dmw_ldb_unpack_idx_unpackSign1, mayLoad = true, Uses = [crUnpackSize, unpackSign1] in
 def VLDB_UNPACK_dmw_ldb_unpack_idx_unpackSign1 : AIE2P_inst_ldb_instr32 <(outs OP_mXb:$dst), (ins eP:$ptr, eDJ:$dj), "vldb.unpack", " $dst, unpacksign1, [$ptr, $dj]">{
 // id: me__instr128_or__ldb__dmw_ldb_unpack__agub_dmw__nrm__agub_dmw__normal__agub_dmw__idx__mPb__mDJb__unpackSign1
 bits<3> ptr;
@@ -8458,7 +8458,7 @@ bits<4> dst;
 let ldb = {ptr, dj, 0b000, dst, 0b1, 0b010};
 }
 
-let Itinerary = II_VLDB_UNPACK_dmw_ldb_unpack_idx_imm_unpackSign0, hasCompleteDecoder = false, mayLoad = true, Uses = [crUnpackSize, unpackSign0] in
+let Itinerary = II_VLDB_UNPACK_dmw_ldb_unpack_idx_imm_unpackSign0, mayLoad = true, Uses = [crUnpackSize, unpackSign0] in
 def VLDB_UNPACK_dmw_ldb_unpack_idx_imm_unpackSign0 : AIE2P_inst_ldb_instr32 <(outs OP_mXb:$dst), (ins eP:$ptr, c9s_step32:$imm), "vldb.unpack", " $dst, unpacksign0, [$ptr, #$imm]">{
 // id: me__instr128_or__ldb__dmw_ldb_unpack__agub_dmw__nrm__agub_dmw__normal__agub_dmw__idx_imm__mPb__m_c09s_step32__unpackSign0
 bits<3> ptr;
@@ -8468,7 +8468,7 @@ bits<4> dst;
 let ldb = {ptr, imm, 0b01, dst, 0b0, 0b010};
 }
 
-let Itinerary = II_VLDB_UNPACK_dmw_ldb_unpack_idx_imm_unpackSign1, hasCompleteDecoder = false, mayLoad = true, Uses = [crUnpackSize, unpackSign1] in
+let Itinerary = II_VLDB_UNPACK_dmw_ldb_unpack_idx_imm_unpackSign1, mayLoad = true, Uses = [crUnpackSize, unpackSign1] in
 def VLDB_UNPACK_dmw_ldb_unpack_idx_imm_unpackSign1 : AIE2P_inst_ldb_instr32 <(outs OP_mXb:$dst), (ins eP:$ptr, c9s_step32:$imm), "vldb.unpack", " $dst, unpacksign1, [$ptr, #$imm]">{
 // id: me__instr128_or__ldb__dmw_ldb_unpack__agub_dmw__nrm__agub_dmw__normal__agub_dmw__idx_imm__mPb__m_c09s_step32__unpackSign1
 bits<3> ptr;
@@ -8478,7 +8478,7 @@ bits<4> dst;
 let ldb = {ptr, imm, 0b01, dst, 0b1, 0b010};
 }
 
-let Itinerary = II_VLDB_UNPACK_dmw_ldb_unpack_pstm_nrm_unpackSign0, hasCompleteDecoder = false, mayLoad = true, Uses = [crUnpackSize, unpackSign0], Constraints = "$ptr_out = $ptr" in
+let Itinerary = II_VLDB_UNPACK_dmw_ldb_unpack_pstm_nrm_unpackSign0, mayLoad = true, Uses = [crUnpackSize, unpackSign0], Constraints = "$ptr_out = $ptr" in
 def VLDB_UNPACK_dmw_ldb_unpack_pstm_nrm_unpackSign0 : AIE2P_inst_ldb_instr32 <(outs OP_mXb:$dst, eP:$ptr_out), (ins eP:$ptr, eM:$mod), "vldb.unpack", " $dst, unpacksign0, [$ptr], $mod">{
 // id: me__instr128_or__ldb__dmw_ldb_unpack__agub_dmw__nrm__agub_dmw__normal__agub_dmw__pstm_nrm__mPb__mMb__unpackSign0
 bits<3> ptr;
@@ -8488,7 +8488,7 @@ bits<4> dst;
 let ldb = {ptr, mod, 0b010, dst, 0b0, 0b010};
 }
 
-let Itinerary = II_VLDB_UNPACK_dmw_ldb_unpack_pstm_nrm_unpackSign1, hasCompleteDecoder = false, mayLoad = true, Uses = [crUnpackSize, unpackSign1], Constraints = "$ptr_out = $ptr" in
+let Itinerary = II_VLDB_UNPACK_dmw_ldb_unpack_pstm_nrm_unpackSign1, mayLoad = true, Uses = [crUnpackSize, unpackSign1], Constraints = "$ptr_out = $ptr" in
 def VLDB_UNPACK_dmw_ldb_unpack_pstm_nrm_unpackSign1 : AIE2P_inst_ldb_instr32 <(outs OP_mXb:$dst, eP:$ptr_out), (ins eP:$ptr, eM:$mod), "vldb.unpack", " $dst, unpacksign1, [$ptr], $mod">{
 // id: me__instr128_or__ldb__dmw_ldb_unpack__agub_dmw__nrm__agub_dmw__normal__agub_dmw__pstm_nrm__mPb__mMb__unpackSign1
 bits<3> ptr;
@@ -8498,7 +8498,7 @@ bits<4> dst;
 let ldb = {ptr, mod, 0b010, dst, 0b1, 0b010};
 }
 
-let Itinerary = II_VLDB_UNPACK_dmw_ldb_unpack_pstm_nrm_imm_unpackSign0, hasCompleteDecoder = false, mayLoad = true, Uses = [crUnpackSize, unpackSign0], Constraints = "$ptr_out = $ptr" in
+let Itinerary = II_VLDB_UNPACK_dmw_ldb_unpack_pstm_nrm_imm_unpackSign0, mayLoad = true, Uses = [crUnpackSize, unpackSign0], Constraints = "$ptr_out = $ptr" in
 def VLDB_UNPACK_dmw_ldb_unpack_pstm_nrm_imm_unpackSign0 : AIE2P_inst_ldb_instr32 <(outs OP_mXb:$dst, eP:$ptr_out), (ins eP:$ptr, c9s_step32:$imm), "vldb.unpack", " $dst, unpacksign0, [$ptr], #$imm">{
 // id: me__instr128_or__ldb__dmw_ldb_unpack__agub_dmw__nrm__agub_dmw__normal__agub_dmw__pstm_nrm_imm__mPb__m_c09s_step32__unpackSign0
 bits<3> ptr;
@@ -8508,7 +8508,7 @@ bits<4> dst;
 let ldb = {ptr, imm, 0b11, dst, 0b0, 0b010};
 }
 
-let Itinerary = II_VLDB_UNPACK_dmw_ldb_unpack_pstm_nrm_imm_unpackSign1, hasCompleteDecoder = false, mayLoad = true, Uses = [crUnpackSize, unpackSign1], Constraints = "$ptr_out = $ptr" in
+let Itinerary = II_VLDB_UNPACK_dmw_ldb_unpack_pstm_nrm_imm_unpackSign1, mayLoad = true, Uses = [crUnpackSize, unpackSign1], Constraints = "$ptr_out = $ptr" in
 def VLDB_UNPACK_dmw_ldb_unpack_pstm_nrm_imm_unpackSign1 : AIE2P_inst_ldb_instr32 <(outs OP_mXb:$dst, eP:$ptr_out), (ins eP:$ptr, c9s_step32:$imm), "vldb.unpack", " $dst, unpacksign1, [$ptr], #$imm">{
 // id: me__instr128_or__ldb__dmw_ldb_unpack__agub_dmw__nrm__agub_dmw__normal__agub_dmw__pstm_nrm_imm__mPb__m_c09s_step32__unpackSign1
 bits<3> ptr;
@@ -8518,7 +8518,7 @@ bits<4> dst;
 let ldb = {ptr, imm, 0b11, dst, 0b1, 0b010};
 }
 
-let Itinerary = II_VLDB_UNPACK_dmx_ldb_unpack_idx_unpackSign0, hasCompleteDecoder = false, mayLoad = true, Uses = [crUnpackSize, unpackSign0] in
+let Itinerary = II_VLDB_UNPACK_dmx_ldb_unpack_idx_unpackSign0, mayLoad = true, Uses = [crUnpackSize, unpackSign0] in
 def VLDB_UNPACK_dmx_ldb_unpack_idx_unpackSign0 : AIE2P_inst_ldb_instr32 <(outs eY:$dst), (ins eP:$ptr, eDJ:$dj), "vldb.unpack", " $dst, unpacksign0, [$ptr, $dj]">{
 // id: me__instr128_or__ldb__dmx_ldb_unpack__agub_dmx__nrm__agub_dmx__normal__agub_dmx__idx__mPb__mDJb__mYb__unpackSign0
 bits<3> ptr;
@@ -8528,7 +8528,7 @@ bits<3> dst;
 let ldb = {ptr, dj, 0b000, dst, dontcare{1}, 0b0, 0b011};
 }
 
-let Itinerary = II_VLDB_UNPACK_dmx_ldb_unpack_idx_unpackSign1, hasCompleteDecoder = false, mayLoad = true, Uses = [crUnpackSize, unpackSign1] in
+let Itinerary = II_VLDB_UNPACK_dmx_ldb_unpack_idx_unpackSign1, mayLoad = true, Uses = [crUnpackSize, unpackSign1] in
 def VLDB_UNPACK_dmx_ldb_unpack_idx_unpackSign1 : AIE2P_inst_ldb_instr32 <(outs eY:$dst), (ins eP:$ptr, eDJ:$dj), "vldb.unpack", " $dst, unpacksign1, [$ptr, $dj]">{
 // id: me__instr128_or__ldb__dmx_ldb_unpack__agub_dmx__nrm__agub_dmx__normal__agub_dmx__idx__mPb__mDJb__mYb__unpackSign1
 bits<3> ptr;
@@ -8538,7 +8538,7 @@ bits<3> dst;
 let ldb = {ptr, dj, 0b000, dst, dontcare{1}, 0b1, 0b011};
 }
 
-let Itinerary = II_VLDB_UNPACK_dmx_ldb_unpack_idx_imm_unpackSign0, hasCompleteDecoder = false, mayLoad = true, Uses = [crUnpackSize, unpackSign0] in
+let Itinerary = II_VLDB_UNPACK_dmx_ldb_unpack_idx_imm_unpackSign0, mayLoad = true, Uses = [crUnpackSize, unpackSign0] in
 def VLDB_UNPACK_dmx_ldb_unpack_idx_imm_unpackSign0 : AIE2P_inst_ldb_instr32 <(outs eY:$dst), (ins eP:$ptr, c10s_step64:$imm), "vldb.unpack", " $dst, unpacksign0, [$ptr, #$imm]">{
 // id: me__instr128_or__ldb__dmx_ldb_unpack__agub_dmx__nrm__agub_dmx__normal__agub_dmx__idx_imm__mPb__m_c10s_step64__mYb__unpackSign0
 bits<3> ptr;
@@ -8548,7 +8548,7 @@ bits<3> dst;
 let ldb = {ptr, imm, 0b01, dst, dontcare{1}, 0b0, 0b011};
 }
 
-let Itinerary = II_VLDB_UNPACK_dmx_ldb_unpack_idx_imm_unpackSign1, hasCompleteDecoder = false, mayLoad = true, Uses = [crUnpackSize, unpackSign1] in
+let Itinerary = II_VLDB_UNPACK_dmx_ldb_unpack_idx_imm_unpackSign1, mayLoad = true, Uses = [crUnpackSize, unpackSign1] in
 def VLDB_UNPACK_dmx_ldb_unpack_idx_imm_unpackSign1 : AIE2P_inst_ldb_instr32 <(outs eY:$dst), (ins eP:$ptr, c10s_step64:$imm), "vldb.unpack", " $dst, unpacksign1, [$ptr, #$imm]">{
 // id: me__instr128_or__ldb__dmx_ldb_unpack__agub_dmx__nrm__agub_dmx__normal__agub_dmx__idx_imm__mPb__m_c10s_step64__mYb__unpackSign1
 bits<3> ptr;
@@ -8558,7 +8558,7 @@ bits<3> dst;
 let ldb = {ptr, imm, 0b01, dst, dontcare{1}, 0b1, 0b011};
 }
 
-let Itinerary = II_VLDB_UNPACK_dmx_ldb_unpack_pstm_nrm_unpackSign0, hasCompleteDecoder = false, mayLoad = true, Uses = [crUnpackSize, unpackSign0], Constraints = "$ptr_out = $ptr" in
+let Itinerary = II_VLDB_UNPACK_dmx_ldb_unpack_pstm_nrm_unpackSign0, mayLoad = true, Uses = [crUnpackSize, unpackSign0], Constraints = "$ptr_out = $ptr" in
 def VLDB_UNPACK_dmx_ldb_unpack_pstm_nrm_unpackSign0 : AIE2P_inst_ldb_instr32 <(outs eY:$dst, eP:$ptr_out), (ins eP:$ptr, eM:$mod), "vldb.unpack", " $dst, unpacksign0, [$ptr], $mod">{
 // id: me__instr128_or__ldb__dmx_ldb_unpack__agub_dmx__nrm__agub_dmx__normal__agub_dmx__pstm_nrm__mPb__mMb__mYb__unpackSign0
 bits<3> ptr;
@@ -8568,7 +8568,7 @@ bits<3> dst;
 let ldb = {ptr, mod, 0b010, dst, dontcare{1}, 0b0, 0b011};
 }
 
-let Itinerary = II_VLDB_UNPACK_dmx_ldb_unpack_pstm_nrm_unpackSign1, hasCompleteDecoder = false, mayLoad = true, Uses = [crUnpackSize, unpackSign1], Constraints = "$ptr_out = $ptr" in
+let Itinerary = II_VLDB_UNPACK_dmx_ldb_unpack_pstm_nrm_unpackSign1, mayLoad = true, Uses = [crUnpackSize, unpackSign1], Constraints = "$ptr_out = $ptr" in
 def VLDB_UNPACK_dmx_ldb_unpack_pstm_nrm_unpackSign1 : AIE2P_inst_ldb_instr32 <(outs eY:$dst, eP:$ptr_out), (ins eP:$ptr, eM:$mod), "vldb.unpack", " $dst, unpacksign1, [$ptr], $mod">{
 // id: me__instr128_or__ldb__dmx_ldb_unpack__agub_dmx__nrm__agub_dmx__normal__agub_dmx__pstm_nrm__mPb__mMb__mYb__unpackSign1
 bits<3> ptr;
@@ -8578,7 +8578,7 @@ bits<3> dst;
 let ldb = {ptr, mod, 0b010, dst, dontcare{1}, 0b1, 0b011};
 }
 
-let Itinerary = II_VLDB_UNPACK_dmx_ldb_unpack_pstm_nrm_imm_unpackSign0, hasCompleteDecoder = false, mayLoad = true, Uses = [crUnpackSize, unpackSign0], Constraints = "$ptr_out = $ptr" in
+let Itinerary = II_VLDB_UNPACK_dmx_ldb_unpack_pstm_nrm_imm_unpackSign0, mayLoad = true, Uses = [crUnpackSize, unpackSign0], Constraints = "$ptr_out = $ptr" in
 def VLDB_UNPACK_dmx_ldb_unpack_pstm_nrm_imm_unpackSign0 : AIE2P_inst_ldb_instr32 <(outs eY:$dst, eP:$ptr_out), (ins eP:$ptr, c10s_step64:$imm), "vldb.unpack", " $dst, unpacksign0, [$ptr], #$imm">{
 // id: me__instr128_or__ldb__dmx_ldb_unpack__agub_dmx__nrm__agub_dmx__normal__agub_dmx__pstm_nrm_imm__mPb__m_c10s_step64__mYb__unpackSign0
 bits<3> ptr;
@@ -8588,7 +8588,7 @@ bits<3> dst;
 let ldb = {ptr, imm, 0b11, dst, dontcare{1}, 0b0, 0b011};
 }
 
-let Itinerary = II_VLDB_UNPACK_dmx_ldb_unpack_pstm_nrm_imm_unpackSign1, hasCompleteDecoder = false, mayLoad = true, Uses = [crUnpackSize, unpackSign1], Constraints = "$ptr_out = $ptr" in
+let Itinerary = II_VLDB_UNPACK_dmx_ldb_unpack_pstm_nrm_imm_unpackSign1, mayLoad = true, Uses = [crUnpackSize, unpackSign1], Constraints = "$ptr_out = $ptr" in
 def VLDB_UNPACK_dmx_ldb_unpack_pstm_nrm_imm_unpackSign1 : AIE2P_inst_ldb_instr32 <(outs eY:$dst, eP:$ptr_out), (ins eP:$ptr, c10s_step64:$imm), "vldb.unpack", " $dst, unpacksign1, [$ptr], #$imm">{
 // id: me__instr128_or__ldb__dmx_ldb_unpack__agub_dmx__nrm__agub_dmx__normal__agub_dmx__pstm_nrm_imm__mPb__m_c10s_step64__mYb__unpackSign1
 bits<3> ptr;

--- a/llvm/lib/Target/AIE/aie2p/AIE2PRegisterInfo.td
+++ b/llvm/lib/Target/AIE/aie2p/AIE2PRegisterInfo.td
@@ -11,6 +11,8 @@
 //  Declarations that describe the AIE2p Register files
 //===----------------------------------------------------------------------===//
 
+include "AIEBaseRegisterInfo.td"
+
 let Namespace = "AIE2P" in {
 
 def sub_l_even : SubRegIndex<32,  0>;
@@ -104,13 +106,11 @@ class AIE2P3BitReg<bits<3> Enc, string n, list<Register> subregs = []> : Registe
 }
 
 class AIE2PRegisterClass <int size, int align, list<ValueType> regTypes, dag reglist, RegAltNameIndex idx = NoRegAltName> :
-               RegisterClass<"AIE2P", regTypes, /*alignment*/size, reglist, idx> {
+               AIEBaseRegisterClass<"AIE2P", regTypes, /*alignment*/size, reglist, idx> {
   dag Regs = reglist;
   let RegInfos = RegInfoByHwMode<
       [DefaultMode],
       [RegInfo</*size*/size, /*spill size*/size, /*spill alignment*/align>]>;
-  let DecodeZeroBitOperand = true;
-  let hasCompleteDecoder = false;
 }
 
   class AIE2PScalarRegisterClass<dag reglist, RegAltNameIndex idx = NoRegAltName>
@@ -213,7 +213,7 @@ class AIE2PRegisterClass <int size, int align, list<ValueType> regTypes, dag reg
       AIE2PRegisterClass<2048, 512, [v64i32, v32i64, v64f32], reglist>;
 
 class AIE2P20BitRegisterClass <dag reglist, RegAltNameIndex idx = NoRegAltName> :
-                 RegisterClass<"AIE2P", [i20], /*alignment*/ 32, reglist, idx> {
+                 AIEBaseRegisterClass<"AIE2P", [i20], /*alignment*/ 32, reglist, idx> {
   dag Regs = reglist;
   let RegInfos = RegInfoByHwMode<
       [DefaultMode],
@@ -222,7 +222,7 @@ class AIE2P20BitRegisterClass <dag reglist, RegAltNameIndex idx = NoRegAltName> 
 }
 
 class AIE2PDim2DRegisterClass <dag reglist, RegAltNameIndex idx = NoRegAltName> :
-                 RegisterClass<"AIE2P", [i20], /*alignment*/ 32, reglist, idx> {
+                 AIEBaseRegisterClass<"AIE2P", [i20], /*alignment*/ 32, reglist, idx> {
   dag Regs = reglist;
   let RegInfos = RegInfoByHwMode<
       [DefaultMode],
@@ -230,7 +230,7 @@ class AIE2PDim2DRegisterClass <dag reglist, RegAltNameIndex idx = NoRegAltName> 
 }
 
 class AIE2PDim3DRegisterClass <dag reglist, RegAltNameIndex idx = NoRegAltName> :
-                 RegisterClass<"AIE2P", [i20], /*alignment*/ 32, reglist, idx> {
+                 AIEBaseRegisterClass<"AIE2P", [i20], /*alignment*/ 32, reglist, idx> {
   dag Regs = reglist;
   let RegInfos = RegInfoByHwMode<
       [DefaultMode],

--- a/llvm/lib/Target/AIE/aie2p/AIE2PRegisterInfo.td
+++ b/llvm/lib/Target/AIE/aie2p/AIE2PRegisterInfo.td
@@ -110,6 +110,7 @@ class AIE2PRegisterClass <int size, int align, list<ValueType> regTypes, dag reg
       [DefaultMode],
       [RegInfo</*size*/size, /*spill size*/size, /*spill alignment*/align>]>;
   let DecodeZeroBitOperand = true;
+  let hasCompleteDecoder = false;
 }
 
   class AIE2PScalarRegisterClass<dag reglist, RegAltNameIndex idx = NoRegAltName>
@@ -191,37 +192,25 @@ class AIE2PRegisterClass <int size, int align, list<ValueType> regTypes, dag reg
 
   class AIE2PVector128RegisterClass<dag reglist>
       : AIE2PRegisterClass<128, 128, [i128, v16i8, v8i16, v8bf16, v4i32, v4f32],
-                           reglist> {
-    let hasCompleteDecoder = 0;
-  }
+                           reglist>;
 
   class AIE2PVector256RegisterClass<dag reglist> :
-      AIE2PRegisterClass<256, 256, [v32i8, v16i16, v16bf16, v8f32, v8i32], reglist> {
-    let hasCompleteDecoder = 0;
-  }
+      AIE2PRegisterClass<256, 256, [v32i8, v16i16, v16bf16, v8f32, v8i32], reglist>;
 
   class AIE2PVector512RegisterClass<dag reglist> :
-      AIE2PRegisterClass<512, 512, [v64i8, v32i16, v32bf16, v16i32, v8i64, v16f32], reglist> {
-    let hasCompleteDecoder = 0;
-  }
+      AIE2PRegisterClass<512, 512, [v64i8, v32i16, v32bf16, v16i32, v8i64, v16f32], reglist>;
 
   class AIE2PVector1024RegisterClass<dag reglist> :
       AIE2PRegisterClass<1024, 512, [v128i8, v64i16, v64bf16, v32i32, v16i64, v32f32], reglist>;
 
   class AIE2PAcc512RegisterClass<dag reglist> :
-      AIE2PRegisterClass<512, 512, [v16i32, v8i64, v16f32], reglist> {
-    let hasCompleteDecoder = 0;
-  }
+      AIE2PRegisterClass<512, 512, [v16i32, v8i64, v16f32], reglist>;
 
   class AIE2PAcc1024RegisterClass<dag reglist> :
-      AIE2PRegisterClass<1024, 512, [v32i32, v16i64, v32f32], reglist> {
-    let hasCompleteDecoder = 0;
-  }
+      AIE2PRegisterClass<1024, 512, [v32i32, v16i64, v32f32], reglist>;
 
   class AIE2PAcc2048RegisterClass<dag reglist> :
-      AIE2PRegisterClass<2048, 512, [v64i32, v32i64, v64f32], reglist> {
-    let hasCompleteDecoder = 0;
-  }
+      AIE2PRegisterClass<2048, 512, [v64i32, v32i64, v64f32], reglist>;
 
 class AIE2P20BitRegisterClass <dag reglist, RegAltNameIndex idx = NoRegAltName> :
                  RegisterClass<"AIE2P", [i20], /*alignment*/ 32, reglist, idx> {
@@ -964,9 +953,7 @@ foreach RC = [eP, eM, eDN, eDJ, eDC, eSP, eSpecial20] in
     def RC # _as_32Bit : AIE2PScalarRegisterClass<(add RC)>;
 
 class AIE2PVector1076FifoRegisterClass<dag reglist> :
-    AIE2PRegisterClass<1088, 512, [i32], reglist> {
-  let hasCompleteDecoder = 0;
-}
+    AIE2PRegisterClass<1088, 512, [i32], reglist>;
 def sub_ptr : SubRegIndex<20,  0>;
 def sub_fifo : SubRegIndex<1024, 20>;
 def sub_avail : SubRegIndex<32, 1044>;


### PR DESCRIPTION
Enabling `hasCompleteDecoder` allows failing early when decoding an incorrect object file. In exchange you have to guarantee that the decoder methods never have to backtrack. That is not always the case for the registers and instructions in AIE targets. To avoid having to identify all the cases were backtracking is needed just to get a small speedup when decoding an incorrect object file this PR disables the `hasCompleteDecoder` flag for all instructions and registers in AIE targets.