### PR TITLE
[AIEX] Fix instruction leaking and improve observer support in combines

### DIFF
--- a/llvm/lib/Target/AIE/AIE2PostLegalizerCustomCombiner.cpp
+++ b/llvm/lib/Target/AIE/AIE2PostLegalizerCustomCombiner.cpp
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// (c) Copyright 2023-2024 Advanced Micro Devices, Inc. or its affiliates
+// (c) Copyright 2023-2025 Advanced Micro Devices, Inc. or its affiliates
 //
 //===----------------------------------------------------------------------===//
 //
@@ -166,7 +166,14 @@ bool AIE2PostLegalizerCustomCombiner::runOnMachineFunction(
   AIE2PostLegalizerCustomCombinerImpl Impl(MF, CInfo, TPC, *KB, CSEInfo,
                                            AIEGlobalPtrIncResults, RuleConfig,
                                            ST, MDT, LI);
-  return Impl.combineMachineInstrs();
+  bool Changed = Impl.combineMachineInstrs();
+
+  // Now that all combining iterations are complete, it's safe to delete
+  // the instructions that were removed (but not erased) during combining.
+  if (AIEGlobalPtrIncResults)
+    AIEGlobalPtrIncResults->finalizeDeferredDeletes(MF);
+
+  return Changed;
 }
 
 char AIE2PostLegalizerCustomCombiner::ID = 0;

--- a/llvm/lib/Target/AIE/AIE2PreLegalizerCombiner.cpp
+++ b/llvm/lib/Target/AIE/AIE2PreLegalizerCombiner.cpp
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// (c) Copyright 2023-2024 Advanced Micro Devices, Inc. or its affiliates
+// (c) Copyright 2023-2025 Advanced Micro Devices, Inc. or its affiliates
 //
 //===----------------------------------------------------------------------===//
 //
