### PR TITLE
[AIEX] Fix SEF peeling scheduling bug

### DIFF
--- a/llvm/lib/Target/AIE/AIEPostPipeliner.cpp
+++ b/llvm/lib/Target/AIE/AIEPostPipeliner.cpp
@@ -820,6 +820,20 @@ void dumpEarliestChain(const ScheduleInfo &Info, int N) {
   dbgs() << "  --> SU" << N << " @" << Info[N].Cycle << "\n";
 }
 
+#ifndef NDEBUG
+/// Recompute Earliest from direct predecessors only.
+int computeEarliestFromPreds(const SUnit &SU, const ScheduleInfo &Info) {
+  int Earliest = 0;
+  for (const SDep &Dep : SU.Preds) {
+    const SUnit *Pred = Dep.getSUnit();
+    if (Pred->isBoundaryNode())
+      continue;
+    const NodeInfo &PredNode = Info[Pred->NodeNum];
+    Earliest = std::max(Earliest, PredNode.Cycle + Dep.getSignedLatency());
+  }
+  return Earliest;
+}
+#endif
 } // namespace
 
 bool PostPipeliner::scheduleOtherIterations(PostPipelinerStrategy &Strategy) {
@@ -833,6 +847,13 @@ bool PostPipeliner::scheduleOtherIterations(PostPipelinerStrategy &Strategy) {
     NodeInfo &Node = Info[N];
     const SUnit &ModuloSU = DAG->SUnits[N - NInstr];
     NodeInfo &ModuloNode = Info[N - NInstr];
+
+#ifndef NDEBUG
+    // Assert that Earliest is still consistent with scheduled predecessors.
+    const int RecomputedEarliest = computeEarliestFromPreds(SU, Info);
+    assert(Node.Earliest >= RecomputedEarliest &&
+           "Earliest is stale: predecessor pushes a later cycle");
+#endif
 
     // Earliest tracks the latencies of the loop carried deps
     const int Earliest = Node.Earliest;

--- a/llvm/lib/Target/AIE/AIEPostPipeliner.cpp
+++ b/llvm/lib/Target/AIE/AIEPostPipeliner.cpp
@@ -926,9 +926,17 @@ bool PostPipeliner::scheduleWithStrategy(PostPipelinerStrategy &S) {
   }
   DEBUG_SUMMARY(dbgs() << "   First iteration successful\n");
   if (!scheduleOtherIterations(S)) {
+    Info.resetRotation();
     return false;
   }
   DEBUG_SUMMARY(dbgs() << "   Other iterations successful\n");
+
+  // Apply pending rotation from peelSideEffectFree() now that validation
+  // has succeeded. This rotates the schedule to the SEF form, prefixing it
+  // with empty cycles so that the first stage only contains SEF instructions.
+  Info.applyRotation(II);
+  Info.resetRotation();
+
   return true;
 }
 
@@ -1444,11 +1452,11 @@ bool PostPipeliner::peelSideEffectFree() {
   if (Info.Length - NSEF <= OneStageFewer * II) {
     DEBUG_SUMMARY(dbgs() << "Can peel SEF stage. " << Info.Length << " - "
                          << NSEF << " <= " << NStages << " * " << II << "\n");
-    // Rotate the schedule to the SEF form. We prefix the schedule with
-    // empty cycles, so that the first stage only contains SEF instructions.
-    // This shifts modulo cycles and stages of all nodes.
+    // Store the pending rotation. The actual rotation will be applied after
+    // scheduleOtherIterations() succeeds, to ensure validation uses consistent
+    // pre-rotation cycle values.
     const int Rotation = II - NSEF;
-    Info.rotate(Rotation, II);
+    Info.setRotation(Rotation);
     NStages--;
     return true;
   }
@@ -1569,9 +1577,12 @@ void NodeInfo::update(int II) {
   Stage = Cycle / II;
 }
 
-void ScheduleInfo::rotate(int Rotation, int II) {
+void ScheduleInfo::applyRotation(int II) {
+  if (PendingRotation == 0)
+    return;
+
   for (int N = 0; N < NInstr; N++) {
-    Nodes[N].Cycle = Nodes[N].Cycle + Rotation;
+    Nodes[N].Cycle = Nodes[N].Cycle + PendingRotation;
     Nodes[N].update(II);
 
     commitCycle(N);

--- a/llvm/lib/Target/AIE/AIEPostPipeliner.h
+++ b/llvm/lib/Target/AIE/AIEPostPipeliner.h
@@ -105,6 +105,11 @@ public:
 };
 
 class ScheduleInfo {
+private:
+  /// Pending rotation to be applied after validation succeeds.
+  /// Set by peelSideEffectFree(), applied in scheduleWithStrategy().
+  int PendingRotation = 0;
+
 public:
   std::vector<NodeInfo> Nodes;
   int NInstr;
@@ -117,6 +122,7 @@ public:
     Nodes.clear();
     Nodes.resize(2 * NInstr);
     Length = 0;
+    PendingRotation = 0;
   }
   NodeInfo &operator[](int N) { return Nodes[N]; }
   const NodeInfo &operator[](int N) const { return Nodes[N]; }
@@ -129,11 +135,18 @@ public:
     Node.Scheduled = true;
     Length = std::max(Length, Node.Cycle + 1);
   }
-  // Insert empty cycles at the start, shifting all cycles.
+  // Set the pending rotation. The actual rotation will be applied after
+  // scheduleOtherIterations() succeeds, to ensure validation uses consistent
+  // pre-rotation cycle values.
   // \param Rotation The number of cycles to insert
+  void setRotation(int Rotation) { PendingRotation = Rotation; }
+  // Apply the pending rotation by inserting empty cycles at the start,
+  // shifting all cycles.
   // \param II The initiation interval used to update
   //           Stage and ModuloCycle of each node.
-  void rotate(int Rotation, int II);
+  void applyRotation(int II);
+  // Reset the pending rotation.
+  void resetRotation() { PendingRotation = 0; }
 };
 
 class PostPipelinerStrategy {

--- a/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/speculative-first-stage.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/speculative-first-stage.mir
@@ -9,8 +9,6 @@
 # RUN:     --start-before=postmisched \
 # RUN:     -o - | FileCheck %s
 
-# XFAIL: *
-
 # This is a simple example of a speculative stage. The first stage gets a load,
 # which is side-effect free. It can run in NS=4 * II=3
 # We have two identical copies, one with MinIterCount=4, which should

--- a/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/speculative-first-stage.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/speculative-first-stage.mir
@@ -9,6 +9,8 @@
 # RUN:     --start-before=postmisched \
 # RUN:     -o - | FileCheck %s
 
+# XFAIL: *
+
 # This is a simple example of a speculative stage. The first stage gets a load,
 # which is side-effect free. It can run in NS=4 * II=3
 # We have two identical copies, one with MinIterCount=4, which should


### PR DESCRIPTION
There was a problem in the software pipeliner that led to incorrect schedules when creating an SEF stage. Rotating the schedule to create that SEF stage was causing an inconsistent state, where the scheduled cycles were updated, but the earliest and latest cycles for unscheduled SUs were not updated accordingly. This inconsistent state led to incorrect schedules being accepted.

Commit 1 adds an assert to verify the state is consistent when scheduling the other iterations and commit 2 fixes the SEF creation to avoid this inconsistent state.