### PR TITLE
Leverage AIEBaseSubtarget

### DIFF
--- a/llvm/lib/Target/AIE/AIE2Subtarget.h
+++ b/llvm/lib/Target/AIE/AIE2Subtarget.h
@@ -85,15 +85,6 @@ public:
     AIEBaseSubtarget::adjustSchedDependency(InstrItins, Def, DefOpIdx, Use,
                                             UseOpIdx, Dep);
   }
-  void getPostRAMutations(std::vector<std::unique_ptr<ScheduleDAGMutation>>
-                              &Mutations) const override {
-    Mutations =
-        AIEBaseSubtarget::getPostRAMutationsImpl(getTargetTriple(), nullptr);
-  }
-  void getSMSMutations(std::vector<std::unique_ptr<ScheduleDAGMutation>>
-                           &Mutations) const override {
-    Mutations = AIEBaseSubtarget::getSMSMutationsImpl(getTargetTriple());
-  }
 
   bool enableSubRegLiveness() const override { return true; }
 

--- a/llvm/lib/Target/AIE/AIE2Subtarget.h
+++ b/llvm/lib/Target/AIE/AIE2Subtarget.h
@@ -58,7 +58,6 @@ public:
 
   bool enableMachineScheduler() const override { return true; }
   bool enablePostRAMachineScheduler() const override { return true; }
-  bool forcePostRAScheduling() const override { return true; }
   bool useAA() const override { return true; }
   bool enableEarlyIfConversion() const override { return true; }
 
@@ -97,14 +96,6 @@ public:
   }
 
   bool enableSubRegLiveness() const override { return true; }
-
-  unsigned classifyGlobalReference(const GlobalValue *GV,
-                                   const TargetMachine &TM) const {
-    if (!TM.shouldAssumeDSOLocal(GV)) {
-      return AIEII::MO_GLOBAL;
-    }
-    return AIEII::MO_None;
-  }
 
 protected:
   std::unique_ptr<CallLowering> CallLoweringInfo;

--- a/llvm/lib/Target/AIE/AIEBaseSubtarget.cpp
+++ b/llvm/lib/Target/AIE/AIEBaseSubtarget.cpp
@@ -939,3 +939,12 @@ bool AIEBaseSubtarget::enableWindowScheduler() const {
 unsigned AIEBaseSubtarget::getCriticalPathLimit() const {
   return IfConversionCritPathLimit;
 }
+
+unsigned
+AIEBaseSubtarget::classifyGlobalReference(const GlobalValue *GV,
+                                          const TargetMachine &TM) const {
+  if (!TM.shouldAssumeDSOLocal(GV)) {
+    return AIEII::MO_GLOBAL;
+  }
+  return AIEII::MO_None;
+}

--- a/llvm/lib/Target/AIE/AIEBaseSubtarget.h
+++ b/llvm/lib/Target/AIE/AIEBaseSubtarget.h
@@ -50,6 +50,16 @@ public:
   bool isAIE2P() const { return getTargetTriple().isAIE2P(); }
   bool isAIE2PS() const { return getTargetTriple().isAIE2PS(); }
 
+  void getSMSMutations(std::vector<std::unique_ptr<ScheduleDAGMutation>>
+                           &Mutations) const override {
+    Mutations = AIEBaseSubtarget::getSMSMutationsImpl(getTargetTriple());
+  }
+  void getPostRAMutations(std::vector<std::unique_ptr<ScheduleDAGMutation>>
+                              &Mutations) const override {
+    Mutations =
+        AIEBaseSubtarget::getPostRAMutationsImpl(getTargetTriple(), nullptr);
+  }
+
   void overrideSchedPolicy(MachineSchedPolicy &Policy,
                            unsigned NumRegionInstrs) const override;
 

--- a/llvm/lib/Target/AIE/AIEBaseSubtarget.h
+++ b/llvm/lib/Target/AIE/AIEBaseSubtarget.h
@@ -81,6 +81,11 @@ public:
   bool enableWindowScheduler() const override;
 
   unsigned getCriticalPathLimit() const override;
+  unsigned classifyGlobalReference(const GlobalValue *GV,
+                                   const TargetMachine &TM) const;
+
+  // All AIE targets need post scheduling for correct instruction timing
+  bool forcePostRAScheduling() const override { return true; }
 };
 } // namespace llvm
 

--- a/llvm/lib/Target/AIE/AIECombinerHelper.cpp
+++ b/llvm/lib/Target/AIE/AIECombinerHelper.cpp
@@ -10,9 +10,8 @@
 
 #include "AIECombinerHelper.h"
 #include "AIE.h"
-#include "AIE2TargetMachine.h"
 #include "AIEBaseInstrInfo.h"
-#include "MCTargetDesc/AIE2MCTargetDesc.h"
+#include "AIEBaseSubtarget.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/Analysis/ConstantFolding.h"
 #include "llvm/Analysis/VectorUtils.h"
@@ -1147,8 +1146,9 @@ bool llvm::matchGlobalValOffset(MachineInstr &MI, MachineRegisterInfo &MRI,
   // transform %g = G_GLOBAL_VALUE @a, for any other case return false
   if (GlobalOp.getOffset() != 0)
     return false;
-  unsigned OpFlags = MF.getSubtarget<AIE2Subtarget>().classifyGlobalReference(
-      GV, MF.getTarget());
+  unsigned OpFlags =
+      MF.getSubtarget<AIEBaseSubtarget>().classifyGlobalReference(
+          GV, MF.getTarget());
   if (OpFlags != AIEII::MO_None)
     return false;
 

--- a/llvm/lib/Target/AIE/aie1/AIE1Subtarget.h
+++ b/llvm/lib/Target/AIE/aie1/AIE1Subtarget.h
@@ -61,7 +61,6 @@ public:
   }
 
   bool enableMachineScheduler() const override { return false; }
