### PR TITLE
[MIR] Update scalar LLT size check from 16 to 32

### DIFF
--- a/llvm/lib/CodeGen/MIRParser/MIParser.cpp
+++ b/llvm/lib/CodeGen/MIRParser/MIParser.cpp
@@ -4,6 +4,9 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// Modifications (c) Copyright 2026 Advanced Micro Devices, Inc. or its
+// affiliates
+//
 //===----------------------------------------------------------------------===//
 //
 // This file implements the parsing of machine instructions.
@@ -1912,7 +1915,7 @@ bool MIParser::parseIRConstant(StringRef::iterator Loc, const Constant *&C) {
 
 // See LLT implementation for bit size limits.
 static bool verifyScalarSize(uint64_t Size) {
-  return Size != 0 && isUInt<16>(Size);
+  return Size != 0 && isUInt<32>(Size);
 }
 
 static bool verifyVectorElementCount(uint64_t NumElts) {

--- a/llvm/test/CodeGen/MIR/AArch64/parse-low-level-type-invalid5.mir
+++ b/llvm/test/CodeGen/MIR/AArch64/parse-low-level-type-invalid5.mir
@@ -1,10 +1,10 @@
 # RUN: not llc -mtriple=aarch64-- -run-pass none -o /dev/null %s 2>&1 | FileCheck %s
 # When a low-level type is larger than supported
 ---
-name: test_scalar_size_65536
+name: test_scalar_size_4294967296
 body: |
   bb.0:
     liveins: $x0
     ; CHECK: [[@LINE+1]]:10: invalid size for scalar type
-    %0:_(s65536) = G_IMPLICIT_DEF
+    %0:_(s4294967296) = G_IMPLICIT_DEF
 ...


### PR DESCRIPTION
See the LLT implementation for scalar types.
``` 
 /// * Non-pointer scalar (isPointer == 0 && isVector == 0):
  ///   SizeInBits: 32;
  static const constexpr BitFieldInfo ScalarSizeFieldInfo{32, 29};
```