### PR TITLE
Revert Hotfixes in SubReg Coalescing and Intrinsic Attributes

### DIFF
--- a/llvm/include/llvm/IR/IntrinsicsAIE2P.td
+++ b/llvm/include/llvm/IR/IntrinsicsAIE2P.td
@@ -101,13 +101,13 @@ class AIE2PAcc64V32I512I  : DefaultAttrsIntrinsic<[llvm_v32i64_ty],
 class AIE2PV16AccFloatToV16Bf : DefaultAttrsIntrinsic<[llvm_v16bf16_ty],
                                           [llvm_v16f32_ty],
                                           [IntrReadMem, IntrInaccessibleMemOnly]>;
-class AIE2PV16BfToV16AccFloat : Intrinsic<[llvm_v16f32_ty], [llvm_v16bf16_ty], [IntrNoMem]>;
+class AIE2PV16BfToV16AccFloat : DefaultAttrsIntrinsic<[llvm_v16f32_ty], [llvm_v16bf16_ty], [IntrNoMem]>;
 
 // v32accfloat to v32bfloat16
 class AIE2PV32AccFloatToV32Bf : DefaultAttrsIntrinsic<[llvm_v32bf16_ty],
                                           [llvm_v32f32_ty],
                                           [IntrReadMem, IntrInaccessibleMemOnly]>;
-class AIE2PV32BfToV32AccFloat : Intrinsic<[llvm_v32f32_ty], [llvm_v32bf16_ty], [IntrNoMem]>;
+class AIE2PV32BfToV32AccFloat : DefaultAttrsIntrinsic<[llvm_v32f32_ty], [llvm_v32bf16_ty], [IntrNoMem]>;
 
 // v16accfloat to v8float
 class AIE2PV16AccFloatToV8Float : DefaultAttrsIntrinsic<[llvm_v8f32_ty],

--- a/llvm/lib/Target/AIE/aie2p/AIE2PRegisterInfo.cpp
+++ b/llvm/lib/Target/AIE/aie2p/AIE2PRegisterInfo.cpp
@@ -617,34 +617,3 @@ bool AIE2PRegisterInfo::isFifoPhysReg(const Register Reg) const {
   return Reg.isPhysical() && (AIE2P::FIFO512RegClass.contains(Reg) ||
                               AIE2P::FIFO1024RegClass.contains(Reg));
 }
-
-bool AIE2PRegisterInfo::shouldCoalesce(
-    MachineInstr *MI, const TargetRegisterClass *SrcRC, unsigned SubReg,
-    const TargetRegisterClass *DstRC, unsigned DstSubReg,
-    const TargetRegisterClass *NewRC, LiveIntervals &LIS) const {
-
-  const unsigned SrcSize = getRegSizeInBits(*SrcRC);
-  const unsigned DstSize = getRegSizeInBits(*DstRC);
-  MachineFunction *MF = MI->getMF();
-  const AIEBaseInstrInfo *TII =
-      static_cast<const AIEBaseInstrInfo *>(MF->getSubtarget().getInstrInfo());
-  const unsigned BasicVectorSize = TII->getBasicVecRegSize();
-  // Should not coalesce if copying from bigger source.
-  if (!EnableCoalescingForWideCopy && SrcSize < DstSize &&
-      (SrcSize >= BasicVectorSize || DstSize >= BasicVectorSize)) {
-    MachineBasicBlock *MBB = MI->getParent();
-    LiveInterval &LI = LIS.getInterval(MI->getOperand(1).getReg());
-    const MachineInstr *FirstMI =
-        LI.empty() ? nullptr : LIS.getInstructionFromIndex(LI.beginIndex());
-    const MachineInstr *LastMI =
-        LI.empty() ? nullptr : LIS.getInstructionFromIndex(LI.endIndex());
-    // Coalescing inside the same basic block found beneficial. So, check that
-    // the LiveInterval is not just local to MBB.
-    if (!FirstMI || FirstMI->getParent() != MBB || !LastMI ||
-        LastMI->getParent() != MBB)
-      return false;
-  }
-
-  return TargetRegisterInfo::shouldCoalesce(MI, SrcRC, SubReg, DstRC, DstSubReg,
-                                            NewRC, LIS);
-}

--- a/llvm/lib/Target/AIE/aie2p/AIE2PRegisterInfo.h
+++ b/llvm/lib/Target/AIE/aie2p/AIE2PRegisterInfo.h
@@ -105,11 +105,6 @@ struct AIE2PRegisterInfo : public AIE2PGenRegisterInfo {
   bool isFifoPhysReg(const Register Reg) const override;
 
   bool isSimplifiableReservedReg(MCRegister PhysReg) const override;
-
-  bool shouldCoalesce(MachineInstr *MI, const TargetRegisterClass *SrcRC,
-                      unsigned SubReg, const TargetRegisterClass *DstRC,
-                      unsigned DstSubReg, const TargetRegisterClass *NewRC,
-                      LiveIntervals &LIS) const override;
 };
 } // namespace llvm
 

