### PR TITLE
[AIE2] Fix compilation warning related to interface mismatch

### DIFF
--- a/llvm/lib/Target/AIE/AIE2InstructionSelector.cpp
+++ b/llvm/lib/Target/AIE/AIE2InstructionSelector.cpp
@@ -146,10 +146,10 @@ private:
                         bool Is32Lanes);
   bool canCombinePACK(MachineInstr &MemOp, MachineInstr &CombOp);
   bool canCombineUNPACKLoad(MachineInstr &MemOp, MachineInstr &CombOp,
-                            MachineRegisterInfo &MRI);
+                            MachineRegisterInfo &MRI) override;
   std::optional<LoadStoreOpcodes> getCombinedOpcodeUNPACKLoad(
       const MachineInstr &MemOp, const MachineInstr &CombOp,
-      std::optional<APInt> Immediate, MachineRegisterInfo &MRI);
+      std::optional<APInt> Immediate, bool IsSigned) override;
 
   // const AIE2TargetMachine &TM;
   const AIE2InstrInfo &TII;
@@ -629,7 +629,7 @@ bool AIE2InstructionSelector::selectVPACK(MachineInstr &I,
 std::optional<LoadStoreOpcodes>
 AIE2InstructionSelector::getCombinedOpcodeUNPACKLoad(
     const MachineInstr &MemOp, const MachineInstr &CombOp,
-    std::optional<APInt> Immediate, MachineRegisterInfo &MRI) {
+    std::optional<APInt> Immediate, bool IsSigned) {
 
   const bool NoImmediate = false;
   if (CombOp.getOpcode() != AIE2::G_INTRINSIC ||
@@ -645,10 +645,8 @@ AIE2InstructionSelector::getCombinedOpcodeUNPACKLoad(
   assert(getLoadStoreSize(MemOp) == 256 && "Unexpected VLDA.UNPACK size");
 
   unsigned ISelOpcode;
-  Register SignReg = CombOp.getOperand(3).getReg();
 
-  auto Sign = getIConstantVRegValWithLookThrough(SignReg, MRI);
-  if (Sign && Sign->Value.getZExtValue()) {
+  if (IsSigned) {
     if (cast<GIntrinsic>(CombOp).getIntrinsicID() ==
         Intrinsic::aie2_unpack_I8_I4) {
       switch (MemOp.getOpcode()) {
@@ -722,7 +720,13 @@ bool AIE2InstructionSelector::canCombineUNPACKLoad(MachineInstr &MemOp,
                                                    MachineInstr &CombOp,
                                                    MachineRegisterInfo &MRI) {
   const std::optional<APInt> NoImmediate = {};
-  return getCombinedOpcodeUNPACKLoad(MemOp, CombOp, NoImmediate, MRI)
+
+  // Determine if the operation is signed by checking the SignReg
+  Register SignReg = CombOp.getOperand(3).getReg();
+  auto Sign = getIConstantVRegValWithLookThrough(SignReg, MRI);
+  bool IsSigned = Sign && Sign->Value.getZExtValue();
+
+  return getCombinedOpcodeUNPACKLoad(MemOp, CombOp, NoImmediate, IsSigned)
       .has_value();
 }
 
@@ -755,13 +759,17 @@ bool AIE2InstructionSelector::selectG_AIE_LOAD_UNPACK(
   if (!AMI)
     return false;
 
+  // Determine if the operation is signed by checking the SignReg
+  Register SignReg = UNPACKI.getOperand(3).getReg();
+  auto Sign = getIConstantVRegValWithLookThrough(SignReg, MRI);
+  bool IsSigned = Sign && Sign->Value.getZExtValue();
+
   std::optional<LoadStoreOpcodes> LSO = getCombinedOpcodeUNPACKLoad(
-      AMI->MemI, UNPACKI, AMI->ImmediateOffset, MRI);
+      AMI->MemI, UNPACKI, AMI->ImmediateOffset, IsSigned);
 
   assert(LSO && "Unexpected VLDB.UNPACK combine failure");
 
   Register DstReg = UNPACKI.getOperand(0).getReg();
-  Register SignReg = UNPACKI.getOperand(3).getReg();
 
   MIB.setInstr(*InsertionPoint);
 


### PR DESCRIPTION
This fixes:

```
 Building CXX object lib/Target/AIE/CMakeFiles/LLVMAIECodeGen.dir/AIE2InstructionSelector.cpp.o
../llvm/lib/Target/AIE/AIE2InstructionSelector.cpp:150:35: warning: '(anonymous namespace)::AIE2InstructionSelector::getCombinedOpcodeUNPACKLoad' hides overloaded virtual function [-Woverloaded-virtual]
  150 |   std::optional<LoadStoreOpcodes> getCombinedOpcodeUNPACKLoad(
      |                                   ^
../llvm/lib/Target/AIE/AIEBaseInstructionSelector.h:215:3: note: hidden overloaded virtual function 'llvm::AIEBaseInstructionSelector::getCombinedOpcodeUNPACKLoad' declared here: type mismatch at 4th parameter ('bool' vs 'MachineRegisterInfo &')
  215 |   getCombinedOpcodeUNPACKLoad(const MachineInstr &MemOp,
      |   ^
../llvm/lib/Target/AIE/AIE2InstructionSelector.cpp:148:8: warning: 'canCombineUNPACKLoad' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
  148 |   bool canCombineUNPACKLoad(MachineInstr &MemOp, MachineInstr &CombOp,
      |        ^
../llvm/lib/Target/AIE/AIEBaseInstructionSelector.h:218:16: note: overridden virtual function is here
  218 |   virtual bool canCombineUNPACKLoad(MachineInstr &MemOp, MachineInstr &CombOp,
      |                ^
2 warnings generated.
```