### PR TITLE
[AIEX] fix const half select G_AIE_VSEL

### DIFF
--- a/llvm/lib/Target/AIE/AIECombinerHelper.cpp
+++ b/llvm/lib/Target/AIE/AIECombinerHelper.cpp
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// (c) Copyright 2023-2025 Advanced Micro Devices, Inc. or its affiliates
+// (c) Copyright 2023-2026 Advanced Micro Devices, Inc. or its affiliates
 //
 //===----------------------------------------------------------------------===//
 
@@ -4782,9 +4782,9 @@ bool llvm::matchVSelToUnmergeConcatOrCopy(MachineInstr &MI,
 
   // Check if it's either half-and-half pattern
   if (SelMask == UpperHalfMask || SelMask == LowerHalfMask) {
-    const bool LowerFromSrc1 = (SelMask == LowerHalfMask);
+    const bool IsUpperMask = (SelMask == UpperHalfMask);
 
-    MatchInfo = [Src1Reg, Src2Reg, DstReg, DstTy, LowerFromSrc1,
+    MatchInfo = [Src1Reg, Src2Reg, DstReg, DstTy, IsUpperMask,
                  &MRI](MachineIRBuilder &B) {
       const LLT HalfTy = DstTy.divide(2);
 
@@ -4797,9 +4797,10 @@ bool llvm::matchVSelToUnmergeConcatOrCopy(MachineInstr &MI,
       const Register Src2Hi = MRI.createGenericVirtualRegister(HalfTy);
       B.buildUnmerge({Src2Lo, Src2Hi}, Src2Reg);
 
-      // Select appropriate halves based on mask pattern
-      const Register LowerHalf = LowerFromSrc1 ? Src1Lo : Src2Lo;
-      const Register UpperHalf = LowerFromSrc1 ? Src2Hi : Src1Hi;
+      // UpperHalfMask (0xFF00): lo from src1, hi from src2
+      // LowerHalfMask (0x00FF): lo from src2, hi from src1
+      const Register LowerHalf = IsUpperMask ? Src1Lo : Src2Lo;
+      const Register UpperHalf = IsUpperMask ? Src2Hi : Src1Hi;
 
       B.buildConcatVectors(DstReg, {LowerHalf, UpperHalf});
     };

--- a/llvm/test/CodeGen/AIE/aie2p/GlobalIsel/combine-vsel-simplify.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/GlobalIsel/combine-vsel-simplify.mir
@@ -3,7 +3,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2025 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2025-2026 Advanced Micro Devices, Inc. or its affiliates
 #
 # RUN: llc -mtriple=aie2p -run-pass=aie2p-prelegalizer-combiner -verify-machineinstrs %s -o - | FileCheck %s
 
@@ -58,8 +58,8 @@ body: |
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: %src1:_(<16 x s32>) = COPY $x0
     ; CHECK-NEXT: %src2:_(<16 x s32>) = COPY $x1
-    ; CHECK-NEXT: [[UV:%[0-9]+]]:_(<8 x s32>), [[UV1:%[0-9]+]]:_(<8 x s32>) = G_UNMERGE_VALUES %src1(<16 x s32>)
-    ; CHECK-NEXT: [[AIE_UNPAD_VECTOR:%[0-9]+]]:_(<8 x s32>) = G_AIE_UNPAD_VECTOR %src2(<16 x s32>)
+    ; CHECK-NEXT: [[AIE_UNPAD_VECTOR:%[0-9]+]]:_(<8 x s32>) = G_AIE_UNPAD_VECTOR %src1(<16 x s32>)
+    ; CHECK-NEXT: [[UV:%[0-9]+]]:_(<8 x s32>), [[UV1:%[0-9]+]]:_(<8 x s32>) = G_UNMERGE_VALUES %src2(<16 x s32>)
     ; CHECK-NEXT: %dst:_(<16 x s32>) = G_CONCAT_VECTORS [[AIE_UNPAD_VECTOR]](<8 x s32>), [[UV1]](<8 x s32>)
     ; CHECK-NEXT: $x0 = COPY %dst(<16 x s32>)
     ; CHECK-NEXT: PseudoRET implicit $lr, implicit $x0
@@ -82,8 +82,8 @@ body: |
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: %src1:_(<16 x s32>) = COPY $x0
     ; CHECK-NEXT: %src2:_(<16 x s32>) = COPY $x1
-    ; CHECK-NEXT: [[AIE_UNPAD_VECTOR:%[0-9]+]]:_(<8 x s32>) = G_AIE_UNPAD_VECTOR %src1(<16 x s32>)
-    ; CHECK-NEXT: [[UV:%[0-9]+]]:_(<8 x s32>), [[UV1:%[0-9]+]]:_(<8 x s32>) = G_UNMERGE_VALUES %src2(<16 x s32>)
+    ; CHECK-NEXT: [[UV:%[0-9]+]]:_(<8 x s32>), [[UV1:%[0-9]+]]:_(<8 x s32>) = G_UNMERGE_VALUES %src1(<16 x s32>)
+    ; CHECK-NEXT: [[AIE_UNPAD_VECTOR:%[0-9]+]]:_(<8 x s32>) = G_AIE_UNPAD_VECTOR %src2(<16 x s32>)
     ; CHECK-NEXT: %dst:_(<16 x s32>) = G_CONCAT_VECTORS [[AIE_UNPAD_VECTOR]](<8 x s32>), [[UV1]](<8 x s32>)
     ; CHECK-NEXT: $x0 = COPY %dst(<16 x s32>)
     ; CHECK-NEXT: PseudoRET implicit $lr, implicit $x0
@@ -146,8 +146,8 @@ body: |
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: %src1:_(<8 x s32>) = COPY $wl0
     ; CHECK-NEXT: %src2:_(<8 x s32>) = COPY $wl1
-    ; CHECK-NEXT: [[UV:%[0-9]+]]:_(<4 x s32>), [[UV1:%[0-9]+]]:_(<4 x s32>) = G_UNMERGE_VALUES %src1(<8 x s32>)
-    ; CHECK-NEXT: [[AIE_UNPAD_VECTOR:%[0-9]+]]:_(<4 x s32>) = G_AIE_UNPAD_VECTOR %src2(<8 x s32>)
+    ; CHECK-NEXT: [[AIE_UNPAD_VECTOR:%[0-9]+]]:_(<4 x s32>) = G_AIE_UNPAD_VECTOR %src1(<8 x s32>)
+    ; CHECK-NEXT: [[UV:%[0-9]+]]:_(<4 x s32>), [[UV1:%[0-9]+]]:_(<4 x s32>) = G_UNMERGE_VALUES %src2(<8 x s32>)
     ; CHECK-NEXT: %dst:_(<8 x s32>) = G_CONCAT_VECTORS [[AIE_UNPAD_VECTOR]](<4 x s32>), [[UV1]](<4 x s32>)
     ; CHECK-NEXT: $wl0 = COPY %dst(<8 x s32>)
     ; CHECK-NEXT: PseudoRET implicit $lr, implicit $wl0
@@ -170,8 +170,8 @@ body: |
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: %src1:_(<8 x s32>) = COPY $wl0
     ; CHECK-NEXT: %src2:_(<8 x s32>) = COPY $wl1
-    ; CHECK-NEXT: [[AIE_UNPAD_VECTOR:%[0-9]+]]:_(<4 x s32>) = G_AIE_UNPAD_VECTOR %src1(<8 x s32>)
-    ; CHECK-NEXT: [[UV:%[0-9]+]]:_(<4 x s32>), [[UV1:%[0-9]+]]:_(<4 x s32>) = G_UNMERGE_VALUES %src2(<8 x s32>)
+    ; CHECK-NEXT: [[UV:%[0-9]+]]:_(<4 x s32>), [[UV1:%[0-9]+]]:_(<4 x s32>) = G_UNMERGE_VALUES %src1(<8 x s32>)
+    ; CHECK-NEXT: [[AIE_UNPAD_VECTOR:%[0-9]+]]:_(<4 x s32>) = G_AIE_UNPAD_VECTOR %src2(<8 x s32>)
     ; CHECK-NEXT: %dst:_(<8 x s32>) = G_CONCAT_VECTORS [[AIE_UNPAD_VECTOR]](<4 x s32>), [[UV1]](<4 x s32>)
     ; CHECK-NEXT: $wl0 = COPY %dst(<8 x s32>)
     ; CHECK-NEXT: PseudoRET implicit $lr, implicit $wl0
@@ -214,8 +214,8 @@ body: |
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: %src1:_(<32 x s16>) = COPY $x0
     ; CHECK-NEXT: %src2:_(<32 x s16>) = COPY $x1
-    ; CHECK-NEXT: [[UV:%[0-9]+]]:_(<16 x s16>), [[UV1:%[0-9]+]]:_(<16 x s16>) = G_UNMERGE_VALUES %src1(<32 x s16>)
-    ; CHECK-NEXT: [[AIE_UNPAD_VECTOR:%[0-9]+]]:_(<16 x s16>) = G_AIE_UNPAD_VECTOR %src2(<32 x s16>)
+    ; CHECK-NEXT: [[AIE_UNPAD_VECTOR:%[0-9]+]]:_(<16 x s16>) = G_AIE_UNPAD_VECTOR %src1(<32 x s16>)
+    ; CHECK-NEXT: [[UV:%[0-9]+]]:_(<16 x s16>), [[UV1:%[0-9]+]]:_(<16 x s16>) = G_UNMERGE_VALUES %src2(<32 x s16>)
     ; CHECK-NEXT: %dst:_(<32 x s16>) = G_CONCAT_VECTORS [[AIE_UNPAD_VECTOR]](<16 x s16>), [[UV1]](<16 x s16>)
     ; CHECK-NEXT: $x0 = COPY %dst(<32 x s16>)
     ; CHECK-NEXT: PseudoRET implicit $lr, implicit $x0
@@ -238,8 +238,8 @@ body: |
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: %src1:_(<32 x s16>) = COPY $x0
     ; CHECK-NEXT: %src2:_(<32 x s16>) = COPY $x1
-    ; CHECK-NEXT: [[AIE_UNPAD_VECTOR:%[0-9]+]]:_(<16 x s16>) = G_AIE_UNPAD_VECTOR %src1(<32 x s16>)
-    ; CHECK-NEXT: [[UV:%[0-9]+]]:_(<16 x s16>), [[UV1:%[0-9]+]]:_(<16 x s16>) = G_UNMERGE_VALUES %src2(<32 x s16>)
+    ; CHECK-NEXT: [[UV:%[0-9]+]]:_(<16 x s16>), [[UV1:%[0-9]+]]:_(<16 x s16>) = G_UNMERGE_VALUES %src1(<32 x s16>)
+    ; CHECK-NEXT: [[AIE_UNPAD_VECTOR:%[0-9]+]]:_(<16 x s16>) = G_AIE_UNPAD_VECTOR %src2(<32 x s16>)
     ; CHECK-NEXT: %dst:_(<32 x s16>) = G_CONCAT_VECTORS [[AIE_UNPAD_VECTOR]](<16 x s16>), [[UV1]](<16 x s16>)
     ; CHECK-NEXT: $x0 = COPY %dst(<32 x s16>)
     ; CHECK-NEXT: PseudoRET implicit $lr, implicit $x0


### PR DESCRIPTION
Fix Selection of VSEL when using halfSelect masks (00FF or FF00).

VSEL works in little endian mode: 
00FF would select src2 for the lower part and src1 for the higher part.
