### PR TITLE
[AIE][NFC] Refactor LoadStoreVectorizer hooks to use inheritance

### DIFF
--- a/llvm/lib/Target/AIE/AIE2TargetTransformInfo.cpp
+++ b/llvm/lib/Target/AIE/AIE2TargetTransformInfo.cpp
@@ -71,25 +71,3 @@ bool AIE2TTIImpl::isHardwareLoopProfitable(Loop *L, ScalarEvolution &SE,
 bool AIE2TTIImpl::isProfitableOuterLSR(const Loop &L) const {
   return Common.isProfitableOuterLSR(L);
 }
-
-unsigned AIE2TTIImpl::getStoreVectorFactor(unsigned VF,
-                                           unsigned StoreSizeInBits,
-                                           unsigned ChainSizeInBytes,
-                                           VectorType *VecTy) const {
-  return Common.getStoreVectorFactor(VF, StoreSizeInBits, ChainSizeInBytes,
-                                     VecTy);
-}
-
-unsigned AIE2TTIImpl::getLoadVectorFactor(unsigned VF, unsigned LoadSizeInBits,
-                                          unsigned ChainSizeInBytes,
-                                          VectorType *VecTy) const {
-  return Common.getLoadVectorFactor(VF, LoadSizeInBits, ChainSizeInBytes,
-                                    VecTy);
-}
-
-bool AIE2TTIImpl::isLegalToVectorizeStoreChain(unsigned ChainSizeInBytes,
-                                               Align Alignment,
-                                               unsigned AddrSpace) const {
-  return Common.isLegalToVectorizeStoreChain(ChainSizeInBytes, Alignment,
-                                             AddrSpace);
-}

--- a/llvm/lib/Target/AIE/AIE2TargetTransformInfo.h
+++ b/llvm/lib/Target/AIE/AIE2TargetTransformInfo.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// (c) Copyright 2023-2024 Advanced Micro Devices, Inc. or its affiliates
+// (c) Copyright 2023-2025 Advanced Micro Devices, Inc. or its affiliates
 //
 //===----------------------------------------------------------------------===//
 //
@@ -59,15 +59,6 @@ public:
                                 AssumptionCache &AC, TargetLibraryInfo *LibInfo,
                                 HardwareLoopInfo &HWLoopInfo);
   bool isProfitableOuterLSR(const Loop &L) const;
-
-  unsigned getStoreVectorFactor(unsigned VF, unsigned StoreSizeInBits,
-                                unsigned ChainSizeInBytes,
-                                VectorType *VecTy) const;
-  unsigned getLoadVectorFactor(unsigned VF, unsigned LoadSizeInBits,
-                               unsigned ChainSizeInBytes,
-                               VectorType *VecTy) const;
-  bool isLegalToVectorizeStoreChain(unsigned ChainSizeInBytes, Align Alignment,
-                                    unsigned AddrSpace) const;
 };
 
 } // end namespace llvm

--- a/llvm/lib/Target/AIE/AIEBaseTargetTransformInfo.cpp
+++ b/llvm/lib/Target/AIE/AIEBaseTargetTransformInfo.cpp
@@ -251,29 +251,3 @@ bool AIETTICommon::isProfitableOuterLSR(const Loop &L) const {
   return ConsiderLSROuterLoops.getNumOccurrences() > 0 ? ConsiderLSROuterLoops
                                                        : true;
 }
-
-unsigned AIETTICommon::getStoreVectorFactor(unsigned VF,
-                                            unsigned StoreSizeInBits,
-                                            unsigned ChainSizeInBytes,
-                                            VectorType *VecTy) const {
-
-  // The cases of interest are 8 and 16-bit only.
-  return (StoreSizeInBits == 8) ? 4 : (StoreSizeInBits == 16) ? 2 : 1;
-}
-
-unsigned AIETTICommon::getLoadVectorFactor(unsigned VF,
-                                           unsigned StoreSizeInBits,
-                                           unsigned ChainSizeInBytes,
-                                           VectorType *VecTy) const {
-  // Block load vectorization, it is costly to extract elements from vectors.
-  return 1;
-}
-
-bool AIETTICommon::isLegalToVectorizeStoreChain(unsigned ChainSizeInBytes,
-                                                Align Alignment,
-                                                unsigned AddrSpace) const {
-  // Start from 4 byte sequences, to reach word stores. Alignment is
-  // considered by default by the pass.
-  // Default return of allowsMisalignedMemoryAccesses is false.
-  return ChainSizeInBytes >= 4;
-}

--- a/llvm/lib/Target/AIE/AIEBaseTargetTransformInfo.h
+++ b/llvm/lib/Target/AIE/AIEBaseTargetTransformInfo.h
@@ -38,15 +38,6 @@ public:
                                 AssumptionCache &AC, TargetLibraryInfo *LibInfo,
                                 HardwareLoopInfo &HWLoopInfo);
   bool isProfitableOuterLSR(const Loop &L) const;
