### PR TITLE
[AIEX][NFC] SImplfy feature checks to exclude only AIE2

### DIFF
--- a/llvm/lib/Target/AIE/AIECombinerHelper.cpp
+++ b/llvm/lib/Target/AIE/AIECombinerHelper.cpp
@@ -2902,14 +2902,14 @@ bool llvm::matchShuffleToExtractInsertEltToBroadcast(MachineInstr &MI,
     return false;
 
   unsigned MinFrequency;
-  if (MI.getMF()->getTarget().getTargetTriple().isAIE2P())
+  if (MI.getMF()->getTarget().getTargetTriple().isAIE2())
+    llvm_unreachable("MinFrequency unimplemented for target.");
+  else
     // The scalarization of G_SHUFFLE_VECTOR in the legalizer is more beneficial
     // if there are more exceptions than NumSrcElems / 2 as AIE2P's VINSERT
     // instrutions require a move to a register used for the index unlike VPUSH.
     MinFrequency = (ShuffleMaxNumInsertions != 0) ? ShuffleMaxNumInsertions
                                                   : NumSrcElems / 2;
-  else
-    llvm_unreachable("MinFrequency unimplemented for target.");
 
   std::optional<FrequentIndexResult> FrequentIdxResult =
       MaskMatch::getFrequentIndexResult(Mask, MinFrequency);
@@ -3023,18 +3023,18 @@ bool llvm::matchMostlySequentialShuffleWithInsertions(MachineInstr &MI,
   const LLT ElemTy = Src1Ty.getElementType();
 
   unsigned MaxNumInsertions;
-  if (MI.getMF()->getTarget().getTargetTriple().isAIE2P())
+  if (MI.getMF()->getTarget().getTargetTriple().isAIE2())
+    llvm_unreachable(
+        "MaxNumInsertions unimplemented for target. Does the target's Insert "
+        "instruction take immediate indices or does it require a register for "
+        "the index?");
+  else
     // The scalarization of G_SHUFFLE_VECTOR in the legalizer is more beneficial
     // if there are more exceptions than NumSrcElems / 2 as AIE2P's VINSERT
     // instructions require a move to a register used for the index unlike
     // VPUSH.
     MaxNumInsertions = (ShuffleMaxNumInsertions != 0) ? ShuffleMaxNumInsertions
                                                       : NumSrcElems / 2;
-  else
-    llvm_unreachable(
-        "MaxNumInsertions unimplemented for target. Does the target's Insert "
-        "instruction take immediate indices or does it require a register for "
-        "the index?");
 
   if (Mask.size() != NumDstElems)
     return false;
@@ -3850,7 +3850,7 @@ ExtendOperand matchExtend(Register SrcReg, MachineRegisterInfo &MRI) {
 
 bool llvm::matchWidenFMul(MachineInstr &FMul, MachineRegisterInfo &MRI,
                           GISelChangeObserver &Observer, BuildFnTy &MatchInfo) {
-  if (!FMul.getMF()->getTarget().getTargetTriple().isAIE2P()) {
+  if (FMul.getMF()->getTarget().getTargetTriple().isAIE2()) {
     return false;
   }
 


### PR DESCRIPTION
Combiner features are now only disabled for aie2, instead of explicitly allowing them for aie2p