-  bool forcePostRAScheduling() const override { return true; }
 
   void overrideSchedPolicy(MachineSchedPolicy &Policy,
                            unsigned NumRegionInstrs) const override {}

--- a/llvm/lib/Target/AIE/aie1/AIE1Subtarget.h
+++ b/llvm/lib/Target/AIE/aie1/AIE1Subtarget.h
@@ -93,11 +93,6 @@ public:
     AIEBaseSubtarget::adjustSchedDependency(InstrItins, Def, DefOpIdx, Use,
                                             UseOpIdx, Dep);
   }
-  void getPostRAMutations(std::vector<std::unique_ptr<ScheduleDAGMutation>>
-                              &Mutations) const override {
-    Mutations =
-        AIEBaseSubtarget::getPostRAMutationsImpl(getTargetTriple(), nullptr);
-  }
 
 protected:
   std::unique_ptr<CallLowering> CallLoweringInfo;

--- a/llvm/lib/Target/AIE/aie2p/AIE2PSubtarget.h
+++ b/llvm/lib/Target/AIE/aie2p/AIE2PSubtarget.h
@@ -80,15 +80,6 @@ public:
     AIEBaseSubtarget::adjustSchedDependency(InstrItins, Def, DefOpIdx, Use,
                                             UseOpIdx, Dep);
   }
-  void getPostRAMutations(std::vector<std::unique_ptr<ScheduleDAGMutation>>
-                              &Mutations) const override {
-    Mutations =
-        AIEBaseSubtarget::getPostRAMutationsImpl(getTargetTriple(), nullptr);
-  }
-  void getSMSMutations(std::vector<std::unique_ptr<ScheduleDAGMutation>>
-                           &Mutations) const override {
-    Mutations = AIEBaseSubtarget::getSMSMutationsImpl(getTargetTriple());
-  }
 
   bool enableSubRegLiveness() const override { return true; }
 

--- a/llvm/lib/Target/AIE/aie2p/AIE2PSubtarget.h
+++ b/llvm/lib/Target/AIE/aie2p/AIE2PSubtarget.h
@@ -53,7 +53,6 @@ public:
                  StringRef FS, StringRef ABIName, const TargetMachine &TM);
   bool enableMachineScheduler() const override { return true; }
   bool enablePostRAMachineScheduler() const override { return true; }
-  bool forcePostRAScheduling() const override { return true; }
   bool useAA() const override { return true; }
   bool enableEarlyIfConversion() const override { return true; }
 
@@ -92,14 +91,6 @@ public:
   }
 
   bool enableSubRegLiveness() const override { return true; }
-
-  unsigned classifyGlobalReference(const GlobalValue *GV,
-                                   const TargetMachine &TM) const {
-    if (!TM.shouldAssumeDSOLocal(GV)) {
-      return AIEII::MO_GLOBAL;
-    }
-    return AIEII::MO_None;
-  }
 
 protected:
   std::unique_ptr<CallLowering> CallLoweringInfo;

--- a/llvm/lib/Target/AIE/aie2ps/AIE2PSSubtarget.h
+++ b/llvm/lib/Target/AIE/aie2ps/AIE2PSSubtarget.h
@@ -65,12 +65,6 @@ public:
     AIEBaseSubtarget::adjustSchedDependency(InstrItins, Def, DefOpIdx, Use,
                                             UseOpIdx, Dep);
   }
-  void getPostRAMutations(std::vector<std::unique_ptr<ScheduleDAGMutation>>
-                              &Mutations) const override {
-    Mutations =
-        AIEBaseSubtarget::getPostRAMutationsImpl(getTargetTriple(), nullptr);
-  }
-
   bool enableSubRegLiveness() const override { return true; }
 
   void ParseSubtargetFeatures(StringRef CPU, StringRef TuneCPU, StringRef FS);

--- a/llvm/lib/Target/AIE/aie2ps/AIE2PSSubtarget.h
+++ b/llvm/lib/Target/AIE/aie2ps/AIE2PSSubtarget.h
@@ -54,7 +54,6 @@ public:
   bool enableMachineScheduler() const override { return true; }
   bool enablePostRAScheduler() const override { return true; }
   bool enablePostRAMachineScheduler() const override { return true; }
-  bool forcePostRAScheduling() const override { return true; }
   bool useAA() const override { return true; }
   bool enableEarlyIfConversion() const override { return true; }
   bool enableWindowScheduler() const override { return true; }
@@ -98,14 +97,6 @@ protected:
   std::unique_ptr<LegalizerInfo> Legalizer;
   std::unique_ptr<RegisterBankInfo> RegBankInfo;
   std::unique_ptr<InstructionSelector> InstSelector;
-
-  unsigned classifyGlobalReference(const GlobalValue *GV,
-                                   const TargetMachine &TM) const {
-    if (!TM.shouldAssumeDSOLocal(GV)) {
-      return AIEII::MO_GLOBAL;
-    }
-    return AIEII::MO_None;
-  }
 
 public:
   const CallLowering *getCallLowering() const override;


### PR DESCRIPTION
Some really AIE-wide overrides have been moved to the new base class of AIEBaseSubtarget.
Apart from tidiness, this provides single-point definition of the DAG mutators for the different scheduling stages. 