--- a/llvm/test/CodeGen/AIE/aie2p/end-to-end/gelu-templated.ll
+++ b/llvm/test/CodeGen/AIE/aie2p/end-to-end/gelu-templated.ll
@@ -17,56 +17,54 @@
 define void @gelu_fn(ptr noalias %ifm, ptr noalias %ofm, ptr nonnull align 64 dereferenceable(64) %params) {
 ; CHECK-LABEL: gelu_fn:
 ; CHECK:       // %bb.0: // %entry
-; CHECK-NEXT:    vlda.conv.fp32.bf16 cml1, [p0], #64; nopb ; nopxm
+; CHECK-NEXT:    vlda.conv.fp32.bf16 cml1, [p0], #64; nopb ; nopxm ; nops
 ; CHECK-NEXT:    movxm r0, #16544
 ; CHECK-NEXT:    vbcst.16 x6, r0
 ; CHECK-NEXT:    lda r1, [p2, #0]; movxm r0, #17280
 ; CHECK-NEXT:    mova r0, #60; vbcst.16 x2, r0
-; CHECK-NEXT:    vadd.f dm3, dm1, dm0, r0
+; CHECK-NEXT:    vadd.f dm1, dm1, dm0, r0
 ; CHECK-NEXT:    vconv.fp32.bf16 cml0, x6
 ; CHECK-NEXT:    nop
-; CHECK-NEXT:    vlda.conv.fp32.bf16 cml2, [p0], #64
-; CHECK-NEXT:    movxm r2, #15821
-; CHECK-NEXT:    mova r2, #255; movx r4, #1; vbcst.16 x4, r2
-; CHECK-NEXT:    vlda.conv.fp32.bf16 cml1, [p0], #64; vconv.bf16.fp32 x8, cml3; lshl r2, r1, r4; vbcst.16 x0, r2
-; CHECK-NEXT:    mova r2, #828; mov m0, r2; vadd.f dm3, dm2, dm0, r0
-; CHECK-NEXT:    vlda.conv.fp32.bf16 cml2, [p0], #64; vmul.f dm2, x8, x2, r2
+; CHECK-NEXT:    vlda.conv.fp32.bf16 cml2, [p0], #64; movxm r2, #15821
+; CHECK-NEXT:    movx r4, #1
+; CHECK-NEXT:    vlda.conv.fp32.bf16 cml1, [p0], #64; movx r2, #255; vbcst.16 x4, r2
+; CHECK-NEXT:    vconv.bf16.fp32 x8, cml1; lshl r2, r1, r4; vbcst.16 x0, r2
+; CHECK-NEXT:    vlda.conv.fp32.bf16 cml2, [p0], #64; movx r2, #828; mov m0, r2; vadd.f dm2, dm2, dm0, r0
+; CHECK-NEXT:    vmul.f dm3, x8, x2, r2
+; CHECK-NEXT:    vadd.f dm1, dm1, dm0, r0
 ; CHECK-NEXT:    nop
-; CHECK-NEXT:    vadd.f dm3, dm1, dm0, r0
+; CHECK-NEXT:    vadd.f dm2, dm2, dm0, r0
 ; CHECK-NEXT:    nop
-; CHECK-NEXT:    vadd.f dm3, dm2, dm0, r0
-; CHECK-NEXT:    vconv.bf16.fp32 x10, cml3
-; CHECK-NEXT:    vconv.bf16.fp32 x8, cml2
-; CHECK-NEXT:    vmul.f dm1, x10, x2, r2
-; CHECK-NEXT:    vconv.bf16.fp32 x1, cml3
-; CHECK-NEXT:    vlda.conv.fp32.bf16 cml1, [p0], #64; vmul.f dm4, x8, x4, r2
-; CHECK-NEXT:    vconv.bf16.fp32 x7, cml3; vmul.f dm2, x1, x2, r2
-; CHECK-NEXT:    nop
+; CHECK-NEXT:    vconv.bf16.fp32 x10, cml2
+; CHECK-NEXT:    vlda.conv.fp32.bf16 cml1, [p0], #64; vconv.bf16.fp32 x8, cml3
+; CHECK-NEXT:    vconv.bf16.fp32 x1, cml1; vmul.f dm3, x10, x2, r2
+; CHECK-NEXT:    vmul.f dm4, x8, x4, r2
+; CHECK-NEXT:    vconv.bf16.fp32 x7, cml2; vmul.f dm3, x1, x2, r2
+; CHECK-NEXT:    vadd.f dm1, dm1, dm0, r0
 ; CHECK-NEXT:    vmul.f dm3, x7, x2, r2
-; CHECK-NEXT:    vconv.bf16.fp32 x10, cml1; vadd.f dm1, dm1, dm0, r0
-; CHECK-NEXT:    nop
-; CHECK-NEXT:    vlda.conv.fp32.bf16 cml2, [p0], #64; vconv.bf16.fp32 x8, cml4; movx r3, #0; vmul.f dm4, x10, x4, r2
-; CHECK-NEXT:    vconv.bf16.fp32 x5, cml2; mov s0, r3
-; CHECK-NEXT:    vfloor.s32.bf16 x1, wl8, s0
-; CHECK-NEXT:    vconv.bf16.fp32 x5, cml3; vmul.f dm4, x5, x4, r2
-; CHECK-NEXT:    vconv.bf16.fp32 x7, cml1; movxm ls, #.LBB0_1; vadd.f dm2, dm2, dm0, r0
-; CHECK-NEXT:    mova r4, #-5; nopb ; vfloor.s32.bf16 x3, wh8, s0; movxm le, #.L_LEnd0; vmul.f dm3, x5, x4, r2
-; CHECK-NEXT:    mova r1, #2; nopb ; vconv.bf16.fp32 x10, cml4; lshl r4, r1, r4; vbcst.16 x6, r3; vmul.f dm4, x7, x2, r2
-; CHECK-NEXT:    vlda.conv.fp32.bf16 cml1, [p0], #64; vshuffle x1, x1, x3, r1
-; CHECK-NEXT:    vfloor.s32.bf16 x9, wl10, s0; vmin_ge.16 x3, r16, x1, x0, vaddsign1
-; CHECK-NEXT:    vfloor.s32.bf16 x3, wh10, s0; add.nc lc, r4, #-7
-; CHECK-NEXT:    nopa ; nopb ; vconv.bf16.fp32 x8, cml4; nopx ; vmax_lt.16 x11, r16, x3, x6, vaddsign1; nopv
-; CHECK-NEXT:    padda [p1], m0; nopb ; nops ; nopxm ; nopv
+; CHECK-NEXT:    vlda.conv.fp32.bf16 cml2, [p0], #64
+; CHECK-NEXT:    vconv.bf16.fp32 x10, cml3
+; CHECK-NEXT:    vconv.bf16.fp32 x8, cml4
+; CHECK-NEXT:    vconv.bf16.fp32 x5, cml3; vmul.f dm4, x10, x4, r2
+; CHECK-NEXT:    vconv.bf16.fp32 x7, cml1; vadd.f dm2, dm2, dm0, r0
+; CHECK-NEXT:    mova r3, #0; vconv.bf16.fp32 x5, cml3; vmul.f dm4, x5, x4, r2
+; CHECK-NEXT:    mov s0, r3; vmul.f dm3, x7, x2, r2
+; CHECK-NEXT:    vlda.conv.fp32.bf16 cml1, [p0], #64; nopb ; vfloor.s32.bf16 x1, wl8, s0; movxm ls, #.LBB0_1; vmul.f dm4, x5, x4, r2
+; CHECK-NEXT:    mova r4, #-5; vfloor.s32.bf16 x3, wh8, s0; movxm le, #.L_LEnd0
+; CHECK-NEXT:    vconv.bf16.fp32 x10, cml4; lshl r4, r1, r4; vbcst.16 x6, r3
+; CHECK-NEXT:    mova r1, #2; add.nc lc, r4, #-7
+; CHECK-NEXT:    nopa ; nopb ; vfloor.s32.bf16 x9, wl10, s0; nopx ; vshuffle x1, x1, x3, r1; nopv
+; CHECK-NEXT:    nopa ; nopb ; vconv.bf16.fp32 x8, cml4; nopx ; vmin_ge.16 x3, r16, x1, x0, vaddsign1; nopv
+; CHECK-NEXT:    padda [p1], m0; nopb ; vfloor.s32.bf16 x3, wh10, s0; nopx ; vmax_lt.16 x11, r16, x3, x6, vaddsign1; nopv
 ; CHECK-NEXT:  .LBB0_1: // %for.body
 ; CHECK-NEXT:    // =>This Inner Loop Header: Depth=1
-; CHECK-NEXT:    nopa ; nopb ; vconv.bf16.fp32 x10, cml2; nopxm ; nopv
-; CHECK-NEXT:    nopa ; nopb ; nops ; nopxm ; vadd.f dm2, dm4, dm0, r0
-; CHECK-NEXT:    vlda.conv.fp32.bf16 cml1, [p0], #64; nopb ; vconv.bf16.fp32 x7, cml4; nopx ; vmov cml4, cml1; vmul.f dm4, x10, x2, r2
-; CHECK-NEXT:    nopa ; nopb ; vst x11, [p1], #64; nopx ; vshuffle x1, x9, x3, r1; nopv
+; CHECK-NEXT:    vlda.conv.fp32.bf16 cml1, [p0], #64; nopb ; vconv.bf16.fp32 x7, cml2; nopxm ; vadd.f dm2, dm2, dm0, r0
+; CHECK-NEXT:    nopa ; nopb ; vst x11, [p1], #64; nopx ; vmov cml2, cml1; nopv
+; CHECK-NEXT:    nopa ; nopb ; vconv.bf16.fp32 x10, cml3; nopx ; vshuffle x1, x9, x3, r1; vmul.f dm3, x7, x2, r2
 ; CHECK-NEXT:    vfloor.s32.bf16 x3, wh8, s0; vmin_ge.16 x5, r16, x1, x0, vaddsign1
 ; CHECK-NEXT:    vfloor.s32.bf16 x9, wl8, s0; vmax_lt.16 x11, r16, x5, x6, vaddsign1
 ; CHECK-NEXT:  .L_LEnd0:
-; CHECK-NEXT:    nopa ; nopb ; vconv.bf16.fp32 x8, cml3; nopxm ; vmul.f dm3, x7, x4, r2
+; CHECK-NEXT:    nopa ; nopb ; vconv.bf16.fp32 x8, cml4; nopxm ; vmul.f dm4, x10, x4, r2
 ; CHECK-NEXT:  // %bb.2:
 ; CHECK-NEXT:    nopa ; nopb ; nops ; nopx ; vshuffle x10, x9, x3, r1; nopv
 ; CHECK-NEXT:    vmin_ge.16 x10, r16, x10, x0, vaddsign1
@@ -79,7 +77,7 @@ define void @gelu_fn(ptr noalias %ifm, ptr noalias %ofm, ptr nonnull align 64 de
 ; CHECK-NEXT:    vshuffle x8, x10, x8, r1
 ; CHECK-NEXT:    vmin_ge.16 x8, r16, x8, x0, vaddsign1
 ; CHECK-NEXT:    vmax_lt.16 x8, r16, x8, x6, vaddsign1
-; CHECK-NEXT:    vconv.bf16.fp32 x8, cml3
+; CHECK-NEXT:    vconv.bf16.fp32 x8, cml4
 ; CHECK-NEXT:    vst x8, [p1], #64
 ; CHECK-NEXT:    vfloor.s32.bf16 x10, wl8, s0
 ; CHECK-NEXT:    vfloor.s32.bf16 x8, wh8, s0
@@ -87,7 +85,7 @@ define void @gelu_fn(ptr noalias %ifm, ptr noalias %ofm, ptr nonnull align 64 de
 ; CHECK-NEXT:    vshuffle x8, x10, x8, r1
 ; CHECK-NEXT:    vmin_ge.16 x8, r16, x8, x0, vaddsign1
 ; CHECK-NEXT:    vmax_lt.16 x8, r16, x8, x6, vaddsign1
-; CHECK-NEXT:    vconv.bf16.fp32 x8, cml4
+; CHECK-NEXT:    vconv.bf16.fp32 x8, cml3
 ; CHECK-NEXT:    vst x8, [p1], #64
 ; CHECK-NEXT:    vmul.f dm3, x8, x4, r2
 ; CHECK-NEXT:    nop

--- a/llvm/test/CodeGen/AIE/aie2p/end-to-end/sigmoid_int8_1.ll
+++ b/llvm/test/CodeGen/AIE/aie2p/end-to-end/sigmoid_int8_1.ll
@@ -12,47 +12,46 @@ define void @sigmoid_int8_1() {
 ; CHECK-LABEL: sigmoid_int8_1:
 ; CHECK:       // %bb.0: // %entry
 ; CHECK-NEXT:    nopa ; nopb ; nops ; movxm ls, #.LBB0_1; nopv
-; CHECK-NEXT:    movxm le, #.L_LEnd0
 ; CHECK-NEXT:    mova p0, #0; mov crunpacksize, #1
-; CHECK-NEXT:    mova r0, #0; vldb.unpack x3, unpacksign0, [p0, #0]; mov crsrsmode, #0
+; CHECK-NEXT:    vldb.unpack x1, unpacksign0, [p0, #0]; movxm le, #.L_LEnd0
+; CHECK-NEXT:    mova r0, #0; mov crsrsmode, #0
 ; CHECK-NEXT:    vbcst.32 x4, r0
 ; CHECK-NEXT:    mova r1, #1; add.nc lc, r0, #-3
 ; CHECK-NEXT:    nopa ; nopb ; nops ; nopx ; vbcst.16 x0, r1; nopv
-; CHECK-NEXT:    nopa ; nopb ; nops ; nopx ; vbcst.16 x2, r0; nopv
-; CHECK-NEXT:    nopa ; vldb.unpack x3, unpacksign0, [p0, #0]; nops ; nopx ; vmov x7, x2; vclr dm0
-; CHECK-NEXT:    nopx ; vmov x6, x2
-; CHECK-NEXT:    vmin_ge.16 x9, r16, x3, x0, vaddsign0
-; CHECK-NEXT:    vmax_lt.16 x8, r16, x9, x2, vaddsign0
-; CHECK-NEXT:    vmov x9, x8
-; CHECK-NEXT:    vldb.unpack x3, unpacksign0, [p0, #0]; mov s0, r0
-; CHECK-NEXT:    vmov x5, x4; vmac dm3, dm0, y4, y3,r0
-; CHECK-NEXT:    vmin_ge.16 x9, r16, x3, x0, vaddsign0
-; CHECK-NEXT:    vmax_lt.16 x8, r16, x9, x2, vaddsign0; vmsc dm4, dm3, y2, y4,r0
-; CHECK-NEXT:    vmov x9, x8
+; CHECK-NEXT:    nopa ; vldb.unpack x1, unpacksign0, [p0, #0]; nops ; nopx ; vbcst.16 x2, r0; vclr dm0
+; CHECK-NEXT:    nopa ; nopb ; nops ; nopx ; vmov x3, x2; nopv
+; CHECK-NEXT:    nopa ; nopx ; vmin_ge.16 x7, r16, x1, x0, vaddsign0
+; CHECK-NEXT:    vmax_lt.16 x6, r16, x7, x2, vaddsign0
+; CHECK-NEXT:    vmov x7, x6
+; CHECK-NEXT:    vldb.unpack x1, unpacksign0, [p0, #0]; mov s0, r0
+; CHECK-NEXT:    vmov x5, x4; vmac dm3, dm0, y3, y1,r0
+; CHECK-NEXT:    vmin_ge.16 x7, r16, x1, x0, vaddsign0
+; CHECK-NEXT:    vmax_lt.16 x6, r16, x7, x2, vaddsign0; vmsc dm4, dm3, y2, y3,r0
+; CHECK-NEXT:    vmov x7, x6
 ; CHECK-NEXT:  .LBB0_1: // %for.body
 ; CHECK-NEXT:    // =>This Inner Loop Header: Depth=1
-; CHECK-NEXT:    nopa ; vldb.unpack x3, unpacksign0, [p0, #0]; nops ; nopxm ; nopv
-; CHECK-NEXT:    vmac dm3, dm0, y4, y3,r0
-; CHECK-NEXT:    vmin_ge.16 x9, r16, x3, x0, vaddsign0
-; CHECK-NEXT:    vmax_lt.16 x8, r16, x9, x2, vaddsign0; vmsc dm4, dm3, y2, y4,r0
+; CHECK-NEXT:    nopa ; vldb.unpack x1, unpacksign0, [p0, #0]; nops ; nopxm ; nopv
+; CHECK-NEXT:    vmac dm3, dm0, y3, y1,r0
+; CHECK-NEXT:    vmin_ge.16 x7, r16, x1, x0, vaddsign0
+; CHECK-NEXT:    vmax_lt.16 x6, r16, x7, x2, vaddsign0; vmsc dm4, dm3, y2, y3,r0
 ; CHECK-NEXT:  .L_LEnd0:
-; CHECK-NEXT:    nopa ; nopb ; vsrs.4x wh11, cml4, s0, srssign0; nopx ; vmov x9, x8; nopv
+; CHECK-NEXT:    nopa ; nopb ; vsrs.4x wh9, cml4, s0, srssign0; nopx ; vmov x7, x6; nopv
 ; CHECK-NEXT:  // %bb.2: // %for.cond.cleanup
 ; CHECK-NEXT:    nopa ; nopb ; nopxm ; nops
-; CHECK-NEXT:    vmac dm3, dm0, y4, y3,r0
-; CHECK-NEXT:    vmin_ge.16 x9, r16, x3, x0, vaddsign0
-; CHECK-NEXT:    vmax_lt.16 x8, r16, x9, x2, vaddsign0; vmsc dm4, dm3, y2, y4,r0
-; CHECK-NEXT:    vsrs.4x wh11, cml4, s0, srssign0; vmov x9, x8
+; CHECK-NEXT:    vmac dm3, dm0, y3, y1,r0
+; CHECK-NEXT:    vmin_ge.16 x7, r16, x1, x0, vaddsign0
+; CHECK-NEXT:    vmax_lt.16 x6, r16, x7, x2, vaddsign0; vmsc dm4, dm3, y2, y3,r0
+; CHECK-NEXT:    vsrs.4x wh9, cml4, s0, srssign0; vmov x7, x6
 ; CHECK-NEXT:    nop
-; CHECK-NEXT:    vmac dm3, dm0, y4, y3,r0
+; CHECK-NEXT:    vmac dm3, dm0, y3, y1,r0
 ; CHECK-NEXT:    nop
-; CHECK-NEXT:    vmsc dm4, dm3, y2, y4,r0
-; CHECK-NEXT:    vsrs.4x wh11, cml4, s0, srssign0
-; CHECK-NEXT:    nop
-; CHECK-NEXT:    nop
+; CHECK-NEXT:    vmsc dm4, dm3, y2, y3,r0
+; CHECK-NEXT:    vsrs.4x wh9, cml4, s0, srssign0
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
-; CHECK-NEXT:    vsrs.4x wh11, cml4, s0, srssign0
+; CHECK-NEXT:    nop
+; CHECK-NEXT:    nop
+; CHECK-NEXT:    vsrs.4x wh9, cml4, s0, srssign0
 ; CHECK-NEXT:    ret lr
 ; CHECK-NEXT:    nop // Delay Slot 5
 ; CHECK-NEXT:    nop // Delay Slot 4

--- a/llvm/test/CodeGen/AIE/aie2p/ra/coalesce-widen-copy.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/ra/coalesce-widen-copy.mir
@@ -19,14 +19,13 @@ body:             |
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   [[MOV_RLC_imm11_pseudo:%[0-9]+]]:er = MOV_RLC_imm11_pseudo 7
   ; CHECK-NEXT:   [[VBCST_16_:%[0-9]+]]:vec512 = VBCST_16 [[MOV_RLC_imm11_pseudo]]
-  ; CHECK-NEXT:   [[VCONV_fp32_bf16_mv_ups_xbf:%[0-9]+]]:ecml = VCONV_fp32_bf16_mv_ups_xbf [[VBCST_16_]]
+  ; CHECK-NEXT:   undef [[VCONV_fp32_bf16_mv_ups_xbf:%[0-9]+]].sub_1024_acc_lo:acc2048 = VCONV_fp32_bf16_mv_ups_xbf [[VBCST_16_]]
   ; CHECK-NEXT:   [[MOV_RLC_imm11_pseudo1:%[0-9]+]]:er = MOV_RLC_imm11_pseudo 0
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT: bb.1:
   ; CHECK-NEXT:   successors: %bb.1(0x80000000)
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT:   undef [[COPY:%[0-9]+]].sub_1024_acc_lo:acc2048 = COPY [[VCONV_fp32_bf16_mv_ups_xbf]]
-  ; CHECK-NEXT:   dead [[VADD_vmac_cm2_add_reg:%[0-9]+]]:acc2048 = VADD_vmac_cm2_add_reg [[COPY]], [[COPY]], [[MOV_RLC_imm11_pseudo1]]
+  ; CHECK-NEXT:   dead [[VADD_vmac_cm2_add_reg:%[0-9]+]]:acc2048 = VADD_vmac_cm2_add_reg [[VCONV_fp32_bf16_mv_ups_xbf]], [[VCONV_fp32_bf16_mv_ups_xbf]], [[MOV_RLC_imm11_pseudo1]]
   ; CHECK-NEXT:   PseudoRET implicit $lr
   bb.0.entry:
     successors: %bb.1
@@ -81,14 +80,13 @@ body:             |
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   [[MOV_RLC_imm11_pseudo:%[0-9]+]]:er = MOV_RLC_imm11_pseudo 7
   ; CHECK-NEXT:   [[VBCST_16_:%[0-9]+]]:vec512 = VBCST_16 [[MOV_RLC_imm11_pseudo]]
-  ; CHECK-NEXT:   [[VCONV_fp32_bf16_mv_ups_xbf:%[0-9]+]]:ecml = VCONV_fp32_bf16_mv_ups_xbf [[VBCST_16_]]
+  ; CHECK-NEXT:   undef [[VCONV_fp32_bf16_mv_ups_xbf:%[0-9]+]].sub_1024_acc_lo:acc2048 = VCONV_fp32_bf16_mv_ups_xbf [[VBCST_16_]]
   ; CHECK-NEXT:   [[MOV_RLC_imm11_pseudo1:%[0-9]+]]:er = MOV_RLC_imm11_pseudo 0
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT: bb.1:
   ; CHECK-NEXT:   successors: %bb.1(0x40000000), %bb.2(0x40000000)
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT:   undef [[COPY:%[0-9]+]].sub_1024_acc_lo:acc2048 = COPY [[VCONV_fp32_bf16_mv_ups_xbf]]
-  ; CHECK-NEXT:   dead [[VADD_vmac_cm2_add_reg:%[0-9]+]]:acc2048 = VADD_vmac_cm2_add_reg [[COPY]], [[COPY]], [[MOV_RLC_imm11_pseudo1]]
+  ; CHECK-NEXT:   dead [[VADD_vmac_cm2_add_reg:%[0-9]+]]:acc2048 = VADD_vmac_cm2_add_reg [[VCONV_fp32_bf16_mv_ups_xbf]], [[VCONV_fp32_bf16_mv_ups_xbf]], [[MOV_RLC_imm11_pseudo1]]
   ; CHECK-NEXT:   PseudoLoopEnd <mcsymbol .L_LEnd0>, %bb.1
   ; CHECK-NEXT:   PseudoJ_jump_imm %bb.2
   ; CHECK-NEXT: {{  $}}

--- a/llvm/test/CodeGen/AIE/aie2p/ra/reg-coalescing-regression.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/ra/reg-coalescing-regression.mir
@@ -22,7 +22,6 @@ body:             |
   ; CHECK-NEXT:   successors: %bb.2(0x80000000)
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   dead [[DEF:%[0-9]+]]:er = IMPLICIT_DEF
-  ; CHECK-NEXT:   [[DEF1:%[0-9]+]]:exe = IMPLICIT_DEF
   ; CHECK-NEXT:   PseudoJ_jump_imm %bb.2
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT: bb.1:
@@ -37,8 +36,6 @@ body:             |
   ; CHECK-NEXT: bb.3:
   ; CHECK-NEXT:   successors: %bb.4(0x04000000), %bb.3(0x7c000000)
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT:   dead undef [[COPY:%[0-9]+]].sub_512_lo:vec1024 = COPY [[DEF1]]
-  ; CHECK-NEXT:   [[DEF1:%[0-9]+]]:exe = IMPLICIT_DEF
   ; CHECK-NEXT:   PseudoJZ undef [[DEF]], %bb.4
   ; CHECK-NEXT:   PseudoJ_jump_imm %bb.3
   ; CHECK-NEXT: {{  $}}

--- a/llvm/test/CodeGen/AIE/aie2p/ra/staged-ra-cycle-in-bundle.ll
+++ b/llvm/test/CodeGen/AIE/aie2p/ra/staged-ra-cycle-in-bundle.ll
@@ -45,8 +45,8 @@ define void @heavy_3d_user(i32 %dimsAI.sroa.5.0.copyload.i, i32 %dimsAI.sroa.7.0
 ; FINE-GRAINED-NEXT:  .LBB0_1: // %for.body.i
 ; FINE-GRAINED-NEXT:    // =>This Loop Header: Depth=1
 ; FINE-GRAINED-NEXT:    // Child Loop BB0_2 Depth 2
-; FINE-GRAINED-NEXT:    nopa ; nopb ; nops ; nopx ; mov dn2, r3; nopv
-; FINE-GRAINED-NEXT:    movs dj2, p6; nopx ; mov dn6, r3
+; FINE-GRAINED-NEXT:    mov dn2, r3
+; FINE-GRAINED-NEXT:    movs dj2, p6; mov dn6, r3
 ; FINE-GRAINED-NEXT:    movs dj6, p6; mov m2, m4
 ; FINE-GRAINED-NEXT:    mova p1, #0; movs dc6, r4; mov r25, r18
 ; FINE-GRAINED-NEXT:    vldb.pop.576.3d ex0, [p1, lf1, r25, d2]
@@ -56,18 +56,17 @@ define void @heavy_3d_user(i32 %dimsAI.sroa.5.0.copyload.i, i32 %dimsAI.sroa.7.0
 ; FINE-GRAINED-NEXT:    movs dn5, r3; vmov lfh1, lfh0
 ; FINE-GRAINED-NEXT:    mova p0, #0; movs dj5, m5; mov dc5, r19
 ; FINE-GRAINED-NEXT:    paddb.3d [p0], d1
-; FINE-GRAINED-NEXT:    mova p0, #0; mov r19, dc5
+; FINE-GRAINED-NEXT:    mov r19, dc5
 ; FINE-GRAINED-NEXT:  .LBB0_2: // %for.body125.i
 ; FINE-GRAINED-NEXT:    // Parent Loop BB0_1 Depth=1
 ; FINE-GRAINED-NEXT:    // => This Inner Loop Header: Depth=2
-; FINE-GRAINED-NEXT:    nopa ; nopb ; nopx ; mov dc6, dc0
-; FINE-GRAINED-NEXT:    mov dn2, r3
-; FINE-GRAINED-NEXT:    movs dc2, dc0; mov dj2, r0
-; FINE-GRAINED-NEXT:    movs m2, r8; mov dj6, r13
-; FINE-GRAINED-NEXT:    movs dn6, r1; mov r25, r18
-; FINE-GRAINED-NEXT:    movs p1, p0; vmov lfl1, x2
+; FINE-GRAINED-NEXT:    nopa ; nopb ; movs dc6, dc0; nopx ; mov dc2, dc0; nopv
+; FINE-GRAINED-NEXT:    movs dj2, r0; mov dn2, r3
+; FINE-GRAINED-NEXT:    movs m2, r8; mov dn6, r1
+; FINE-GRAINED-NEXT:    mova p1, #0; movs dj6, r13; mov r25, r18
+; FINE-GRAINED-NEXT:    vldb.pop.576.3d ex4, [p1, lf1, r25, d2]; vmov lfl1, x2
 ; FINE-GRAINED-NEXT:  .L_LEnd0:
-; FINE-GRAINED-NEXT:    nopa ; vldb.pop.576.3d ex4, [p1, lf1, r25, d2]; nops ; nopx ; vmov lfh1, x3; nopv
+; FINE-GRAINED-NEXT:    nopa ; nopb ; nops ; nopx ; vmov lfh1, x3; nopv
 ; FINE-GRAINED-NEXT:  // %bb.3: // %for.cond.cleanup124.i
 ; FINE-GRAINED-NEXT:    // in Loop: Header=BB0_1 Depth=1
 ; FINE-GRAINED-NEXT:    nopa ; nopb ; nops ; nopx ; mov m0, m5; nopv
@@ -167,7 +166,7 @@ define void @heavy_3d_user(i32 %dimsAI.sroa.5.0.copyload.i, i32 %dimsAI.sroa.7.0
 ; COARSE-GRAINED-NEXT:  .LBB0_1: // %for.body.i
 ; COARSE-GRAINED-NEXT:    // =>This Loop Header: Depth=1
 ; COARSE-GRAINED-NEXT:    // Child Loop BB0_2 Depth 2
-; COARSE-GRAINED-NEXT:    lda m0, [sp, #-344]; nopb ; nopx // 4-byte Folded Reload
+; COARSE-GRAINED-NEXT:    lda m0, [sp, #-344]; nopxm // 4-byte Folded Reload
 ; COARSE-GRAINED-NEXT:    lda dc0, [sp, #-332] // 4-byte Folded Reload
 ; COARSE-GRAINED-NEXT:    lda dj4, [sp, #-320] // 4-byte Folded Reload
 ; COARSE-GRAINED-NEXT:    nop
@@ -195,16 +194,16 @@ define void @heavy_3d_user(i32 %dimsAI.sroa.5.0.copyload.i, i32 %dimsAI.sroa.7.0
 ; COARSE-GRAINED-NEXT:    mova p0, #0; st dn5, [sp, #-228] // 4-byte Folded Spill
 ; COARSE-GRAINED-NEXT:    paddb.3d [p0], d1; st dj5, [sp, #-224] // 4-byte Folded Spill
 ; COARSE-GRAINED-NEXT:    st dc1, [sp, #-236] // 4-byte Folded Spill
-; COARSE-GRAINED-NEXT:    mova p0, #0; st dc5, [sp, #-220] // 4-byte Folded Spill
+; COARSE-GRAINED-NEXT:    st dc5, [sp, #-220] // 4-byte Folded Spill
 ; COARSE-GRAINED-NEXT:  .LBB0_2: // %for.body125.i
 ; COARSE-GRAINED-NEXT:    // Parent Loop BB0_1 Depth=1
 ; COARSE-GRAINED-NEXT:    // => This Inner Loop Header: Depth=2
-; COARSE-GRAINED-NEXT:    nops ; mov dn1, dn3
-; COARSE-GRAINED-NEXT:    movs m1, m3; mov dj1, dj3
-; COARSE-GRAINED-NEXT:    movs dc1, dc3; mov dn5, dn7
-; COARSE-GRAINED-NEXT:    movs m5, m7; mov dc5, dc7
-; COARSE-GRAINED-NEXT:    movs dj5, dj7; mov r25, r3
-; COARSE-GRAINED-NEXT:    movs p1, p0; vmov lfl1, x2
+; COARSE-GRAINED-NEXT:    nopa ; nopx ; mov m1, m3
+; COARSE-GRAINED-NEXT:    mov dj1, dj3
+; COARSE-GRAINED-NEXT:    movs dn1, dn3; mov dc1, dc3
+; COARSE-GRAINED-NEXT:    movs m5, m7; mov dj5, dj7
+; COARSE-GRAINED-NEXT:    movs dn5, dn7; mov r25, r3
+; COARSE-GRAINED-NEXT:    mova p1, #0; movs dc5, dc7; vmov lfl1, x2
 ; COARSE-GRAINED-NEXT:  .L_LEnd0:
 ; COARSE-GRAINED-NEXT:    nopa ; vldb.pop.576.3d ex4, [p1, lf1, r25, d1]; nops ; nopx ; vmov lfh1, x3; nopv
 ; COARSE-GRAINED-NEXT:  // %bb.3: // %for.cond.cleanup124.i


### PR DESCRIPTION
Originally these changes were introduced to limit performance impacts, when partially defined SubRegisters are spilled. 
This is caused by the InlineSpiller.cpp only being able to spill full registers. 
So instead of spilling the defined SubRegisters, Inlinespiller will spill the whole Register (also the undefined components). 

Without Register Sequence generation only the defined Registers are spilled and only later register sequenced.
This later register sequencing however is suboptimal and may introduce moves.

Thus these hotifxes limited 
1) which intrinsics can be hoisted outside of a loop body
2) Register Sequence generation within a MBB.

With a proper SubRegister Spilling (https://github.com/Xilinx/llvm-aie/pull/713), these hotfixes can be removed.