### PR TITLE
[NFC][AIE][InstructionSelector] Remove unused private field.

### DIFF
--- a/llvm/lib/Target/AIE/AIEBaseInstructionSelector.cpp
+++ b/llvm/lib/Target/AIE/AIEBaseInstructionSelector.cpp
@@ -24,7 +24,7 @@ using namespace llvm;
 
 AIEBaseInstructionSelector::AIEBaseInstructionSelector(
     const AIEBaseSubtarget &STI, const AIEBaseRegisterBankInfo &RBI)
-    : InstructionSelector(), STI(STI), TII(*STI.getInstrInfo()),
+    : InstructionSelector(), TII(*STI.getInstrInfo()),
       TRI(*static_cast<const AIEBaseRegisterInfo *>(STI.getRegisterInfo())),
       RBI(RBI) {}
 

--- a/llvm/lib/Target/AIE/AIEBaseInstructionSelector.h
+++ b/llvm/lib/Target/AIE/AIEBaseInstructionSelector.h
@@ -220,7 +220,6 @@ private:
                           CodeGenCoverage &CoverageInfo) const = 0;
 
 private:
-  const AIEBaseSubtarget &STI;
   const AIEBaseInstrInfo &TII;
   const AIEBaseRegisterInfo &TRI;
   const AIEBaseRegisterBankInfo &RBI;


### PR DESCRIPTION
This avoids a warning.