### PR TITLE
[AIE2PS] Implement getSMSMutations subtarget hook

### DIFF
--- a/llvm/lib/Target/AIE/aie2ps/AIE2PSSubtarget.h
+++ b/llvm/lib/Target/AIE/aie2ps/AIE2PSSubtarget.h
@@ -85,6 +85,11 @@ public:
         AIEBaseSubtarget::getPostRAMutationsImpl(getTargetTriple(), nullptr);
   }
 
+  void getSMSMutations(std::vector<std::unique_ptr<ScheduleDAGMutation>>
+                           &Mutations) const override {
+    Mutations = AIEBaseSubtarget::getSMSMutationsImpl(getTargetTriple());
+  }
+
   // Finer-grained live ranges, giving more accurate use-def chains.
   bool enableSubRegLiveness() const override { return true; }
 


### PR DESCRIPTION
This helps PreSWP to reach better schedules and also discover better candidates for PostSWP.