### PR TITLE
[AIEX][NFC] Fix -Woverloaded-virtual warning in AIEBaseSubtarget

### DIFF
--- a/llvm/lib/Target/AIE/AIEBaseSubtarget.h
+++ b/llvm/lib/Target/AIE/AIEBaseSubtarget.h
@@ -53,6 +53,7 @@ public:
   void overrideSchedPolicy(MachineSchedPolicy &Policy,
                            unsigned NumRegionInstrs) const override;
 
+  using TargetSubtargetInfo::adjustSchedDependency;
   void adjustSchedDependency(const InstrItineraryData &Itineraries, SUnit *Def,
                              int DefOpIdx, SUnit *Use, int UseOpIdx,
                              SDep &Dep) const;


### PR DESCRIPTION
After the subtarget inheritance linearization, AIEBaseSubtarget now inherits from TargetSubtargetInfo. The non-virtual adjustSchedDependency helper (with InstrItineraryData parameter) hides the virtual overload from TargetSubtargetInfo, triggering -Woverloaded-virtual.

Add a using declaration to bring the base class virtual into scope.