@@ -382,7 +382,7 @@ bool AIE2PreLegalizerCombinerImpl::tryToCombineIntrinsic(
   switch (IntrinsicID) {
   case Intrinsic::aie2_vshift_I512_I512: {
     return CombineVecShiftByZero &&
-           llvm::tryToCombineVectorShiftsByZero(MI, MRI);
+           llvm::tryToCombineVectorShiftsByZero(MI, MRI, Observer);
   }
   case Intrinsic::aie2_set_I512_I128: {
     return tryToCombineSetExtract(MI);

--- a/llvm/lib/Target/AIE/AIECombine.td
+++ b/llvm/lib/Target/AIE/AIECombine.td
@@ -47,7 +47,7 @@ def combine_extract_vector_elt_and_zsa_ext : GICombineRule<
   (defs root:$root, combine_extract_vector_elt_and_zsa_ext_matchdata:$matchinfo),
   (match (wip_match_opcode G_EXTRACT_VECTOR_ELT): $root,
   [{ return matchExtractVecEltAndExt(*${root}, MRI, ${matchinfo}); }]),
-  (apply [{ applyExtractVecEltAndExt(*${root}, MRI, B, ${matchinfo}); }])
+  (apply [{ applyExtractVecEltAndExt(*${root}, MRI, B, ${matchinfo}, Observer); }])
 >;
 
 def combine_extract_vector_assert_combine : GICombineRule<
@@ -68,7 +68,7 @@ def combine_splat_vector : GICombineRule<
   (defs root:$root, combine_splat_vector_matchdata:$matchinfo),
   (match (wip_match_opcode G_BUILD_VECTOR): $root,
   [{ return matchSplatVector(*${root}, MRI, ${matchinfo}); }]),
-  (apply [{ applySplatVector(*${root}, MRI, B, ${matchinfo}); }])
+  (apply [{ applySplatVector(*${root}, MRI, B, ${matchinfo}, Observer); }])
 >;
 
 def combine_single_diff_build_vector_matchdata: GIDefMatchData<"AIESingleDiffLaneBuildVectorMatchData">;
@@ -76,7 +76,7 @@ def combine_single_diff_build_vector : GICombineRule<
   (defs root:$root, combine_single_diff_build_vector_matchdata:$matchinfo),
   (match (wip_match_opcode G_BUILD_VECTOR): $root,
   [{ return matchSingleDiffLaneBuildVector(*${root}, MRI, ${matchinfo}); }]),
-  (apply [{ applySingleDiffLaneBuildVector(*${root}, MRI, B, ${matchinfo}); }])
+  (apply [{ applySingleDiffLaneBuildVector(*${root}, MRI, B, ${matchinfo}, Observer); }])
 >;
 
 def combine_pad_vector_matchdata: GIDefMatchData<"Register">;
@@ -84,28 +84,28 @@ def combine_pad_vector : GICombineRule<
   (defs root:$root, combine_pad_vector_matchdata:$matchinfo),
   (match (wip_match_opcode G_BUILD_VECTOR): $root,
   [{ return matchPadVector(*${root}, MRI, (const AIEBaseInstrInfo &)B.getTII(), ${matchinfo}); }]),
-  (apply [{ applyPadVector(*${root}, MRI, B, ${matchinfo}); }])
+  (apply [{ applyPadVector(*${root}, MRI, B, ${matchinfo}, Observer); }])
 >;
 
 def combine_concat_to_pad_vector : GICombineRule<
   (defs root:$root, combine_pad_vector_matchdata:$matchinfo),
   (match (wip_match_opcode G_CONCAT_VECTORS): $root,
   [{ return matchConcatPadVector(*${root}, MRI, (const AIEBaseInstrInfo &)B.getTII(), ${matchinfo}); }]),
-  (apply [{ applyPadVector(*${root}, MRI, B, ${matchinfo}); }])
+  (apply [{ applyPadVector(*${root}, MRI, B, ${matchinfo}, Observer); }])
 >;
 
 def combine_unpad_vector : GICombineRule<
   (defs root:$root),
   (match (wip_match_opcode G_UNMERGE_VALUES): $root,
   [{ return matchUnpadVector(*${root}, MRI, (const AIEBaseInstrInfo &)B.getTII()); }]),
-  (apply [{ applyUnpadVector(*${root}, MRI, B); }])
+  (apply [{ applyUnpadVector(*${root}, MRI, B, Observer); }])
 >;
 
 def combine_vector_broadcast : GICombineRule<
   (defs root:$root, combine_splat_vector_matchdata:$matchinfo),
   (match (wip_match_opcode G_SHUFFLE_VECTOR): $root,
          [{ return matchBroadcastElement(*${root}, MRI, ${matchinfo}); }]),
-  (apply [{ applySplatVector(*${root}, MRI, B, ${matchinfo}); }])>;
+  (apply [{ applySplatVector(*${root}, MRI, B, ${matchinfo}, Observer); }])>;
 
 def combine_vector_shuffle_broadcast : GICombineRule<
   (defs root:$root, build_fn_matchinfo:$matchinfo),
@@ -152,7 +152,7 @@ def combine_vector_shuffle_bcst_to_copy : GICombineRule<
 def combine_paired_extracts : GICombineRule<
   (defs root:$root, build_fn_matchinfo:$matchinfo),
   (match (wip_match_opcode G_EXTRACT_VECTOR_ELT): $root,
-         [{ return matchPairedExtracts(*${root}, MRI, Helper, (const AIEBaseInstrInfo &)B.getTII(), ${matchinfo}); }]),
+         [{ return matchPairedExtracts(*${root}, MRI, Helper, (const AIEBaseInstrInfo &)B.getTII(), Observer, ${matchinfo}); }]),
   (apply [{ Helper.applyBuildFn(*${root}, ${matchinfo}); }])>;
 
 def combine_vector_shuffle_to_extract_insert_elt_to_broadcast : GICombineRule<
@@ -328,7 +328,7 @@ def combine_extract_concat : GICombineRule<
   (defs root:$root, combine_extract_concat_matchdata:$matchinfo),
   (match (wip_match_opcode G_INTRINSIC): $root,
   [{ return matchExtractConcat(*${root}, MRI, (const AIEBaseInstrInfo &)B.getTII(), ${matchinfo}); }]),
-  (apply [{ applyExtractConcat(*${root}, MRI, B, ${matchinfo}); }])
+  (apply [{ applyExtractConcat(*${root}, MRI, B, ${matchinfo}, Observer); }])
 >;
 
 def combine_unmerge_concat_matchdata: GIDefMatchData<"std::pair<MachineInstr *, unsigned>">;
@@ -336,7 +336,7 @@ def combine_unmerge_concat : GICombineRule<
   (defs root:$root, combine_unmerge_concat_matchdata:$matchinfo),
   (match (wip_match_opcode G_UNMERGE_VALUES): $root,
   [{ return matchUnmergeConcat(*${root}, MRI, (const AIEBaseInstrInfo &)B.getTII(), ${matchinfo}); }]),
-  (apply [{ applyUnmergeConcat(*${root}, MRI, B, ${matchinfo}); }])
+  (apply [{ applyUnmergeConcat(*${root}, MRI, B, ${matchinfo}, Observer); }])
 >;
 
 def combine_upd_to_concat_matchdata: GIDefMatchData<"std::map<unsigned, Register>">;
@@ -344,7 +344,7 @@ def combine_upd_to_concat : GICombineRule<
   (defs root:$root, combine_upd_to_concat_matchdata:$matchinfo),
   (match (wip_match_opcode G_INTRINSIC): $root,
   [{ return matchUpdToConcat(*${root}, MRI, (const AIEBaseInstrInfo &)B.getTII(), ${matchinfo}); }]),
-  (apply [{ applyUpdToConcat(*${root}, MRI, B, ${matchinfo}); }])
+  (apply [{ applyUpdToConcat(*${root}, MRI, B, ${matchinfo}, Observer); }])
 >;
 
 def combine_load_store_increment : GICombineRule <
@@ -358,7 +358,7 @@ def combine_add_vector_elt_undef : GICombineRule <
   (defs root:$root),
   (match (wip_match_opcode G_AIE_ADD_VECTOR_ELT_HI):$root,
           [{ return matchAddVecEltUndef(*${root}, MRI, B.getTII()); }]),
-  (apply [{ applyAddVecEltUndef(*${root}, MRI, B); }] )
+  (apply [{ applyAddVecEltUndef(*${root}, MRI, B, Observer); }] )
 >;
 
 def combine_load_store_split_matchdata: GIDefMatchData<"unsigned">;
@@ -366,7 +366,7 @@ def combine_load_store_split : GICombineRule<
   (defs root:$root, combine_load_store_split_matchdata:$matchinfo),
   (match (wip_match_opcode G_LOAD, G_STORE): $root,
   [{ return matchLoadStoreSplit(cast<GLoadStore>(*${root}), MRI, (const AIEBaseInstrInfo &)B.getTII(), ${matchinfo}); }]),
-  (apply [{ applyLoadStoreSplit(cast<GLoadStore>(*${root}), MRI, B, ${matchinfo}); }])
+  (apply [{ applyLoadStoreSplit(cast<GLoadStore>(*${root}), MRI, B, ${matchinfo}, Observer); }])
 >;
 
 def combine_offset_load_store_ptradd_matchdata: GIDefMatchData<"std::pair<Register, int64_t>">;
@@ -374,7 +374,7 @@ def combine_offset_load_store_ptradd : GICombineRule<
   (defs root:$root, combine_offset_load_store_ptradd_matchdata:$matchinfo),
   (match (wip_match_opcode G_AIE_OFFSET_LOAD, G_AIE_OFFSET_STORE): $root,
   [{ return matchOffsetLoadStorePtrAdd(*${root}, MRI, (const AIEBaseInstrInfo &)B.getTII(), ${matchinfo}); }]),
-  (apply [{ applyOffsetLoadStorePtrAdd(*${root}, MRI, B, ${matchinfo}); }])
+  (apply [{ applyOffsetLoadStorePtrAdd(*${root}, MRI, B, ${matchinfo}, Observer); }])
 >;
 
 def combine_offset_load_store_share_ptradd_matchdata: GIDefMatchData<"Register">;
@@ -382,7 +382,7 @@ def combine_offset_load_store_share_ptradd : GICombineRule<
   (defs root:$root, combine_offset_load_store_share_ptradd_matchdata:$matchinfo),
   (match (wip_match_opcode G_AIE_OFFSET_LOAD, G_AIE_OFFSET_STORE): $root,
   [{ return matchOffsetLoadStoreSharePtrAdd(*${root}, MRI, Helper, (const AIEBaseInstrInfo &)B.getTII(), ${matchinfo}); }]),
-  (apply [{ applyOffsetLoadStoreSharePtrAdd(*${root}, MRI, B, ${matchinfo}); }])
+  (apply [{ applyOffsetLoadStoreSharePtrAdd(*${root}, MRI, B, ${matchinfo}, Observer); }])
 >;
 
 

--- a/llvm/lib/Target/AIE/AIECombinerHelper.cpp
+++ b/llvm/lib/Target/AIE/AIECombinerHelper.cpp
@@ -741,7 +741,8 @@ void llvm::applyConcatUnmergePhis(MachineInstr &ConcatI,
       MRI.getVRegDef(*MatchInfo.UnmergeSourceReg)->getParent();
   NewPHI->addOperand(MachineOperand::CreateMBB(UnmergeMBB));
   LLVM_DEBUG(dbgs() << "Created New Instruction " << *NewPHI.getInstr());
-  ConcatI.removeFromParent();
+  Observer.erasingInstr(ConcatI);
+  ConcatI.eraseFromParent();
 }
 
 bool llvm::matchGlobalPtrModOptimizer(MachineInstr &MemI,
@@ -811,7 +812,9 @@ void llvm::applyLdStInc(MachineInstr &MemI, MachineRegisterInfo &MRI,
     if (Helper.dominates(*Instr, *NewInstr))
       continue;
 
+    Observer.changingInstr(*Instr);
     Instr->moveBefore(NewInstr);
+    Observer.changedInstr(*Instr);
     LLVM_DEBUG(dbgs() << "Move Instr before " << *Instr);
   }
 
@@ -827,7 +830,9 @@ void llvm::applyLdStInc(MachineInstr &MemI, MachineRegisterInfo &MRI,
         continue;
 
       LLVM_DEBUG(dbgs() << "Delaying Instr " << *Instr);
+      Observer.changingInstr(*Instr);
       Instr->moveBefore(CombinedInsertionPoint);
+      Observer.changedInstr(*Instr);
     }
   }
 
@@ -866,9 +871,19 @@ void llvm::applyLdStInc(MachineInstr &MemI, MachineRegisterInfo &MRI,
     assert(RemoveMI->getParent() &&
            "RemoveMI was already deleted. This Combiner may have a conflict "
            "with the Combiner that already removed the MachineInstr.");
+    // Notify observer, then remove from BB, then defer deletion.
+    // We defer actual deallocation until end of combining pass because
+    // later combiners may reference this instruction via the remapping
+    // mechanism (createMapping/getMappedInstr).
+    Observer.erasingInstr(*RemoveMI);
     RemoveMI->removeFromParent();
+    GlobalCombinerPtr->deferDelete(RemoveMI);
   }
+
+  // Notify observer, remove from BB, then defer deletion for root instruction.
+  Observer.erasingInstr(MemI);
   MemI.removeFromParent();
+  GlobalCombinerPtr->deferDelete(&MemI);
 }
 
 // Match all equivalents of these:
@@ -897,10 +912,12 @@ bool llvm::matchAddVecEltUndef(MachineInstr &MI, MachineRegisterInfo &MRI,
 }
 
 void llvm::applyAddVecEltUndef(MachineInstr &MI, MachineRegisterInfo &MRI,
-                               MachineIRBuilder &B) {
+                               MachineIRBuilder &B,
+                               GISelChangeObserver &Observer) {
   B.setDebugLoc(MI.getDebugLoc());
   B.buildCopy(MI.getOperand(0), MI.getOperand(1));
-  MI.removeFromParent();
+  Observer.erasingInstr(MI);
+  MI.eraseFromParent();
 }
 
 // Return the base offset, base offset is decided based on the
@@ -1082,9 +1099,10 @@ bool llvm::matchExtractVecEltAndExt(
   return false;
 }
 
-void llvm::applyExtractVecEltAndExt(
-    MachineInstr &MI, MachineRegisterInfo &MRI, MachineIRBuilder &B,
-    std::pair<MachineInstr *, bool> &MatchInfo) {
+void llvm::applyExtractVecEltAndExt(MachineInstr &MI, MachineRegisterInfo &MRI,
+                                    MachineIRBuilder &B,
+                                    std::pair<MachineInstr *, bool> &MatchInfo,
+                                    GISelChangeObserver &Observer) {
   B.setInstrAndDebugLoc(MI);
   auto [MatchMI, IsSignedExt] = MatchInfo;
   const Register ExtractDstReg = MI.getOperand(0).getReg();
@@ -1112,7 +1130,9 @@ void llvm::applyExtractVecEltAndExt(
     B.buildExtOrTrunc(MatchMI->getOpcode(), ExtendDstReg, Assert32BitDst);
   }
 
+  Observer.erasingInstr(MI);
   MI.eraseFromParent();
+  Observer.erasingInstr(*MatchMI);
   MatchMI->eraseFromParent();
 }
 
@@ -1261,10 +1281,12 @@ static void buildBroadcastVector(MachineIRBuilder &B, MachineRegisterInfo &MRI,
 
 bool llvm::applySplatVector(MachineInstr &MI, MachineRegisterInfo &MRI,
                             MachineIRBuilder &B,
-                            std::pair<Register, Register> &MatchInfo) {
+                            std::pair<Register, Register> &MatchInfo,
+                            GISelChangeObserver &Observer) {
   B.setInstrAndDebugLoc(MI);
   auto [DstVecReg, SrcReg] = MatchInfo;
   buildBroadcastVector(B, MRI, SrcReg, DstVecReg);
+  Observer.erasingInstr(MI);
   MI.eraseFromParent();
   return true;
 }
@@ -1341,7 +1363,8 @@ bool llvm::matchSingleDiffLaneBuildVector(
 
 bool llvm::applySingleDiffLaneBuildVector(
     MachineInstr &MI, MachineRegisterInfo &MRI, MachineIRBuilder &B,
-    AIESingleDiffLaneBuildVectorMatchData &MatchInfo) {
+    AIESingleDiffLaneBuildVectorMatchData &MatchInfo,
+    GISelChangeObserver &Observer) {
   B.setInstrAndDebugLoc(MI);
   const Register DstVecReg = MatchInfo.DstVecReg;
   const LLT DstVecRegTy = MRI.getType(DstVecReg);
@@ -1353,6 +1376,7 @@ bool llvm::applySingleDiffLaneBuildVector(
       B.buildConstant(S32, MatchInfo.DifferingIndex).getReg(0);
   B.buildInsertVectorElement(DstVecReg, BcstDstReg, MatchInfo.DifferingReg,
                              IdxReg);
+  Observer.erasingInstr(MI);
   MI.eraseFromParent();
   return true;
 }
@@ -1436,12 +1460,14 @@ bool llvm::matchUnpadVector(MachineInstr &MI, MachineRegisterInfo &MRI,
 }
 
 void llvm::applyUnpadVector(MachineInstr &MI, MachineRegisterInfo &MRI,
-                            MachineIRBuilder &B) {
+                            MachineIRBuilder &B,
+                            GISelChangeObserver &Observer) {
   B.setInstrAndDebugLoc(MI);
   const AIEBaseInstrInfo &AIETII = (const AIEBaseInstrInfo &)B.getTII();
   Register DstReg = MI.getOperand(0).getReg();
   Register SrcReg = MI.getOperand(MI.getNumDefs()).getReg();
   B.buildInstr(AIETII.getGenericUnpadVectorOpcode(), {DstReg}, {SrcReg});
+  Observer.erasingInstr(MI);
   MI.eraseFromParent();
 }
 
@@ -1513,12 +1539,14 @@ bool llvm::matchConcatPadVector(MachineInstr &MI, MachineRegisterInfo &MRI,
 }
 
 void llvm::applyPadVector(MachineInstr &MI, MachineRegisterInfo &MRI,
-                          MachineIRBuilder &B, Register MatchedInputVector) {
+                          MachineIRBuilder &B, Register MatchedInputVector,
+                          GISelChangeObserver &Observer) {
   B.setInstrAndDebugLoc(MI);
   const AIEBaseInstrInfo &AIETII = (const AIEBaseInstrInfo &)B.getTII();
   Register DstReg = MI.getOperand(0).getReg();
   B.buildInstr(AIETII.getGenericPadVectorOpcode(), {DstReg},
                {MatchedInputVector});
+  Observer.erasingInstr(MI);
   MI.eraseFromParent();
 }
 
@@ -1570,12 +1598,14 @@ bool llvm::matchExtractConcat(MachineInstr &MI, MachineRegisterInfo &MRI,
 }
 
 void llvm::applyExtractConcat(MachineInstr &MI, MachineRegisterInfo &MRI,
-                              MachineIRBuilder &B, Register &MatchInfo) {
+                              MachineIRBuilder &B, Register &MatchInfo,
+                              GISelChangeObserver &Observer) {
   B.setInstrAndDebugLoc(MI);
   Register DstReg = MI.getOperand(0).getReg();
   Register SrcReg = MatchInfo;
 
   B.buildCopy(DstReg, SrcReg);
+  Observer.erasingInstr(MI);
   MI.eraseFromParent();
 }
 
@@ -1611,7 +1641,8 @@ bool llvm::matchUnmergeConcat(MachineInstr &MI, MachineRegisterInfo &MRI,
 
 void llvm::applyUnmergeConcat(MachineInstr &MI, MachineRegisterInfo &MRI,
                               MachineIRBuilder &B,
-                              std::pair<MachineInstr *, unsigned> &MatchInfo) {
+                              std::pair<MachineInstr *, unsigned> &MatchInfo,
+                              GISelChangeObserver &Observer) {
   B.setInstrAndDebugLoc(MI);
   auto [ConcatMI, Offset] = MatchInfo;
 
@@ -1621,6 +1652,7 @@ void llvm::applyUnmergeConcat(MachineInstr &MI, MachineRegisterInfo &MRI,
     B.buildCopy(DstReg, SrcReg);
   }
 
+  Observer.erasingInstr(MI);
   MI.eraseFromParent();
 }
 
@@ -1708,7 +1740,8 @@ MachineInstr &findClosestToUseInsertPoint(MachineInstr &MI,
 
 void llvm::applyUpdToConcat(MachineInstr &MI, MachineRegisterInfo &MRI,
                             MachineIRBuilder &B,
-                            std::map<unsigned, Register> &IndexRegMap) {
+                            std::map<unsigned, Register> &IndexRegMap,
+                            GISelChangeObserver &Observer) {
   B.setDebugLoc(MI.getDebugLoc());
   B.setInstr(findClosestToUseInsertPoint(MI, MRI));
 
@@ -1719,6 +1752,7 @@ void llvm::applyUpdToConcat(MachineInstr &MI, MachineRegisterInfo &MRI,
 
   B.buildConcatVectors(MI.getOperand(0).getReg(), SrcRegs);
 
+  Observer.erasingInstr(MI);
   MI.eraseFromParent();
 }
 
@@ -1750,7 +1784,8 @@ bool llvm::matchLoadStoreSplit(GLoadStore &MI, MachineRegisterInfo &MRI,
 }
 
 void llvm::applyLoadStoreSplit(GLoadStore &MI, MachineRegisterInfo &MRI,
-                               MachineIRBuilder &B, const unsigned MaxMemSize) {
+                               MachineIRBuilder &B, const unsigned MaxMemSize,
+                               GISelChangeObserver &Observer) {
 
   assert(MaxMemSize && "MaxMemSize should be specified!");
   B.setInstrAndDebugLoc(MI);
@@ -1790,6 +1825,7 @@ void llvm::applyLoadStoreSplit(GLoadStore &MI, MachineRegisterInfo &MRI,
     B.buildConcatVectors(ValReg, NarrowRegs);
   }
 
+  Observer.erasingInstr(MI);
   MI.eraseFromParent();
 }
 
@@ -1835,14 +1871,17 @@ bool llvm::matchOffsetLoadStorePtrAdd(MachineInstr &MI,
 
 void llvm::applyOffsetLoadStorePtrAdd(
     MachineInstr &MI, MachineRegisterInfo &MRI, MachineIRBuilder &B,
-    const std::pair<Register, int64_t> &RegOffset) {
+    const std::pair<Register, int64_t> &RegOffset,
+    GISelChangeObserver &Observer) {
   B.setInstrAndDebugLoc(MI);
 
   Register NewOffsetReg =
       B.buildConstant(LLT::scalar(20), RegOffset.second).getReg(0);
 
+  Observer.changingInstr(MI);
   MI.getOperand(1).setReg(RegOffset.first);
   MI.getOperand(2).setReg(NewOffsetReg);
+  Observer.changedInstr(MI);
 }
 
 /// Match something like this:
@@ -1906,12 +1945,15 @@ bool llvm::matchOffsetLoadStoreSharePtrAdd(MachineInstr &MI,
 void llvm::applyOffsetLoadStoreSharePtrAdd(MachineInstr &MI,
                                            MachineRegisterInfo &MRI,
                                            MachineIRBuilder &B,
-                                           Register &PtrAddReg) {
+                                           Register &PtrAddReg,
+                                           GISelChangeObserver &Observer) {
 
   Register NewOffsetReg = B.buildConstant(LLT::scalar(20), 0).getReg(0);
 
+  Observer.changingInstr(MI);
   MI.getOperand(1).setReg(PtrAddReg);
   MI.getOperand(2).setReg(NewOffsetReg);
+  Observer.changedInstr(MI);
 }
 
 static bool isPowerOfTwoOrZero(unsigned Height) {
@@ -1935,7 +1977,8 @@ static bool isPowerOfTwoOrZero(unsigned Height) {
 ///        %1:_(<16 x s32>), %2:_(s32), %2:_(s32)
 /// To :   3%:_(<16 x s32>) = COPY %X
 bool llvm::tryToCombineVectorShiftsByZero(MachineInstr &MI,
-                                          MachineRegisterInfo &MRI) {
+                                          MachineRegisterInfo &MRI,
+                                          GISelChangeObserver &Observer) {
 
   const Register DstReg = MI.getOperand(0).getReg();
   const Register SrcReg = MI.getOperand(2).getReg();
@@ -1952,6 +1995,7 @@ bool llvm::tryToCombineVectorShiftsByZero(MachineInstr &MI,
 
   MachineIRBuilder MIRBuilder(MI);
   MIRBuilder.buildCopy(DstReg, SrcReg);
+  Observer.erasingInstr(MI);
   MI.eraseFromParent();
 
   return true;
@@ -3069,6 +3113,7 @@ bool llvm::matchShuffleBcstToCopy(MachineInstr &MI, MachineRegisterInfo &MRI,
 bool llvm::matchPairedExtracts(MachineInstr &MI, MachineRegisterInfo &MRI,
                                CombinerHelper &Helper,
                                const TargetInstrInfo &TII,
+                               GISelChangeObserver &Observer,
                                BuildFnTy &MatchInfo) {
   assert(MI.getOpcode() == TargetOpcode::G_EXTRACT_VECTOR_ELT);
   const AIEBaseInstrInfo &AIETII = (const AIEBaseInstrInfo &)TII;
@@ -3129,7 +3174,7 @@ bool llvm::matchPairedExtracts(MachineInstr &MI, MachineRegisterInfo &MRI,
   if (!NextExtractMI)
     return false;
 
-  MatchInfo = [=, &MRI](MachineIRBuilder &B) {
+  MatchInfo = [=, &MRI, &Observer](MachineIRBuilder &B) {
     const Register NewExtendedDstReg = MRI.createGenericVirtualRegister(S64);
     const Register NewIdxReg = B.buildConstant(S32, *IndexCst / 2).getReg(0);
 
@@ -3142,7 +3187,9 @@ bool llvm::matchPairedExtracts(MachineInstr &MI, MachineRegisterInfo &MRI,
     // so DCE will remove it. Another practical effect is, if we don't do
     // this, we will have a SSA violation because of the last buildCopy.
     const Register NewDeadReg = MRI.cloneVirtualRegister(NextDstReg);
+    Observer.changingInstr(*NextExtractMI);
     NextExtractMI->getOperand(0).setReg(NewDeadReg);
+    Observer.changedInstr(*NextExtractMI);
 
     B.buildExtractVectorElement(NewExtendedDstReg, CastedVecReg, NewIdxReg);
     auto Split = B.buildUnmerge(S32, NewExtendedDstReg);
@@ -3305,8 +3352,7 @@ static void retypePhiNode(MachineInstr &Phi, bool IsSigned, LLT NewType,
   MachineBasicBlock::iterator InsertPt = MBB->getFirstNonPHI();
   B.setInsertPt(*MBB, InsertPt);
   // Change the output.
-  Observer.createdInstr(
-      *B.buildInstr(ChangeDefOpcode).addDef(DefReg).addUse(NewDefReg));
+  B.buildInstr(ChangeDefOpcode).addDef(DefReg).addUse(NewDefReg);
   Observer.changingInstr(Phi);
   Phi.getOperand(0).setReg(NewDefReg);
   Observer.changedInstr(Phi);
@@ -3340,8 +3386,7 @@ static void retypePhiNode(MachineInstr &Phi, bool IsSigned, LLT NewType,
 
     if (!NewSrcReg) {
       NewSrcReg = MRI.createGenericVirtualRegister(NewType);
-      Observer.createdInstr(
-          *B.buildInstr(ChangeUseOpcode).addDef(NewSrcReg).addUse(SrcReg));
+      B.buildInstr(ChangeUseOpcode).addDef(NewSrcReg).addUse(SrcReg);
     }
 
     Observer.changingInstr(Phi);
@@ -3443,6 +3488,7 @@ bool llvm::matchNarrowTruncConstant(MachineInstr &MI, MachineRegisterInfo &MRI,
     Observer.changingAllUsesOfReg(MRI, FromReg);
     MRI.replaceRegWith(FromReg, NewConstant->getOperand(0).getReg());
     Observer.finishedChangingAllUsesOfReg();
+    Observer.erasingInstr(MI);
     MI.eraseFromParent();
   };
 
@@ -3481,7 +3527,7 @@ bool llvm::matchNarrowTruncLoad(MachineInstr &MI, MachineRegisterInfo &MRI,
     // Build Zext after the load, not before.
     MachineBasicBlock &MBB = *MI.getParent();
     B.setInsertPt(MBB, MI.getNextNode() ? MI.getNextNode() : MBB.end());
-    Observer.createdInstr(*B.buildZExt(DstReg, NewDstReg));
+    B.buildZExt(DstReg, NewDstReg);
   };
 
   return true;
@@ -3512,6 +3558,7 @@ bool llvm::matchNarrowZext(MachineInstr &MI, MachineRegisterInfo &MRI,
       Observer.changingInstr(DstMI);
       changeLoadStoreDataRegister(DstMI, MI.getOperand(1).getReg(), MRI);
       Observer.changedInstr(DstMI);
+      Observer.erasingInstr(MI);
       MI.eraseFromParent();
     };
     return true;
@@ -3681,7 +3728,7 @@ bool llvm::matchBitcastUnmerge(MachineInstr &Unmerge, MachineRegisterInfo &MRI,
       OrigDef.setReg(DefReg);
       Observer.changedInstr(Unmerge);
 
-      Observer.createdInstr(*B.buildBitcast(OrigDefReg, DefReg));
+      B.buildBitcast(OrigDefReg, DefReg);
     }
   };
 
@@ -3999,10 +4046,10 @@ bool llvm::matchPeelMemset(MachineInstr &MI, MachineRegisterInfo &MRI,
       Register NewPtrReg = MRI.cloneVirtualRegister(PtrReg);
       Register OffsetReg =
           B.buildConstant(LLT::scalar(20), CurrentOffset).getReg(0);
-      Observer.createdInstr(*B.buildInstr(TargetOpcode::G_PTR_ADD)
-                                 .addDef(NewPtrReg)
-                                 .addReg(PtrReg)
-                                 .addReg(OffsetReg));
+      B.buildInstr(TargetOpcode::G_PTR_ADD)
+          .addDef(NewPtrReg)
+          .addReg(PtrReg)
+          .addReg(OffsetReg);
       return NewPtrReg;
     };
 
@@ -4039,6 +4086,7 @@ bool llvm::matchPeelMemset(MachineInstr &MI, MachineRegisterInfo &MRI,
 
     // No bytes left to memset.
     if (NewSize == 0) {
+      Observer.erasingInstr(MI);
       MI.eraseFromParent();
       return;
     }
@@ -4047,11 +4095,13 @@ bool llvm::matchPeelMemset(MachineInstr &MI, MachineRegisterInfo &MRI,
     assert(matchAlignment<4>(MemsetOffset) && "Memset still unaligned?");
     // Now, what remains is aligned, we just need to fix Offset, Size and MMO.
     MachineMemOperand *NewMMOMemSet = BuildMMO(MMO->getSize(), Align(4));
+    Observer.changingInstr(MI);
     MI.dropMemRefs(MF); // Safe to drop the MMO now.
     MI.addMemOperand(MF, NewMMOMemSet);
     MI.getOperand(2).setReg(
         B.buildConstant(LLT::scalar(20), NewSize).getReg(0));
     MI.getOperand(0).setReg(BuildPADD(MemsetOffset));
+    Observer.changedInstr(MI);
   };
 
   return true;
@@ -4287,7 +4337,7 @@ bool llvm::matchExtractVecEltAssertBcst(MachineInstr &MI,
 
     // Remove G_ASSERT_[S/Z]EXT
     Observer.erasingInstr(AssertExt);
-    AssertExt.removeFromParent();
+    AssertExt.eraseFromParent();
   };
 
   return true;

--- a/llvm/lib/Target/AIE/AIECombinerHelper.h
+++ b/llvm/lib/Target/AIE/AIECombinerHelper.h
@@ -120,7 +120,7 @@ bool matchAddVecEltUndef(MachineInstr &MI, MachineRegisterInfo &MRI,
                          const TargetInstrInfo &TII);
 /// Combine G_AIE_ADD_VECTOR_ELT_HI with COPY
 void applyAddVecEltUndef(MachineInstr &MI, MachineRegisterInfo &MRI,
-                         MachineIRBuilder &B);
+                         MachineIRBuilder &B, GISelChangeObserver &Observer);
 /// combine G_GLOBAL_VALUE with G_CONSTANT and store in \a MatchData
 /// \return true if it is possible to combine
 void applyGlobalValOffset(MachineInstr &MI, MachineRegisterInfo &MRI,
@@ -160,20 +160,23 @@ bool matchExtractVecEltAndExt(MachineInstr &MI, MachineRegisterInfo &MRI,
                               std::pair<MachineInstr *, bool> &MatchInfo);
 void applyExtractVecEltAndExt(MachineInstr &MI, MachineRegisterInfo &MRI,
                               MachineIRBuilder &B,
-                              std::pair<MachineInstr *, bool> &MatchInfo);
+                              std::pair<MachineInstr *, bool> &MatchInfo,
+                              GISelChangeObserver &Observer);
 
 bool matchSplatVector(MachineInstr &MI, MachineRegisterInfo &MRI,
                       std::pair<Register, Register> &MatchInfo);
 bool applySplatVector(MachineInstr &MI, MachineRegisterInfo &MRI,
                       MachineIRBuilder &B,
-                      std::pair<Register, Register> &MatchInfo);
+                      std::pair<Register, Register> &MatchInfo,
+                      GISelChangeObserver &Observer);
 
 bool matchSingleDiffLaneBuildVector(
     MachineInstr &MI, MachineRegisterInfo &MRI,
     AIESingleDiffLaneBuildVectorMatchData &MatchInfo);
 bool applySingleDiffLaneBuildVector(
     MachineInstr &MI, MachineRegisterInfo &MRI, MachineIRBuilder &B,
-    AIESingleDiffLaneBuildVectorMatchData &MatchInfo);
+    AIESingleDiffLaneBuildVectorMatchData &MatchInfo,
+    GISelChangeObserver &Observer);
 
 bool matchSymmetricBuildVector(MachineInstr &MI, MachineRegisterInfo &MRI,
                                GISelChangeObserver &Observer,
@@ -182,7 +185,7 @@ bool matchSymmetricBuildVector(MachineInstr &MI, MachineRegisterInfo &MRI,
 bool matchUnpadVector(MachineInstr &MI, MachineRegisterInfo &MRI,
                       const AIEBaseInstrInfo &TII);
 void applyUnpadVector(MachineInstr &MI, MachineRegisterInfo &MRI,
-                      MachineIRBuilder &B);
+                      MachineIRBuilder &B, GISelChangeObserver &Observer);
 
 bool matchPadVector(MachineInstr &MI, MachineRegisterInfo &MRI,
                     const AIEBaseInstrInfo &TII, Register &MatchedInputVector);
@@ -190,32 +193,38 @@ bool matchConcatPadVector(MachineInstr &MI, MachineRegisterInfo &MRI,
                           const AIEBaseInstrInfo &TII,
                           Register &MatchedInputVector);
 void applyPadVector(MachineInstr &MI, MachineRegisterInfo &MRI,
-                    MachineIRBuilder &B, Register MatchedInputVector);
-bool tryToCombineVectorShiftsByZero(MachineInstr &MI, MachineRegisterInfo &MRI);
+                    MachineIRBuilder &B, Register MatchedInputVector,
+                    GISelChangeObserver &Observer);
+bool tryToCombineVectorShiftsByZero(MachineInstr &MI, MachineRegisterInfo &MRI,
+                                    GISelChangeObserver &Observer);
 
 bool matchExtractConcat(MachineInstr &MI, MachineRegisterInfo &MRI,
                         const AIEBaseInstrInfo &TII, Register &MatchInfo);
 void applyExtractConcat(MachineInstr &MI, MachineRegisterInfo &MRI,
-                        MachineIRBuilder &B, Register &MatchInfo);
+                        MachineIRBuilder &B, Register &MatchInfo,
+                        GISelChangeObserver &Observer);
 
 bool matchUnmergeConcat(MachineInstr &MI, MachineRegisterInfo &MRI,
                         const AIEBaseInstrInfo &TII,
                         std::pair<MachineInstr *, unsigned> &MatchInfo);
 void applyUnmergeConcat(MachineInstr &MI, MachineRegisterInfo &MRI,
                         MachineIRBuilder &B,
-                        std::pair<MachineInstr *, unsigned> &MatchInfo);
+                        std::pair<MachineInstr *, unsigned> &MatchInfo,
+                        GISelChangeObserver &Observer);
 
 bool matchUpdToConcat(MachineInstr &MI, MachineRegisterInfo &MRI,
                       const AIEBaseInstrInfo &TII,
                       std::map<unsigned, Register> &IndexRegMap);
 void applyUpdToConcat(MachineInstr &MI, MachineRegisterInfo &MRI,
                       MachineIRBuilder &B,
-                      std::map<unsigned, Register> &IndexRegMap);
+                      std::map<unsigned, Register> &IndexRegMap,
+                      GISelChangeObserver &Observer);
 
 bool matchLoadStoreSplit(GLoadStore &MI, MachineRegisterInfo &MRI,
                          const AIEBaseInstrInfo &TII, unsigned &MaxMemSize);
 void applyLoadStoreSplit(GLoadStore &MI, MachineRegisterInfo &MRI,
-                         MachineIRBuilder &B, const unsigned MaxMemSize);
+                         MachineIRBuilder &B, const unsigned MaxMemSize,
+                         GISelChangeObserver &Observer);
 
 bool matchOffsetLoadStorePtrAdd(MachineInstr &MI, MachineRegisterInfo &MRI,
                                 const AIEBaseInstrInfo &TII,
@@ -223,7 +232,8 @@ bool matchOffsetLoadStorePtrAdd(MachineInstr &MI, MachineRegisterInfo &MRI,
 
 void applyOffsetLoadStorePtrAdd(MachineInstr &MI, MachineRegisterInfo &MRI,
                                 MachineIRBuilder &B,
-                                const std::pair<Register, int64_t> &RegOffset);
+                                const std::pair<Register, int64_t> &RegOffset,
+                                GISelChangeObserver &Observer);
 
 bool matchOffsetLoadStoreSharePtrAdd(MachineInstr &MI, MachineRegisterInfo &MRI,
                                      CombinerHelper &Helper,
@@ -231,7 +241,8 @@ bool matchOffsetLoadStoreSharePtrAdd(MachineInstr &MI, MachineRegisterInfo &MRI,
                                      Register &PtrAddReg);
 
 void applyOffsetLoadStoreSharePtrAdd(MachineInstr &MI, MachineRegisterInfo &MRI,
-                                     MachineIRBuilder &B, Register &PtrAddReg);
+                                     MachineIRBuilder &B, Register &PtrAddReg,
+                                     GISelChangeObserver &Observer);
 
 bool matchShuffleToExtractSubvec(MachineInstr &MI, MachineRegisterInfo &MRI,
                                  const AIEBaseInstrInfo &TII,
@@ -252,7 +263,7 @@ bool matchShuffleToExtractInsertElt(MachineInstr &MI, MachineRegisterInfo &MRI,
 
 bool matchPairedExtracts(MachineInstr &MI, MachineRegisterInfo &MRI,
                          CombinerHelper &Helper, const TargetInstrInfo &TII,
-                         BuildFnTy &MatchInfo);
+                         GISelChangeObserver &Observer, BuildFnTy &MatchInfo);
 
 bool matchShuffleToExtractInsertEltToBroadcast(MachineInstr &MI,
                                                MachineRegisterInfo &MRI,

--- a/llvm/lib/Target/AIE/AIEPtrModOptimizer.h
+++ b/llvm/lib/Target/AIE/AIEPtrModOptimizer.h
@@ -19,6 +19,7 @@
 
 #include "AIE.h"
 #include "AIEGlobalCombiner.h"
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/CodeGen/MachineFunction.h"
 #include "llvm/CodeGen/MachineFunctionPass.h"
 #include "llvm/CodeGen/MachineModuleInfo.h"
@@ -40,6 +41,12 @@ class FoundCombiners {
   /// The keys are to be replaced MachineInstructions, and the values the newly
   /// inserted Instructions.
   std::map<MachineInstr *, MachineInstr *> ConvertedInstrs;
+
+  /// Instructions to be deleted at the end of the combining pass.
+  /// We defer deletion because analysis pass results contain raw pointers
+  /// to instructions, and later combiners may reference already-removed
+  /// instructions via remapping.
+  SmallVector<MachineInstr *, 32> DeferredDeletes;
 
   /// If a MachineInstr is remapped to a new Instruction through a previous
   /// Combiner, update the MachineInstr and \return valid MachineInstructions
@@ -71,6 +78,26 @@ public:
 
   /// \return whether Analysis Pass generated this Object
   bool hasAnalysis() const { return GeneratedFromAnalysisPass; }
+
+  /// Add an instruction to be deleted at the end of the combining pass.
+  /// Has to be called *after* removeFromParent()
+  void deferDelete(MachineInstr *MI) {
+    assert(!MI->getParent() &&
+           "Instruction must not have a parent before deferring");
+    DeferredDeletes.push_back(MI);
+  }
+
+  /// Actually delete all deferred instructions. Should be called at the end
+  /// of the combining pass after all iterations complete.
+  void finalizeDeferredDeletes(MachineFunction &MF) {
+    llvm::dbgs() << "Finalizing deferred deletes\n";
+    for (MachineInstr *MI : DeferredDeletes) {
+      // Instructions have been removed from their BB via removeFromParent().
+      // Use MachineFunction::deleteMachineInstr() to deallocate them.
+      MF.deleteMachineInstr(MI);
+    }
+    DeferredDeletes.clear();
+  }
 };
 } // namespace llvm::AIE
 

--- a/llvm/lib/Target/AIE/aie2p/AIE2PPostLegalizerCustomCombiner.cpp
+++ b/llvm/lib/Target/AIE/aie2p/AIE2PPostLegalizerCustomCombiner.cpp
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+// (c) Copyright 2024-2025 Advanced Micro Devices, Inc. or its affiliates
 //
 //===--------------------------------------------------------------------===//
 //
@@ -165,7 +165,14 @@ bool AIE2PPostLegalizerCustomCombiner::runOnMachineFunction(
   AIE2PPostLegalizerCustomCombinerImpl Impl(MF, CInfo, TPC, *KB, CSEInfo,
                                             AIEGlobalPtrIncResults, RuleConfig,
                                             ST, MDT, LI);
-  return Impl.combineMachineInstrs();
+  bool Changed = Impl.combineMachineInstrs();
+
+  // Now that all combining iterations are complete, it's safe to delete
+  // the instructions that were removed (but not erased) during combining.
+  if (AIEGlobalPtrIncResults)
+    AIEGlobalPtrIncResults->finalizeDeferredDeletes(MF);
+
+  return Changed;
 }
 
 char AIE2PPostLegalizerCustomCombiner::ID = 0;

--- a/llvm/lib/Target/AIE/aie2p/AIE2PPreLegalizerCombiner.cpp
+++ b/llvm/lib/Target/AIE/aie2p/AIE2PPreLegalizerCombiner.cpp
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+// (c) Copyright 2024-2025 Advanced Micro Devices, Inc. or its affiliates
 //
 //===--------------------------------------------------------------------===//
 //
@@ -99,7 +99,7 @@ bool AIE2PPreLegalizerCombinerImpl::tryToCombineIntrinsic(
   switch (cast<GIntrinsic>(MI).getIntrinsicID()) {
   case Intrinsic::aie2p_vshift_I512_I512: {
     return CombineVecShiftByZero &&
-           llvm::tryToCombineVectorShiftsByZero(MI, MRI);
+           llvm::tryToCombineVectorShiftsByZero(MI, MRI, Observer);
   }
   default:
     break;


### PR DESCRIPTION
We were using `removeFromParent` and `eraseFromParent` very inconsistently in the combiners. This PR cleans them up to always use `eraseFromParent` to prevent leaking memory. In the case of the `GlobalCombiners`, a new deferred deletion was needed, because the combiner creates a map of combined instructions to be used later in the pass. Immediately deleting the instructions would lead to dangling pointers.
Also, some missing observer calls were added and unnecessary ones removed (the MachineIRBuilder automatically calls `createdInstr` when building an instruction).
Note: AFAIK the new observer calls could have QoR implications by enabling more optimizations that rely on these updates from the observer (e.g. CSE). I'll run the benchmarks but I don't expect any changes in practice. The main goal of this PR is to get rid of the memory leaks.