-
-  unsigned getStoreVectorFactor(unsigned VF, unsigned StoreSizeInBits,
-                                unsigned ChainSizeInBytes,
-                                VectorType *VecTy) const;
-  unsigned getLoadVectorFactor(unsigned VF, unsigned LoadSizeInBits,
-                               unsigned ChainSizeInBytes,
-                               VectorType *VecTy) const;
-  bool isLegalToVectorizeStoreChain(unsigned ChainSizeInBytes, Align Alignment,
-                                    unsigned AddrSpace) const;
 };
 
 template <typename T> class AIEBaseTTIImpl : public BasicTTIImplBase<T> {
@@ -87,6 +78,38 @@ public:
   bool isHardwareLoopProfitable(Loop *L, ScalarEvolution &SE,
                                 AssumptionCache &AC, TargetLibraryInfo *LibInfo,
                                 HardwareLoopInfo &HWLoopInfo);
+
+  // We define a store vector factor of  4 for 8-bit and 2 for 16-bit. This
+  // allows combining 2 16-bit stores or 4 8-bit stores into a single 32-bit
+  // vector store. This is deemed beneficial because of the LMS nature of
+  // part-word stores which require more cycles to complete and need to stay
+  // clear of other memory instructions.
+  unsigned getStoreVectorFactor(unsigned VF, unsigned StoreSizeInBits,
+                                unsigned ChainSizeInBytes,
+                                VectorType *VecTy) const {
+    // The cases of interest are 8 and 16-bit only.
+    return (StoreSizeInBits == 8) ? 4 : (StoreSizeInBits == 16) ? 2 : 1;
+  }
+
+  // This load vector factor of 1 basically prevents load vectorization which is
+  // deemed too expensive. The reason being that we have to shift out each
+  // element after the block load and perform a sign extension for each, whereas
+  // the scalarized approach results in only 4 part-word loads with implicit
+  // sign extension.
+  unsigned getLoadVectorFactor(unsigned VF, unsigned LoadSizeInBits,
+                               unsigned ChainSizeInBytes,
+                               VectorType *VecTy) const {
+    // Block load vectorization, it is costly to extract elements from vectors.
+    return 1;
+  }
+
+  bool isLegalToVectorizeStoreChain(unsigned ChainSizeInBytes, Align Alignment,
+                                    unsigned AddrSpace) const {
+    // Start from 4 byte sequences, to reach word stores. Alignment is
+    // considered by default by the pass.
+    // Default return of allowsMisalignedMemoryAccesses is false.
+    return ChainSizeInBytes >= 4;
+  }
 };
 
 } // end namespace llvm

--- a/llvm/lib/Target/AIE/aie2p/AIE2PTargetTransformInfo.cpp
+++ b/llvm/lib/Target/AIE/aie2p/AIE2PTargetTransformInfo.cpp
@@ -128,25 +128,3 @@ bool AIE2PTTIImpl::isHardwareLoopProfitable(Loop *L, ScalarEvolution &SE,
 bool AIE2PTTIImpl::isProfitableOuterLSR(const Loop &L) const {
   return Common.isProfitableOuterLSR(L);
 }
-
-unsigned AIE2PTTIImpl::getStoreVectorFactor(unsigned VF,
-                                            unsigned StoreSizeInBits,
-                                            unsigned ChainSizeInBytes,
-                                            VectorType *VecTy) const {
-  return Common.getStoreVectorFactor(VF, StoreSizeInBits, ChainSizeInBytes,
-                                     VecTy);
-}
-
-unsigned AIE2PTTIImpl::getLoadVectorFactor(unsigned VF, unsigned LoadSizeInBits,
-                                           unsigned ChainSizeInBytes,
-                                           VectorType *VecTy) const {
-  return Common.getLoadVectorFactor(VF, LoadSizeInBits, ChainSizeInBytes,
-                                    VecTy);
-}
-
-bool AIE2PTTIImpl::isLegalToVectorizeStoreChain(unsigned ChainSizeInBytes,
-                                                Align Alignment,
-                                                unsigned AddrSpace) const {
-  return Common.isLegalToVectorizeStoreChain(ChainSizeInBytes, Alignment,
-                                             AddrSpace);
-}

--- a/llvm/lib/Target/AIE/aie2p/AIE2PTargetTransformInfo.h
+++ b/llvm/lib/Target/AIE/aie2p/AIE2PTargetTransformInfo.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+// (c) Copyright 2024-2025 Advanced Micro Devices, Inc. or its affiliates
 //
 //===----------------------------------------------------------------------===//
 //
@@ -41,15 +41,6 @@ public:
                                 AssumptionCache &AC, TargetLibraryInfo *LibInfo,
                                 HardwareLoopInfo &HWLoopInfo);
   bool isProfitableOuterLSR(const Loop &L) const;
-
-  unsigned getStoreVectorFactor(unsigned VF, unsigned StoreSizeInBits,
-                                unsigned ChainSizeInBytes,
-                                VectorType *VecTy) const;
-  unsigned getLoadVectorFactor(unsigned VF, unsigned LoadSizeInBits,
-                               unsigned ChainSizeInBytes,
-                               VectorType *VecTy) const;
-  bool isLegalToVectorizeStoreChain(unsigned ChainSizeInBytes, Align Alignment,
-                                    unsigned AddrSpace) const;
 };
 
 } // end namespace llvm


### PR DESCRIPTION
Move LoadStoreVectorizer TTI hooks (getStoreVectorFactor, getLoadVectorFactor, isLegalToVectorizeStoreChain) from AIETTICommon helper class to AIEBaseTTIImpl template. This makes them automatically available to all AIE targets through inheritance.