### PR TITLE
[AIE2][AIE2P] Delete unnecessary PostRAScheduler hook

### DIFF
--- a/llvm/lib/Target/AIE/AIE2Subtarget.h
+++ b/llvm/lib/Target/AIE/AIE2Subtarget.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// (c) Copyright 2023-2025 Advanced Micro Devices, Inc. or its affiliates
+// (c) Copyright 2023-2026 Advanced Micro Devices, Inc. or its affiliates
 //
 //===----------------------------------------------------------------------===//
 //
@@ -65,7 +65,6 @@ public:
   bool enableWindowScheduler() const override {
     return AIEBaseSubtarget::enableWindowScheduler();
   }
-  bool enablePostRAScheduler() const override { return true; }
   bool enablePostRAMachineScheduler() const override { return true; }
   bool forcePostRAScheduling() const override { return true; }
   bool useAA() const override { return true; }

--- a/llvm/lib/Target/AIE/aie2p/AIE2PSubtarget.h
+++ b/llvm/lib/Target/AIE/aie2p/AIE2PSubtarget.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// (c) Copyright 2024-2025 Advanced Micro Devices, Inc. or its affiliates
+// (c) Copyright 2024-2026 Advanced Micro Devices, Inc. or its affiliates
 //
 //===----------------------------------------------------------------------===//
 //
@@ -59,7 +59,6 @@ public:
   bool enableWindowScheduler() const override {
     return AIEBaseSubtarget::enableWindowScheduler();
   }
-  bool enablePostRAScheduler() const override { return true; }
   bool enablePostRAMachineScheduler() const override { return true; }
   bool forcePostRAScheduling() const override { return true; }
   bool useAA() const override { return true; }


### PR DESCRIPTION
AIE2 and AIE2P use the post-RA machine scheduler, so these subtarget hooks are never called.