### PR TITLE
Preserve PDL symbol names 

### DIFF
--- a/mlir/lib/Conversion/PDLToPDLInterp/PDLToPDLInterp.cpp
+++ b/mlir/lib/Conversion/PDLToPDLInterp/PDLToPDLInterp.cpp
@@ -634,8 +634,11 @@ void PatternLowering::generate(SuccessNode *successNode, Block *&currentBlock) {
 SymbolRefAttr PatternLowering::generateRewriter(
     pdl::PatternOp pattern, SmallVectorImpl<Position *> &usedMatchValues) {
   builder.setInsertionPointToEnd(rewriterModule.getBody());
+  StringRef rewriterName = "pdl_generated_rewriter";
+  if (auto symName = pattern.getSymName())
+    rewriterName = symName.value();
   auto rewriterFunc = builder.create<pdl_interp::FuncOp>(
-      pattern.getLoc(), "pdl_generated_rewriter",
+      pattern.getLoc(), rewriterName,
       builder.getFunctionType(std::nullopt, std::nullopt));
   rewriterSymbolTable.insert(rewriterFunc);
 

--- a/mlir/lib/Rewrite/ByteCode.cpp
+++ b/mlir/lib/Rewrite/ByteCode.cpp
@@ -3,7 +3,7 @@
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// Modifications (c) Copyright 2025 Advanced Micro Devices, Inc. or its
+// Modifications (c) Copyright 2025-2026 Advanced Micro Devices, Inc. or its
 // affiliates
 //
 //===----------------------------------------------------------------------===//
@@ -42,18 +42,24 @@ PDLByteCodePattern PDLByteCodePattern::create(pdl_interp::RecordMatchOp matchOp,
   PatternBenefit benefit = matchOp.getBenefit();
   MLIRContext *ctx = matchOp.getContext();
 
+  StringRef debugName = matchOp.getRewriter().getLeafReference().getValue();
   // Collect the set of generated operations.
   SmallVector<StringRef, 8> generatedOps;
   if (ArrayAttr generatedOpsAttr = matchOp.getGeneratedOpsAttr())
     generatedOps =
         llvm::to_vector<8>(generatedOpsAttr.getAsValueRange<StringAttr>());
 
-  // Check to see if this is pattern matches a specific operation type.
-  if (std::optional<StringRef> rootKind = matchOp.getRootKind())
-    return PDLByteCodePattern(rewriterAddr, configSet, *rootKind, benefit, ctx,
-                              generatedOps);
-  return PDLByteCodePattern(rewriterAddr, configSet, MatchAnyOpTypeTag(),
-                            benefit, ctx, generatedOps);
+  // Check to see if this pattern matches a specific operation type.
+  std::optional<StringRef> rootKind = matchOp.getRootKind();
+  PDLByteCodePattern pattern =
+      rootKind
+          ? PDLByteCodePattern(rewriterAddr, configSet, *rootKind, benefit, ctx,
+                               generatedOps)
+          : PDLByteCodePattern(rewriterAddr, configSet, MatchAnyOpTypeTag(),
+                               benefit, ctx, generatedOps);
+
+  pattern.setDebugName(debugName);
+  return pattern;
 }
 
 //===----------------------------------------------------------------------===//

--- a/mlir/test/Conversion/PDLToPDLInterp/pdl-to-pdl-interp-rewriter.mlir
+++ b/mlir/test/Conversion/PDLToPDLInterp/pdl-to-pdl-interp-rewriter.mlir
@@ -276,3 +276,30 @@ module @create_empty_region {
     }
   }
 }
