### PR TITLE
[AIE2P] add shrinking vshuffle to shuffle with insertions

### DIFF
--- a/llvm/lib/Target/AIE/AIECombine.td
+++ b/llvm/lib/Target/AIE/AIECombine.td
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// (c) Copyright 2023-2025 Advanced Micro Devices, Inc. or its affiliates
+// (c) Copyright 2023-2026 Advanced Micro Devices, Inc. or its affiliates
 //
 //===----------------------------------------------------------------------===//
 include "llvm/Target/GlobalISel/Combine.td"
@@ -137,10 +137,10 @@ def combine_vector_shuffle_to_copy : GICombineRule<
          [{ return matchShuffleToCopy(*${root}, MRI, ${matchinfo}); }]),
   (apply [{ Helper.applyBuildFn(*${root}, ${matchinfo}); }])>;
 
-def combine_vector_shuffle_to_extract_insert_elt : GICombineRule<
+def combine_mostly_sequential_shuffle_with_insertions : GICombineRule<
   (defs root:$root, build_fn_matchinfo:$matchinfo),
   (match (wip_match_opcode G_SHUFFLE_VECTOR): $root,
-         [{ return matchShuffleToExtractInsertElt(*${root}, MRI, ${matchinfo}); }]),
+         [{ return matchMostlySequentialShuffleWithInsertions(*${root}, MRI, ${matchinfo}); }]),
   (apply [{ Helper.applyBuildFn(*${root}, ${matchinfo}); }])>;
 
 def combine_vector_shuffle_bcst_to_copy : GICombineRule<
