### PR TITLE
Fix: avoid passing local variable to lambda by reference

### DIFF
--- a/llvm/lib/Target/AIE/AIECombinerHelper.cpp
+++ b/llvm/lib/Target/AIE/AIECombinerHelper.cpp
@@ -2378,7 +2378,7 @@ static bool matchShuffleToVecEltBroadcast(MachineInstr &MI,
     return true;
   }
 
-  MatchInfo = [=, &MRI, &SrcTy](MachineIRBuilder &B) {
+  MatchInfo = [=, &MRI](MachineIRBuilder &B) {
     const LLT DstElemTy = SrcTy.getElementType();
     auto Extr =
         B.buildExtractVectorElementConstant(DstElemTy, SrcReg, *UniqOpIdx);


### PR DESCRIPTION
The variable is local, so it is freed after the end of the function. This tripped ASAN's use-after-free check when the lambda was called.