### PR TITLE
Fix: update maxTileFoldSize dtype

### DIFF
--- a/mlir/include/mlir/Dialect/Tosa/Transforms/Passes.td
+++ b/mlir/include/mlir/Dialect/Tosa/Transforms/Passes.td
@@ -39,7 +39,7 @@ def TosaLayerwiseConstantFoldPass : Pass<"tosa-layerwise-constant-fold", "func::
     Option<"enableTileFolding", "enable-tile-folding", "bool",
             /*default=*/"false",
             "Enables folding of tosa.tile operation. May generate bigger constant values.">,
-    Option<"maxTileFoldSize", "max-tile-fold-size", "int",
+    Option<"maxTileFoldSize", "max-tile-fold-size", "std::int64_t",
             /*default=*/"0",
             "Maximum size in bytes of the constant to be generated when folding a tosa.tile operation. A value of 0 means no limit.">,
   ];

--- a/mlir/lib/Dialect/Tosa/Transforms/TosaFolders.cpp
+++ b/mlir/lib/Dialect/Tosa/Transforms/TosaFolders.cpp
@@ -1953,7 +1953,7 @@ DenseElementsAttr tile(DenseElementsAttr inputValues, ShapedType outputType) {
 struct TosaFoldConstantTile : public TosaFoldConstantBase<tosa::TileOp> {
 
   TosaFoldConstantTile(MLIRContext *ctxt, bool foldSplatOrSingleUseOnly,
-                       int maxSizeToFold)
+                       int64_t maxSizeToFold)
       : TosaFoldConstantBase<tosa::TileOp>(ctxt, foldSplatOrSingleUseOnly),
         maxSizeToFold(maxSizeToFold) {}
 
@@ -1989,7 +1989,7 @@ struct TosaFoldConstantTile : public TosaFoldConstantBase<tosa::TileOp> {
     return success();
   }
 
-  const int maxSizeToFold;
+  const int64_t maxSizeToFold;
 };
 
 /// Getting the axes position of the element which is located


### PR DESCRIPTION
Update tosa-layerwise-constant-fold pass to use std::int64_t for maxTileFoldSize to increase the threshold for folding tile operations.