@@ -309,7 +309,7 @@ def aie2p_additional_combines : GICombineGroup<[
   combine_vector_broadcast,
   combine_vector_shuffle_vsel,
   combine_vector_shuffle_broadcast,
-  combine_vector_shuffle_to_extract_insert_elt,
+  combine_mostly_sequential_shuffle_with_insertions,
   combine_vector_shuffle_concat_extracted_subvectors,
   combine_paired_extracts,
   combine_widen_fmul,

--- a/llvm/lib/Target/AIE/AIECombinerHelper.cpp
+++ b/llvm/lib/Target/AIE/AIECombinerHelper.cpp
@@ -2968,20 +2968,32 @@ bool llvm::matchShuffleToExtractInsertEltToBroadcast(MachineInstr &MI,
   return true;
 }
 
-/// Match something like this:
-/// %0:_(<32 x s16>) = COPY $x0
-/// %1:_(<32 x s16>) = COPY $x1
-/// %2:_(<32 x s16>) = G_SHUFFLE_VECTOR %0:_(<32 x s16>), %1:_, shufflemask(0,
-/// 1, 2, 3, 4, 5, 6, 7, 32, 9, 10, 11, 12, 13, 14, 15, undef, 17, 18, 19, 20,
-/// 21, 22, 23, undef, 25, 26, 27, 28, 29, 30, 31)
-
-/// To convert to:
-/// %3:_(s32) = G_CONSTANT i32 0
-/// %4:_(<32 x s16>) = G_EXTRACT_VECTOR_ELT %1:_(<32 x s16>), %3:_(s32)
-/// %0:_(<32 x s32>) = G_AIE_INSERT_VECTOR_ELT %0:(<32 x s16>), %4:_(s16), 8
-bool llvm::matchShuffleToExtractInsertElt(MachineInstr &MI,
-                                          MachineRegisterInfo &MRI,
-                                          BuildFnTy &MatchInfo) {
+/// Match shuffle vectors that are mostly sequential (identity or extract
+/// subvector) with a few element insertions from either source.
+///
+/// Handles two cases:
+/// 1. Same-size shuffles: Dst and Src have the same type, mask is mostly
+///    identity with exceptions inserted from Src1 or Src2.
+/// 2. Shrinking shuffles: Dst is smaller than Src (e.g., 16->8 elements),
+///    mask extracts a prefix subvector with exceptions from Src2.
+///
+/// Same-size example:
+///   %2:_(<32 x s16>) = G_SHUFFLE_VECTOR %0, %1, shufflemask(0, 1, ..., 32,
+///   ...)
+/// Converts to:
+///   %elt = G_EXTRACT_VECTOR_ELT %1, 0
+///   %2 = G_INSERT_VECTOR_ELT %0, %elt, 8
+///
+/// Shrinking example:
+///   %2:_(<8 x s32>) = G_SHUFFLE_VECTOR %0(<16 x s32>), %1,
+///                       shufflemask(0, 16, undef, undef, 4, 5, 6, 7)
+/// Converts to:
+///   %unpad = G_AIE_UNPAD_VECTOR %0(<16 x s32>)
+///   %elt = G_EXTRACT_VECTOR_ELT %1, 0
+///   %2 = G_INSERT_VECTOR_ELT %unpad, %elt, 1
+bool llvm::matchMostlySequentialShuffleWithInsertions(MachineInstr &MI,
+                                                      MachineRegisterInfo &MRI,
+                                                      BuildFnTy &MatchInfo) {
   assert(MI.getOpcode() == TargetOpcode::G_SHUFFLE_VECTOR);
 
   const Register DstReg = MI.getOperand(0).getReg();
@@ -2991,11 +3003,24 @@ bool llvm::matchShuffleToExtractInsertElt(MachineInstr &MI,
 
   const LLT DstTy = MRI.getType(DstReg);
   const LLT Src1Ty = MRI.getType(Src1Reg);
-  if (DstTy != Src1Ty)
+
+  if (!DstTy.isVector() || !Src1Ty.isVector())
     return false;
 
-  const unsigned NumSrcElems = Src1Ty.isVector() ? Src1Ty.getNumElements() : 1;
-  const LLT ElemTy = MRI.getType(Src1Reg).getElementType();
+  const unsigned NumDstElems = DstTy.getNumElements();
+  const unsigned NumSrcElems = Src1Ty.getNumElements();
+
+  // Element types must match
+  if (DstTy.getElementType() != Src1Ty.getElementType())
+    return false;
+
+  // No growing shuffles; shrinking requires divisibility
+  if (NumSrcElems % NumDstElems != 0)
+    return false;
+
+  const bool IsShrinking = NumSrcElems > NumDstElems;
+
+  const LLT ElemTy = Src1Ty.getElementType();
 
   unsigned MaxNumInsertions;
   if (MI.getMF()->getTarget().getTargetTriple().isAIE2P())
@@ -3011,7 +3036,7 @@ bool llvm::matchShuffleToExtractInsertElt(MachineInstr &MI,
         "instruction take immediate indices or does it require a register for "
         "the index?");
 
-  if (Mask.size() != NumSrcElems)
+  if (Mask.size() != NumDstElems)
     return false;
 
   if (MaskMatch::isMaskWithAllUndefs(Mask))
@@ -3034,9 +3059,17 @@ bool llvm::matchShuffleToExtractInsertElt(MachineInstr &MI,
     return false;
 
   MatchInfo = [=, &MRI](MachineIRBuilder &B) {
-    Register InsertSrc = Src1Reg;
-    Register InsertDst;
+    // For shrinking shuffles, first extract the subvector using UNPAD
+    Register InsertSrc;
+    if (IsShrinking) {
+      InsertSrc = MRI.createGenericVirtualRegister(DstTy);
+      const AIEBaseInstrInfo &TII = getAIETII(B);
+      B.buildInstr(TII.getGenericUnpadVectorOpcode(), {InsertSrc}, {Src1Reg});
+    } else {
+      InsertSrc = Src1Reg;
+    }
 
+    Register InsertDst;
     for (const unsigned ExceptionIdx : Exceptions) {
       Register VecToExtract =
           Mask[ExceptionIdx] < (int)NumSrcElems ? Src1Reg : Src2Reg;
@@ -3049,7 +3082,7 @@ bool llvm::matchShuffleToExtractInsertElt(MachineInstr &MI,
 
       InsertDst = (ExceptionIdx == Exceptions.back())
                       ? DstReg
-                      : MRI.createGenericVirtualRegister(Src1Ty);
+                      : MRI.createGenericVirtualRegister(DstTy);
 
       B.buildInsertVectorElement(InsertDst, InsertSrc, ExtrElt,
                                  ExceptionIdxReg);

--- a/llvm/lib/Target/AIE/AIECombinerHelper.h
+++ b/llvm/lib/Target/AIE/AIECombinerHelper.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// (c) Copyright 2023-2025 Advanced Micro Devices, Inc. or its affiliates
+// (c) Copyright 2023-2026 Advanced Micro Devices, Inc. or its affiliates
 //
 //===----------------------------------------------------------------------===//
 
@@ -258,8 +258,9 @@ bool matchShuffleToCopy(MachineInstr &MI, MachineRegisterInfo &MRI,
 bool matchShuffleBcstToCopy(MachineInstr &MI, MachineRegisterInfo &MRI,
                             const TargetInstrInfo &TII, BuildFnTy &MatchInfo);
 
-bool matchShuffleToExtractInsertElt(MachineInstr &MI, MachineRegisterInfo &MRI,
-                                    BuildFnTy &MatchInfo);
+bool matchMostlySequentialShuffleWithInsertions(MachineInstr &MI,
+                                                MachineRegisterInfo &MRI,
+                                                BuildFnTy &MatchInfo);
 
 bool matchPairedExtracts(MachineInstr &MI, MachineRegisterInfo &MRI,
                          CombinerHelper &Helper, const TargetInstrInfo &TII,

--- a/llvm/test/CodeGen/AIE/GlobalISel/prelegalizercombiner-shuffle-vector.mir
+++ b/llvm/test/CodeGen/AIE/GlobalISel/prelegalizercombiner-shuffle-vector.mir
@@ -1742,23 +1742,26 @@ body:             |
 ...
 
 ---
-# Shrinking shuffles (16 -> 8 elements) with single element
-# insertion from Src2.
+# Shrinking shuffles (16 -> 8 elements) with single element insertion from Src2
+# are combined to: extract subvec + insert element.
 
-name: shuffle_vector_shrinking_insert_pos1_not_combined
+name: shuffle_vector_shrinking_insert_pos1
 alignment:       16
 tracksRegLiveness: true
 body:             |
   bb.0.entry:
     liveins: $x0, $x1
-
-    ; CHECK-LABEL: name: shuffle_vector_shrinking_insert_pos1_not_combined
+    ; CHECK-LABEL: name: shuffle_vector_shrinking_insert_pos1
     ; CHECK: liveins: $x0, $x1
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<16 x s32>) = COPY $x0
     ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(<16 x s32>) = COPY $x1
-    ; CHECK-NEXT: [[SHUF:%[0-9]+]]:_(<8 x s32>) = G_SHUFFLE_VECTOR [[COPY]](<16 x s32>), [[COPY1]], shufflemask(0, 16, undef, undef, 4, 5, 6, 7)
-    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[SHUF]](<8 x s32>)
+    ; CHECK-NEXT: [[UNPAD:%[0-9]+]]:_(<8 x s32>) = G_AIE_UNPAD_VECTOR [[COPY]](<16 x s32>)
+    ; CHECK-NEXT: [[C:%[0-9]+]]:_(s32) = G_CONSTANT i32 0
+    ; CHECK-NEXT: [[EVEC:%[0-9]+]]:_(s32) = G_EXTRACT_VECTOR_ELT [[COPY1]](<16 x s32>), [[C]](s32)
+    ; CHECK-NEXT: [[C1:%[0-9]+]]:_(s32) = G_CONSTANT i32 1
+    ; CHECK-NEXT: [[IVEC:%[0-9]+]]:_(<8 x s32>) = G_INSERT_VECTOR_ELT [[UNPAD]], [[EVEC]](s32), [[C1]](s32)
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[IVEC]](<8 x s32>)
     %0:_(<16 x s32>) = COPY $x0
     %1:_(<16 x s32>) = COPY $x1
     %2:_(<8 x s32>) = G_SHUFFLE_VECTOR %0(<16 x s32>), %1, shufflemask(0, 16, undef, undef, 4, 5, 6, 7)
@@ -1766,20 +1769,23 @@ body:             |
 ...
 
 ---
-name: shuffle_vector_shrinking_insert_pos2_not_combined
+name: shuffle_vector_shrinking_insert_pos2
 alignment:       16
 tracksRegLiveness: true
 body:             |
   bb.0.entry:
     liveins: $x0, $x1
-
-    ; CHECK-LABEL: name: shuffle_vector_shrinking_insert_pos2_not_combined
+    ; CHECK-LABEL: name: shuffle_vector_shrinking_insert_pos2
     ; CHECK: liveins: $x0, $x1
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<16 x s32>) = COPY $x0
     ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(<16 x s32>) = COPY $x1
-    ; CHECK-NEXT: [[SHUF:%[0-9]+]]:_(<8 x s32>) = G_SHUFFLE_VECTOR [[COPY]](<16 x s32>), [[COPY1]], shufflemask(0, 1, 16, undef, 4, 5, 6, 7)
-    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[SHUF]](<8 x s32>)
+    ; CHECK-NEXT: [[UNPAD:%[0-9]+]]:_(<8 x s32>) = G_AIE_UNPAD_VECTOR [[COPY]](<16 x s32>)
+    ; CHECK-NEXT: [[C:%[0-9]+]]:_(s32) = G_CONSTANT i32 0
+    ; CHECK-NEXT: [[EVEC:%[0-9]+]]:_(s32) = G_EXTRACT_VECTOR_ELT [[COPY1]](<16 x s32>), [[C]](s32)
+    ; CHECK-NEXT: [[C1:%[0-9]+]]:_(s32) = G_CONSTANT i32 2
+    ; CHECK-NEXT: [[IVEC:%[0-9]+]]:_(<8 x s32>) = G_INSERT_VECTOR_ELT [[UNPAD]], [[EVEC]](s32), [[C1]](s32)
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[IVEC]](<8 x s32>)
     %0:_(<16 x s32>) = COPY $x0
     %1:_(<16 x s32>) = COPY $x1
     %2:_(<8 x s32>) = G_SHUFFLE_VECTOR %0(<16 x s32>), %1, shufflemask(0, 1, 16, undef, 4, 5, 6, 7)
@@ -1787,20 +1793,23 @@ body:             |
 ...
 
 ---
-name: shuffle_vector_shrinking_insert_pos3_not_combined
+name: shuffle_vector_shrinking_insert_pos3
 alignment:       16
 tracksRegLiveness: true
 body:             |
   bb.0.entry:
     liveins: $x0, $x1
-
-    ; CHECK-LABEL: name: shuffle_vector_shrinking_insert_pos3_not_combined
+    ; CHECK-LABEL: name: shuffle_vector_shrinking_insert_pos3
     ; CHECK: liveins: $x0, $x1
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<16 x s32>) = COPY $x0
     ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(<16 x s32>) = COPY $x1
-    ; CHECK-NEXT: [[SHUF:%[0-9]+]]:_(<8 x s32>) = G_SHUFFLE_VECTOR [[COPY]](<16 x s32>), [[COPY1]], shufflemask(0, 1, 2, 16, 4, 5, 6, 7)
-    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[SHUF]](<8 x s32>)
+    ; CHECK-NEXT: [[UNPAD:%[0-9]+]]:_(<8 x s32>) = G_AIE_UNPAD_VECTOR [[COPY]](<16 x s32>)
+    ; CHECK-NEXT: [[C:%[0-9]+]]:_(s32) = G_CONSTANT i32 0
+    ; CHECK-NEXT: [[EVEC:%[0-9]+]]:_(s32) = G_EXTRACT_VECTOR_ELT [[COPY1]](<16 x s32>), [[C]](s32)
+    ; CHECK-NEXT: [[C1:%[0-9]+]]:_(s32) = G_CONSTANT i32 3
+    ; CHECK-NEXT: [[IVEC:%[0-9]+]]:_(<8 x s32>) = G_INSERT_VECTOR_ELT [[UNPAD]], [[EVEC]](s32), [[C1]](s32)
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[IVEC]](<8 x s32>)
     %0:_(<16 x s32>) = COPY $x0
     %1:_(<16 x s32>) = COPY $x1
     %2:_(<8 x s32>) = G_SHUFFLE_VECTOR %0(<16 x s32>), %1, shufflemask(0, 1, 2, 16, 4, 5, 6, 7)

--- a/llvm/test/CodeGen/AIE/GlobalISel/prelegalizercombiner-shuffle-vector.mir
+++ b/llvm/test/CodeGen/AIE/GlobalISel/prelegalizercombiner-shuffle-vector.mir
@@ -1740,3 +1740,69 @@ body:             |
     %2:_(<16 x s32>) = G_SHUFFLE_VECTOR %0:_(<16 x s32>), %1:_, shufflemask(17, 17, 17, 17, 17, 17, 17, 2, 3, 0, 0, 0, 0, 0, 0, 0)
     PseudoRET implicit $lr, implicit %2
 ...
+
+---
+# Shrinking shuffles (16 -> 8 elements) with single element
+# insertion from Src2.
+
+name: shuffle_vector_shrinking_insert_pos1_not_combined
+alignment:       16
+tracksRegLiveness: true
+body:             |
+  bb.0.entry:
+    liveins: $x0, $x1
+
+    ; CHECK-LABEL: name: shuffle_vector_shrinking_insert_pos1_not_combined
+    ; CHECK: liveins: $x0, $x1
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<16 x s32>) = COPY $x0
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(<16 x s32>) = COPY $x1
+    ; CHECK-NEXT: [[SHUF:%[0-9]+]]:_(<8 x s32>) = G_SHUFFLE_VECTOR [[COPY]](<16 x s32>), [[COPY1]], shufflemask(0, 16, undef, undef, 4, 5, 6, 7)
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[SHUF]](<8 x s32>)
+    %0:_(<16 x s32>) = COPY $x0
+    %1:_(<16 x s32>) = COPY $x1
+    %2:_(<8 x s32>) = G_SHUFFLE_VECTOR %0(<16 x s32>), %1, shufflemask(0, 16, undef, undef, 4, 5, 6, 7)
+    PseudoRET implicit $lr, implicit %2
+...
+
+---
+name: shuffle_vector_shrinking_insert_pos2_not_combined
+alignment:       16
+tracksRegLiveness: true
+body:             |
+  bb.0.entry:
+    liveins: $x0, $x1
+
+    ; CHECK-LABEL: name: shuffle_vector_shrinking_insert_pos2_not_combined
+    ; CHECK: liveins: $x0, $x1
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<16 x s32>) = COPY $x0
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(<16 x s32>) = COPY $x1
+    ; CHECK-NEXT: [[SHUF:%[0-9]+]]:_(<8 x s32>) = G_SHUFFLE_VECTOR [[COPY]](<16 x s32>), [[COPY1]], shufflemask(0, 1, 16, undef, 4, 5, 6, 7)
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[SHUF]](<8 x s32>)
+    %0:_(<16 x s32>) = COPY $x0
+    %1:_(<16 x s32>) = COPY $x1
+    %2:_(<8 x s32>) = G_SHUFFLE_VECTOR %0(<16 x s32>), %1, shufflemask(0, 1, 16, undef, 4, 5, 6, 7)
+    PseudoRET implicit $lr, implicit %2
+...
+
+---
+name: shuffle_vector_shrinking_insert_pos3_not_combined
+alignment:       16
+tracksRegLiveness: true
+body:             |
+  bb.0.entry:
+    liveins: $x0, $x1
+
+    ; CHECK-LABEL: name: shuffle_vector_shrinking_insert_pos3_not_combined
+    ; CHECK: liveins: $x0, $x1
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<16 x s32>) = COPY $x0
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(<16 x s32>) = COPY $x1
+    ; CHECK-NEXT: [[SHUF:%[0-9]+]]:_(<8 x s32>) = G_SHUFFLE_VECTOR [[COPY]](<16 x s32>), [[COPY1]], shufflemask(0, 1, 2, 16, 4, 5, 6, 7)
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[SHUF]](<8 x s32>)
+    %0:_(<16 x s32>) = COPY $x0
+    %1:_(<16 x s32>) = COPY $x1
+    %2:_(<8 x s32>) = G_SHUFFLE_VECTOR %0(<16 x s32>), %1, shufflemask(0, 1, 2, 16, 4, 5, 6, 7)
+    PseudoRET implicit $lr, implicit %2
+...


### PR DESCRIPTION
<img width="4400" height="1800" alt="Core_Compute_Insn_Count_perf_sorted_reduced" src="https://github.com/user-attachments/assets/c31b2e9f-0414-4894-8430-58bed5b4f345" />

<img width="4400" height="1800" alt="Core_PMSize_perf_sorted_reduced_absolute" src="https://github.com/user-attachments/assets/1813c466-d43a-4d76-8ade-b2e16229ef98" />

<img width="4400" height="1800" alt="Core_StackSize_perf_sorted_reduced_absolute" src="https://github.com/user-attachments/assets/5484f83d-f9e1-4d72-b57a-a8f1852387e7" />
