### PR TITLE
Add missing depends on generated headers

### DIFF
--- a/mlir/lib/Dialect/EmitC/Transforms/CMakeLists.txt
+++ b/mlir/lib/Dialect/EmitC/Transforms/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Modifications (c) Copyright 2026 Advanced Micro Devices, Inc. or its
+# affiliates
+
 add_mlir_dialect_library(MLIREmitCTransforms
   Transforms.cpp
   FormExpressions.cpp
@@ -9,6 +12,7 @@ add_mlir_dialect_library(MLIREmitCTransforms
 
   DEPENDS
   MLIREmitCTransformsIncGen
+  MLIRFuncOpsIncGen
 
   LINK_LIBS PUBLIC
   MLIRIR

--- a/mlir/lib/Rewrite/CMakeLists.txt
+++ b/mlir/lib/Rewrite/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Modifications (c) Copyright 2026 Advanced Micro Devices, Inc. or its
+# affiliates
+
 set(LLVM_OPTIONAL_SOURCES ByteCode.cpp)
 
 add_mlir_library(MLIRRewrite
@@ -10,6 +13,7 @@ add_mlir_library(MLIRRewrite
   DEPENDS
   mlir-generic-headers
   MLIRConversionPassIncGen
+  MLIRPDLOpsIncGen
 
   LINK_LIBS PUBLIC
   MLIRIR


### PR DESCRIPTION
These can cause build failures on a clean build