+
+// -----
+
+// CHECK-LABEL: module @named_pattern
+module @named_pattern {
+  // CHECK: pdl_interp.func @matcher(%[[ARG0:.*]]: !pdl.operation) {
+  // CHECK:   pdl_interp.check_operation_name of %[[ARG0]] is "foo.op" -> ^bb2, ^bb1
+  // CHECK: ^bb1:
+  // CHECK:   pdl_interp.finalize
+  // CHECK: ^bb2:
+  // CHECK:   pdl_interp.check_operand_count of %[[ARG0]] is 0 -> ^bb3, ^bb1
+  // CHECK: ^bb3:
+  // CHECK:   pdl_interp.check_result_count of %[[ARG0]] is 0 -> ^bb4, ^bb1
+  // CHECK: ^bb4:
+  // CHECK:   pdl_interp.record_match @rewriters::@my_pattern(%[[ARG0]] : !pdl.operation) : benefit(1), loc([%[[ARG0]]]), root("foo.op") -> ^bb1
+  // CHECK: }
+  // CHECK: module @rewriters {
+  // CHECK:   pdl_interp.func @my_pattern(%[[ARG0:.*]]: !pdl.operation) {
+  // CHECK:     pdl_interp.apply_rewrite "rewriter"(%[[ARG0]] : !pdl.operation)
+  // CHECK:     pdl_interp.finalize
+  // CHECK:   }
+  // CHECK: }
+  pdl.pattern @my_pattern : benefit(1) {
+    %root = operation "foo.op"
+    rewrite %root with "rewriter"
+  }
+}

--- a/mlir/test/Rewrite/pdl-bytecode-debug.mlir
+++ b/mlir/test/Rewrite/pdl-bytecode-debug.mlir
@@ -336,3 +336,31 @@ module @patterns {
 module @ir attributes { test.apply_rewrite_4 } {
   "test.op"() : () -> ()
 }
+
+// -----
+
+
+module @patterns {
+  pdl_interp.func @matcher(%root : !pdl.operation) {
+    pdl_interp.check_operation_name of %root is "test.op" -> ^pat, ^end
+
+  ^pat:
+    pdl_interp.record_match @rewriters::@named_pattern(%root : !pdl.operation) : benefit(1), loc([%root]), root("test.op") -> ^end
+
+  ^end:
+    pdl_interp.finalize
+  }
+
+  module @rewriters {
+    pdl_interp.func @named_pattern(%root : !pdl.operation) {
+      %op = pdl_interp.create_operation "test.replaced_by_pattern"
+      pdl_interp.erase %root
+      pdl_interp.finalize
+    }
+  }
+}
+
+// CHECK: Pattern named_pattern
+module @ir {
+  "test.op"() : () -> ()
+}


### PR DESCRIPTION
This change fixes the absence of PDL symbol names (PDLL pattern names) on using `--debug`.

this PR include the testing for the pdl_interp symbol name propagation: taken from https://github.com/llvm/llvm-project/pull/149481/changes/bff70da233c5d2d2a597d7bc06710b5cae7416cf by https://github.com/jumerckx

Testing for the GreedyPatternRewriter logger (propagating Debugging names) is in _PR#32098_ in our project.

**For reviewers:**
Root cause and what this PR is fixing:
Not preserving symbold names when loweing: PDLL -> PDL dialect -> PDLInterp dialect -> ByteCode : utilised by Greedy Logger

At the moment the [Greedy Logger logs pattern meta data including the debugName](https://github.com/Xilinx/llvm-aie/blob/aie-public/mlir/lib/Transforms/Utils/GreedyPatternRewriteDriver.cpp#L565-L576) (which is not propagated from PDL symbols). The greedy logger [invokes the PatternApplicator](https://github.com/Xilinx/llvm-aie/blob/aie-public/mlir/lib/Transforms/Utils/GreedyPatternRewriteDriver.cpp#L614-L615) For native C++ rewrites, those are native RewritePattern instances, where debugName(s) are set, so the Logger works as expected.

For PDLL rewrites, those are PDLByteCodePattern instances (which inherit Pattern), [created in ByteCode.cpp](https://github.com/Xilinx/llvm-aie/blob/aie-public/mlir/lib/Rewrite/ByteCode.cpp#L39-L57), here we were not attaching the symbol names from PDLinterpret (fixed by this PR). To resolve the actual symbol name, the name should be initally preserved in PDLToPDLInterp.cpp, at the moment the leaf is just a generic [pdl_generated_rewriter_#\<num>](https://github.com/Xilinx/llvm-aie/blob/aie-public/mlir/lib/Conversion/PDLToPDLInterp/PDLToPDLInterp.cpp#L634-L640).
The PR resolves the correct symbol name to be propagated to the rest of the flow. 

Readings: [1](https://reviews.llvm.org/D89107), [2](https://discourse.llvm.org/t/whats-the-purpose-of-pdl-pattern/73369), [3](https://mlir.llvm.org/docs/Dialects/PDLInterpOps/)
