### PR TITLE
Allow AnyInteger for quant.scast

### DIFF
--- a/mlir/include/mlir/Dialect/Quant/IR/QuantBase.td
+++ b/mlir/include/mlir/Dialect/Quant/IR/QuantBase.td
@@ -229,24 +229,24 @@ def quant_QuantizedType :
 
 def quant_ScalarType :
     Type<Or<[
-      AnySignlessInteger.predicate,
+      AnyInteger.predicate,
       AnyFloat.predicate,
       quant_QuantizedType.predicate
     ]>,
-    "signless integer, float, or quantized scalar">;
+    "integer, float, or quantized scalar">;
 
 def quant_IntegerOrQuantizedType :
     Type<Or<[
-      AnySignlessInteger.predicate,
+      AnyInteger.predicate,
       quant_QuantizedType.predicate
     ]>,
-    "signless integer or quantized type">;
+    "integer or quantized type">;
 
 def quant_FloatScalarOrTensor :
     quant_ScalarOrTensorOf<AnyFloat>;
 
 def quant_IntegerScalarOrTensor :
-    quant_ScalarOrTensorOf<AnySignlessInteger>;
+    quant_ScalarOrTensorOf<AnyInteger>;
 
 def quant_QuantizedScalarOrTensor :
     quant_ScalarOrTensorOf<quant_QuantizedType>;

--- a/mlir/include/mlir/Dialect/Quant/IR/QuantOps.td
+++ b/mlir/include/mlir/Dialect/Quant/IR/QuantOps.td
@@ -184,17 +184,16 @@ def quant_StorageCastOp : quant_Op<"scast", [
     quant_IntegerAndQuantizedCombination]> {
   let summary = "Storage cast operation";
   let description = [{
-    Convert a value from a quantized type to the corresponding signless integer
-    storage type, or vice versa. This conversion simply involves a
-    reinterpretation of the input bits and does not involve any data
-    manipulation.
+    Convert a value from a quantized type to the corresponding storage type,
+    or vice versa. This conversion simply involves a reinterpretation of the
+    input bits and does not involve any data manipulation.
 
     The following syntactic restrictions must be met:
 
-    - Operand `input` must be a scalar or tensor of a signless integer or
+    - Operand `input` must be a scalar or tensor of a integer or
       `!quant.uniform` type.
 
-    - The result must be a scalar or tensor of a signless integer or
+    - The result must be a scalar or tensor of a integer or
       `!quant.uniform` type.
 
     - If the operand is a scalar or tensor of type integer, the result must be
@@ -205,7 +204,7 @@ def quant_StorageCastOp : quant_Op<"scast", [
       same shape, including matching static and dynamic dimensions.
 
     - The width of the `storageType` parameter of the quantized type of the
-      operand or result must match the width of the signless integer type of
+      operand or result must match the width of the integer type of
       the operand or result.
 
     - If the operand or result uses per-channel quantization, its
@@ -221,7 +220,7 @@ def quant_StorageCastOp : quant_Op<"scast", [
     // Cast a dynamically shaped tensor of quantized values into their storage type
     %result = quant.scast %input : tensor<?x!quant.uniform<i8:f32, 2.0>> to tensor<?xi8>
 
-    // Cast an unranked tensor of signless integers into a quantized type using
+    // Cast an unranked tensor of integers into a quantized type using
     // per-channel quantization
     %result = quant.scast %input : tensor<*xi8> to tensor<*x!quant.uniform<i8:f32:1, {2.0, 3.0}>>
     ```

--- a/mlir/test/Dialect/Quant/invalid.mlir
+++ b/mlir/test/Dialect/Quant/invalid.mlir
@@ -164,9 +164,9 @@ func.func @qcast_per_axis_invalid_rank(%arg0: tensor<2x3x4xf32>) {
 // -----
 
 !qalias = !quant.uniform<i8:f32, 1.0>
-func.func @scast_invalid_input(%arg0: si32) {
-  // expected-error@+1 {{operand #0 must be scalar or tensor of signless integer or quantized type}}
-  %0 = quant.scast %arg0 : si32 to !qalias
+func.func @scast_invalid_input(%arg0: f32) {
+  // expected-error@+1 {{operand #0 must be scalar or tensor of integer or quantized type}}
+  %0 = quant.scast %arg0 : f32 to !qalias
   return
 }
 
@@ -174,8 +174,8 @@ func.func @scast_invalid_input(%arg0: si32) {
 
 !qalias = !quant.uniform<i8:f32, 1.0>
 func.func @scast_invalid_result(%arg0: !qalias) {
-  // expected-error@+1 {{result #0 must be scalar or tensor of signless integer or quantized type}}
-  %0 = quant.scast %arg0 : !qalias to si32
+  // expected-error@+1 {{result #0 must be scalar or tensor of integer or quantized type}}
+  %0 = quant.scast %arg0 : !qalias to f32
   return
 }
 


### PR DESCRIPTION
- Allow any integer type to be used with storage cast
- Checking if the `integerType == quantType.storageType` is already present.
- Fix tests that checks if the storage type is integer