### PR TITLE
[AIEX] Shared post-legalizer custom combines list

### DIFF
--- a/llvm/lib/Target/AIE/AIECombine.td
+++ b/llvm/lib/Target/AIE/AIECombine.td
@@ -429,33 +429,36 @@ def combine_global_load_store_increment : GICombineRule <
 
 
 
+// Post-legalizer custom combines: shared base plus per-target additions.
+def aie_postlegalizer_custom_shared_combines : GICombineGroup<[
+  combine_broadcast_extract_to_copy,
+  combine_global_load_store_increment,
+  combine_load_store_increment,
+  ptr_add_immed_chain,
+  combine_offset_load_store_ptradd,
+  combine_offset_load_store_share_ptradd,
+  combine_add_vector_elt_undef,
+  combine_insert_extract_vector_elt_to_copy
+]>;
+
+def aie2_postlegalizer_custom_combines : GICombineGroup<[
+  combine_load_store_split,
+  combine_extract_concat,
+  combine_unmerge_concat,
+  combine_upd_to_concat
+]>;
+
+def aie2p_postlegalizer_custom_combines : GICombineGroup<[
+  combine_extract_vector_assert_combine,
+  combine_extract_broadcast_to_scalar
+]>;
+
 def AIE2PostLegalizerCustomCombiner
-    : GICombiner<"AIE2PostLegalizerCustomCombinerImpl", [ combine_broadcast_extract_to_copy,
-                                                          combine_global_load_store_increment,
-                                                          combine_load_store_split,
-                                                          ptr_add_immed_chain,
-                                                          combine_load_store_increment,
-                                                          combine_offset_load_store_ptradd,
-                                                          combine_offset_load_store_share_ptradd,
-                                                          combine_add_vector_elt_undef,
-                                                          combine_extract_concat,
-                                                          combine_unmerge_concat,
-                                                          combine_upd_to_concat,
-                                                          combine_insert_extract_vector_elt_to_copy
-                                                          ]> {
+    : GICombiner<"AIE2PostLegalizerCustomCombinerImpl",
+                 [aie_postlegalizer_custom_shared_combines, aie2_postlegalizer_custom_combines]> {
 }
 
 def AIE2PPostLegalizerCustomCombiner
-    : GICombiner<"AIE2PPostLegalizerCustomCombinerImpl", [  
-                                                            combine_broadcast_extract_to_copy,
-                                                            combine_extract_vector_assert_combine,
-                                                            combine_global_load_store_increment,
-                                                            combine_load_store_increment,
-                                                            ptr_add_immed_chain,
-                                                            combine_offset_load_store_ptradd,
-                                                            combine_offset_load_store_share_ptradd,
-                                                            combine_add_vector_elt_undef,
-                                                            combine_insert_extract_vector_elt_to_copy,
-                                                            combine_extract_broadcast_to_scalar
-                                                             ]> {
+    : GICombiner<"AIE2PPostLegalizerCustomCombinerImpl",
+                 [aie_postlegalizer_custom_shared_combines, aie2p_postlegalizer_custom_combines]> {
 }


### PR DESCRIPTION
Create a `aie_postlegalizer_custom_shared_combines` list with the combines used by all targets.

We already do this for the pre-legalization combines. I think this is not a completely NFC, because we are reordering some combines. We'll have to run some benchmarks to verify that QoR is not affected.