### PR TITLE
Preliminiaries for postregalloc in postpipeliner

### DIFF
--- a/llvm/include/llvm/CodeGen/ScheduleDAGInstrs.h
+++ b/llvm/include/llvm/CodeGen/ScheduleDAGInstrs.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// Modifications (c) Copyright 2023-2024 Advanced Micro Devices, Inc. or its
+// Modifications (c) Copyright 2023-2026 Advanced Micro Devices, Inc. or its
 // affiliates
 //
 //===----------------------------------------------------------------------===//
@@ -169,7 +169,7 @@ namespace llvm {
     /// Tracks the last instruction(s) in this region defining each virtual
     /// register. There may be multiple current definitions for a register with
     /// disjunct lanemasks.
-    VReg2SUnitMultiMap CurrentVRegDefs;
+    VReg2SUnitOperIdxMultiMap CurrentVRegDefs;
     /// Tracks the last instructions in this region using each virtual register.
     VReg2SUnitOperIdxMultiMap CurrentVRegUses;
 

--- a/llvm/lib/CodeGen/ScheduleDAGInstrs.cpp
+++ b/llvm/lib/CodeGen/ScheduleDAGInstrs.cpp
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// Modifications (c) Copyright 2023-2024 Advanced Micro Devices, Inc. or its
+// Modifications (c) Copyright 2023-2026 Advanced Micro Devices, Inc. or its
 // affiliates
 //
 //===----------------------------------------------------------------------===//
@@ -491,8 +491,8 @@ void ScheduleDAGInstrs::addVRegDefDeps(SUnit *SU, unsigned OperIdx) {
   // are not eliminated sometime during scheduling. The output dependence edge
   // is also useful if output latency exceeds def-use latency.
   LaneBitmask LaneMask = DefLaneMask;
-  for (VReg2SUnit &V2SU : make_range(CurrentVRegDefs.find(Reg),
-                                     CurrentVRegDefs.end())) {
+  for (VReg2SUnitOperIdx &V2SU :
+       make_range(CurrentVRegDefs.find(Reg), CurrentVRegDefs.end())) {
     // Ignore defs for other lanes.
     if ((V2SU.LaneMask & LaneMask).none())
       continue;
@@ -512,17 +512,19 @@ void ScheduleDAGInstrs::addVRegDefDeps(SUnit *SU, unsigned OperIdx) {
 
     // Update current definition. This can get tricky if the def was about a
     // bigger lanemask before. We then have to shrink it and create a new
-    // VReg2SUnit for the non-overlapping part.
+    // VReg2SUnitOperIdx for the non-overlapping part.
     LaneBitmask OverlapMask = V2SU.LaneMask & LaneMask;
     LaneBitmask NonOverlapMask = V2SU.LaneMask & ~LaneMask;
     V2SU.SU = SU;
     V2SU.LaneMask = OverlapMask;
+    V2SU.OperandIndex = OperIdx;
     if (NonOverlapMask.any())
-      CurrentVRegDefs.insert(VReg2SUnit(Reg, NonOverlapMask, DefSU));
+      CurrentVRegDefs.insert(
+          VReg2SUnitOperIdx(Reg, NonOverlapMask, V2SU.OperandIndex, DefSU));
   }
   // If there was no CurrentVRegDefs entry for some lanes yet, create one.
   if (LaneMask.any())
-    CurrentVRegDefs.insert(VReg2SUnit(Reg, LaneMask, SU));
+    CurrentVRegDefs.insert(VReg2SUnitOperIdx(Reg, LaneMask, OperIdx, SU));
 }
 
 /// Adds a register data dependency if the instruction that defines the
@@ -544,8 +546,8 @@ void ScheduleDAGInstrs::addVRegUseDeps(SUnit *SU, unsigned OperIdx) {
   CurrentVRegUses.insert(VReg2SUnitOperIdx(Reg, LaneMask, OperIdx, SU));
 
   // Add antidependences to the following defs of the vreg.
-  for (VReg2SUnit &V2SU : make_range(CurrentVRegDefs.find(Reg),
-                                     CurrentVRegDefs.end())) {
+  for (VReg2SUnitOperIdx &V2SU :
+       make_range(CurrentVRegDefs.find(Reg), CurrentVRegDefs.end())) {
     // Ignore defs for unrelated lanes.
     LaneBitmask PrevDefLaneMask = V2SU.LaneMask;
     if ((PrevDefLaneMask & LaneMask).none())
@@ -554,7 +556,7 @@ void ScheduleDAGInstrs::addVRegUseDeps(SUnit *SU, unsigned OperIdx) {
       continue;
 
     SDep Dep(SU, SDep::Anti, Reg);
-    V2SU.SU->addPred(Dep);
+    adjustAndAddPred(V2SU.SU, Dep, OperIdx, V2SU.OperandIndex, &SchedModel);
   }
 }
 

--- a/llvm/lib/Target/AIE/AIEInterBlockScheduling.cpp
+++ b/llvm/lib/Target/AIE/AIEInterBlockScheduling.cpp
@@ -375,7 +375,9 @@ bool InterBlockScheduling::leaveBlock() {
   // After scheduling a basic block, check convergence to determine which block
   // to schedule next and with what parameters
   auto &BS = *CurrentBlockState;
-  switch (updateFixPoint(BS)) {
+  const auto Stage = updateFixPoint(BS);
+  BS.FixPoint.Stage = Stage;
+  switch (Stage) {
   case SchedulingStage::GatheringRegions:
   case SchedulingStage::SchedulingNotConverged:
   case SchedulingStage::Scheduling:
@@ -516,7 +518,7 @@ MachineInstr *InterBlockScheduling::latencyConverged(BlockState &BS) const {
 
 SchedulingStage InterBlockScheduling::updateFixPoint(BlockState &BS) {
   if (BS.Kind != BlockType::Loop) {
-    return BS.FixPoint.Stage = SchedulingStage::SchedulingDone;
+    return SchedulingStage::SchedulingDone;
   }
 
   if (BS.FixPoint.Stage == SchedulingStage::GatheringRegions) {
@@ -525,7 +527,7 @@ SchedulingStage InterBlockScheduling::updateFixPoint(BlockState &BS) {
     // Now we can create the interblock edges between the top and the bottom
     // region
     BS.initInterBlock(*Context, *HR);
-    return BS.FixPoint.Stage = SchedulingStage::Scheduling;
+    return SchedulingStage::Scheduling;
   }
 
   BS.FixPoint.NumIters++;
@@ -540,7 +542,8 @@ SchedulingStage InterBlockScheduling::updateScheduling(BlockState &BS) {
   if (BS.FixPoint.NumIters >
       MaxExpensiveIterations + 2 * HR->getConflictHorizon()) {
     report_fatal_error("Inter-block scheduling did not converge.");
-    return BS.FixPoint.Stage = SchedulingStage::SchedulingNotConverged;
+
+    return SchedulingStage::SchedulingNotConverged;
   }
 
   if (MachineInstr *MINeedsHigherCap = latencyConverged(BS)) {
@@ -557,7 +560,7 @@ SchedulingStage InterBlockScheduling::updateScheduling(BlockState &BS) {
                            << " LM=" << BS.FixPoint.LatencyMargin
                            << " MIM=" << Res.first->second << "\n");
     // Iterate on CurMBB
-    return BS.FixPoint.Stage = SchedulingStage::Scheduling;
+    return SchedulingStage::Scheduling;
   }
 
   // Before pushing BS.getBottom() instructions up to avoid resource hazards,
@@ -574,7 +577,7 @@ SchedulingStage InterBlockScheduling::updateScheduling(BlockState &BS) {
         DEBUG_LOOPAWARE(dbgs() << "  not converged: resources ExtraDepth="
                                << ExtraDepth << "\n");
         // Iterate on CurMBB
-        return BS.FixPoint.Stage = SchedulingStage::Scheduling;
+        return SchedulingStage::Scheduling;
       }
       DEBUG_LOOPAWARE(dbgs() << "  not converged: Depth biasing failed\n");
     }
@@ -596,7 +599,7 @@ SchedulingStage InterBlockScheduling::updateScheduling(BlockState &BS) {
                            << " LM=" << BS.FixPoint.LatencyMargin
                            << " MIM=" << Res.first->second << "\n");
     // Iterate on CurMBB
-    return BS.FixPoint.Stage = SchedulingStage::Scheduling;
+    return SchedulingStage::Scheduling;
   }
 
   DEBUG_LOOPAWARE(dbgs() << "Converged,"
@@ -611,10 +614,10 @@ SchedulingStage InterBlockScheduling::updateScheduling(BlockState &BS) {
     if (PostSWP.isPostPipelineCandidate(*BS.TheBlock)) {
       BS.FixPoint.II = PostSWP.getResMII(*BS.TheBlock);
       BS.FixPoint.IITries = 1;
-      return BS.FixPoint.Stage = SchedulingStage::Pipelining;
+      return SchedulingStage::Pipelining;
     }
   }
-  return BS.FixPoint.Stage = SchedulingStage::SchedulingDone;
+  return SchedulingStage::SchedulingDone;
 }
 
 SchedulingStage InterBlockScheduling::updatePipelining(BlockState &BS) {
@@ -627,7 +630,7 @@ SchedulingStage InterBlockScheduling::updatePipelining(BlockState &BS) {
   // We cut off at larger IIs to prevent excessive compilation time.
   if (++BS.FixPoint.II <= PostPipelinerMaxII &&
       ++BS.FixPoint.IITries <= PostPipelinerMaxTryII) {
-    return BS.FixPoint.Stage = SchedulingStage::Pipelining;
+    return SchedulingStage::Pipelining;
   }
 
   auto *BB = BS.TheBlock;
@@ -639,9 +642,9 @@ SchedulingStage InterBlockScheduling::updatePipelining(BlockState &BS) {
            << "No schedule found.";
   });
 
-  // Fall back to the loop schedule. Note that we can only have II != 0
+  // Fall back to the loop schedule. Note that we can only enter pipeline mode
   // after the loop schedule has stabilized.
-  return BS.FixPoint.Stage = SchedulingStage::PipeliningFailed;
+  return SchedulingStage::PipeliningFailed;
 }
 
 bool InterBlockScheduling::successorsAreScheduled(

--- a/llvm/lib/Target/AIE/AIEInterBlockScheduling.cpp
+++ b/llvm/lib/Target/AIE/AIEInterBlockScheduling.cpp
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// (c) Copyright 2024-2025 Advanced Micro Devices, Inc. or its affiliates
+// (c) Copyright 2024-2026 Advanced Micro Devices, Inc. or its affiliates
 //
 //===----------------------------------------------------------------------===//
 // Implementations of the classes used to support inter-block scheduling
@@ -66,6 +66,10 @@ static cl::opt<bool> EnableMultiSlotInstrMaterialization(
     "aie-preassign-multi-slot-instr", cl::Hidden, cl::init(true),
     cl::desc("Statically materialize Multi-Slot Pseudo Instructions in "
              "loops."));
+
+static cl::opt<bool>
+    MaterializeAll("aie-materialize-all", cl::Hidden, cl::init(false),
+                   cl::desc("Materialize all Multi-Slot Pseudo Instructions."));
 
 static cl::opt<int> PostPipelinerMaxTryII(
     "aie-postpipeliner-maxtry-ii", cl::init(20),
@@ -1184,8 +1188,9 @@ void BlockState::initInterBlock(const MachineSchedContext &Context,
 
     // perform static assignment of multi-slot pseudos
     if (EnableMultiSlotInstrMaterialization &&
-        PostSWP->isPostPipelineCandidate(*TheBlock))
-      staticallyMaterializeMultiSlotInstructions(*TheBlock, HR);
+        PostSWP->isPostPipelineCandidate(*TheBlock)) {
+      staticallyMaterializeMultiSlotInstructions(*TheBlock, HR, MaterializeAll);
+    }
   }
 
   // We are called just after the first round of scheduling a block.

--- a/llvm/lib/Target/AIE/AIEMaxLatencyFinder.cpp
+++ b/llvm/lib/Target/AIE/AIEMaxLatencyFinder.cpp
@@ -79,12 +79,10 @@ static bool overlap(const MachineOperand &SrcOp, const MachineOperand &DstOp,
                     const TargetRegisterInfo *TRI) {
   Register SrcReg = SrcOp.getReg();
   Register DstReg = DstOp.getReg();
-  for (MCRegAliasIterator Ali(SrcReg, TRI, true); Ali.isValid(); ++Ali) {
-    if (*Ali == DstReg.asMCReg()) {
-      return true;
-    }
-  }
-  return false;
+
+  // Use TRI's regsOverlap which handles both physical and virtual registers,
+  // including subregisters and lane masks
+  return TRI->regsOverlap(SrcReg, DstReg);
 }
 
 /// Check whether Dst depends on Src

--- a/llvm/lib/Target/AIE/AIEMultiSlotInstrMaterializer.cpp
+++ b/llvm/lib/Target/AIE/AIEMultiSlotInstrMaterializer.cpp
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// (c) Copyright 2025 Advanced Micro Devices, Inc. or its affiliates
+// (c) Copyright 2025-2026 Advanced Micro Devices, Inc. or its affiliates
 //
 //===----------------------------------------------------------------------===//
 //
@@ -15,6 +15,10 @@
 
 #include "AIEMultiSlotInstrMaterializer.h"
 #include "AIEHazardRecognizer.h"
+#include "AIESlotStatistics.h"
+#include "llvm/CodeGen/MachineBasicBlock.h"
+#include "llvm/CodeGen/MachineInstr.h"
+#include "llvm/Support/ErrorHandling.h"
 
 using namespace llvm;
 
@@ -24,6 +28,7 @@ static cl::opt<bool> SkipSingleSlotAssignment(
     "aie-skip-single-slot-assignment", cl::Hidden, cl::init(true),
     cl::desc("Skip preassigning if all multi-slot instr are assigned to the "
              "same Slot."));
+
 namespace llvm::AIE {
 
 class SlotMapping {
@@ -189,6 +194,84 @@ bool assignSlots(SlotMapping &SlotToBanks, const MachineBasicBlock &MBB,
   return true;
 }
 
+namespace {
+void materializeMSP(MachineInstr *MSP, SlotStatistics &Statistics,
+                    const AIEBaseInstrInfo *TII) {
+
+  SlotCounts Counts = Statistics.MSPSlotCounts[MSP];
+
+  // 0. If we can't materialize in a given slot, we are worse
+  // 1. If Fixed is smaller than an alternative, we won't be increasing the
+  //    slot requirements
+  // 2. If Free is smaller than an alternative, we lower the probability that
+  //    we force another MSP past the current maximum.
+  auto Better = [&Statistics, &Counts](int A, int B) {
+    if (!Counts.at(A)) {
+      return false;
+    }
+    if (!Counts.at(B)) {
+      return true;
+    }
+    if (Statistics.Fixed.at(A) == Statistics.Fixed.at(B)) {
+      return Statistics.Free.at(A) < Statistics.Free.at(B);
+    }
+    return Statistics.Fixed.at(A) < Statistics.Fixed.at(B);
+  };
+  int BestSlot = 0;
+  for (int S = 1; S < Counts.size(); S++) {
+    if (Better(S, BestSlot)) {
+      BestSlot = S;
+    }
+  }
+  // We should always find an alternative, even if it's not perfect.
+  assert(Counts.at(BestSlot));
+  // Reverse lookup of the alternative that matches BestSlot.
+  auto FindOpcode = [TII, Opcode = MSP->getOpcode()](int BestSlot) {
+    const AIEBaseMCFormats *Formats = TII->getFormatInterface();
+    auto *Alternatives = Formats->getAlternateInstsOpcode(Opcode);
+    for (auto Opcode : *Alternatives) {
+      if (Formats->getSlotKind(Opcode) == MCSlotKind(BestSlot)) {
+        return Opcode;
+      }
+    }
+    llvm_unreachable("BestSlot alternative not found");
+  };
+
+  LLVM_DEBUG(dbgs() << "Materializing " << *MSP);
+
+  // Materialize MSP
+  MSP->setDesc(TII->get(FindOpcode(BestSlot)));
+  // Update statistics
+  Statistics.Fixed[BestSlot] += SlotStatistics::Unit;
+  Statistics.Free -= Counts;
+  LLVM_DEBUG(dbgs() << "           to " << *MSP);
+  LLVM_DEBUG(dbgs() << "New Fixed:\n" << Statistics.Fixed << "\n");
+}
+
+void materializeToMinimizeSlotTotals(MachineBasicBlock &MBB,
+                                     const AIEBaseInstrInfo *TII) {
+  SlotStatistics Statistics = computeSlotStatistics(MBB, TII);
+  // Sort the list by increasing alternative count
+  llvm::sort(Statistics.MSPs, [Formats = TII->getFormatInterface()](
+                                  MachineInstr *A, MachineInstr *B) {
+    auto *AltA = Formats->getAlternateInstsOpcode(A->getOpcode());
+    auto *AltB = Formats->getAlternateInstsOpcode(B->getOpcode());
+
+    return AltA->size() < AltB->size();
+  });
+  LLVM_DEBUG(dbgs() << "Statistics:\n");
+  LLVM_DEBUG(Statistics.dump());
+  LLVM_DEBUG(dbgs() << "----\n");
+
+  // This is still pretty greedy. Just materialize each instruction
+  // based on the current total slotcounts.
+  for (auto *MSP : Statistics.MSPs) {
+    materializeMSP(MSP, Statistics, TII);
+  }
+}
+
+} // namespace
+
 /// Materialise \p MI into its slot assigned by \p SlotToBanks .
 void materializeInstr(MachineInstr &MI, const SlotMapping &SlotToBanks,
                       const AIEBaseInstrInfo *TII,
@@ -223,7 +306,8 @@ void materializeSlots(const SlotMapping &SlotToBanks, MachineBasicBlock &MBB,
 }
 
 void staticallyMaterializeMultiSlotInstructions(MachineBasicBlock &MBB,
-                                                const AIEHazardRecognizer &HR) {
+                                                const AIEHazardRecognizer &HR,
+                                                bool MaterializeAll) {
   LLVM_DEBUG(dbgs() << "Statically Assigning multi slot pseudos for "
                     << MBB.getName() << "\n");
 
@@ -232,14 +316,17 @@ void staticallyMaterializeMultiSlotInstructions(MachineBasicBlock &MBB,
 
   auto SlotToBanks = getAssignedSlots(MBB, TII, HR);
 
-  if (!assignSlots(SlotToBanks, MBB, TII, HR)) {
+  if (assignSlots(SlotToBanks, MBB, TII, HR)) {
+    materializeSlots(SlotToBanks, MBB, TII, HR);
+  } else {
     LLVM_DEBUG(
         dbgs()
-        << "Could not find Slot Assignments, Skipping materialization\n");
-    return;
+        << "Could not find slot assignments, skipping bank materialization\n");
   }
 
-  materializeSlots(SlotToBanks, MBB, TII, HR);
+  if (MaterializeAll) {
+    materializeToMinimizeSlotTotals(MBB, TII);
+  }
 }
 } // namespace llvm::AIE
 //

--- a/llvm/lib/Target/AIE/AIEMultiSlotInstrMaterializer.h
+++ b/llvm/lib/Target/AIE/AIEMultiSlotInstrMaterializer.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// (c) Copyright 2025 Advanced Micro Devices, Inc. or its affiliates
+// (c) Copyright 2025-2026 Advanced Micro Devices, Inc. or its affiliates
 //
 //===----------------------------------------------------------------------===//
 //
@@ -12,11 +12,11 @@
 // block loop to help loop pipelining.
 //
 //===----------------------------------------------------------------------===//
-#include "AIEBaseInstrInfo.h"
 
 namespace llvm {
 class AIEHazardRecognizer;
-}
+class MachineBasicBlock;
+} // namespace llvm
 
 namespace llvm::AIE {
 
@@ -24,6 +24,7 @@ namespace llvm::AIE {
 /// \p MBB .
 /// FIXME: Currently we are only handling multi-slot memory load pseudos.
 void staticallyMaterializeMultiSlotInstructions(MachineBasicBlock &MBB,
-                                                const AIEHazardRecognizer &HR);
+                                                const AIEHazardRecognizer &HR,
+                                                bool MaterializeAll = false);
 
 } // namespace llvm::AIE

--- a/llvm/lib/Target/AIE/AIEPostPipeliner.cpp
+++ b/llvm/lib/Target/AIE/AIEPostPipeliner.cpp
@@ -562,6 +562,7 @@ namespace {
 
 void dumpGraph(const ScheduleInfo &Info, ScheduleDAGInstrs *DAG) {
   dbgs() << "digraph {\n";
+  const auto *TRI = DAG->MF.getSubtarget().getRegisterInfo();
 
   // Prescan backedge destinations and declare them to have a different shape.
   for (int K = 0; K < Info.NInstr; K++) {
@@ -590,7 +591,23 @@ void dumpGraph(const ScheduleInfo &Info, ScheduleDAGInstrs *DAG) {
       if (S >= Info.NInstr) {
         dbgs() << "_" << S % Info.NInstr;
       }
-      dbgs() << " [ label=\"" << Dep.getSignedLatency() << "\"";
+      dbgs() << " [ label=\"" << Dep.getSignedLatency();
+      switch (Dep.getKind()) {
+      case SDep::Data:
+      case SDep::Output:
+      case SDep::Anti: {
+        const Register Reg = Dep.getReg();
+        if (Reg.isPhysical()) {
+          dbgs() << format(" %s ", TRI->getName(Reg));
+        } else {
+          dbgs() << format(" VR%d ", Register::virtReg2Index(Reg));
+        }
+        break;
+      }
+      case SDep::Order:
+        break;
+      }
+      dbgs() << "\"";
       switch (Dep.getKind()) {
       case SDep::Data:
         dbgs() << " color=red ";

--- a/llvm/lib/Target/AIE/AIEPostPipeliner.cpp
+++ b/llvm/lib/Target/AIE/AIEPostPipeliner.cpp
@@ -48,6 +48,27 @@ static cl::opt<int> PresetII("aie-postpipeliner-target-ii",
 
 PipelineScheduleVisitor::~PipelineScheduleVisitor() {}
 
+std::optional<int> PostPipelinerStrategy::fitInInterval(
+    MachineInstr &MI, int First, int Last, int II,
+    const AIEHazardRecognizer &HR,
+    ResourceScoreboard<FuncUnitWrapper> &Scoreboard) {
+  assert(First <= Last);
+  const int Step = fromTop() ? 1 : -1;
+  if (Step < 0) {
+    std::swap(First, Last);
+  }
+
+  const int Limit = Last + Step;
+  for (int C = First; C != Limit; C += Step) {
+    const int Mod = C % II;
+    if (!HR.checkConflict(Scoreboard, MI, Mod)) {
+      return C;
+    }
+  }
+
+  return std::nullopt;
+}
+
 class PostPipelineDumper : public PipelineScheduleVisitor {
 public:
   PostPipelineDumper() : PipelineScheduleVisitor() {}
@@ -231,25 +252,6 @@ void PostPipeliner::scheduleNode(SUnit &SU, int Cycle,
   if (Next < int(Info.Nodes.size())) {
     Info[Next].Earliest = std::max(Info[Next].Earliest, Cycle + II);
   }
-}
-
-// Check resources. We only insert at the position modulo II. Since we insert
-// all iterations separately, the resources that wrap around accumulate in the
-// overflow area, causing conflicts when inserting future iterations
-int PostPipeliner::fit(MachineInstr *MI, int First, int Last, int II) {
-  const int Step = First > Last ? -1 : 1;
-  LLVM_DEBUG(dbgs() << "   " << First << ", " << Last << ", " << Step << "\n");
-  for (int C = First; C != Last; C += Step) {
-    int Mod = C % II;
-    LLVM_DEBUG(dbgs() << "   at " << C << " (" << Mod << ")\n");
-    if (!HR.checkConflict(Scoreboard, *MI, Mod)) {
-      LLVM_DEBUG(dbgs() << "    Success\n");
-      return C;
-    }
-  }
-  LLVM_DEBUG(dbgs() << "    Fail\n");
-
-  return -1;
 }
 
 // Account for predecessor that require the same resources by pushing Earliest
@@ -747,20 +749,20 @@ bool PostPipeliner::scheduleFirstIteration(PostPipelinerStrategy &Strategy) {
   const int PipelineDepth = HR.getPipelineDepth();
   for (int K = 0; K < NInstr; K++) {
     const int N = mostUrgent(Strategy);
-    LLVM_DEBUG(dbgs() << "  Trying " << N << "\n");
     SUnit &SU = DAG->SUnits[N];
-    MachineInstr *MI = SU.getInstr();
+    MachineInstr *const MI = SU.getInstr();
     const int Earliest = Strategy.earliest(SU);
     const int Latest = Strategy.latest(SU);
+    LLVM_DEBUG(
+        dbgs() << format("  Trying %d in [%d, %d]\n", N, Earliest, Latest));
     if (Earliest > Latest) {
-      LLVM_DEBUG(dbgs() << "Latency violation at node " << N << " interval=["
-                        << Earliest << ", " << Latest << "]\n");
+      LLVM_DEBUG(dbgs() << "  Latency violation.\n");
       return false;
     }
 
-    const int Actual = Strategy.fromTop() ? fit(MI, Earliest, Latest + 1, II)
-                                          : fit(MI, Latest, Earliest - 1, II);
-    if (Actual < 0) {
+    auto OptCycle =
+        Strategy.fitInInterval(*MI, Earliest, Latest, II, HR, Scoreboard);
+    if (!OptCycle) {
       LLVM_DEBUG(dbgs() << "Out of resources\n");
 
       // The node might have been given too tight Earliest/Latest attributes.
@@ -769,6 +771,7 @@ bool PostPipeliner::scheduleFirstIteration(PostPipelinerStrategy &Strategy) {
       Info[N].TweakedLatest = {};
       return false;
     }
+    const int Actual = *OptCycle;
     Strategy.selected(SU);
     const int ModCycle = Actual % II;
     const MemoryBankBits MemoryBanks = HR.getMemoryBanks(MI);

--- a/llvm/lib/Target/AIE/AIEPostPipeliner.cpp
+++ b/llvm/lib/Target/AIE/AIEPostPipeliner.cpp
@@ -420,6 +420,7 @@ std::optional<int> computeHeight(HCache &Heights, SUnit *Start, SUnit *End) {
 // caching the height to Src.
 
 void PostPipeliner::computeRecMII() {
+  RecMII = 0;
   for (int K = 0; K < NInstr; K++) {
     SUnit &Src = DAG->SUnits[K];
     for (auto &Dep : Src.Succs) {

--- a/llvm/lib/Target/AIE/AIEPostPipeliner.h
+++ b/llvm/lib/Target/AIE/AIEPostPipeliner.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// (c) Copyright 2024-2025 Advanced Micro Devices, Inc. or its affiliates
+// (c) Copyright 2024-2026 Advanced Micro Devices, Inc. or its affiliates
 //
 //===----------------------------------------------------------------------===//
 // This file contains a simple post-RA pipeliner. It tries to wrap the linear
@@ -182,6 +182,15 @@ public:
   // Report a final selection. This marks the start of selecting a new node.
   // fromTop() should be invariant between calls to selected()
   virtual void selected(const SUnit &N) {};
+
+  // Decide a cycle in [Earliest, Latest] to insert MI, based on resource
+  // hazards. Returns the chosen cycle on success, or an empty optional if none
+  // fits. The default implementation uses fromTop() to determine scan
+  // direction.
+  virtual std::optional<int>
+  fitInInterval(MachineInstr &MI, int Earliest, int Latest, int II,
+                const AIEHazardRecognizer &HR,
+                ResourceScoreboard<FuncUnitWrapper> &Scoreboard);
 };
 
 class PipelineScheduleVisitor {
@@ -256,11 +265,6 @@ class PostPipeliner {
   /// stage count against MinIterCount and the number of copies in the DAG.
   /// Returns true if these checks indicate that the schedule can be implmented.
   bool checkStages();
-
-  // return the first Cycle: Earliest <= Cycle < Earliest+NTries where MI fits
-  // in the scoreboard, -1 if it doesn't fit. The insertion point is taken
-  // modulo II.
-  int fit(MachineInstr *MI, int Earliest, int NTries, int II);
 
   /// Provide some look ahead by seeing the effect of the first iteration
   /// on the second iteration. May return false if the II isn't feasible.

--- a/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/add-store.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/add-store.mir
@@ -3,10 +3,10 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2025 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2025-2026 Advanced Micro Devices, Inc. or its affiliates
 
 # RUN: llc --mtriple=aie2 -O2 --start-before=postmisched %s \
-# RUN:     --debug-only=postpipeliner-summary -o - | FileCheck %s
+# RUN:     -o - | FileCheck %s
 
 # add-store can run in a two-stage II=1 pipeline
 

--- a/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/conv2d.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/conv2d.mir
@@ -4,11 +4,11 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2024-2026 Advanced Micro Devices, Inc. or its affiliates
 
 
 # RUN: llc -O2 --mtriple=aie2 --start-before=postmisched  %s \
-# RUN:  --debug-only=postpipeliner-summary -o - 2>&1 | FileCheck %s
+# RUN:  -o - 2>&1 | FileCheck %s
 
 --- |
   define dso_local void @conv2d.loop.nest(ptr %add.ptr6.i51, ptr %add.ptr5, ptr %cond, ptr %cond.i50, <16 x i32> %0, i32 %cond67.i79, i20 %idx.ext.i.i81, i20 %idx.ext.i404.i, i20 %idx.ext.i410.i, i20 %idx.ext.i434.i85, i32 %1, i20 %2, i20 %3, i20 %4, i20 %5, i20 %6, i32 %7, i32 %8, i32 %or9.i.i.i.i.i96, i32 %9, i20 %idx.ext.i422.i82, i20 %10, i20 %11, i20 %12, i20 %13, i20 %14, i20 %15, i20 %16, i20 %17, i20 %18, i20 %19, i20 %20, i20 %21, i20 %22, i20 %23, i32 %conv192.i107, i20 %24, i20 %idx.ext.i428.i, i20 %25, i20 %26, i20 %27, i32 %28) #0 {

--- a/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/conv2d_bf16-1.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/conv2d_bf16-1.mir
@@ -3,10 +3,10 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2024-2026 Advanced Micro Devices, Inc. or its affiliates
 
 # RUN: llc --mtriple=aie2 -O2 --start-before=postmisched %s \
-# RUN:   --debug-only=postpipeliner-summary -o - | FileCheck %s
+# RUN:   -o - | FileCheck %s
 
 
 # derived from conv2d_bf16_0

--- a/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/conv2d_bf16-2.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/conv2d_bf16-2.mir
@@ -3,10 +3,10 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2025 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2025-2026 Advanced Micro Devices, Inc. or its affiliates
 
 # RUN: llc --mtriple=aie2 -O2 --start-before=postmisched %s \
-# RUN:   --debug-only=postpipeliner-summary -o - | FileCheck %s
+# RUN:   -o - | FileCheck %s
 
 
 # derived from conv2d_bf16_0

--- a/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/conv2d_bf16-feasibleRA.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/conv2d_bf16-feasibleRA.mir
@@ -3,10 +3,10 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2025 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2025-2026 Advanced Micro Devices, Inc. or its affiliates
 
 # RUN: llc --mtriple=aie2 -O2 --start-before=postmisched %s \
-# RUN:   --debug-only=postpipeliner-summary -o - | FileCheck %s
+# RUN:   -o - | FileCheck %s
 
 
 # derived from conv2d_bf16_0

--- a/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/conv2d_bf16.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/conv2d_bf16.mir
@@ -3,10 +3,10 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2024-2026 Advanced Micro Devices, Inc. or its affiliates
 
 # RUN: llc --mtriple=aie2 -O2 --start-before=postmisched %s \
-# RUN:   --debug-only=postpipeliner-summary -o - | FileCheck %s
+# RUN:   -o - | FileCheck %s
 
 
 # derived from conv2d_bf16_0

--- a/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/gemm-feasibleRA-nopstinc.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/gemm-feasibleRA-nopstinc.mir
@@ -4,10 +4,10 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2024-2026 Advanced Micro Devices, Inc. or its affiliates
 
 # RUN: llc --mtriple=aie2 -O2 --start-before=postmisched %s \
-# RUN:   --debug-only=postpipeliner,postpipeliner-summary -o - | FileCheck %s
+# RUN:   -o - | FileCheck %s
 
 
 # derived from gemm_bf16_0

--- a/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/gemm-feasibleRA.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/gemm-feasibleRA.mir
@@ -3,10 +3,10 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2024-2026 Advanced Micro Devices, Inc. or its affiliates
 
 # RUN: llc --mtriple=aie2 -O2 --start-before=postmisched %s \
-# RUN:   --debug-only=postpipeliner,postpipeliner-summary -o - | FileCheck %s
+# RUN:   -o - | FileCheck %s
 
 
 # derived from gemm_bf16_0

--- a/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/gemm-nopresched-nobanks.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/gemm-nopresched-nobanks.mir
@@ -3,10 +3,10 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2024-2026 Advanced Micro Devices, Inc. or its affiliates
 
 # RUN: llc --mtriple=aie2 -O2 --start-before=postmisched %s \
-# RUN:   --debug-only=postpipeliner-summary -o - | FileCheck %s
+# RUN:   -o - | FileCheck %s
 
 
 # derived from gemm_bf16_0

--- a/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/gemm-nopresched.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/gemm-nopresched.mir
@@ -6,7 +6,7 @@
 # (c) Copyright 2024-2026 Advanced Micro Devices, Inc. or its affiliates
 
 # RUN: llc --mtriple=aie2 -O2 --start-before=postmisched %s \
-# RUN:   --debug-only=postpipeliner-summary -o - | FileCheck %s
+# RUN:   -o - | FileCheck %s
 
 
 # derived from gemm_bf16_0

--- a/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/gemm-nopresched.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/gemm-nopresched.mir
@@ -3,7 +3,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2024-2026 Advanced Micro Devices, Inc. or its affiliates
 
 # RUN: llc --mtriple=aie2 -O2 --start-before=postmisched %s \
 # RUN:   --debug-only=postpipeliner-summary -o - | FileCheck %s
@@ -60,9 +60,9 @@
   ; CHECK-NEXT:    vshuffle x6, x8, x0, r3; vmac.f bml6, bml6, x10, x7, r2
   ; CHECK-NEXT:    vshuffle x2, x8, x0, r16; vmac.f bml5, bml5, x9, x7, r2
   ; CHECK-NEXT:  .L_LEnd0:
-  ; CHECK-NEXT:    vshuffle x10, x1, x3, r3; vmac.f bmh4, bmh4, x6, x5, r2
+  ; CHECK-NEXT:    nopb ; nopa ; nops ; nopx ; vshuffle x10, x1, x3, r3; vmac.f bmh4, bmh4, x6, x5, r2
   ; CHECK-NEXT:  // %bb.3: // %for.cond.cleanup
-  ; CHECK-NEXT:    vshuffle x9, x1, x3, r16; vmac.f bmh5, bmh5, x2, x5, r2
+  ; CHECK-NEXT:    nopb ; nopa ; nops ; nopx ; vshuffle x9, x1, x3, r16; vmac.f bmh5, bmh5, x2, x5, r2
   ; CHECK-NEXT:    vshuffle x3, x11, x11, r6; vmac.f bmh6, bmh6, x10, x5, r2
   ; CHECK-NEXT:    vshuffle x0, x0, x0, r6; vmac.f bmh7, bmh7, x9, x5, r2
   ; CHECK-NEXT:    vshuffle x7, x7, x7, r6; vmac.f bmh0, bmh0, x6, x3, r2

--- a/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/round.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/round.mir
@@ -3,9 +3,9 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2024-2026 Advanced Micro Devices, Inc. or its affiliates
 
-# RUN: llc --mtriple=aie2 -O2 --start-before=postmisched %s -o - --debug-only=postpipeliner-summary | FileCheck %s
+# RUN: llc --mtriple=aie2 -O2 --start-before=postmisched %s -o - | FileCheck %s
 
 # Inspired by Round
 # Currently we don't get this post-pipelined, because the RecMII is

--- a/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/unpack-extract-block-cycles.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/unpack-extract-block-cycles.mir
@@ -3,10 +3,10 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2025 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2025-2026 Advanced Micro Devices, Inc. or its affiliates
 
 # RUN: llc --mtriple=aie2 -O2 --start-before=postmisched %s \
-# RUN:     --debug-only=postpipeliner-summary -o - 2>&1 | FileCheck %s
+# RUN:     -o - 2>&1 | FileCheck %s
 
 # The goal of this test is to verify that we are blocking the first cycles in the
 # top scoreboard when we don't have enough guaranteed context in the SWP loop

--- a/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/unpack-extract-war.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/unpack-extract-war.mir
@@ -3,10 +3,10 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2025 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2025-2026 Advanced Micro Devices, Inc. or its affiliates
 
 # RUN: llc --mtriple=aie2 -O2 --start-before=postmisched %s \
-# RUN:     --debug-only=postpipeliner-summary -o - 2>&1 | FileCheck %s
+# RUN:     -o - 2>&1 | FileCheck %s
 
 # The goal of this test is to verify that we are respecting WAR dependencies between a pipelined
 # loop and its epilogue. VUNPACK_D16_D8 in the loop is a late reader of its input, so VMOV_mv_w (epilogue)

--- a/llvm/test/CodeGen/AIE/aie2p/elongate/zol_phdr_loopbundles_112bytes.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/elongate/zol_phdr_loopbundles_112bytes.mir
@@ -3,7 +3,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2025 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2025-2026 Advanced Micro Devices, Inc. or its affiliates
 
 # RUN: llc --mtriple=aie2p --start-before=postmisched %s -o - | FileCheck %s
 
@@ -43,9 +43,9 @@
   ; CHECK-NEXT:    vldb x0, [p0], #64; add r0, r0, #-1; vadd.16 x6, x4, x1
   ; CHECK-NEXT:    vldb x2, [p0], #64; vadd.16 x4, x6, x0
   ; CHECK-NEXT:  .L_LEnd0:
-  ; CHECK-NEXT:    vldb x1, [p0], #128
+  ; CHECK-NEXT:    nopa ; vldb x1, [p0], #128; nops ; nopxm ; nopv
   ; CHECK-NEXT:  // %bb.2: // %for.cond.cleanup
-  ; CHECK-NEXT:    vadd.16 x6, x4, x1
+  ; CHECK-NEXT:    nops ; vadd.16 x6, x4, x1
   ; CHECK-NEXT:    vadd.16 x4, x6, x0
   ; CHECK-NEXT:    nop
   ; CHECK-NEXT:    vadd.16 x6, x4, x1

--- a/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/Conv2D_bfp16_conv.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/Conv2D_bfp16_conv.mir
@@ -3,12 +3,12 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2025 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2025-2026 Advanced Micro Devices, Inc. or its affiliates
 
 # RUN: llc --mtriple=aie2p --aie-loop-min-tripcount=4 --aie-addrspace-none-is-safe=0 %s \
-# RUN:   --start-before=postmisched --debug-only=postpipeliner-summary -o - | FileCheck %s --check-prefix=CONSERVATIVE
+# RUN:   --start-before=postmisched -o - | FileCheck %s --check-prefix=CONSERVATIVE
 # RUN: llc --mtriple=aie2p --aie-loop-min-tripcount=4 --aie-addrspace-none-is-safe=1 %s \
-# RUN:   --start-before=postmisched --debug-only=postpipeliner-summary -o - | FileCheck %s --check-prefix=OPTIMISTIC
+# RUN:   --start-before=postmisched -o - | FileCheck %s --check-prefix=OPTIMISTIC
 
 
 --- |

--- a/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/Conv2D_bfp16_kernel_fixedslot.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/Conv2D_bfp16_kernel_fixedslot.mir
@@ -3,10 +3,10 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2025 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2025-2026 Advanced Micro Devices, Inc. or its affiliates
 
 # RUN: llc --mtriple=aie2p --aie-loop-min-tripcount=7 %s \
-# RUN:   --start-before=postmisched --debug-only=postpipeliner-summary -o - | FileCheck %s
+# RUN:   --start-before=postmisched -o - | FileCheck %s
 
 
 --- |

--- a/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/Conv2D_bfp16_kernel_multislot.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/Conv2D_bfp16_kernel_multislot.mir
@@ -3,10 +3,10 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2025 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2025-2026 Advanced Micro Devices, Inc. or its affiliates
 
 # RUN: llc --mtriple=aie2p --aie-loop-min-tripcount=7 %s \
-# RUN:   --start-before=postmisched --debug-only=postpipeliner-summary --aie-preassign-multi-slot-instr=true -o - | FileCheck %s
+# RUN:   --start-before=postmisched --aie-preassign-multi-slot-instr=true -o - | FileCheck %s
 
 
 --- |

--- a/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/gemm-bfp16-v10.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/gemm-bfp16-v10.mir
@@ -3,11 +3,11 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2025 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2025-2026 Advanced Micro Devices, Inc. or its affiliates
 
 # RUN: llc -verify-machineinstrs --mtriple=aie2p -O2 \
 # RUN:   --start-before=postmisched %s \
-# RUN:   --debug-only=postpipeliner-summary -o - | FileCheck %s
+# RUN:   -o - | FileCheck %s
 
 
 # derived from GEMM_Bfp16_opt_0

--- a/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/gemm-bfp16-v2.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/gemm-bfp16-v2.mir
@@ -3,11 +3,11 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2025 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2025-2026 Advanced Micro Devices, Inc. or its affiliates
 
 # RUN: llc -verify-machineinstrs --mtriple=aie2p -O2 \
 # RUN:   --start-before=postmisched %s \
-# RUN:   --debug-only=postpipeliner-summary -o - | FileCheck %s
+# RUN:   -o - | FileCheck %s
 
 
 # derived from GEMM_Bfp16_opt_0

--- a/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/gemm-bfp16-v3.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/gemm-bfp16-v3.mir
@@ -3,11 +3,11 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2025 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2025-2026 Advanced Micro Devices, Inc. or its affiliates
 
 # RUN: llc -verify-machineinstrs --mtriple=aie2p -O2 \
 # RUN:   --start-before=postmisched %s \
-# RUN:   --debug-only=postpipeliner-summary -o - | FileCheck %s
+# RUN:   -o - | FileCheck %s
 
 
 # derived from GEMM_Bfp16_opt_0

--- a/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/gemm-bfp16-v4.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/gemm-bfp16-v4.mir
@@ -3,11 +3,11 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2025 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2025-2026 Advanced Micro Devices, Inc. or its affiliates
 
 # RUN: llc -verify-machineinstrs --mtriple=aie2p -O2 \
 # RUN:   --start-before=postmisched %s \
-# RUN:   --debug-only=postpipeliner-summary -o - | FileCheck %s
+# RUN:   -o - | FileCheck %s
 
 
 # derived from GEMM_Bfp16_opt_0

--- a/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/gemm-bfp16-v6.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/gemm-bfp16-v6.mir
@@ -3,10 +3,10 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2025 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2025-2026 Advanced Micro Devices, Inc. or its affiliates
 
 # RUN: llc --mtriple=aie2p -O2 --start-before=postmisched %s \
-# RUN:   --debug-only=postpipeliner-summary -o - | FileCheck %s
+# RUN:   -o - | FileCheck %s
 
 
 # derived from GEMM_Bfp16_opt_0

--- a/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/gemm-bfp16-v7.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/gemm-bfp16-v7.mir
@@ -3,12 +3,12 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2025 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2025-2026 Advanced Micro Devices, Inc. or its affiliates
 
 # RUN: llc -verify-machineinstrs --mtriple=aie2p -O2 \
 # RUN:   --aie-addrspace-none-is-safe=1	\
 # RUN:   --start-before=postmisched %s \
-# RUN:   --debug-only=postpipeliner-summary -o - | FileCheck %s
+# RUN:   -o - | FileCheck %s
 
 
 # derived from GEMM_Bfp16_opt_0

--- a/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/gemm-bfp16-v8.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/gemm-bfp16-v8.mir
@@ -3,12 +3,12 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2025 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2025-2026 Advanced Micro Devices, Inc. or its affiliates
 
 # RUN: llc -verify-machineinstrs --mtriple=aie2p -O2 \
 # RUN:   --start-before=postmisched %s \
 # RUN:   --aie-addrspace-none-is-safe=1	\
-# RUN:   --debug-only=postpipeliner-summary -o - | FileCheck %s
+# RUN:   -o - | FileCheck %s
 
 
 # derived from GEMM_Bfp16_opt_0

--- a/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/gemm-bfp16-v9.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/gemm-bfp16-v9.mir
@@ -3,11 +3,11 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2025 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2025-2026 Advanced Micro Devices, Inc. or its affiliates
 
 # RUN: llc -verify-machineinstrs --mtriple=aie2p -O2 \
 # RUN:   --start-before=postmisched %s \
-# RUN:   --debug-only=postpipeliner-summary -o - | FileCheck %s
+# RUN:   -o - | FileCheck %s
 
 
 # derived from GEMM_Bfp16_opt_0

--- a/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/gemm-bfp16.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/gemm-bfp16.mir
@@ -3,11 +3,11 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2025 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2025-2026 Advanced Micro Devices, Inc. or its affiliates
 
 # RUN: llc -verify-machineinstrs --mtriple=aie2p -O2 \
 # RUN:   --start-before=postmisched %s \
-# RUN:   --debug-only=postpipeliner,postpipeliner-summary -o - | FileCheck %s
+# RUN:   -o - | FileCheck %s
 
 
 # derived from GEMM_Bfp16_opt_0

--- a/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/scale.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/scale.mir
@@ -3,11 +3,11 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2025 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2025-2026 Advanced Micro Devices, Inc. or its affiliates
 
 # RUN: llc -verify-machineinstrs --mtriple=aie2p %s \
 # RUN:     --start-before=postmisched \
-# RUN:     --debug-only=postpipeliner-summary -o - | FileCheck %s
+# RUN:     -o - | FileCheck %s
 
 # This should pipeline into NS=14 * II=1
 

--- a/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/speculative-first-stage.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/speculative-first-stage.mir
@@ -3,11 +3,11 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2025 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2025-2026 Advanced Micro Devices, Inc. or its affiliates
 
 # RUN: llc -verify-machineinstrs --mtriple=aie2p %s \
 # RUN:     --start-before=postmisched \
-# RUN:     --debug-only=postpipeliner-summary -o - | FileCheck %s
+# RUN:     -o - | FileCheck %s
 
 # This is a simple example of a speculative stage. The first stage gets a load,
 # which is side-effect free. It can run in NS=4 * II=3


### PR DESCRIPTION
A bunch of commits with small generalizations.
In particular, the relax assumptions about absence of physical registers in post scheduler logic, which is essential for postregalloc.