### PR TITLE
[AIEX] fixup! matchNarrowTruncLoad

### DIFF
--- a/llvm/lib/Target/AIE/AIECombinerHelper.cpp
+++ b/llvm/lib/Target/AIE/AIECombinerHelper.cpp
@@ -3785,7 +3785,8 @@ bool llvm::matchNarrowTruncLoad(MachineInstr &MI, MachineRegisterInfo &MRI,
 
   // We should have a G_LOAD feeding interesting truncations.
   const Register DstReg = MI.getOperand(0).getReg();
-  if (!all_of(MRI.use_instructions(DstReg), IsProfitableTruncToS20))
+  if (MRI.use_nodbg_empty(DstReg) ||
+      !all_of(MRI.use_instructions(DstReg), IsProfitableTruncToS20))
     return false;
 
   MatchInfo = [=, &MI, &MRI, &Observer](MachineIRBuilder &B) {

--- a/llvm/test/CodeGen/AIE/GlobalISel/combine-trunc-load-s20-no-narrow.mir
+++ b/llvm/test/CodeGen/AIE/GlobalISel/combine-trunc-load-s20-no-narrow.mir
@@ -1,0 +1,31 @@
+#
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# (c) Copyright 2025-2026 Advanced Micro Devices, Inc. or its affiliates
+#
+# all_of on an empty use set returns true and the combiner narrows the load, 
+# then re-processes and crashes building G_ZEXT(s20, s20).
+#
+# RUN: llc -mtriple aie2 -run-pass=aie2-prelegalizer-combiner %s -o - | FileCheck %s
+# RUN: llc -mtriple aie2p -run-pass=aie2p-prelegalizer-combiner %s -o - | FileCheck %s
+# RUN: llc -mtriple aie2ps -run-pass=aie2ps-prelegalizer-combiner %s -o - | FileCheck %s
+
+---
+name:            G_LOAD_no_trunc_user
+legalized:       false
+tracksRegLiveness: true
+body:             |
+  bb.0:
+    liveins: $p0
+    ; CHECK-LABEL: name: G_LOAD_no_trunc_user
+    ; CHECK: liveins: $p0
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(p0) = COPY $p0
+    ; CHECK-NEXT: [[LOAD:%[0-9]+]]:_(s32) = G_LOAD [[COPY]](p0) :: (volatile load (s32))
+    ; CHECK-NEXT: PseudoRET implicit $lr
+    %0:_(p0) = COPY $p0
+    %1:_(s32) = G_LOAD %0(p0) :: (volatile load (s32))
+    PseudoRET implicit $lr
+...


### PR DESCRIPTION
Fix an assertion failure ("invalid narrowing extend") in `matchNarrowTruncLoad`. Add an early return when the load's destination register is already s20.