### PR TITLE
[AIE2PS] change v256mx9 into two v128mx9 according to the specification

### DIFF
--- a/clang/lib/Headers/aie2ps/aie2ps_pp.h
+++ b/clang/lib/Headers/aie2ps/aie2ps_pp.h
@@ -751,9 +751,9 @@
       a.tileShiftG3, a.exponentE0, a.exponentE1, a.exponentE2, a.exponentE3
 #define UNPACK_V64MX9(a) a.mantissa, a.tileShift, a.exponent
 #define UNPACK_V256MX9(a)                                                      \
-  a.mantissaX0, a.mantissaX1, a.mantissaX2, a.mantissaX3, a.tileShiftG0,       \
-      a.tileShiftG1, a.tileShiftG2, a.tileShiftG3, a.exponentE0, a.exponentE1, \
-      a.exponentE2, a.exponentE3
+  a.l.mantissaX0, a.l.mantissaX1, a.h.mantissaX0, a.h.mantissaX1,              \
+      a.l.tileShiftG0, a.l.tileShiftG1, a.h.tileShiftG0, a.h.tileShiftG1,      \
+      a.l.exponentE0, a.l.exponentE1, a.h.exponentE0, a.h.exponentE1
 
 #define IS_MX4_VARIANT(V)                                                      \
   PP_CMP(V, VARIANT_BFP13xBFP13_1_4x16_16x16T_v128mx4_v256mx4)

--- a/clang/lib/Headers/aie2ps/aie2ps_upd_ext.h
+++ b/clang/lib/Headers/aie2ps/aie2ps_upd_ext.h
@@ -5,7 +5,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+// (c) Copyright 2024-2026 Advanced Micro Devices, Inc. or its affiliates
 //
 //===----------------------------------------------------------------------===//
 
@@ -2294,19 +2294,13 @@ INTRINSIC(v64bfp16p) extract_v64bfp16p(v128bfp16p a, int idx) {
 // v256mx9
 INTRINSIC(v256mx9) insert(v256mx9 v, int idx, v128mx9 vsub) {
   if (idx == 0)
-    return {vsub.mantissaX0,  vsub.mantissaX1,  v.mantissaX2,  v.mantissaX3,
-            vsub.tileShiftG0, vsub.tileShiftG1, v.tileShiftG2, v.tileShiftG3,
-            vsub.exponentE0,  vsub.exponentE1,  v.exponentE2,  v.exponentE3};
-  return {v.mantissaX0,  v.mantissaX1,  vsub.mantissaX0,  vsub.mantissaX1,
-          v.tileShiftG0, v.tileShiftG1, vsub.tileShiftG0, vsub.tileShiftG1,
-          v.exponentE0,  v.exponentE1,  vsub.exponentE0,  vsub.exponentE1};
+    return {vsub, v.h};
+  return {v.l, vsub};
 }
 INTRINSIC(v128mx9) extract_v128mx9(v256mx9 v, int idx) {
   if (idx == 0)
-    return {v.mantissaX0,  v.mantissaX1, v.tileShiftG0,
-            v.tileShiftG1, v.exponentE0, v.exponentE1};
-  return {v.mantissaX2,  v.mantissaX3, v.tileShiftG2,
-          v.tileShiftG3, v.exponentE2, v.exponentE3};
+    return v.l;
+  return v.h;
 }
 INTRINSIC(v128bfp16p) extract_v128bfp16p(v256bfp16p a, int idx) {
   return extract_v128mx9(a, idx);

--- a/clang/lib/Headers/aiebase_typedefs.h
+++ b/clang/lib/Headers/aiebase_typedefs.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// (c) Copyright 2023-2024 Advanced Micro Devices, Inc. or its affiliates
+// (c) Copyright 2023-2026 Advanced Micro Devices, Inc. or its affiliates
 //
 //===----------------------------------------------------------------------===//
 
@@ -668,18 +668,7 @@ __attribute__((aligned(8)));
 
 // 2560 bit
 struct v256mx9 {
-  v16int32 mantissaX0;
-  v16int32 mantissaX1;
-  v16int32 mantissaX2;
-  v16int32 mantissaX3;
-  v2int32 tileShiftG0;
-  v2int32 tileShiftG1;
-  v2int32 tileShiftG2;
-  v2int32 tileShiftG3;
-  v2int32 exponentE0;
-  v2int32 exponentE1;
-  v2int32 exponentE2;
-  v2int32 exponentE3;
+  struct v128mx9 l, h;
 } __attribute__((packed)) __attribute__((return_in_regs))
 __attribute__((aligned(8)));
 

--- a/clang/test/CodeGen/aie/aie2ps/aie2ps-abi-bfp16.cpp
+++ b/clang/test/CodeGen/aie/aie2ps/aie2ps-abi-bfp16.cpp
@@ -120,40 +120,10 @@ extern "C" {
 // CHECK-NEXT:    [[TMP0:%.*]] = alloca [[STRUCT_V256MX9]], align 8
 // CHECK-NEXT:    [[TMP1:%.*]] = getelementptr inbounds nuw [[STRUCT_V256MX9]], ptr [[TMP0]], i32 0, i32 0
 // CHECK-NEXT:    [[TMP2:%.*]] = extractvalue [[STRUCT_V256MX9]] [[DOTCOERCE]], 0
-// CHECK-NEXT:    store <16 x i32> [[TMP2]], ptr [[TMP1]], align 8
+// CHECK-NEXT:    store [[STRUCT_V128MX9:%.*]] [[TMP2]], ptr [[TMP1]], align 8
 // CHECK-NEXT:    [[TMP3:%.*]] = getelementptr inbounds nuw [[STRUCT_V256MX9]], ptr [[TMP0]], i32 0, i32 1
 // CHECK-NEXT:    [[TMP4:%.*]] = extractvalue [[STRUCT_V256MX9]] [[DOTCOERCE]], 1
-// CHECK-NEXT:    store <16 x i32> [[TMP4]], ptr [[TMP3]], align 8
-// CHECK-NEXT:    [[TMP5:%.*]] = getelementptr inbounds nuw [[STRUCT_V256MX9]], ptr [[TMP0]], i32 0, i32 2
-// CHECK-NEXT:    [[TMP6:%.*]] = extractvalue [[STRUCT_V256MX9]] [[DOTCOERCE]], 2
-// CHECK-NEXT:    store <16 x i32> [[TMP6]], ptr [[TMP5]], align 8
-// CHECK-NEXT:    [[TMP7:%.*]] = getelementptr inbounds nuw [[STRUCT_V256MX9]], ptr [[TMP0]], i32 0, i32 3
-// CHECK-NEXT:    [[TMP8:%.*]] = extractvalue [[STRUCT_V256MX9]] [[DOTCOERCE]], 3
-// CHECK-NEXT:    store <16 x i32> [[TMP8]], ptr [[TMP7]], align 8
-// CHECK-NEXT:    [[TMP9:%.*]] = getelementptr inbounds nuw [[STRUCT_V256MX9]], ptr [[TMP0]], i32 0, i32 4
-// CHECK-NEXT:    [[TMP10:%.*]] = extractvalue [[STRUCT_V256MX9]] [[DOTCOERCE]], 4
-// CHECK-NEXT:    store <2 x i32> [[TMP10]], ptr [[TMP9]], align 8
-// CHECK-NEXT:    [[TMP11:%.*]] = getelementptr inbounds nuw [[STRUCT_V256MX9]], ptr [[TMP0]], i32 0, i32 5
-// CHECK-NEXT:    [[TMP12:%.*]] = extractvalue [[STRUCT_V256MX9]] [[DOTCOERCE]], 5
-// CHECK-NEXT:    store <2 x i32> [[TMP12]], ptr [[TMP11]], align 8
-// CHECK-NEXT:    [[TMP13:%.*]] = getelementptr inbounds nuw [[STRUCT_V256MX9]], ptr [[TMP0]], i32 0, i32 6
-// CHECK-NEXT:    [[TMP14:%.*]] = extractvalue [[STRUCT_V256MX9]] [[DOTCOERCE]], 6
-// CHECK-NEXT:    store <2 x i32> [[TMP14]], ptr [[TMP13]], align 8
-// CHECK-NEXT:    [[TMP15:%.*]] = getelementptr inbounds nuw [[STRUCT_V256MX9]], ptr [[TMP0]], i32 0, i32 7
-// CHECK-NEXT:    [[TMP16:%.*]] = extractvalue [[STRUCT_V256MX9]] [[DOTCOERCE]], 7
-// CHECK-NEXT:    store <2 x i32> [[TMP16]], ptr [[TMP15]], align 8
-// CHECK-NEXT:    [[TMP17:%.*]] = getelementptr inbounds nuw [[STRUCT_V256MX9]], ptr [[TMP0]], i32 0, i32 8
-// CHECK-NEXT:    [[TMP18:%.*]] = extractvalue [[STRUCT_V256MX9]] [[DOTCOERCE]], 8
-// CHECK-NEXT:    store <2 x i32> [[TMP18]], ptr [[TMP17]], align 8
-// CHECK-NEXT:    [[TMP19:%.*]] = getelementptr inbounds nuw [[STRUCT_V256MX9]], ptr [[TMP0]], i32 0, i32 9
-// CHECK-NEXT:    [[TMP20:%.*]] = extractvalue [[STRUCT_V256MX9]] [[DOTCOERCE]], 9
-// CHECK-NEXT:    store <2 x i32> [[TMP20]], ptr [[TMP19]], align 8
-// CHECK-NEXT:    [[TMP21:%.*]] = getelementptr inbounds nuw [[STRUCT_V256MX9]], ptr [[TMP0]], i32 0, i32 10
-// CHECK-NEXT:    [[TMP22:%.*]] = extractvalue [[STRUCT_V256MX9]] [[DOTCOERCE]], 10
-// CHECK-NEXT:    store <2 x i32> [[TMP22]], ptr [[TMP21]], align 8
-// CHECK-NEXT:    [[TMP23:%.*]] = getelementptr inbounds nuw [[STRUCT_V256MX9]], ptr [[TMP0]], i32 0, i32 11
-// CHECK-NEXT:    [[TMP24:%.*]] = extractvalue [[STRUCT_V256MX9]] [[DOTCOERCE]], 11
-// CHECK-NEXT:    store <2 x i32> [[TMP24]], ptr [[TMP23]], align 8
+// CHECK-NEXT:    store [[STRUCT_V128MX9]] [[TMP4]], ptr [[TMP3]], align 8
 // CHECK-NEXT:    ret void
 //
     void pass_v256mx9(v256mx9) {}
@@ -162,18 +132,20 @@ extern "C" {
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[RETVAL:%.*]] = alloca [[STRUCT_V256MX9:%.*]], align 8
 // CHECK-NEXT:    call void @llvm.memset.p0.i64(ptr align 8 [[RETVAL]], i8 0, i64 320, i1 false)
-// CHECK-NEXT:    [[MANTISSAX0:%.*]] = getelementptr inbounds nuw [[STRUCT_V256MX9]], ptr [[RETVAL]], i32 0, i32 0
-// CHECK-NEXT:    [[MANTISSAX1:%.*]] = getelementptr inbounds nuw [[STRUCT_V256MX9]], ptr [[RETVAL]], i32 0, i32 1
-// CHECK-NEXT:    [[MANTISSAX2:%.*]] = getelementptr inbounds nuw [[STRUCT_V256MX9]], ptr [[RETVAL]], i32 0, i32 2
-// CHECK-NEXT:    [[MANTISSAX3:%.*]] = getelementptr inbounds nuw [[STRUCT_V256MX9]], ptr [[RETVAL]], i32 0, i32 3
-// CHECK-NEXT:    [[TILESHIFTG0:%.*]] = getelementptr inbounds nuw [[STRUCT_V256MX9]], ptr [[RETVAL]], i32 0, i32 4
-// CHECK-NEXT:    [[TILESHIFTG1:%.*]] = getelementptr inbounds nuw [[STRUCT_V256MX9]], ptr [[RETVAL]], i32 0, i32 5
-// CHECK-NEXT:    [[TILESHIFTG2:%.*]] = getelementptr inbounds nuw [[STRUCT_V256MX9]], ptr [[RETVAL]], i32 0, i32 6
-// CHECK-NEXT:    [[TILESHIFTG3:%.*]] = getelementptr inbounds nuw [[STRUCT_V256MX9]], ptr [[RETVAL]], i32 0, i32 7
-// CHECK-NEXT:    [[EXPONENTE0:%.*]] = getelementptr inbounds nuw [[STRUCT_V256MX9]], ptr [[RETVAL]], i32 0, i32 8
-// CHECK-NEXT:    [[EXPONENTE1:%.*]] = getelementptr inbounds nuw [[STRUCT_V256MX9]], ptr [[RETVAL]], i32 0, i32 9
-// CHECK-NEXT:    [[EXPONENTE2:%.*]] = getelementptr inbounds nuw [[STRUCT_V256MX9]], ptr [[RETVAL]], i32 0, i32 10
-// CHECK-NEXT:    [[EXPONENTE3:%.*]] = getelementptr inbounds nuw [[STRUCT_V256MX9]], ptr [[RETVAL]], i32 0, i32 11
+// CHECK-NEXT:    [[L:%.*]] = getelementptr inbounds nuw [[STRUCT_V256MX9]], ptr [[RETVAL]], i32 0, i32 0
+// CHECK-NEXT:    [[MANTISSAX0:%.*]] = getelementptr inbounds nuw [[STRUCT_V128MX9:%.*]], ptr [[L]], i32 0, i32 0
+// CHECK-NEXT:    [[MANTISSAX1:%.*]] = getelementptr inbounds nuw [[STRUCT_V128MX9]], ptr [[L]], i32 0, i32 1
+// CHECK-NEXT:    [[TILESHIFTG0:%.*]] = getelementptr inbounds nuw [[STRUCT_V128MX9]], ptr [[L]], i32 0, i32 2
+// CHECK-NEXT:    [[TILESHIFTG1:%.*]] = getelementptr inbounds nuw [[STRUCT_V128MX9]], ptr [[L]], i32 0, i32 3
+// CHECK-NEXT:    [[EXPONENTE0:%.*]] = getelementptr inbounds nuw [[STRUCT_V128MX9]], ptr [[L]], i32 0, i32 4
+// CHECK-NEXT:    [[EXPONENTE1:%.*]] = getelementptr inbounds nuw [[STRUCT_V128MX9]], ptr [[L]], i32 0, i32 5
+// CHECK-NEXT:    [[H:%.*]] = getelementptr inbounds nuw [[STRUCT_V256MX9]], ptr [[RETVAL]], i32 0, i32 1
+// CHECK-NEXT:    [[MANTISSAX01:%.*]] = getelementptr inbounds nuw [[STRUCT_V128MX9]], ptr [[H]], i32 0, i32 0
+// CHECK-NEXT:    [[MANTISSAX12:%.*]] = getelementptr inbounds nuw [[STRUCT_V128MX9]], ptr [[H]], i32 0, i32 1
+// CHECK-NEXT:    [[TILESHIFTG03:%.*]] = getelementptr inbounds nuw [[STRUCT_V128MX9]], ptr [[H]], i32 0, i32 2
+// CHECK-NEXT:    [[TILESHIFTG14:%.*]] = getelementptr inbounds nuw [[STRUCT_V128MX9]], ptr [[H]], i32 0, i32 3
+// CHECK-NEXT:    [[EXPONENTE05:%.*]] = getelementptr inbounds nuw [[STRUCT_V128MX9]], ptr [[H]], i32 0, i32 4
+// CHECK-NEXT:    [[EXPONENTE16:%.*]] = getelementptr inbounds nuw [[STRUCT_V128MX9]], ptr [[H]], i32 0, i32 5
 // CHECK-NEXT:    [[TMP0:%.*]] = load [[STRUCT_V256MX9]], ptr [[RETVAL]], align 8
 // CHECK-NEXT:    ret [[STRUCT_V256MX9]] [[TMP0]]
 //

--- a/clang/test/CodeGen/aie/aie2ps/aie2ps-upd-ext-intrinsic.cpp
+++ b/clang/test/CodeGen/aie/aie2ps/aie2ps-upd-ext-intrinsic.cpp
@@ -1119,7 +1119,6 @@ v32float8 test_set_v32float8 (int idx, v16float8 a ) { return set_v32float8(idx,
 
 
 
-//
 // CHECK-LABEL: @_Z11test_insert10v64bfloat8i10v16bfloat8(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[TMP0:%.*]] = extractvalue [[STRUCT_V64BFLOAT8:%.*]] [[V_COERCE:%.*]], 0
@@ -1184,6 +1183,7 @@ v64bfloat8 test_insert (v64bfloat8 v, int idx, v16bfloat8 b ) { return insert(v,
 // CHECK-NEXT:    ret void
 //
 v64float8 test_insert (v64float8 v, int idx, v16float8 b ) { return insert(v, idx, b); }
+//
 // CHECK-LABEL: @_Z11test_insert10v32bfloat8i10v16bfloat8(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[TMP0:%.*]] = extractvalue [[STRUCT_V32BFLOAT8:%.*]] [[A_COERCE:%.*]], 0
@@ -1533,119 +1533,67 @@ v4int8 test_extract_prime (v128mx9 m, int idx) { return extract_prime(m, idx); }
 // CHECK-NEXT:    [[CMP_I:%.*]] = icmp eq i32 [[IDX:%.*]], 0
 // CHECK-NEXT:    br i1 [[CMP_I]], label [[IF_THEN_I:%.*]], label [[IF_END_I:%.*]]
 // CHECK:       if.then.i:
-// CHECK-NEXT:    [[TMP6:%.*]] = extractvalue [[STRUCT_V256MX9:%.*]] [[M_COERCE:%.*]], 11
-// CHECK-NEXT:    [[TMP7:%.*]] = extractvalue [[STRUCT_V256MX9]] [[M_COERCE]], 10
-// CHECK-NEXT:    [[TMP8:%.*]] = extractvalue [[STRUCT_V256MX9]] [[M_COERCE]], 7
-// CHECK-NEXT:    [[TMP9:%.*]] = extractvalue [[STRUCT_V256MX9]] [[M_COERCE]], 6
-// CHECK-NEXT:    [[TMP10:%.*]] = extractvalue [[STRUCT_V256MX9]] [[M_COERCE]], 3
-// CHECK-NEXT:    [[TMP11:%.*]] = extractvalue [[STRUCT_V256MX9]] [[M_COERCE]], 2
+// CHECK-NEXT:    [[TMP6:%.*]] = extractvalue [[STRUCT_V256MX9:%.*]] [[M_COERCE:%.*]], 1
+// CHECK-NEXT:    [[DOTFCA_5_EXTRACT21_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP6]], 5
+// CHECK-NEXT:    [[DOTFCA_4_EXTRACT19_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP6]], 4
+// CHECK-NEXT:    [[DOTFCA_3_EXTRACT17_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP6]], 3
+// CHECK-NEXT:    [[DOTFCA_2_EXTRACT15_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP6]], 2
+// CHECK-NEXT:    [[DOTFCA_1_EXTRACT13_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP6]], 1
+// CHECK-NEXT:    [[DOTFCA_0_EXTRACT11_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP6]], 0
 // CHECK-NEXT:    br label [[_ZL6INSERT7V256MX9I7V128MX9_EXIT:%.*]]
 // CHECK:       if.end.i:
-// CHECK-NEXT:    [[TMP12:%.*]] = extractvalue [[STRUCT_V256MX9]] [[M_COERCE]], 9
-// CHECK-NEXT:    [[TMP13:%.*]] = extractvalue [[STRUCT_V256MX9]] [[M_COERCE]], 8
-// CHECK-NEXT:    [[TMP14:%.*]] = extractvalue [[STRUCT_V256MX9]] [[M_COERCE]], 5
-// CHECK-NEXT:    [[TMP15:%.*]] = extractvalue [[STRUCT_V256MX9]] [[M_COERCE]], 4
-// CHECK-NEXT:    [[TMP16:%.*]] = extractvalue [[STRUCT_V256MX9]] [[M_COERCE]], 1
-// CHECK-NEXT:    [[TMP17:%.*]] = extractvalue [[STRUCT_V256MX9]] [[M_COERCE]], 0
+// CHECK-NEXT:    [[TMP7:%.*]] = extractvalue [[STRUCT_V256MX9]] [[M_COERCE]], 0
+// CHECK-NEXT:    [[DOTFCA_5_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP7]], 5
+// CHECK-NEXT:    [[DOTFCA_4_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP7]], 4
+// CHECK-NEXT:    [[DOTFCA_3_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP7]], 3
+// CHECK-NEXT:    [[DOTFCA_2_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP7]], 2
+// CHECK-NEXT:    [[DOTFCA_1_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP7]], 1
+// CHECK-NEXT:    [[DOTFCA_0_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP7]], 0
 // CHECK-NEXT:    br label [[_ZL6INSERT7V256MX9I7V128MX9_EXIT]]
 // CHECK:       _ZL6insert7v256mx9i7v128mx9.exit:
-// CHECK-NEXT:    [[RETVAL_SROA_0_0_I:%.*]] = phi <16 x i32> [ [[TMP0]], [[IF_THEN_I]] ], [ [[TMP17]], [[IF_END_I]] ]
-// CHECK-NEXT:    [[RETVAL_SROA_3_0_I:%.*]] = phi <16 x i32> [ [[TMP1]], [[IF_THEN_I]] ], [ [[TMP16]], [[IF_END_I]] ]
-// CHECK-NEXT:    [[RETVAL_SROA_6_0_I:%.*]] = phi <16 x i32> [ [[TMP11]], [[IF_THEN_I]] ], [ [[TMP0]], [[IF_END_I]] ]
-// CHECK-NEXT:    [[RETVAL_SROA_9_0_I:%.*]] = phi <16 x i32> [ [[TMP10]], [[IF_THEN_I]] ], [ [[TMP1]], [[IF_END_I]] ]
-// CHECK-NEXT:    [[RETVAL_SROA_12_0_I:%.*]] = phi <2 x i32> [ [[TMP2]], [[IF_THEN_I]] ], [ [[TMP15]], [[IF_END_I]] ]
-// CHECK-NEXT:    [[RETVAL_SROA_15_0_I:%.*]] = phi <2 x i32> [ [[TMP3]], [[IF_THEN_I]] ], [ [[TMP14]], [[IF_END_I]] ]
-// CHECK-NEXT:    [[RETVAL_SROA_18_0_I:%.*]] = phi <2 x i32> [ [[TMP9]], [[IF_THEN_I]] ], [ [[TMP2]], [[IF_END_I]] ]
-// CHECK-NEXT:    [[RETVAL_SROA_21_0_I:%.*]] = phi <2 x i32> [ [[TMP8]], [[IF_THEN_I]] ], [ [[TMP3]], [[IF_END_I]] ]
-// CHECK-NEXT:    [[RETVAL_SROA_24_0_I:%.*]] = phi <2 x i32> [ [[TMP4]], [[IF_THEN_I]] ], [ [[TMP13]], [[IF_END_I]] ]
-// CHECK-NEXT:    [[RETVAL_SROA_27_0_I:%.*]] = phi <2 x i32> [ [[TMP5]], [[IF_THEN_I]] ], [ [[TMP12]], [[IF_END_I]] ]
-// CHECK-NEXT:    [[RETVAL_SROA_30_0_I:%.*]] = phi <2 x i32> [ [[TMP7]], [[IF_THEN_I]] ], [ [[TMP4]], [[IF_END_I]] ]
-// CHECK-NEXT:    [[RETVAL_SROA_33_0_I:%.*]] = phi <2 x i32> [ [[TMP6]], [[IF_THEN_I]] ], [ [[TMP5]], [[IF_END_I]] ]
-// CHECK-NEXT:    [[DOTFCA_0_INSERT_I:%.*]] = insertvalue [[STRUCT_V256MX9]] poison, <16 x i32> [[RETVAL_SROA_0_0_I]], 0
-// CHECK-NEXT:    [[DOTFCA_1_INSERT_I:%.*]] = insertvalue [[STRUCT_V256MX9]] [[DOTFCA_0_INSERT_I]], <16 x i32> [[RETVAL_SROA_3_0_I]], 1
-// CHECK-NEXT:    [[DOTFCA_2_INSERT_I:%.*]] = insertvalue [[STRUCT_V256MX9]] [[DOTFCA_1_INSERT_I]], <16 x i32> [[RETVAL_SROA_6_0_I]], 2
-// CHECK-NEXT:    [[DOTFCA_3_INSERT_I:%.*]] = insertvalue [[STRUCT_V256MX9]] [[DOTFCA_2_INSERT_I]], <16 x i32> [[RETVAL_SROA_9_0_I]], 3
-// CHECK-NEXT:    [[DOTFCA_4_INSERT_I:%.*]] = insertvalue [[STRUCT_V256MX9]] [[DOTFCA_3_INSERT_I]], <2 x i32> [[RETVAL_SROA_12_0_I]], 4
-// CHECK-NEXT:    [[DOTFCA_5_INSERT_I:%.*]] = insertvalue [[STRUCT_V256MX9]] [[DOTFCA_4_INSERT_I]], <2 x i32> [[RETVAL_SROA_15_0_I]], 5
-// CHECK-NEXT:    [[DOTFCA_6_INSERT_I:%.*]] = insertvalue [[STRUCT_V256MX9]] [[DOTFCA_5_INSERT_I]], <2 x i32> [[RETVAL_SROA_18_0_I]], 6
-// CHECK-NEXT:    [[DOTFCA_7_INSERT_I:%.*]] = insertvalue [[STRUCT_V256MX9]] [[DOTFCA_6_INSERT_I]], <2 x i32> [[RETVAL_SROA_21_0_I]], 7
-// CHECK-NEXT:    [[DOTFCA_8_INSERT_I:%.*]] = insertvalue [[STRUCT_V256MX9]] [[DOTFCA_7_INSERT_I]], <2 x i32> [[RETVAL_SROA_24_0_I]], 8
-// CHECK-NEXT:    [[DOTFCA_9_INSERT_I:%.*]] = insertvalue [[STRUCT_V256MX9]] [[DOTFCA_8_INSERT_I]], <2 x i32> [[RETVAL_SROA_27_0_I]], 9
-// CHECK-NEXT:    [[DOTFCA_10_INSERT_I:%.*]] = insertvalue [[STRUCT_V256MX9]] [[DOTFCA_9_INSERT_I]], <2 x i32> [[RETVAL_SROA_30_0_I]], 10
-// CHECK-NEXT:    [[DOTFCA_11_INSERT_I:%.*]] = insertvalue [[STRUCT_V256MX9]] [[DOTFCA_10_INSERT_I]], <2 x i32> [[RETVAL_SROA_33_0_I]], 11
-// CHECK-NEXT:    ret [[STRUCT_V256MX9]] [[DOTFCA_11_INSERT_I]]
+// CHECK-NEXT:    [[RETVAL_SROA_0_0_I:%.*]] = phi <16 x i32> [ [[TMP0]], [[IF_THEN_I]] ], [ [[DOTFCA_0_EXTRACT_I]], [[IF_END_I]] ]
+// CHECK-NEXT:    [[RETVAL_SROA_3_0_I:%.*]] = phi <16 x i32> [ [[TMP1]], [[IF_THEN_I]] ], [ [[DOTFCA_1_EXTRACT_I]], [[IF_END_I]] ]
+// CHECK-NEXT:    [[RETVAL_SROA_6_0_I:%.*]] = phi <2 x i32> [ [[TMP2]], [[IF_THEN_I]] ], [ [[DOTFCA_2_EXTRACT_I]], [[IF_END_I]] ]
+// CHECK-NEXT:    [[RETVAL_SROA_9_0_I:%.*]] = phi <2 x i32> [ [[TMP3]], [[IF_THEN_I]] ], [ [[DOTFCA_3_EXTRACT_I]], [[IF_END_I]] ]
+// CHECK-NEXT:    [[RETVAL_SROA_12_0_I:%.*]] = phi <2 x i32> [ [[TMP4]], [[IF_THEN_I]] ], [ [[DOTFCA_4_EXTRACT_I]], [[IF_END_I]] ]
+// CHECK-NEXT:    [[RETVAL_SROA_15_0_I:%.*]] = phi <2 x i32> [ [[TMP5]], [[IF_THEN_I]] ], [ [[DOTFCA_5_EXTRACT_I]], [[IF_END_I]] ]
+// CHECK-NEXT:    [[RETVAL_SROA_18_0_I:%.*]] = phi <16 x i32> [ [[DOTFCA_0_EXTRACT11_I]], [[IF_THEN_I]] ], [ [[TMP0]], [[IF_END_I]] ]
+// CHECK-NEXT:    [[RETVAL_SROA_21_0_I:%.*]] = phi <16 x i32> [ [[DOTFCA_1_EXTRACT13_I]], [[IF_THEN_I]] ], [ [[TMP1]], [[IF_END_I]] ]
+// CHECK-NEXT:    [[RETVAL_SROA_24_0_I:%.*]] = phi <2 x i32> [ [[DOTFCA_2_EXTRACT15_I]], [[IF_THEN_I]] ], [ [[TMP2]], [[IF_END_I]] ]
+// CHECK-NEXT:    [[RETVAL_SROA_27_0_I:%.*]] = phi <2 x i32> [ [[DOTFCA_3_EXTRACT17_I]], [[IF_THEN_I]] ], [ [[TMP3]], [[IF_END_I]] ]
+// CHECK-NEXT:    [[RETVAL_SROA_30_0_I:%.*]] = phi <2 x i32> [ [[DOTFCA_4_EXTRACT19_I]], [[IF_THEN_I]] ], [ [[TMP4]], [[IF_END_I]] ]
+// CHECK-NEXT:    [[RETVAL_SROA_33_0_I:%.*]] = phi <2 x i32> [ [[DOTFCA_5_EXTRACT21_I]], [[IF_THEN_I]] ], [ [[TMP5]], [[IF_END_I]] ]
+// CHECK-NEXT:    [[DOTFCA_0_0_INSERT32:%.*]] = insertvalue [[STRUCT_V256MX9]] poison, <16 x i32> [[RETVAL_SROA_0_0_I]], 0, 0
+// CHECK-NEXT:    [[DOTFCA_0_1_INSERT33:%.*]] = insertvalue [[STRUCT_V256MX9]] [[DOTFCA_0_0_INSERT32]], <16 x i32> [[RETVAL_SROA_3_0_I]], 0, 1
+// CHECK-NEXT:    [[DOTFCA_0_2_INSERT34:%.*]] = insertvalue [[STRUCT_V256MX9]] [[DOTFCA_0_1_INSERT33]], <2 x i32> [[RETVAL_SROA_6_0_I]], 0, 2
+// CHECK-NEXT:    [[DOTFCA_0_3_INSERT35:%.*]] = insertvalue [[STRUCT_V256MX9]] [[DOTFCA_0_2_INSERT34]], <2 x i32> [[RETVAL_SROA_9_0_I]], 0, 3
+// CHECK-NEXT:    [[DOTFCA_0_4_INSERT36:%.*]] = insertvalue [[STRUCT_V256MX9]] [[DOTFCA_0_3_INSERT35]], <2 x i32> [[RETVAL_SROA_12_0_I]], 0, 4
+// CHECK-NEXT:    [[DOTFCA_0_5_INSERT37:%.*]] = insertvalue [[STRUCT_V256MX9]] [[DOTFCA_0_4_INSERT36]], <2 x i32> [[RETVAL_SROA_15_0_I]], 0, 5
+// CHECK-NEXT:    [[DOTFCA_1_0_INSERT38:%.*]] = insertvalue [[STRUCT_V256MX9]] [[DOTFCA_0_5_INSERT37]], <16 x i32> [[RETVAL_SROA_18_0_I]], 1, 0
+// CHECK-NEXT:    [[DOTFCA_1_1_INSERT39:%.*]] = insertvalue [[STRUCT_V256MX9]] [[DOTFCA_1_0_INSERT38]], <16 x i32> [[RETVAL_SROA_21_0_I]], 1, 1
+// CHECK-NEXT:    [[DOTFCA_1_2_INSERT40:%.*]] = insertvalue [[STRUCT_V256MX9]] [[DOTFCA_1_1_INSERT39]], <2 x i32> [[RETVAL_SROA_24_0_I]], 1, 2
+// CHECK-NEXT:    [[DOTFCA_1_3_INSERT41:%.*]] = insertvalue [[STRUCT_V256MX9]] [[DOTFCA_1_2_INSERT40]], <2 x i32> [[RETVAL_SROA_27_0_I]], 1, 3
+// CHECK-NEXT:    [[DOTFCA_1_4_INSERT42:%.*]] = insertvalue [[STRUCT_V256MX9]] [[DOTFCA_1_3_INSERT41]], <2 x i32> [[RETVAL_SROA_30_0_I]], 1, 4
+// CHECK-NEXT:    [[DOTFCA_1_5_INSERT43:%.*]] = insertvalue [[STRUCT_V256MX9]] [[DOTFCA_1_4_INSERT42]], <2 x i32> [[RETVAL_SROA_33_0_I]], 1, 5
+// CHECK-NEXT:    ret [[STRUCT_V256MX9]] [[DOTFCA_1_5_INSERT43]]
 //
 v256mx9 test_insert (v256mx9 m, int idx, v128mx9 a) { return insert(m, idx, a); }
 // CHECK-LABEL: @_Z20test_extract_v128mx97v256mx9i(
 // CHECK-NEXT:  entry:
+// CHECK-NEXT:    [[TMP0:%.*]] = extractvalue [[STRUCT_V256MX9:%.*]] [[A_COERCE:%.*]], 0
+// CHECK-NEXT:    [[TMP1:%.*]] = extractvalue [[STRUCT_V256MX9]] [[A_COERCE]], 1
 // CHECK-NEXT:    [[CMP_I:%.*]] = icmp eq i32 [[IDX:%.*]], 0
-// CHECK-NEXT:    br i1 [[CMP_I]], label [[IF_THEN_I:%.*]], label [[IF_END_I:%.*]]
-// CHECK:       if.then.i:
-// CHECK-NEXT:    [[TMP0:%.*]] = extractvalue [[STRUCT_V256MX9:%.*]] [[A_COERCE:%.*]], 9
-// CHECK-NEXT:    [[TMP1:%.*]] = extractvalue [[STRUCT_V256MX9]] [[A_COERCE]], 8
-// CHECK-NEXT:    [[TMP2:%.*]] = extractvalue [[STRUCT_V256MX9]] [[A_COERCE]], 5
-// CHECK-NEXT:    [[TMP3:%.*]] = extractvalue [[STRUCT_V256MX9]] [[A_COERCE]], 4
-// CHECK-NEXT:    [[TMP4:%.*]] = extractvalue [[STRUCT_V256MX9]] [[A_COERCE]], 1
-// CHECK-NEXT:    [[TMP5:%.*]] = extractvalue [[STRUCT_V256MX9]] [[A_COERCE]], 0
-// CHECK-NEXT:    br label [[_ZL15EXTRACT_V128MX97V256MX9I_EXIT:%.*]]
-// CHECK:       if.end.i:
-// CHECK-NEXT:    [[TMP6:%.*]] = extractvalue [[STRUCT_V256MX9]] [[A_COERCE]], 11
-// CHECK-NEXT:    [[TMP7:%.*]] = extractvalue [[STRUCT_V256MX9]] [[A_COERCE]], 10
-// CHECK-NEXT:    [[TMP8:%.*]] = extractvalue [[STRUCT_V256MX9]] [[A_COERCE]], 7
-// CHECK-NEXT:    [[TMP9:%.*]] = extractvalue [[STRUCT_V256MX9]] [[A_COERCE]], 6
-// CHECK-NEXT:    [[TMP10:%.*]] = extractvalue [[STRUCT_V256MX9]] [[A_COERCE]], 3
-// CHECK-NEXT:    [[TMP11:%.*]] = extractvalue [[STRUCT_V256MX9]] [[A_COERCE]], 2
-// CHECK-NEXT:    br label [[_ZL15EXTRACT_V128MX97V256MX9I_EXIT]]
-// CHECK:       _ZL15extract_v128mx97v256mx9i.exit:
-// CHECK-NEXT:    [[RETVAL_SROA_0_0_I:%.*]] = phi <16 x i32> [ [[TMP5]], [[IF_THEN_I]] ], [ [[TMP11]], [[IF_END_I]] ]
-// CHECK-NEXT:    [[RETVAL_SROA_3_0_I:%.*]] = phi <16 x i32> [ [[TMP4]], [[IF_THEN_I]] ], [ [[TMP10]], [[IF_END_I]] ]
-// CHECK-NEXT:    [[RETVAL_SROA_6_0_I:%.*]] = phi <2 x i32> [ [[TMP3]], [[IF_THEN_I]] ], [ [[TMP9]], [[IF_END_I]] ]
-// CHECK-NEXT:    [[RETVAL_SROA_9_0_I:%.*]] = phi <2 x i32> [ [[TMP2]], [[IF_THEN_I]] ], [ [[TMP8]], [[IF_END_I]] ]
-// CHECK-NEXT:    [[RETVAL_SROA_12_0_I:%.*]] = phi <2 x i32> [ [[TMP1]], [[IF_THEN_I]] ], [ [[TMP7]], [[IF_END_I]] ]
-// CHECK-NEXT:    [[RETVAL_SROA_15_0_I:%.*]] = phi <2 x i32> [ [[TMP0]], [[IF_THEN_I]] ], [ [[TMP6]], [[IF_END_I]] ]
-// CHECK-NEXT:    [[DOTFCA_0_INSERT_I:%.*]] = insertvalue [[STRUCT_V128MX9:%.*]] poison, <16 x i32> [[RETVAL_SROA_0_0_I]], 0
-// CHECK-NEXT:    [[DOTFCA_1_INSERT_I:%.*]] = insertvalue [[STRUCT_V128MX9]] [[DOTFCA_0_INSERT_I]], <16 x i32> [[RETVAL_SROA_3_0_I]], 1
-// CHECK-NEXT:    [[DOTFCA_2_INSERT_I:%.*]] = insertvalue [[STRUCT_V128MX9]] [[DOTFCA_1_INSERT_I]], <2 x i32> [[RETVAL_SROA_6_0_I]], 2
-// CHECK-NEXT:    [[DOTFCA_3_INSERT_I:%.*]] = insertvalue [[STRUCT_V128MX9]] [[DOTFCA_2_INSERT_I]], <2 x i32> [[RETVAL_SROA_9_0_I]], 3
-// CHECK-NEXT:    [[DOTFCA_4_INSERT_I:%.*]] = insertvalue [[STRUCT_V128MX9]] [[DOTFCA_3_INSERT_I]], <2 x i32> [[RETVAL_SROA_12_0_I]], 4
-// CHECK-NEXT:    [[DOTFCA_5_INSERT_I:%.*]] = insertvalue [[STRUCT_V128MX9]] [[DOTFCA_4_INSERT_I]], <2 x i32> [[RETVAL_SROA_15_0_I]], 5
-// CHECK-NEXT:    ret [[STRUCT_V128MX9]] [[DOTFCA_5_INSERT_I]]
+// CHECK-NEXT:    [[DOTPN_I:%.*]] = select i1 [[CMP_I]], [[STRUCT_V128MX9:%.*]] [[TMP0]], [[STRUCT_V128MX9]] [[TMP1]]
+// CHECK-NEXT:    ret [[STRUCT_V128MX9]] [[DOTPN_I]]
 //
 v128mx9 test_extract_v128mx9 (v256mx9 a, int idx) { return extract_v128mx9(a, idx); }
 // CHECK-LABEL: @_Z23test_extract_v128bfp16p7v256mx9i(
 // CHECK-NEXT:  entry:
+// CHECK-NEXT:    [[TMP0:%.*]] = extractvalue [[STRUCT_V256MX9:%.*]] [[A_COERCE:%.*]], 0
+// CHECK-NEXT:    [[TMP1:%.*]] = extractvalue [[STRUCT_V256MX9]] [[A_COERCE]], 1
 // CHECK-NEXT:    [[CMP_I_I:%.*]] = icmp eq i32 [[IDX:%.*]], 0
-// CHECK-NEXT:    br i1 [[CMP_I_I]], label [[IF_THEN_I_I:%.*]], label [[IF_END_I_I:%.*]]
-// CHECK:       if.then.i.i:
-// CHECK-NEXT:    [[TMP0:%.*]] = extractvalue [[STRUCT_V256MX9:%.*]] [[A_COERCE:%.*]], 9
-// CHECK-NEXT:    [[TMP1:%.*]] = extractvalue [[STRUCT_V256MX9]] [[A_COERCE]], 8
-// CHECK-NEXT:    [[TMP2:%.*]] = extractvalue [[STRUCT_V256MX9]] [[A_COERCE]], 5
-// CHECK-NEXT:    [[TMP3:%.*]] = extractvalue [[STRUCT_V256MX9]] [[A_COERCE]], 4
-// CHECK-NEXT:    [[TMP4:%.*]] = extractvalue [[STRUCT_V256MX9]] [[A_COERCE]], 1
-// CHECK-NEXT:    [[TMP5:%.*]] = extractvalue [[STRUCT_V256MX9]] [[A_COERCE]], 0
-// CHECK-NEXT:    br label [[_ZL18EXTRACT_V128BFP16P7V256MX9I_EXIT:%.*]]
-// CHECK:       if.end.i.i:
-// CHECK-NEXT:    [[TMP6:%.*]] = extractvalue [[STRUCT_V256MX9]] [[A_COERCE]], 11
-// CHECK-NEXT:    [[TMP7:%.*]] = extractvalue [[STRUCT_V256MX9]] [[A_COERCE]], 10
-// CHECK-NEXT:    [[TMP8:%.*]] = extractvalue [[STRUCT_V256MX9]] [[A_COERCE]], 7
-// CHECK-NEXT:    [[TMP9:%.*]] = extractvalue [[STRUCT_V256MX9]] [[A_COERCE]], 6
-// CHECK-NEXT:    [[TMP10:%.*]] = extractvalue [[STRUCT_V256MX9]] [[A_COERCE]], 3
-// CHECK-NEXT:    [[TMP11:%.*]] = extractvalue [[STRUCT_V256MX9]] [[A_COERCE]], 2
-// CHECK-NEXT:    br label [[_ZL18EXTRACT_V128BFP16P7V256MX9I_EXIT]]
-// CHECK:       _ZL18extract_v128bfp16p7v256mx9i.exit:
-// CHECK-NEXT:    [[RETVAL_SROA_0_0_I_I:%.*]] = phi <16 x i32> [ [[TMP5]], [[IF_THEN_I_I]] ], [ [[TMP11]], [[IF_END_I_I]] ]
-// CHECK-NEXT:    [[RETVAL_SROA_3_0_I_I:%.*]] = phi <16 x i32> [ [[TMP4]], [[IF_THEN_I_I]] ], [ [[TMP10]], [[IF_END_I_I]] ]
-// CHECK-NEXT:    [[RETVAL_SROA_6_0_I_I:%.*]] = phi <2 x i32> [ [[TMP3]], [[IF_THEN_I_I]] ], [ [[TMP9]], [[IF_END_I_I]] ]
-// CHECK-NEXT:    [[RETVAL_SROA_9_0_I_I:%.*]] = phi <2 x i32> [ [[TMP2]], [[IF_THEN_I_I]] ], [ [[TMP8]], [[IF_END_I_I]] ]
-// CHECK-NEXT:    [[RETVAL_SROA_12_0_I_I:%.*]] = phi <2 x i32> [ [[TMP1]], [[IF_THEN_I_I]] ], [ [[TMP7]], [[IF_END_I_I]] ]
-// CHECK-NEXT:    [[RETVAL_SROA_15_0_I_I:%.*]] = phi <2 x i32> [ [[TMP0]], [[IF_THEN_I_I]] ], [ [[TMP6]], [[IF_END_I_I]] ]
-// CHECK-NEXT:    [[DOTFCA_0_INSERT_I_I:%.*]] = insertvalue [[STRUCT_V128MX9:%.*]] poison, <16 x i32> [[RETVAL_SROA_0_0_I_I]], 0
-// CHECK-NEXT:    [[DOTFCA_1_INSERT_I_I:%.*]] = insertvalue [[STRUCT_V128MX9]] [[DOTFCA_0_INSERT_I_I]], <16 x i32> [[RETVAL_SROA_3_0_I_I]], 1
-// CHECK-NEXT:    [[DOTFCA_2_INSERT_I_I:%.*]] = insertvalue [[STRUCT_V128MX9]] [[DOTFCA_1_INSERT_I_I]], <2 x i32> [[RETVAL_SROA_6_0_I_I]], 2
-// CHECK-NEXT:    [[DOTFCA_3_INSERT_I_I:%.*]] = insertvalue [[STRUCT_V128MX9]] [[DOTFCA_2_INSERT_I_I]], <2 x i32> [[RETVAL_SROA_9_0_I_I]], 3
-// CHECK-NEXT:    [[DOTFCA_4_INSERT_I_I:%.*]] = insertvalue [[STRUCT_V128MX9]] [[DOTFCA_3_INSERT_I_I]], <2 x i32> [[RETVAL_SROA_12_0_I_I]], 4
-// CHECK-NEXT:    [[DOTFCA_5_INSERT_I_I:%.*]] = insertvalue [[STRUCT_V128MX9]] [[DOTFCA_4_INSERT_I_I]], <2 x i32> [[RETVAL_SROA_15_0_I_I]], 5
-// CHECK-NEXT:    ret [[STRUCT_V128MX9]] [[DOTFCA_5_INSERT_I_I]]
+// CHECK-NEXT:    [[DOTPN_I_I:%.*]] = select i1 [[CMP_I_I]], [[STRUCT_V128MX9:%.*]] [[TMP0]], [[STRUCT_V128MX9]] [[TMP1]]
+// CHECK-NEXT:    ret [[STRUCT_V128MX9]] [[DOTPN_I_I]]
 //
 v128bfp16p test_extract_v128bfp16p (v256bfp16p a, int idx) { return extract_v128bfp16p(a, idx); }
 // CHECK-LABEL: @_Z11test_insert7v256mx9i6v64mx9(

--- a/clang/test/CodeGen/aie/aie2ps/aie2ps-vmult-intrinsic.cpp
+++ b/clang/test/CodeGen/aie/aie2ps/aie2ps-vmult-intrinsic.cpp
@@ -2320,7 +2320,6 @@ v64acc32 test_addmac_elem_64_conf(v64uint8 a, int sgn_x, v64int8 b, int sgn_y,
   return addmac_elem_64_conf(a, sgn_x, b, sgn_y, acc1, acc2, zero_acc1, shift16,
                              sub_mul, sub_acc1, sub_acc2);
 }
-//
 // CHECK-LABEL: define dso_local inreg noundef <64 x i32> @_Z24test_addmsc_elem_64_confDv64_hiDv64_aiDv64_u7__acc32S1_iiiii(
 // CHECK-SAME: <64 x i8> noundef [[A:%.*]], i32 noundef [[SGN_X:%.*]], <64 x i8> noundef [[B:%.*]], i32 noundef [[SGN_Y:%.*]], <64 x i32> inreg noundef [[ACC1:%.*]], <64 x i32> inreg noundef [[ACC2:%.*]], i32 noundef [[ZERO_ACC1:%.*]], i32 noundef [[SHIFT16:%.*]], i32 noundef [[SUB_MUL:%.*]], i32 noundef [[SUB_ACC1:%.*]], i32 noundef [[SUB_ACC2:%.*]]) local_unnamed_addr #[[ATTR0]] {
 // CHECK-NEXT:  entry:
@@ -38218,23 +38217,25 @@ v64accfloat test_addmsc_8x8_8x8_conf(v64bfloat8 a, int sgn_x, v64bfloat8 b,
 // CHECK-LABEL: define dso_local inreg noundef <64 x float> @_Z20test_mul_4x16_16x16T6v64mx97v256mx9(
 // CHECK-SAME: [[STRUCT_V64MX9:%.*]] [[A_COERCE:%.*]], [[STRUCT_V256MX9:%.*]] [[B_COERCE:%.*]]) local_unnamed_addr #[[ATTR1]] {
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[TMP0:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 0
-// CHECK-NEXT:    [[TMP1:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 1
-// CHECK-NEXT:    [[TMP2:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 2
-// CHECK-NEXT:    [[TMP3:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 0
-// CHECK-NEXT:    [[TMP4:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 1
-// CHECK-NEXT:    [[TMP5:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 2
-// CHECK-NEXT:    [[TMP6:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 3
-// CHECK-NEXT:    [[TMP7:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 4
-// CHECK-NEXT:    [[TMP8:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 5
-// CHECK-NEXT:    [[TMP9:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 6
-// CHECK-NEXT:    [[TMP10:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 7
-// CHECK-NEXT:    [[TMP11:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 8
-// CHECK-NEXT:    [[TMP12:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 9
-// CHECK-NEXT:    [[TMP13:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 10
-// CHECK-NEXT:    [[TMP14:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 11
-// CHECK-NEXT:    [[TMP15:%.*]] = tail call noundef <64 x float> @llvm.aie2ps.BFP640.BFP2560.ACC2048.bf.mul.conf(<16 x i32> [[TMP0]], <2 x i32> [[TMP1]], <2 x i32> [[TMP2]], <16 x i32> [[TMP3]], <16 x i32> [[TMP4]], <16 x i32> [[TMP5]], <16 x i32> [[TMP6]], <2 x i32> [[TMP7]], <2 x i32> [[TMP8]], <2 x i32> [[TMP9]], <2 x i32> [[TMP10]], <2 x i32> [[TMP11]], <2 x i32> [[TMP12]], <2 x i32> [[TMP13]], <2 x i32> [[TMP14]], i32 972)
-// CHECK-NEXT:    ret <64 x float> [[TMP15]]
+// CHECK-NEXT:    [[TMP0:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 0
+// CHECK-NEXT:    [[TMP1:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 1
+// CHECK-NEXT:    [[TMP2:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 0
+// CHECK-NEXT:    [[TMP3:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 1
+// CHECK-NEXT:    [[TMP4:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 2
+// CHECK-NEXT:    [[DOTFCA_0_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9:%.*]] [[TMP0]], 0
+// CHECK-NEXT:    [[DOTFCA_1_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 1
+// CHECK-NEXT:    [[DOTFCA_2_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 2
+// CHECK-NEXT:    [[DOTFCA_3_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 3
+// CHECK-NEXT:    [[DOTFCA_4_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 4
+// CHECK-NEXT:    [[DOTFCA_5_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 5
+// CHECK-NEXT:    [[DOTFCA_0_EXTRACT17_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 0
+// CHECK-NEXT:    [[DOTFCA_1_EXTRACT19_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 1
+// CHECK-NEXT:    [[DOTFCA_2_EXTRACT21_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 2
+// CHECK-NEXT:    [[DOTFCA_3_EXTRACT23_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 3
+// CHECK-NEXT:    [[DOTFCA_4_EXTRACT25_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 4
+// CHECK-NEXT:    [[DOTFCA_5_EXTRACT27_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 5
+// CHECK-NEXT:    [[TMP5:%.*]] = tail call noundef <64 x float> @llvm.aie2ps.BFP640.BFP2560.ACC2048.bf.mul.conf(<16 x i32> [[TMP2]], <2 x i32> [[TMP3]], <2 x i32> [[TMP4]], <16 x i32> [[DOTFCA_0_EXTRACT_I]], <16 x i32> [[DOTFCA_1_EXTRACT_I]], <16 x i32> [[DOTFCA_0_EXTRACT17_I]], <16 x i32> [[DOTFCA_1_EXTRACT19_I]], <2 x i32> [[DOTFCA_2_EXTRACT_I]], <2 x i32> [[DOTFCA_3_EXTRACT_I]], <2 x i32> [[DOTFCA_2_EXTRACT21_I]], <2 x i32> [[DOTFCA_3_EXTRACT23_I]], <2 x i32> [[DOTFCA_4_EXTRACT_I]], <2 x i32> [[DOTFCA_5_EXTRACT_I]], <2 x i32> [[DOTFCA_4_EXTRACT25_I]], <2 x i32> [[DOTFCA_5_EXTRACT27_I]], i32 972)
+// CHECK-NEXT:    ret <64 x float> [[TMP5]]
 //
 v64accfloat test_mul_4x16_16x16T(v64mx9 a, v256mx9 b) {
   return mul_4x16_16x16T(a, b);
@@ -38242,23 +38243,25 @@ v64accfloat test_mul_4x16_16x16T(v64mx9 a, v256mx9 b) {
 // CHECK-LABEL: define dso_local inreg noundef <64 x float> @_Z23test_negmul_4x16_16x16T6v64mx97v256mx9(
 // CHECK-SAME: [[STRUCT_V64MX9:%.*]] [[A_COERCE:%.*]], [[STRUCT_V256MX9:%.*]] [[B_COERCE:%.*]]) local_unnamed_addr #[[ATTR1]] {
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[TMP0:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 0
-// CHECK-NEXT:    [[TMP1:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 1
-// CHECK-NEXT:    [[TMP2:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 2
-// CHECK-NEXT:    [[TMP3:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 0
-// CHECK-NEXT:    [[TMP4:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 1
-// CHECK-NEXT:    [[TMP5:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 2
-// CHECK-NEXT:    [[TMP6:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 3
-// CHECK-NEXT:    [[TMP7:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 4
-// CHECK-NEXT:    [[TMP8:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 5
-// CHECK-NEXT:    [[TMP9:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 6
-// CHECK-NEXT:    [[TMP10:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 7
-// CHECK-NEXT:    [[TMP11:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 8
-// CHECK-NEXT:    [[TMP12:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 9
-// CHECK-NEXT:    [[TMP13:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 10
-// CHECK-NEXT:    [[TMP14:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 11
-// CHECK-NEXT:    [[TMP15:%.*]] = tail call noundef <64 x float> @llvm.aie2ps.BFP640.BFP2560.ACC2048.bf.negmul.conf(<16 x i32> [[TMP0]], <2 x i32> [[TMP1]], <2 x i32> [[TMP2]], <16 x i32> [[TMP3]], <16 x i32> [[TMP4]], <16 x i32> [[TMP5]], <16 x i32> [[TMP6]], <2 x i32> [[TMP7]], <2 x i32> [[TMP8]], <2 x i32> [[TMP9]], <2 x i32> [[TMP10]], <2 x i32> [[TMP11]], <2 x i32> [[TMP12]], <2 x i32> [[TMP13]], <2 x i32> [[TMP14]], i32 972)
-// CHECK-NEXT:    ret <64 x float> [[TMP15]]
+// CHECK-NEXT:    [[TMP0:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 0
+// CHECK-NEXT:    [[TMP1:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 1
+// CHECK-NEXT:    [[TMP2:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 0
+// CHECK-NEXT:    [[TMP3:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 1
+// CHECK-NEXT:    [[TMP4:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 2
+// CHECK-NEXT:    [[DOTFCA_0_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9:%.*]] [[TMP0]], 0
+// CHECK-NEXT:    [[DOTFCA_1_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 1
+// CHECK-NEXT:    [[DOTFCA_2_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 2
+// CHECK-NEXT:    [[DOTFCA_3_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 3
+// CHECK-NEXT:    [[DOTFCA_4_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 4
+// CHECK-NEXT:    [[DOTFCA_5_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 5
+// CHECK-NEXT:    [[DOTFCA_0_EXTRACT17_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 0
+// CHECK-NEXT:    [[DOTFCA_1_EXTRACT19_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 1
+// CHECK-NEXT:    [[DOTFCA_2_EXTRACT21_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 2
+// CHECK-NEXT:    [[DOTFCA_3_EXTRACT23_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 3
+// CHECK-NEXT:    [[DOTFCA_4_EXTRACT25_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 4
+// CHECK-NEXT:    [[DOTFCA_5_EXTRACT27_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 5
+// CHECK-NEXT:    [[TMP5:%.*]] = tail call noundef <64 x float> @llvm.aie2ps.BFP640.BFP2560.ACC2048.bf.negmul.conf(<16 x i32> [[TMP2]], <2 x i32> [[TMP3]], <2 x i32> [[TMP4]], <16 x i32> [[DOTFCA_0_EXTRACT_I]], <16 x i32> [[DOTFCA_1_EXTRACT_I]], <16 x i32> [[DOTFCA_0_EXTRACT17_I]], <16 x i32> [[DOTFCA_1_EXTRACT19_I]], <2 x i32> [[DOTFCA_2_EXTRACT_I]], <2 x i32> [[DOTFCA_3_EXTRACT_I]], <2 x i32> [[DOTFCA_2_EXTRACT21_I]], <2 x i32> [[DOTFCA_3_EXTRACT23_I]], <2 x i32> [[DOTFCA_4_EXTRACT_I]], <2 x i32> [[DOTFCA_5_EXTRACT_I]], <2 x i32> [[DOTFCA_4_EXTRACT25_I]], <2 x i32> [[DOTFCA_5_EXTRACT27_I]], i32 972)
+// CHECK-NEXT:    ret <64 x float> [[TMP5]]
 //
 v64accfloat test_negmul_4x16_16x16T(v64mx9 a, v256mx9 b) {
   return negmul_4x16_16x16T(a, b);
@@ -38266,23 +38269,25 @@ v64accfloat test_negmul_4x16_16x16T(v64mx9 a, v256mx9 b) {
 // CHECK-LABEL: define dso_local inreg noundef <64 x float> @_Z20test_mac_4x16_16x16T6v64mx97v256mx9Dv64_u10__accfloat(
 // CHECK-SAME: [[STRUCT_V64MX9:%.*]] [[A_COERCE:%.*]], [[STRUCT_V256MX9:%.*]] [[B_COERCE:%.*]], <64 x float> inreg noundef [[ACC:%.*]]) local_unnamed_addr #[[ATTR1]] {
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[TMP0:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 0
-// CHECK-NEXT:    [[TMP1:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 1
-// CHECK-NEXT:    [[TMP2:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 2
-// CHECK-NEXT:    [[TMP3:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 0
-// CHECK-NEXT:    [[TMP4:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 1
-// CHECK-NEXT:    [[TMP5:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 2
-// CHECK-NEXT:    [[TMP6:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 3
-// CHECK-NEXT:    [[TMP7:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 4
-// CHECK-NEXT:    [[TMP8:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 5
-// CHECK-NEXT:    [[TMP9:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 6
-// CHECK-NEXT:    [[TMP10:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 7
-// CHECK-NEXT:    [[TMP11:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 8
-// CHECK-NEXT:    [[TMP12:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 9
-// CHECK-NEXT:    [[TMP13:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 10
-// CHECK-NEXT:    [[TMP14:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 11
-// CHECK-NEXT:    [[TMP15:%.*]] = tail call noundef <64 x float> @llvm.aie2ps.BFP640.BFP2560.ACC2048.bf.mac.conf(<16 x i32> [[TMP0]], <2 x i32> [[TMP1]], <2 x i32> [[TMP2]], <16 x i32> [[TMP3]], <16 x i32> [[TMP4]], <16 x i32> [[TMP5]], <16 x i32> [[TMP6]], <2 x i32> [[TMP7]], <2 x i32> [[TMP8]], <2 x i32> [[TMP9]], <2 x i32> [[TMP10]], <2 x i32> [[TMP11]], <2 x i32> [[TMP12]], <2 x i32> [[TMP13]], <2 x i32> [[TMP14]], <64 x float> [[ACC]], i32 972)
-// CHECK-NEXT:    ret <64 x float> [[TMP15]]
+// CHECK-NEXT:    [[TMP0:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 0
+// CHECK-NEXT:    [[TMP1:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 1
+// CHECK-NEXT:    [[TMP2:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 0
+// CHECK-NEXT:    [[TMP3:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 1
+// CHECK-NEXT:    [[TMP4:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 2
+// CHECK-NEXT:    [[DOTFCA_0_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9:%.*]] [[TMP0]], 0
+// CHECK-NEXT:    [[DOTFCA_1_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 1
+// CHECK-NEXT:    [[DOTFCA_2_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 2
+// CHECK-NEXT:    [[DOTFCA_3_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 3
+// CHECK-NEXT:    [[DOTFCA_4_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 4
+// CHECK-NEXT:    [[DOTFCA_5_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 5
+// CHECK-NEXT:    [[DOTFCA_0_EXTRACT17_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 0
+// CHECK-NEXT:    [[DOTFCA_1_EXTRACT19_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 1
+// CHECK-NEXT:    [[DOTFCA_2_EXTRACT21_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 2
+// CHECK-NEXT:    [[DOTFCA_3_EXTRACT23_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 3
+// CHECK-NEXT:    [[DOTFCA_4_EXTRACT25_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 4
+// CHECK-NEXT:    [[DOTFCA_5_EXTRACT27_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 5
+// CHECK-NEXT:    [[TMP5:%.*]] = tail call noundef <64 x float> @llvm.aie2ps.BFP640.BFP2560.ACC2048.bf.mac.conf(<16 x i32> [[TMP2]], <2 x i32> [[TMP3]], <2 x i32> [[TMP4]], <16 x i32> [[DOTFCA_0_EXTRACT_I]], <16 x i32> [[DOTFCA_1_EXTRACT_I]], <16 x i32> [[DOTFCA_0_EXTRACT17_I]], <16 x i32> [[DOTFCA_1_EXTRACT19_I]], <2 x i32> [[DOTFCA_2_EXTRACT_I]], <2 x i32> [[DOTFCA_3_EXTRACT_I]], <2 x i32> [[DOTFCA_2_EXTRACT21_I]], <2 x i32> [[DOTFCA_3_EXTRACT23_I]], <2 x i32> [[DOTFCA_4_EXTRACT_I]], <2 x i32> [[DOTFCA_5_EXTRACT_I]], <2 x i32> [[DOTFCA_4_EXTRACT25_I]], <2 x i32> [[DOTFCA_5_EXTRACT27_I]], <64 x float> [[ACC]], i32 972)
+// CHECK-NEXT:    ret <64 x float> [[TMP5]]
 //
 v64accfloat test_mac_4x16_16x16T(v64mx9 a, v256mx9 b, v64accfloat acc) {
   return mac_4x16_16x16T(a, b, acc);
@@ -38290,23 +38295,25 @@ v64accfloat test_mac_4x16_16x16T(v64mx9 a, v256mx9 b, v64accfloat acc) {
 // CHECK-LABEL: define dso_local inreg noundef <64 x float> @_Z20test_msc_4x16_16x16T6v64mx97v256mx9Dv64_u10__accfloat(
 // CHECK-SAME: [[STRUCT_V64MX9:%.*]] [[A_COERCE:%.*]], [[STRUCT_V256MX9:%.*]] [[B_COERCE:%.*]], <64 x float> inreg noundef [[ACC:%.*]]) local_unnamed_addr #[[ATTR1]] {
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[TMP0:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 0
-// CHECK-NEXT:    [[TMP1:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 1
-// CHECK-NEXT:    [[TMP2:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 2
-// CHECK-NEXT:    [[TMP3:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 0
-// CHECK-NEXT:    [[TMP4:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 1
-// CHECK-NEXT:    [[TMP5:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 2
-// CHECK-NEXT:    [[TMP6:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 3
-// CHECK-NEXT:    [[TMP7:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 4
-// CHECK-NEXT:    [[TMP8:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 5
-// CHECK-NEXT:    [[TMP9:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 6
-// CHECK-NEXT:    [[TMP10:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 7
-// CHECK-NEXT:    [[TMP11:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 8
-// CHECK-NEXT:    [[TMP12:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 9
-// CHECK-NEXT:    [[TMP13:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 10
-// CHECK-NEXT:    [[TMP14:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 11
-// CHECK-NEXT:    [[TMP15:%.*]] = tail call noundef <64 x float> @llvm.aie2ps.BFP640.BFP2560.ACC2048.bf.msc.conf(<16 x i32> [[TMP0]], <2 x i32> [[TMP1]], <2 x i32> [[TMP2]], <16 x i32> [[TMP3]], <16 x i32> [[TMP4]], <16 x i32> [[TMP5]], <16 x i32> [[TMP6]], <2 x i32> [[TMP7]], <2 x i32> [[TMP8]], <2 x i32> [[TMP9]], <2 x i32> [[TMP10]], <2 x i32> [[TMP11]], <2 x i32> [[TMP12]], <2 x i32> [[TMP13]], <2 x i32> [[TMP14]], <64 x float> [[ACC]], i32 972)
-// CHECK-NEXT:    ret <64 x float> [[TMP15]]
+// CHECK-NEXT:    [[TMP0:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 0
+// CHECK-NEXT:    [[TMP1:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 1
+// CHECK-NEXT:    [[TMP2:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 0
+// CHECK-NEXT:    [[TMP3:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 1
+// CHECK-NEXT:    [[TMP4:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 2
+// CHECK-NEXT:    [[DOTFCA_0_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9:%.*]] [[TMP0]], 0
+// CHECK-NEXT:    [[DOTFCA_1_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 1
+// CHECK-NEXT:    [[DOTFCA_2_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 2
+// CHECK-NEXT:    [[DOTFCA_3_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 3
+// CHECK-NEXT:    [[DOTFCA_4_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 4
+// CHECK-NEXT:    [[DOTFCA_5_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 5
+// CHECK-NEXT:    [[DOTFCA_0_EXTRACT17_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 0
+// CHECK-NEXT:    [[DOTFCA_1_EXTRACT19_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 1
+// CHECK-NEXT:    [[DOTFCA_2_EXTRACT21_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 2
+// CHECK-NEXT:    [[DOTFCA_3_EXTRACT23_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 3
+// CHECK-NEXT:    [[DOTFCA_4_EXTRACT25_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 4
+// CHECK-NEXT:    [[DOTFCA_5_EXTRACT27_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 5
+// CHECK-NEXT:    [[TMP5:%.*]] = tail call noundef <64 x float> @llvm.aie2ps.BFP640.BFP2560.ACC2048.bf.msc.conf(<16 x i32> [[TMP2]], <2 x i32> [[TMP3]], <2 x i32> [[TMP4]], <16 x i32> [[DOTFCA_0_EXTRACT_I]], <16 x i32> [[DOTFCA_1_EXTRACT_I]], <16 x i32> [[DOTFCA_0_EXTRACT17_I]], <16 x i32> [[DOTFCA_1_EXTRACT19_I]], <2 x i32> [[DOTFCA_2_EXTRACT_I]], <2 x i32> [[DOTFCA_3_EXTRACT_I]], <2 x i32> [[DOTFCA_2_EXTRACT21_I]], <2 x i32> [[DOTFCA_3_EXTRACT23_I]], <2 x i32> [[DOTFCA_4_EXTRACT_I]], <2 x i32> [[DOTFCA_5_EXTRACT_I]], <2 x i32> [[DOTFCA_4_EXTRACT25_I]], <2 x i32> [[DOTFCA_5_EXTRACT27_I]], <64 x float> [[ACC]], i32 972)
+// CHECK-NEXT:    ret <64 x float> [[TMP5]]
 //
 v64accfloat test_msc_4x16_16x16T(v64mx9 a, v256mx9 b, v64accfloat acc) {
   return msc_4x16_16x16T(a, b, acc);
@@ -38314,23 +38321,25 @@ v64accfloat test_msc_4x16_16x16T(v64mx9 a, v256mx9 b, v64accfloat acc) {
 // CHECK-LABEL: define dso_local inreg noundef <64 x float> @_Z23test_addmac_4x16_16x16T6v64mx97v256mx9Dv64_u10__accfloatS1_(
 // CHECK-SAME: [[STRUCT_V64MX9:%.*]] [[A_COERCE:%.*]], [[STRUCT_V256MX9:%.*]] [[B_COERCE:%.*]], <64 x float> inreg noundef [[ACC1:%.*]], <64 x float> inreg noundef [[ACC2:%.*]]) local_unnamed_addr #[[ATTR1]] {
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[TMP0:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 0
-// CHECK-NEXT:    [[TMP1:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 1
-// CHECK-NEXT:    [[TMP2:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 2
-// CHECK-NEXT:    [[TMP3:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 0
-// CHECK-NEXT:    [[TMP4:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 1
-// CHECK-NEXT:    [[TMP5:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 2
-// CHECK-NEXT:    [[TMP6:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 3
-// CHECK-NEXT:    [[TMP7:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 4
-// CHECK-NEXT:    [[TMP8:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 5
-// CHECK-NEXT:    [[TMP9:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 6
-// CHECK-NEXT:    [[TMP10:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 7
-// CHECK-NEXT:    [[TMP11:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 8
-// CHECK-NEXT:    [[TMP12:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 9
-// CHECK-NEXT:    [[TMP13:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 10
-// CHECK-NEXT:    [[TMP14:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 11
-// CHECK-NEXT:    [[TMP15:%.*]] = tail call noundef <64 x float> @llvm.aie2ps.BFP640.BFP2560.ACC2048.bf.addmac.conf(<16 x i32> [[TMP0]], <2 x i32> [[TMP1]], <2 x i32> [[TMP2]], <16 x i32> [[TMP3]], <16 x i32> [[TMP4]], <16 x i32> [[TMP5]], <16 x i32> [[TMP6]], <2 x i32> [[TMP7]], <2 x i32> [[TMP8]], <2 x i32> [[TMP9]], <2 x i32> [[TMP10]], <2 x i32> [[TMP11]], <2 x i32> [[TMP12]], <2 x i32> [[TMP13]], <2 x i32> [[TMP14]], <64 x float> [[ACC1]], <64 x float> [[ACC2]], i32 972)
-// CHECK-NEXT:    ret <64 x float> [[TMP15]]
+// CHECK-NEXT:    [[TMP0:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 0
+// CHECK-NEXT:    [[TMP1:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 1
+// CHECK-NEXT:    [[TMP2:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 0
+// CHECK-NEXT:    [[TMP3:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 1
+// CHECK-NEXT:    [[TMP4:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 2
+// CHECK-NEXT:    [[DOTFCA_0_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9:%.*]] [[TMP0]], 0
+// CHECK-NEXT:    [[DOTFCA_1_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 1
+// CHECK-NEXT:    [[DOTFCA_2_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 2
+// CHECK-NEXT:    [[DOTFCA_3_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 3
+// CHECK-NEXT:    [[DOTFCA_4_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 4
+// CHECK-NEXT:    [[DOTFCA_5_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 5
+// CHECK-NEXT:    [[DOTFCA_0_EXTRACT17_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 0
+// CHECK-NEXT:    [[DOTFCA_1_EXTRACT19_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 1
+// CHECK-NEXT:    [[DOTFCA_2_EXTRACT21_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 2
+// CHECK-NEXT:    [[DOTFCA_3_EXTRACT23_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 3
+// CHECK-NEXT:    [[DOTFCA_4_EXTRACT25_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 4
+// CHECK-NEXT:    [[DOTFCA_5_EXTRACT27_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 5
+// CHECK-NEXT:    [[TMP5:%.*]] = tail call noundef <64 x float> @llvm.aie2ps.BFP640.BFP2560.ACC2048.bf.addmac.conf(<16 x i32> [[TMP2]], <2 x i32> [[TMP3]], <2 x i32> [[TMP4]], <16 x i32> [[DOTFCA_0_EXTRACT_I]], <16 x i32> [[DOTFCA_1_EXTRACT_I]], <16 x i32> [[DOTFCA_0_EXTRACT17_I]], <16 x i32> [[DOTFCA_1_EXTRACT19_I]], <2 x i32> [[DOTFCA_2_EXTRACT_I]], <2 x i32> [[DOTFCA_3_EXTRACT_I]], <2 x i32> [[DOTFCA_2_EXTRACT21_I]], <2 x i32> [[DOTFCA_3_EXTRACT23_I]], <2 x i32> [[DOTFCA_4_EXTRACT_I]], <2 x i32> [[DOTFCA_5_EXTRACT_I]], <2 x i32> [[DOTFCA_4_EXTRACT25_I]], <2 x i32> [[DOTFCA_5_EXTRACT27_I]], <64 x float> [[ACC1]], <64 x float> [[ACC2]], i32 972)
+// CHECK-NEXT:    ret <64 x float> [[TMP5]]
 //
 v64accfloat test_addmac_4x16_16x16T(v64mx9 a, v256mx9 b, v64accfloat acc1,
                                     v64accfloat acc2) {
@@ -38339,23 +38348,25 @@ v64accfloat test_addmac_4x16_16x16T(v64mx9 a, v256mx9 b, v64accfloat acc1,
 // CHECK-LABEL: define dso_local inreg noundef <64 x float> @_Z23test_addmsc_4x16_16x16T6v64mx97v256mx9Dv64_u10__accfloatS1_(
 // CHECK-SAME: [[STRUCT_V64MX9:%.*]] [[A_COERCE:%.*]], [[STRUCT_V256MX9:%.*]] [[B_COERCE:%.*]], <64 x float> inreg noundef [[ACC1:%.*]], <64 x float> inreg noundef [[ACC2:%.*]]) local_unnamed_addr #[[ATTR1]] {
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[TMP0:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 0
-// CHECK-NEXT:    [[TMP1:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 1
-// CHECK-NEXT:    [[TMP2:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 2
-// CHECK-NEXT:    [[TMP3:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 0
-// CHECK-NEXT:    [[TMP4:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 1
-// CHECK-NEXT:    [[TMP5:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 2
-// CHECK-NEXT:    [[TMP6:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 3
-// CHECK-NEXT:    [[TMP7:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 4
-// CHECK-NEXT:    [[TMP8:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 5
-// CHECK-NEXT:    [[TMP9:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 6
-// CHECK-NEXT:    [[TMP10:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 7
-// CHECK-NEXT:    [[TMP11:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 8
-// CHECK-NEXT:    [[TMP12:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 9
-// CHECK-NEXT:    [[TMP13:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 10
-// CHECK-NEXT:    [[TMP14:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 11
-// CHECK-NEXT:    [[TMP15:%.*]] = tail call noundef <64 x float> @llvm.aie2ps.BFP640.BFP2560.ACC2048.bf.addmsc.conf(<16 x i32> [[TMP0]], <2 x i32> [[TMP1]], <2 x i32> [[TMP2]], <16 x i32> [[TMP3]], <16 x i32> [[TMP4]], <16 x i32> [[TMP5]], <16 x i32> [[TMP6]], <2 x i32> [[TMP7]], <2 x i32> [[TMP8]], <2 x i32> [[TMP9]], <2 x i32> [[TMP10]], <2 x i32> [[TMP11]], <2 x i32> [[TMP12]], <2 x i32> [[TMP13]], <2 x i32> [[TMP14]], <64 x float> [[ACC1]], <64 x float> [[ACC2]], i32 972)
-// CHECK-NEXT:    ret <64 x float> [[TMP15]]
+// CHECK-NEXT:    [[TMP0:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 0
+// CHECK-NEXT:    [[TMP1:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 1
+// CHECK-NEXT:    [[TMP2:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 0
+// CHECK-NEXT:    [[TMP3:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 1
+// CHECK-NEXT:    [[TMP4:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 2
+// CHECK-NEXT:    [[DOTFCA_0_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9:%.*]] [[TMP0]], 0
+// CHECK-NEXT:    [[DOTFCA_1_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 1
+// CHECK-NEXT:    [[DOTFCA_2_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 2
+// CHECK-NEXT:    [[DOTFCA_3_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 3
+// CHECK-NEXT:    [[DOTFCA_4_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 4
+// CHECK-NEXT:    [[DOTFCA_5_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 5
+// CHECK-NEXT:    [[DOTFCA_0_EXTRACT17_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 0
+// CHECK-NEXT:    [[DOTFCA_1_EXTRACT19_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 1
+// CHECK-NEXT:    [[DOTFCA_2_EXTRACT21_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 2
+// CHECK-NEXT:    [[DOTFCA_3_EXTRACT23_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 3
+// CHECK-NEXT:    [[DOTFCA_4_EXTRACT25_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 4
+// CHECK-NEXT:    [[DOTFCA_5_EXTRACT27_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 5
+// CHECK-NEXT:    [[TMP5:%.*]] = tail call noundef <64 x float> @llvm.aie2ps.BFP640.BFP2560.ACC2048.bf.addmsc.conf(<16 x i32> [[TMP2]], <2 x i32> [[TMP3]], <2 x i32> [[TMP4]], <16 x i32> [[DOTFCA_0_EXTRACT_I]], <16 x i32> [[DOTFCA_1_EXTRACT_I]], <16 x i32> [[DOTFCA_0_EXTRACT17_I]], <16 x i32> [[DOTFCA_1_EXTRACT19_I]], <2 x i32> [[DOTFCA_2_EXTRACT_I]], <2 x i32> [[DOTFCA_3_EXTRACT_I]], <2 x i32> [[DOTFCA_2_EXTRACT21_I]], <2 x i32> [[DOTFCA_3_EXTRACT23_I]], <2 x i32> [[DOTFCA_4_EXTRACT_I]], <2 x i32> [[DOTFCA_5_EXTRACT_I]], <2 x i32> [[DOTFCA_4_EXTRACT25_I]], <2 x i32> [[DOTFCA_5_EXTRACT27_I]], <64 x float> [[ACC1]], <64 x float> [[ACC2]], i32 972)
+// CHECK-NEXT:    ret <64 x float> [[TMP5]]
 //
 v64accfloat test_addmsc_4x16_16x16T(v64mx9 a, v256mx9 b, v64accfloat acc1,
                                     v64accfloat acc2) {
@@ -38364,27 +38375,29 @@ v64accfloat test_addmsc_4x16_16x16T(v64mx9 a, v256mx9 b, v64accfloat acc1,
 // CHECK-LABEL: define dso_local inreg noundef <64 x float> @_Z20test_mul_4x16_16x16T6v64mx9i7v256mx9i(
 // CHECK-SAME: [[STRUCT_V64MX9:%.*]] [[A_COERCE:%.*]], i32 noundef [[SGN_X:%.*]], [[STRUCT_V256MX9:%.*]] [[B_COERCE:%.*]], i32 noundef [[SGN_Y:%.*]]) local_unnamed_addr #[[ATTR1]] {
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[TMP0:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 0
-// CHECK-NEXT:    [[TMP1:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 1
-// CHECK-NEXT:    [[TMP2:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 2
-// CHECK-NEXT:    [[TMP3:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 0
-// CHECK-NEXT:    [[TMP4:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 1
-// CHECK-NEXT:    [[TMP5:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 2
-// CHECK-NEXT:    [[TMP6:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 3
-// CHECK-NEXT:    [[TMP7:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 4
-// CHECK-NEXT:    [[TMP8:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 5
-// CHECK-NEXT:    [[TMP9:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 6
-// CHECK-NEXT:    [[TMP10:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 7
-// CHECK-NEXT:    [[TMP11:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 8
-// CHECK-NEXT:    [[TMP12:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 9
-// CHECK-NEXT:    [[TMP13:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 10
-// CHECK-NEXT:    [[TMP14:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 11
+// CHECK-NEXT:    [[TMP0:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 0
+// CHECK-NEXT:    [[TMP1:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 1
+// CHECK-NEXT:    [[TMP2:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 0
+// CHECK-NEXT:    [[TMP3:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 1
+// CHECK-NEXT:    [[TMP4:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 2
+// CHECK-NEXT:    [[DOTFCA_0_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9:%.*]] [[TMP0]], 0
+// CHECK-NEXT:    [[DOTFCA_1_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 1
+// CHECK-NEXT:    [[DOTFCA_2_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 2
+// CHECK-NEXT:    [[DOTFCA_3_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 3
+// CHECK-NEXT:    [[DOTFCA_4_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 4
+// CHECK-NEXT:    [[DOTFCA_5_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 5
+// CHECK-NEXT:    [[DOTFCA_0_EXTRACT17_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 0
+// CHECK-NEXT:    [[DOTFCA_1_EXTRACT19_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 1
+// CHECK-NEXT:    [[DOTFCA_2_EXTRACT21_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 2
+// CHECK-NEXT:    [[DOTFCA_3_EXTRACT23_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 3
+// CHECK-NEXT:    [[DOTFCA_4_EXTRACT25_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 4
+// CHECK-NEXT:    [[DOTFCA_5_EXTRACT27_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 5
 // CHECK-NEXT:    [[SHL20_I_I:%.*]] = shl i32 [[SGN_X]], 9
 // CHECK-NEXT:    [[SHL21_I_I:%.*]] = shl i32 [[SGN_Y]], 8
 // CHECK-NEXT:    [[OR12_I_I:%.*]] = or i32 [[SHL20_I_I]], [[SHL21_I_I]]
 // CHECK-NEXT:    [[OR25_I_I:%.*]] = or disjoint i32 [[OR12_I_I]], 204
-// CHECK-NEXT:    [[TMP15:%.*]] = tail call noundef <64 x float> @llvm.aie2ps.BFP640.BFP2560.ACC2048.bf.mul.conf(<16 x i32> [[TMP0]], <2 x i32> [[TMP1]], <2 x i32> [[TMP2]], <16 x i32> [[TMP3]], <16 x i32> [[TMP4]], <16 x i32> [[TMP5]], <16 x i32> [[TMP6]], <2 x i32> [[TMP7]], <2 x i32> [[TMP8]], <2 x i32> [[TMP9]], <2 x i32> [[TMP10]], <2 x i32> [[TMP11]], <2 x i32> [[TMP12]], <2 x i32> [[TMP13]], <2 x i32> [[TMP14]], i32 [[OR25_I_I]])
-// CHECK-NEXT:    ret <64 x float> [[TMP15]]
+// CHECK-NEXT:    [[TMP5:%.*]] = tail call noundef <64 x float> @llvm.aie2ps.BFP640.BFP2560.ACC2048.bf.mul.conf(<16 x i32> [[TMP2]], <2 x i32> [[TMP3]], <2 x i32> [[TMP4]], <16 x i32> [[DOTFCA_0_EXTRACT_I]], <16 x i32> [[DOTFCA_1_EXTRACT_I]], <16 x i32> [[DOTFCA_0_EXTRACT17_I]], <16 x i32> [[DOTFCA_1_EXTRACT19_I]], <2 x i32> [[DOTFCA_2_EXTRACT_I]], <2 x i32> [[DOTFCA_3_EXTRACT_I]], <2 x i32> [[DOTFCA_2_EXTRACT21_I]], <2 x i32> [[DOTFCA_3_EXTRACT23_I]], <2 x i32> [[DOTFCA_4_EXTRACT_I]], <2 x i32> [[DOTFCA_5_EXTRACT_I]], <2 x i32> [[DOTFCA_4_EXTRACT25_I]], <2 x i32> [[DOTFCA_5_EXTRACT27_I]], i32 [[OR25_I_I]])
+// CHECK-NEXT:    ret <64 x float> [[TMP5]]
 //
 v64accfloat test_mul_4x16_16x16T(v64mx9 a, int sgn_x, v256mx9 b, int sgn_y) {
   return mul_4x16_16x16T(a, sgn_x, b, sgn_y);
@@ -38392,27 +38405,29 @@ v64accfloat test_mul_4x16_16x16T(v64mx9 a, int sgn_x, v256mx9 b, int sgn_y) {
 // CHECK-LABEL: define dso_local inreg noundef <64 x float> @_Z23test_negmul_4x16_16x16T6v64mx9i7v256mx9i(
 // CHECK-SAME: [[STRUCT_V64MX9:%.*]] [[A_COERCE:%.*]], i32 noundef [[SGN_X:%.*]], [[STRUCT_V256MX9:%.*]] [[B_COERCE:%.*]], i32 noundef [[SGN_Y:%.*]]) local_unnamed_addr #[[ATTR1]] {
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[TMP0:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 0
-// CHECK-NEXT:    [[TMP1:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 1
-// CHECK-NEXT:    [[TMP2:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 2
-// CHECK-NEXT:    [[TMP3:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 0
-// CHECK-NEXT:    [[TMP4:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 1
-// CHECK-NEXT:    [[TMP5:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 2
-// CHECK-NEXT:    [[TMP6:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 3
-// CHECK-NEXT:    [[TMP7:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 4
-// CHECK-NEXT:    [[TMP8:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 5
-// CHECK-NEXT:    [[TMP9:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 6
-// CHECK-NEXT:    [[TMP10:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 7
-// CHECK-NEXT:    [[TMP11:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 8
-// CHECK-NEXT:    [[TMP12:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 9
-// CHECK-NEXT:    [[TMP13:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 10
-// CHECK-NEXT:    [[TMP14:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 11
+// CHECK-NEXT:    [[TMP0:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 0
+// CHECK-NEXT:    [[TMP1:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 1
+// CHECK-NEXT:    [[TMP2:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 0
+// CHECK-NEXT:    [[TMP3:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 1
+// CHECK-NEXT:    [[TMP4:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 2
+// CHECK-NEXT:    [[DOTFCA_0_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9:%.*]] [[TMP0]], 0
+// CHECK-NEXT:    [[DOTFCA_1_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 1
+// CHECK-NEXT:    [[DOTFCA_2_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 2
+// CHECK-NEXT:    [[DOTFCA_3_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 3
+// CHECK-NEXT:    [[DOTFCA_4_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 4
+// CHECK-NEXT:    [[DOTFCA_5_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 5
+// CHECK-NEXT:    [[DOTFCA_0_EXTRACT17_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 0
+// CHECK-NEXT:    [[DOTFCA_1_EXTRACT19_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 1
+// CHECK-NEXT:    [[DOTFCA_2_EXTRACT21_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 2
+// CHECK-NEXT:    [[DOTFCA_3_EXTRACT23_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 3
+// CHECK-NEXT:    [[DOTFCA_4_EXTRACT25_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 4
+// CHECK-NEXT:    [[DOTFCA_5_EXTRACT27_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 5
 // CHECK-NEXT:    [[SHL20_I_I:%.*]] = shl i32 [[SGN_X]], 9
 // CHECK-NEXT:    [[SHL21_I_I:%.*]] = shl i32 [[SGN_Y]], 8
 // CHECK-NEXT:    [[OR12_I_I:%.*]] = or i32 [[SHL20_I_I]], [[SHL21_I_I]]
 // CHECK-NEXT:    [[OR25_I_I:%.*]] = or disjoint i32 [[OR12_I_I]], 204
-// CHECK-NEXT:    [[TMP15:%.*]] = tail call noundef <64 x float> @llvm.aie2ps.BFP640.BFP2560.ACC2048.bf.negmul.conf(<16 x i32> [[TMP0]], <2 x i32> [[TMP1]], <2 x i32> [[TMP2]], <16 x i32> [[TMP3]], <16 x i32> [[TMP4]], <16 x i32> [[TMP5]], <16 x i32> [[TMP6]], <2 x i32> [[TMP7]], <2 x i32> [[TMP8]], <2 x i32> [[TMP9]], <2 x i32> [[TMP10]], <2 x i32> [[TMP11]], <2 x i32> [[TMP12]], <2 x i32> [[TMP13]], <2 x i32> [[TMP14]], i32 [[OR25_I_I]])
-// CHECK-NEXT:    ret <64 x float> [[TMP15]]
+// CHECK-NEXT:    [[TMP5:%.*]] = tail call noundef <64 x float> @llvm.aie2ps.BFP640.BFP2560.ACC2048.bf.negmul.conf(<16 x i32> [[TMP2]], <2 x i32> [[TMP3]], <2 x i32> [[TMP4]], <16 x i32> [[DOTFCA_0_EXTRACT_I]], <16 x i32> [[DOTFCA_1_EXTRACT_I]], <16 x i32> [[DOTFCA_0_EXTRACT17_I]], <16 x i32> [[DOTFCA_1_EXTRACT19_I]], <2 x i32> [[DOTFCA_2_EXTRACT_I]], <2 x i32> [[DOTFCA_3_EXTRACT_I]], <2 x i32> [[DOTFCA_2_EXTRACT21_I]], <2 x i32> [[DOTFCA_3_EXTRACT23_I]], <2 x i32> [[DOTFCA_4_EXTRACT_I]], <2 x i32> [[DOTFCA_5_EXTRACT_I]], <2 x i32> [[DOTFCA_4_EXTRACT25_I]], <2 x i32> [[DOTFCA_5_EXTRACT27_I]], i32 [[OR25_I_I]])
+// CHECK-NEXT:    ret <64 x float> [[TMP5]]
 //
 v64accfloat test_negmul_4x16_16x16T(v64mx9 a, int sgn_x, v256mx9 b, int sgn_y) {
   return negmul_4x16_16x16T(a, sgn_x, b, sgn_y);
@@ -38420,27 +38435,29 @@ v64accfloat test_negmul_4x16_16x16T(v64mx9 a, int sgn_x, v256mx9 b, int sgn_y) {
 // CHECK-LABEL: define dso_local inreg noundef <64 x float> @_Z20test_mac_4x16_16x16T6v64mx9i7v256mx9iDv64_u10__accfloat(
 // CHECK-SAME: [[STRUCT_V64MX9:%.*]] [[A_COERCE:%.*]], i32 noundef [[SGN_X:%.*]], [[STRUCT_V256MX9:%.*]] [[B_COERCE:%.*]], i32 noundef [[SGN_Y:%.*]], <64 x float> inreg noundef [[ACC:%.*]]) local_unnamed_addr #[[ATTR1]] {
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[TMP0:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 0
-// CHECK-NEXT:    [[TMP1:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 1
-// CHECK-NEXT:    [[TMP2:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 2
-// CHECK-NEXT:    [[TMP3:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 0
-// CHECK-NEXT:    [[TMP4:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 1
-// CHECK-NEXT:    [[TMP5:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 2
-// CHECK-NEXT:    [[TMP6:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 3
-// CHECK-NEXT:    [[TMP7:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 4
-// CHECK-NEXT:    [[TMP8:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 5
-// CHECK-NEXT:    [[TMP9:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 6
-// CHECK-NEXT:    [[TMP10:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 7
-// CHECK-NEXT:    [[TMP11:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 8
-// CHECK-NEXT:    [[TMP12:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 9
-// CHECK-NEXT:    [[TMP13:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 10
-// CHECK-NEXT:    [[TMP14:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 11
+// CHECK-NEXT:    [[TMP0:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 0
+// CHECK-NEXT:    [[TMP1:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 1
+// CHECK-NEXT:    [[TMP2:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 0
+// CHECK-NEXT:    [[TMP3:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 1
+// CHECK-NEXT:    [[TMP4:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 2
+// CHECK-NEXT:    [[DOTFCA_0_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9:%.*]] [[TMP0]], 0
+// CHECK-NEXT:    [[DOTFCA_1_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 1
+// CHECK-NEXT:    [[DOTFCA_2_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 2
+// CHECK-NEXT:    [[DOTFCA_3_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 3
+// CHECK-NEXT:    [[DOTFCA_4_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 4
+// CHECK-NEXT:    [[DOTFCA_5_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 5
+// CHECK-NEXT:    [[DOTFCA_0_EXTRACT17_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 0
+// CHECK-NEXT:    [[DOTFCA_1_EXTRACT19_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 1
+// CHECK-NEXT:    [[DOTFCA_2_EXTRACT21_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 2
+// CHECK-NEXT:    [[DOTFCA_3_EXTRACT23_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 3
+// CHECK-NEXT:    [[DOTFCA_4_EXTRACT25_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 4
+// CHECK-NEXT:    [[DOTFCA_5_EXTRACT27_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 5
 // CHECK-NEXT:    [[SHL20_I_I:%.*]] = shl i32 [[SGN_X]], 9
 // CHECK-NEXT:    [[SHL21_I_I:%.*]] = shl i32 [[SGN_Y]], 8
 // CHECK-NEXT:    [[OR12_I_I:%.*]] = or i32 [[SHL20_I_I]], [[SHL21_I_I]]
 // CHECK-NEXT:    [[OR25_I_I:%.*]] = or disjoint i32 [[OR12_I_I]], 204
-// CHECK-NEXT:    [[TMP15:%.*]] = tail call noundef <64 x float> @llvm.aie2ps.BFP640.BFP2560.ACC2048.bf.mac.conf(<16 x i32> [[TMP0]], <2 x i32> [[TMP1]], <2 x i32> [[TMP2]], <16 x i32> [[TMP3]], <16 x i32> [[TMP4]], <16 x i32> [[TMP5]], <16 x i32> [[TMP6]], <2 x i32> [[TMP7]], <2 x i32> [[TMP8]], <2 x i32> [[TMP9]], <2 x i32> [[TMP10]], <2 x i32> [[TMP11]], <2 x i32> [[TMP12]], <2 x i32> [[TMP13]], <2 x i32> [[TMP14]], <64 x float> [[ACC]], i32 [[OR25_I_I]])
-// CHECK-NEXT:    ret <64 x float> [[TMP15]]
+// CHECK-NEXT:    [[TMP5:%.*]] = tail call noundef <64 x float> @llvm.aie2ps.BFP640.BFP2560.ACC2048.bf.mac.conf(<16 x i32> [[TMP2]], <2 x i32> [[TMP3]], <2 x i32> [[TMP4]], <16 x i32> [[DOTFCA_0_EXTRACT_I]], <16 x i32> [[DOTFCA_1_EXTRACT_I]], <16 x i32> [[DOTFCA_0_EXTRACT17_I]], <16 x i32> [[DOTFCA_1_EXTRACT19_I]], <2 x i32> [[DOTFCA_2_EXTRACT_I]], <2 x i32> [[DOTFCA_3_EXTRACT_I]], <2 x i32> [[DOTFCA_2_EXTRACT21_I]], <2 x i32> [[DOTFCA_3_EXTRACT23_I]], <2 x i32> [[DOTFCA_4_EXTRACT_I]], <2 x i32> [[DOTFCA_5_EXTRACT_I]], <2 x i32> [[DOTFCA_4_EXTRACT25_I]], <2 x i32> [[DOTFCA_5_EXTRACT27_I]], <64 x float> [[ACC]], i32 [[OR25_I_I]])
+// CHECK-NEXT:    ret <64 x float> [[TMP5]]
 //
 v64accfloat test_mac_4x16_16x16T(v64mx9 a, int sgn_x, v256mx9 b, int sgn_y,
                                  v64accfloat acc) {
@@ -38449,27 +38466,29 @@ v64accfloat test_mac_4x16_16x16T(v64mx9 a, int sgn_x, v256mx9 b, int sgn_y,
 // CHECK-LABEL: define dso_local inreg noundef <64 x float> @_Z20test_msc_4x16_16x16T6v64mx9i7v256mx9iDv64_u10__accfloat(
 // CHECK-SAME: [[STRUCT_V64MX9:%.*]] [[A_COERCE:%.*]], i32 noundef [[SGN_X:%.*]], [[STRUCT_V256MX9:%.*]] [[B_COERCE:%.*]], i32 noundef [[SGN_Y:%.*]], <64 x float> inreg noundef [[ACC:%.*]]) local_unnamed_addr #[[ATTR1]] {
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[TMP0:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 0
-// CHECK-NEXT:    [[TMP1:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 1
-// CHECK-NEXT:    [[TMP2:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 2
-// CHECK-NEXT:    [[TMP3:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 0
-// CHECK-NEXT:    [[TMP4:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 1
-// CHECK-NEXT:    [[TMP5:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 2
-// CHECK-NEXT:    [[TMP6:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 3
-// CHECK-NEXT:    [[TMP7:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 4
-// CHECK-NEXT:    [[TMP8:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 5
-// CHECK-NEXT:    [[TMP9:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 6
-// CHECK-NEXT:    [[TMP10:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 7
-// CHECK-NEXT:    [[TMP11:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 8
-// CHECK-NEXT:    [[TMP12:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 9
-// CHECK-NEXT:    [[TMP13:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 10
-// CHECK-NEXT:    [[TMP14:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 11
+// CHECK-NEXT:    [[TMP0:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 0
+// CHECK-NEXT:    [[TMP1:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 1
+// CHECK-NEXT:    [[TMP2:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 0
+// CHECK-NEXT:    [[TMP3:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 1
+// CHECK-NEXT:    [[TMP4:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 2
+// CHECK-NEXT:    [[DOTFCA_0_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9:%.*]] [[TMP0]], 0
+// CHECK-NEXT:    [[DOTFCA_1_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 1
+// CHECK-NEXT:    [[DOTFCA_2_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 2
+// CHECK-NEXT:    [[DOTFCA_3_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 3
+// CHECK-NEXT:    [[DOTFCA_4_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 4
+// CHECK-NEXT:    [[DOTFCA_5_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 5
+// CHECK-NEXT:    [[DOTFCA_0_EXTRACT17_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 0
+// CHECK-NEXT:    [[DOTFCA_1_EXTRACT19_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 1
+// CHECK-NEXT:    [[DOTFCA_2_EXTRACT21_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 2
+// CHECK-NEXT:    [[DOTFCA_3_EXTRACT23_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 3
+// CHECK-NEXT:    [[DOTFCA_4_EXTRACT25_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 4
+// CHECK-NEXT:    [[DOTFCA_5_EXTRACT27_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 5
 // CHECK-NEXT:    [[SHL20_I_I:%.*]] = shl i32 [[SGN_X]], 9
 // CHECK-NEXT:    [[SHL21_I_I:%.*]] = shl i32 [[SGN_Y]], 8
 // CHECK-NEXT:    [[OR12_I_I:%.*]] = or i32 [[SHL20_I_I]], [[SHL21_I_I]]
 // CHECK-NEXT:    [[OR25_I_I:%.*]] = or disjoint i32 [[OR12_I_I]], 204
-// CHECK-NEXT:    [[TMP15:%.*]] = tail call noundef <64 x float> @llvm.aie2ps.BFP640.BFP2560.ACC2048.bf.msc.conf(<16 x i32> [[TMP0]], <2 x i32> [[TMP1]], <2 x i32> [[TMP2]], <16 x i32> [[TMP3]], <16 x i32> [[TMP4]], <16 x i32> [[TMP5]], <16 x i32> [[TMP6]], <2 x i32> [[TMP7]], <2 x i32> [[TMP8]], <2 x i32> [[TMP9]], <2 x i32> [[TMP10]], <2 x i32> [[TMP11]], <2 x i32> [[TMP12]], <2 x i32> [[TMP13]], <2 x i32> [[TMP14]], <64 x float> [[ACC]], i32 [[OR25_I_I]])
-// CHECK-NEXT:    ret <64 x float> [[TMP15]]
+// CHECK-NEXT:    [[TMP5:%.*]] = tail call noundef <64 x float> @llvm.aie2ps.BFP640.BFP2560.ACC2048.bf.msc.conf(<16 x i32> [[TMP2]], <2 x i32> [[TMP3]], <2 x i32> [[TMP4]], <16 x i32> [[DOTFCA_0_EXTRACT_I]], <16 x i32> [[DOTFCA_1_EXTRACT_I]], <16 x i32> [[DOTFCA_0_EXTRACT17_I]], <16 x i32> [[DOTFCA_1_EXTRACT19_I]], <2 x i32> [[DOTFCA_2_EXTRACT_I]], <2 x i32> [[DOTFCA_3_EXTRACT_I]], <2 x i32> [[DOTFCA_2_EXTRACT21_I]], <2 x i32> [[DOTFCA_3_EXTRACT23_I]], <2 x i32> [[DOTFCA_4_EXTRACT_I]], <2 x i32> [[DOTFCA_5_EXTRACT_I]], <2 x i32> [[DOTFCA_4_EXTRACT25_I]], <2 x i32> [[DOTFCA_5_EXTRACT27_I]], <64 x float> [[ACC]], i32 [[OR25_I_I]])
+// CHECK-NEXT:    ret <64 x float> [[TMP5]]
 //
 v64accfloat test_msc_4x16_16x16T(v64mx9 a, int sgn_x, v256mx9 b, int sgn_y,
                                  v64accfloat acc) {
@@ -38478,27 +38497,29 @@ v64accfloat test_msc_4x16_16x16T(v64mx9 a, int sgn_x, v256mx9 b, int sgn_y,
 // CHECK-LABEL: define dso_local inreg noundef <64 x float> @_Z23test_addmac_4x16_16x16T6v64mx9i7v256mx9iDv64_u10__accfloatS1_(
 // CHECK-SAME: [[STRUCT_V64MX9:%.*]] [[A_COERCE:%.*]], i32 noundef [[SGN_X:%.*]], [[STRUCT_V256MX9:%.*]] [[B_COERCE:%.*]], i32 noundef [[SGN_Y:%.*]], <64 x float> inreg noundef [[ACC1:%.*]], <64 x float> inreg noundef [[ACC2:%.*]]) local_unnamed_addr #[[ATTR1]] {
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[TMP0:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 0
-// CHECK-NEXT:    [[TMP1:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 1
-// CHECK-NEXT:    [[TMP2:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 2
-// CHECK-NEXT:    [[TMP3:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 0
-// CHECK-NEXT:    [[TMP4:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 1
-// CHECK-NEXT:    [[TMP5:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 2
-// CHECK-NEXT:    [[TMP6:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 3
-// CHECK-NEXT:    [[TMP7:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 4
-// CHECK-NEXT:    [[TMP8:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 5
-// CHECK-NEXT:    [[TMP9:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 6
-// CHECK-NEXT:    [[TMP10:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 7
-// CHECK-NEXT:    [[TMP11:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 8
-// CHECK-NEXT:    [[TMP12:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 9
-// CHECK-NEXT:    [[TMP13:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 10
-// CHECK-NEXT:    [[TMP14:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 11
+// CHECK-NEXT:    [[TMP0:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 0
+// CHECK-NEXT:    [[TMP1:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 1
+// CHECK-NEXT:    [[TMP2:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 0
+// CHECK-NEXT:    [[TMP3:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 1
+// CHECK-NEXT:    [[TMP4:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 2
+// CHECK-NEXT:    [[DOTFCA_0_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9:%.*]] [[TMP0]], 0
+// CHECK-NEXT:    [[DOTFCA_1_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 1
+// CHECK-NEXT:    [[DOTFCA_2_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 2
+// CHECK-NEXT:    [[DOTFCA_3_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 3
+// CHECK-NEXT:    [[DOTFCA_4_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 4
+// CHECK-NEXT:    [[DOTFCA_5_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 5
+// CHECK-NEXT:    [[DOTFCA_0_EXTRACT17_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 0
+// CHECK-NEXT:    [[DOTFCA_1_EXTRACT19_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 1
+// CHECK-NEXT:    [[DOTFCA_2_EXTRACT21_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 2
+// CHECK-NEXT:    [[DOTFCA_3_EXTRACT23_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 3
+// CHECK-NEXT:    [[DOTFCA_4_EXTRACT25_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 4
+// CHECK-NEXT:    [[DOTFCA_5_EXTRACT27_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 5
 // CHECK-NEXT:    [[SHL20_I_I:%.*]] = shl i32 [[SGN_X]], 9
 // CHECK-NEXT:    [[SHL21_I_I:%.*]] = shl i32 [[SGN_Y]], 8
 // CHECK-NEXT:    [[OR12_I_I:%.*]] = or i32 [[SHL20_I_I]], [[SHL21_I_I]]
 // CHECK-NEXT:    [[OR25_I_I:%.*]] = or disjoint i32 [[OR12_I_I]], 204
-// CHECK-NEXT:    [[TMP15:%.*]] = tail call noundef <64 x float> @llvm.aie2ps.BFP640.BFP2560.ACC2048.bf.addmac.conf(<16 x i32> [[TMP0]], <2 x i32> [[TMP1]], <2 x i32> [[TMP2]], <16 x i32> [[TMP3]], <16 x i32> [[TMP4]], <16 x i32> [[TMP5]], <16 x i32> [[TMP6]], <2 x i32> [[TMP7]], <2 x i32> [[TMP8]], <2 x i32> [[TMP9]], <2 x i32> [[TMP10]], <2 x i32> [[TMP11]], <2 x i32> [[TMP12]], <2 x i32> [[TMP13]], <2 x i32> [[TMP14]], <64 x float> [[ACC1]], <64 x float> [[ACC2]], i32 [[OR25_I_I]])
-// CHECK-NEXT:    ret <64 x float> [[TMP15]]
+// CHECK-NEXT:    [[TMP5:%.*]] = tail call noundef <64 x float> @llvm.aie2ps.BFP640.BFP2560.ACC2048.bf.addmac.conf(<16 x i32> [[TMP2]], <2 x i32> [[TMP3]], <2 x i32> [[TMP4]], <16 x i32> [[DOTFCA_0_EXTRACT_I]], <16 x i32> [[DOTFCA_1_EXTRACT_I]], <16 x i32> [[DOTFCA_0_EXTRACT17_I]], <16 x i32> [[DOTFCA_1_EXTRACT19_I]], <2 x i32> [[DOTFCA_2_EXTRACT_I]], <2 x i32> [[DOTFCA_3_EXTRACT_I]], <2 x i32> [[DOTFCA_2_EXTRACT21_I]], <2 x i32> [[DOTFCA_3_EXTRACT23_I]], <2 x i32> [[DOTFCA_4_EXTRACT_I]], <2 x i32> [[DOTFCA_5_EXTRACT_I]], <2 x i32> [[DOTFCA_4_EXTRACT25_I]], <2 x i32> [[DOTFCA_5_EXTRACT27_I]], <64 x float> [[ACC1]], <64 x float> [[ACC2]], i32 [[OR25_I_I]])
+// CHECK-NEXT:    ret <64 x float> [[TMP5]]
 //
 v64accfloat test_addmac_4x16_16x16T(v64mx9 a, int sgn_x, v256mx9 b, int sgn_y,
                                     v64accfloat acc1, v64accfloat acc2) {
@@ -38507,27 +38528,29 @@ v64accfloat test_addmac_4x16_16x16T(v64mx9 a, int sgn_x, v256mx9 b, int sgn_y,
 // CHECK-LABEL: define dso_local inreg noundef <64 x float> @_Z23test_addmsc_4x16_16x16T6v64mx9i7v256mx9iDv64_u10__accfloatS1_(
 // CHECK-SAME: [[STRUCT_V64MX9:%.*]] [[A_COERCE:%.*]], i32 noundef [[SGN_X:%.*]], [[STRUCT_V256MX9:%.*]] [[B_COERCE:%.*]], i32 noundef [[SGN_Y:%.*]], <64 x float> inreg noundef [[ACC1:%.*]], <64 x float> inreg noundef [[ACC2:%.*]]) local_unnamed_addr #[[ATTR1]] {
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[TMP0:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 0
-// CHECK-NEXT:    [[TMP1:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 1
-// CHECK-NEXT:    [[TMP2:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 2
-// CHECK-NEXT:    [[TMP3:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 0
-// CHECK-NEXT:    [[TMP4:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 1
-// CHECK-NEXT:    [[TMP5:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 2
-// CHECK-NEXT:    [[TMP6:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 3
-// CHECK-NEXT:    [[TMP7:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 4
-// CHECK-NEXT:    [[TMP8:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 5
-// CHECK-NEXT:    [[TMP9:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 6
-// CHECK-NEXT:    [[TMP10:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 7
-// CHECK-NEXT:    [[TMP11:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 8
-// CHECK-NEXT:    [[TMP12:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 9
-// CHECK-NEXT:    [[TMP13:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 10
-// CHECK-NEXT:    [[TMP14:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 11
+// CHECK-NEXT:    [[TMP0:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 0
+// CHECK-NEXT:    [[TMP1:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 1
+// CHECK-NEXT:    [[TMP2:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 0
+// CHECK-NEXT:    [[TMP3:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 1
+// CHECK-NEXT:    [[TMP4:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 2
+// CHECK-NEXT:    [[DOTFCA_0_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9:%.*]] [[TMP0]], 0
+// CHECK-NEXT:    [[DOTFCA_1_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 1
+// CHECK-NEXT:    [[DOTFCA_2_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 2
+// CHECK-NEXT:    [[DOTFCA_3_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 3
+// CHECK-NEXT:    [[DOTFCA_4_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 4
+// CHECK-NEXT:    [[DOTFCA_5_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 5
+// CHECK-NEXT:    [[DOTFCA_0_EXTRACT17_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 0
+// CHECK-NEXT:    [[DOTFCA_1_EXTRACT19_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 1
+// CHECK-NEXT:    [[DOTFCA_2_EXTRACT21_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 2
+// CHECK-NEXT:    [[DOTFCA_3_EXTRACT23_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 3
+// CHECK-NEXT:    [[DOTFCA_4_EXTRACT25_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 4
+// CHECK-NEXT:    [[DOTFCA_5_EXTRACT27_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 5
 // CHECK-NEXT:    [[SHL20_I_I:%.*]] = shl i32 [[SGN_X]], 9
 // CHECK-NEXT:    [[SHL21_I_I:%.*]] = shl i32 [[SGN_Y]], 8
 // CHECK-NEXT:    [[OR12_I_I:%.*]] = or i32 [[SHL20_I_I]], [[SHL21_I_I]]
 // CHECK-NEXT:    [[OR25_I_I:%.*]] = or disjoint i32 [[OR12_I_I]], 204
-// CHECK-NEXT:    [[TMP15:%.*]] = tail call noundef <64 x float> @llvm.aie2ps.BFP640.BFP2560.ACC2048.bf.addmsc.conf(<16 x i32> [[TMP0]], <2 x i32> [[TMP1]], <2 x i32> [[TMP2]], <16 x i32> [[TMP3]], <16 x i32> [[TMP4]], <16 x i32> [[TMP5]], <16 x i32> [[TMP6]], <2 x i32> [[TMP7]], <2 x i32> [[TMP8]], <2 x i32> [[TMP9]], <2 x i32> [[TMP10]], <2 x i32> [[TMP11]], <2 x i32> [[TMP12]], <2 x i32> [[TMP13]], <2 x i32> [[TMP14]], <64 x float> [[ACC1]], <64 x float> [[ACC2]], i32 [[OR25_I_I]])
-// CHECK-NEXT:    ret <64 x float> [[TMP15]]
+// CHECK-NEXT:    [[TMP5:%.*]] = tail call noundef <64 x float> @llvm.aie2ps.BFP640.BFP2560.ACC2048.bf.addmsc.conf(<16 x i32> [[TMP2]], <2 x i32> [[TMP3]], <2 x i32> [[TMP4]], <16 x i32> [[DOTFCA_0_EXTRACT_I]], <16 x i32> [[DOTFCA_1_EXTRACT_I]], <16 x i32> [[DOTFCA_0_EXTRACT17_I]], <16 x i32> [[DOTFCA_1_EXTRACT19_I]], <2 x i32> [[DOTFCA_2_EXTRACT_I]], <2 x i32> [[DOTFCA_3_EXTRACT_I]], <2 x i32> [[DOTFCA_2_EXTRACT21_I]], <2 x i32> [[DOTFCA_3_EXTRACT23_I]], <2 x i32> [[DOTFCA_4_EXTRACT_I]], <2 x i32> [[DOTFCA_5_EXTRACT_I]], <2 x i32> [[DOTFCA_4_EXTRACT25_I]], <2 x i32> [[DOTFCA_5_EXTRACT27_I]], <64 x float> [[ACC1]], <64 x float> [[ACC2]], i32 [[OR25_I_I]])
+// CHECK-NEXT:    ret <64 x float> [[TMP5]]
 //
 v64accfloat test_addmsc_4x16_16x16T(v64mx9 a, int sgn_x, v256mx9 b, int sgn_y,
                                     v64accfloat acc1, v64accfloat acc2) {
@@ -38536,25 +38559,27 @@ v64accfloat test_addmsc_4x16_16x16T(v64mx9 a, int sgn_x, v256mx9 b, int sgn_y,
 // CHECK-LABEL: define dso_local inreg noundef <64 x float> @_Z25test_mul_4x16_16x16T_conf6v64mx97v256mx9i(
 // CHECK-SAME: [[STRUCT_V64MX9:%.*]] [[A_COERCE:%.*]], [[STRUCT_V256MX9:%.*]] [[B_COERCE:%.*]], i32 noundef [[SUB_MUL:%.*]]) local_unnamed_addr #[[ATTR1]] {
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[TMP0:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 0
-// CHECK-NEXT:    [[TMP1:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 1
-// CHECK-NEXT:    [[TMP2:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 2
-// CHECK-NEXT:    [[TMP3:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 0
-// CHECK-NEXT:    [[TMP4:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 1
-// CHECK-NEXT:    [[TMP5:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 2
-// CHECK-NEXT:    [[TMP6:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 3
-// CHECK-NEXT:    [[TMP7:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 4
-// CHECK-NEXT:    [[TMP8:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 5
-// CHECK-NEXT:    [[TMP9:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 6
-// CHECK-NEXT:    [[TMP10:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 7
-// CHECK-NEXT:    [[TMP11:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 8
-// CHECK-NEXT:    [[TMP12:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 9
-// CHECK-NEXT:    [[TMP13:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 10
-// CHECK-NEXT:    [[TMP14:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 11
+// CHECK-NEXT:    [[TMP0:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 0
+// CHECK-NEXT:    [[TMP1:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 1
+// CHECK-NEXT:    [[TMP2:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 0
+// CHECK-NEXT:    [[TMP3:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 1
+// CHECK-NEXT:    [[TMP4:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 2
+// CHECK-NEXT:    [[DOTFCA_0_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9:%.*]] [[TMP0]], 0
+// CHECK-NEXT:    [[DOTFCA_1_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 1
+// CHECK-NEXT:    [[DOTFCA_2_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 2
+// CHECK-NEXT:    [[DOTFCA_3_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 3
+// CHECK-NEXT:    [[DOTFCA_4_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 4
+// CHECK-NEXT:    [[DOTFCA_5_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 5
+// CHECK-NEXT:    [[DOTFCA_0_EXTRACT17_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 0
+// CHECK-NEXT:    [[DOTFCA_1_EXTRACT19_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 1
+// CHECK-NEXT:    [[DOTFCA_2_EXTRACT21_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 2
+// CHECK-NEXT:    [[DOTFCA_3_EXTRACT23_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 3
+// CHECK-NEXT:    [[DOTFCA_4_EXTRACT25_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 4
+// CHECK-NEXT:    [[DOTFCA_5_EXTRACT27_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 5
 // CHECK-NEXT:    [[SHL2_I_I:%.*]] = shl i32 [[SUB_MUL]], 11
 // CHECK-NEXT:    [[OR25_I_I:%.*]] = or disjoint i32 [[SHL2_I_I]], 972
-// CHECK-NEXT:    [[TMP15:%.*]] = tail call noundef <64 x float> @llvm.aie2ps.BFP640.BFP2560.ACC2048.bf.mul.conf(<16 x i32> [[TMP0]], <2 x i32> [[TMP1]], <2 x i32> [[TMP2]], <16 x i32> [[TMP3]], <16 x i32> [[TMP4]], <16 x i32> [[TMP5]], <16 x i32> [[TMP6]], <2 x i32> [[TMP7]], <2 x i32> [[TMP8]], <2 x i32> [[TMP9]], <2 x i32> [[TMP10]], <2 x i32> [[TMP11]], <2 x i32> [[TMP12]], <2 x i32> [[TMP13]], <2 x i32> [[TMP14]], i32 [[OR25_I_I]])
-// CHECK-NEXT:    ret <64 x float> [[TMP15]]
+// CHECK-NEXT:    [[TMP5:%.*]] = tail call noundef <64 x float> @llvm.aie2ps.BFP640.BFP2560.ACC2048.bf.mul.conf(<16 x i32> [[TMP2]], <2 x i32> [[TMP3]], <2 x i32> [[TMP4]], <16 x i32> [[DOTFCA_0_EXTRACT_I]], <16 x i32> [[DOTFCA_1_EXTRACT_I]], <16 x i32> [[DOTFCA_0_EXTRACT17_I]], <16 x i32> [[DOTFCA_1_EXTRACT19_I]], <2 x i32> [[DOTFCA_2_EXTRACT_I]], <2 x i32> [[DOTFCA_3_EXTRACT_I]], <2 x i32> [[DOTFCA_2_EXTRACT21_I]], <2 x i32> [[DOTFCA_3_EXTRACT23_I]], <2 x i32> [[DOTFCA_4_EXTRACT_I]], <2 x i32> [[DOTFCA_5_EXTRACT_I]], <2 x i32> [[DOTFCA_4_EXTRACT25_I]], <2 x i32> [[DOTFCA_5_EXTRACT27_I]], i32 [[OR25_I_I]])
+// CHECK-NEXT:    ret <64 x float> [[TMP5]]
 //
 v64accfloat test_mul_4x16_16x16T_conf(v64mx9 a, v256mx9 b, int sub_mul) {
   return mul_4x16_16x16T_conf(a, b, sub_mul);
@@ -38562,25 +38587,27 @@ v64accfloat test_mul_4x16_16x16T_conf(v64mx9 a, v256mx9 b, int sub_mul) {
 // CHECK-LABEL: define dso_local inreg noundef <64 x float> @_Z28test_negmul_4x16_16x16T_conf6v64mx97v256mx9i(
 // CHECK-SAME: [[STRUCT_V64MX9:%.*]] [[A_COERCE:%.*]], [[STRUCT_V256MX9:%.*]] [[B_COERCE:%.*]], i32 noundef [[SUB_MUL:%.*]]) local_unnamed_addr #[[ATTR1]] {
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[TMP0:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 0
-// CHECK-NEXT:    [[TMP1:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 1
-// CHECK-NEXT:    [[TMP2:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 2
-// CHECK-NEXT:    [[TMP3:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 0
-// CHECK-NEXT:    [[TMP4:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 1
-// CHECK-NEXT:    [[TMP5:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 2
-// CHECK-NEXT:    [[TMP6:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 3
-// CHECK-NEXT:    [[TMP7:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 4
-// CHECK-NEXT:    [[TMP8:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 5
-// CHECK-NEXT:    [[TMP9:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 6
-// CHECK-NEXT:    [[TMP10:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 7
-// CHECK-NEXT:    [[TMP11:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 8
-// CHECK-NEXT:    [[TMP12:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 9
-// CHECK-NEXT:    [[TMP13:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 10
-// CHECK-NEXT:    [[TMP14:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 11
+// CHECK-NEXT:    [[TMP0:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 0
+// CHECK-NEXT:    [[TMP1:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 1
+// CHECK-NEXT:    [[TMP2:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 0
+// CHECK-NEXT:    [[TMP3:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 1
+// CHECK-NEXT:    [[TMP4:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 2
+// CHECK-NEXT:    [[DOTFCA_0_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9:%.*]] [[TMP0]], 0
+// CHECK-NEXT:    [[DOTFCA_1_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 1
+// CHECK-NEXT:    [[DOTFCA_2_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 2
+// CHECK-NEXT:    [[DOTFCA_3_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 3
+// CHECK-NEXT:    [[DOTFCA_4_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 4
+// CHECK-NEXT:    [[DOTFCA_5_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 5
+// CHECK-NEXT:    [[DOTFCA_0_EXTRACT17_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 0
+// CHECK-NEXT:    [[DOTFCA_1_EXTRACT19_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 1
+// CHECK-NEXT:    [[DOTFCA_2_EXTRACT21_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 2
+// CHECK-NEXT:    [[DOTFCA_3_EXTRACT23_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 3
+// CHECK-NEXT:    [[DOTFCA_4_EXTRACT25_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 4
+// CHECK-NEXT:    [[DOTFCA_5_EXTRACT27_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 5
 // CHECK-NEXT:    [[SHL2_I_I:%.*]] = shl i32 [[SUB_MUL]], 11
 // CHECK-NEXT:    [[OR25_I_I:%.*]] = or disjoint i32 [[SHL2_I_I]], 972
-// CHECK-NEXT:    [[TMP15:%.*]] = tail call noundef <64 x float> @llvm.aie2ps.BFP640.BFP2560.ACC2048.bf.negmul.conf(<16 x i32> [[TMP0]], <2 x i32> [[TMP1]], <2 x i32> [[TMP2]], <16 x i32> [[TMP3]], <16 x i32> [[TMP4]], <16 x i32> [[TMP5]], <16 x i32> [[TMP6]], <2 x i32> [[TMP7]], <2 x i32> [[TMP8]], <2 x i32> [[TMP9]], <2 x i32> [[TMP10]], <2 x i32> [[TMP11]], <2 x i32> [[TMP12]], <2 x i32> [[TMP13]], <2 x i32> [[TMP14]], i32 [[OR25_I_I]])
-// CHECK-NEXT:    ret <64 x float> [[TMP15]]
+// CHECK-NEXT:    [[TMP5:%.*]] = tail call noundef <64 x float> @llvm.aie2ps.BFP640.BFP2560.ACC2048.bf.negmul.conf(<16 x i32> [[TMP2]], <2 x i32> [[TMP3]], <2 x i32> [[TMP4]], <16 x i32> [[DOTFCA_0_EXTRACT_I]], <16 x i32> [[DOTFCA_1_EXTRACT_I]], <16 x i32> [[DOTFCA_0_EXTRACT17_I]], <16 x i32> [[DOTFCA_1_EXTRACT19_I]], <2 x i32> [[DOTFCA_2_EXTRACT_I]], <2 x i32> [[DOTFCA_3_EXTRACT_I]], <2 x i32> [[DOTFCA_2_EXTRACT21_I]], <2 x i32> [[DOTFCA_3_EXTRACT23_I]], <2 x i32> [[DOTFCA_4_EXTRACT_I]], <2 x i32> [[DOTFCA_5_EXTRACT_I]], <2 x i32> [[DOTFCA_4_EXTRACT25_I]], <2 x i32> [[DOTFCA_5_EXTRACT27_I]], i32 [[OR25_I_I]])
+// CHECK-NEXT:    ret <64 x float> [[TMP5]]
 //
 v64accfloat test_negmul_4x16_16x16T_conf(v64mx9 a, v256mx9 b, int sub_mul) {
   return negmul_4x16_16x16T_conf(a, b, sub_mul);
@@ -38588,28 +38615,30 @@ v64accfloat test_negmul_4x16_16x16T_conf(v64mx9 a, v256mx9 b, int sub_mul) {
 // CHECK-LABEL: define dso_local inreg noundef <64 x float> @_Z25test_mac_4x16_16x16T_conf6v64mx97v256mx9Dv64_u10__accfloatiii(
 // CHECK-SAME: [[STRUCT_V64MX9:%.*]] [[A_COERCE:%.*]], [[STRUCT_V256MX9:%.*]] [[B_COERCE:%.*]], <64 x float> inreg noundef [[ACC:%.*]], i32 noundef [[ZERO_ACC:%.*]], i32 noundef [[SUB_MUL:%.*]], i32 noundef [[SUB_ACC1:%.*]]) local_unnamed_addr #[[ATTR1]] {
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[TMP0:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 0
-// CHECK-NEXT:    [[TMP1:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 1
-// CHECK-NEXT:    [[TMP2:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 2
-// CHECK-NEXT:    [[TMP3:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 0
-// CHECK-NEXT:    [[TMP4:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 1
-// CHECK-NEXT:    [[TMP5:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 2
-// CHECK-NEXT:    [[TMP6:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 3
-// CHECK-NEXT:    [[TMP7:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 4
-// CHECK-NEXT:    [[TMP8:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 5
-// CHECK-NEXT:    [[TMP9:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 6
-// CHECK-NEXT:    [[TMP10:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 7
-// CHECK-NEXT:    [[TMP11:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 8
-// CHECK-NEXT:    [[TMP12:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 9
-// CHECK-NEXT:    [[TMP13:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 10
-// CHECK-NEXT:    [[TMP14:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 11
+// CHECK-NEXT:    [[TMP0:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 0
+// CHECK-NEXT:    [[TMP1:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 1
+// CHECK-NEXT:    [[TMP2:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 0
+// CHECK-NEXT:    [[TMP3:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 1
+// CHECK-NEXT:    [[TMP4:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 2
+// CHECK-NEXT:    [[DOTFCA_0_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9:%.*]] [[TMP0]], 0
+// CHECK-NEXT:    [[DOTFCA_1_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 1
+// CHECK-NEXT:    [[DOTFCA_2_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 2
+// CHECK-NEXT:    [[DOTFCA_3_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 3
+// CHECK-NEXT:    [[DOTFCA_4_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 4
+// CHECK-NEXT:    [[DOTFCA_5_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 5
+// CHECK-NEXT:    [[DOTFCA_0_EXTRACT17_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 0
+// CHECK-NEXT:    [[DOTFCA_1_EXTRACT19_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 1
+// CHECK-NEXT:    [[DOTFCA_2_EXTRACT21_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 2
+// CHECK-NEXT:    [[DOTFCA_3_EXTRACT23_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 3
+// CHECK-NEXT:    [[DOTFCA_4_EXTRACT25_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 4
+// CHECK-NEXT:    [[DOTFCA_5_EXTRACT27_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 5
 // CHECK-NEXT:    [[SHL2_I_I:%.*]] = shl i32 [[SUB_MUL]], 11
 // CHECK-NEXT:    [[SHL4_I_I:%.*]] = shl i32 [[SUB_ACC1]], 12
 // CHECK-NEXT:    [[OR3_I_I:%.*]] = or i32 [[ZERO_ACC]], [[SHL2_I_I]]
 // CHECK-NEXT:    [[OR9_I_I:%.*]] = or i32 [[OR3_I_I]], [[SHL4_I_I]]
 // CHECK-NEXT:    [[OR25_I_I:%.*]] = or i32 [[OR9_I_I]], 972
-// CHECK-NEXT:    [[TMP15:%.*]] = tail call noundef <64 x float> @llvm.aie2ps.BFP640.BFP2560.ACC2048.bf.mac.conf(<16 x i32> [[TMP0]], <2 x i32> [[TMP1]], <2 x i32> [[TMP2]], <16 x i32> [[TMP3]], <16 x i32> [[TMP4]], <16 x i32> [[TMP5]], <16 x i32> [[TMP6]], <2 x i32> [[TMP7]], <2 x i32> [[TMP8]], <2 x i32> [[TMP9]], <2 x i32> [[TMP10]], <2 x i32> [[TMP11]], <2 x i32> [[TMP12]], <2 x i32> [[TMP13]], <2 x i32> [[TMP14]], <64 x float> [[ACC]], i32 [[OR25_I_I]])
-// CHECK-NEXT:    ret <64 x float> [[TMP15]]
+// CHECK-NEXT:    [[TMP5:%.*]] = tail call noundef <64 x float> @llvm.aie2ps.BFP640.BFP2560.ACC2048.bf.mac.conf(<16 x i32> [[TMP2]], <2 x i32> [[TMP3]], <2 x i32> [[TMP4]], <16 x i32> [[DOTFCA_0_EXTRACT_I]], <16 x i32> [[DOTFCA_1_EXTRACT_I]], <16 x i32> [[DOTFCA_0_EXTRACT17_I]], <16 x i32> [[DOTFCA_1_EXTRACT19_I]], <2 x i32> [[DOTFCA_2_EXTRACT_I]], <2 x i32> [[DOTFCA_3_EXTRACT_I]], <2 x i32> [[DOTFCA_2_EXTRACT21_I]], <2 x i32> [[DOTFCA_3_EXTRACT23_I]], <2 x i32> [[DOTFCA_4_EXTRACT_I]], <2 x i32> [[DOTFCA_5_EXTRACT_I]], <2 x i32> [[DOTFCA_4_EXTRACT25_I]], <2 x i32> [[DOTFCA_5_EXTRACT27_I]], <64 x float> [[ACC]], i32 [[OR25_I_I]])
+// CHECK-NEXT:    ret <64 x float> [[TMP5]]
 //
 v64accfloat test_mac_4x16_16x16T_conf(v64mx9 a, v256mx9 b, v64accfloat acc,
                                       int zero_acc, int sub_mul, int sub_acc1) {
@@ -38618,28 +38647,30 @@ v64accfloat test_mac_4x16_16x16T_conf(v64mx9 a, v256mx9 b, v64accfloat acc,
 // CHECK-LABEL: define dso_local inreg noundef <64 x float> @_Z25test_msc_4x16_16x16T_conf6v64mx97v256mx9Dv64_u10__accfloatiii(
 // CHECK-SAME: [[STRUCT_V64MX9:%.*]] [[A_COERCE:%.*]], [[STRUCT_V256MX9:%.*]] [[B_COERCE:%.*]], <64 x float> inreg noundef [[ACC:%.*]], i32 noundef [[ZERO_ACC:%.*]], i32 noundef [[SUB_MUL:%.*]], i32 noundef [[SUB_ACC1:%.*]]) local_unnamed_addr #[[ATTR1]] {
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[TMP0:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 0
-// CHECK-NEXT:    [[TMP1:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 1
-// CHECK-NEXT:    [[TMP2:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 2
-// CHECK-NEXT:    [[TMP3:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 0
-// CHECK-NEXT:    [[TMP4:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 1
-// CHECK-NEXT:    [[TMP5:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 2
-// CHECK-NEXT:    [[TMP6:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 3
-// CHECK-NEXT:    [[TMP7:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 4
-// CHECK-NEXT:    [[TMP8:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 5
-// CHECK-NEXT:    [[TMP9:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 6
-// CHECK-NEXT:    [[TMP10:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 7
-// CHECK-NEXT:    [[TMP11:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 8
-// CHECK-NEXT:    [[TMP12:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 9
-// CHECK-NEXT:    [[TMP13:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 10
-// CHECK-NEXT:    [[TMP14:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 11
+// CHECK-NEXT:    [[TMP0:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 0
+// CHECK-NEXT:    [[TMP1:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 1
+// CHECK-NEXT:    [[TMP2:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 0
+// CHECK-NEXT:    [[TMP3:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 1
+// CHECK-NEXT:    [[TMP4:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 2
+// CHECK-NEXT:    [[DOTFCA_0_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9:%.*]] [[TMP0]], 0
+// CHECK-NEXT:    [[DOTFCA_1_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 1
+// CHECK-NEXT:    [[DOTFCA_2_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 2
+// CHECK-NEXT:    [[DOTFCA_3_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 3
+// CHECK-NEXT:    [[DOTFCA_4_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 4
+// CHECK-NEXT:    [[DOTFCA_5_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 5
+// CHECK-NEXT:    [[DOTFCA_0_EXTRACT17_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 0
+// CHECK-NEXT:    [[DOTFCA_1_EXTRACT19_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 1
+// CHECK-NEXT:    [[DOTFCA_2_EXTRACT21_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 2
+// CHECK-NEXT:    [[DOTFCA_3_EXTRACT23_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 3
+// CHECK-NEXT:    [[DOTFCA_4_EXTRACT25_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 4
+// CHECK-NEXT:    [[DOTFCA_5_EXTRACT27_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 5
 // CHECK-NEXT:    [[SHL2_I_I:%.*]] = shl i32 [[SUB_MUL]], 11
 // CHECK-NEXT:    [[SHL4_I_I:%.*]] = shl i32 [[SUB_ACC1]], 12
 // CHECK-NEXT:    [[OR3_I_I:%.*]] = or i32 [[ZERO_ACC]], [[SHL2_I_I]]
 // CHECK-NEXT:    [[OR9_I_I:%.*]] = or i32 [[OR3_I_I]], [[SHL4_I_I]]
 // CHECK-NEXT:    [[OR25_I_I:%.*]] = or i32 [[OR9_I_I]], 972
-// CHECK-NEXT:    [[TMP15:%.*]] = tail call noundef <64 x float> @llvm.aie2ps.BFP640.BFP2560.ACC2048.bf.msc.conf(<16 x i32> [[TMP0]], <2 x i32> [[TMP1]], <2 x i32> [[TMP2]], <16 x i32> [[TMP3]], <16 x i32> [[TMP4]], <16 x i32> [[TMP5]], <16 x i32> [[TMP6]], <2 x i32> [[TMP7]], <2 x i32> [[TMP8]], <2 x i32> [[TMP9]], <2 x i32> [[TMP10]], <2 x i32> [[TMP11]], <2 x i32> [[TMP12]], <2 x i32> [[TMP13]], <2 x i32> [[TMP14]], <64 x float> [[ACC]], i32 [[OR25_I_I]])
-// CHECK-NEXT:    ret <64 x float> [[TMP15]]
+// CHECK-NEXT:    [[TMP5:%.*]] = tail call noundef <64 x float> @llvm.aie2ps.BFP640.BFP2560.ACC2048.bf.msc.conf(<16 x i32> [[TMP2]], <2 x i32> [[TMP3]], <2 x i32> [[TMP4]], <16 x i32> [[DOTFCA_0_EXTRACT_I]], <16 x i32> [[DOTFCA_1_EXTRACT_I]], <16 x i32> [[DOTFCA_0_EXTRACT17_I]], <16 x i32> [[DOTFCA_1_EXTRACT19_I]], <2 x i32> [[DOTFCA_2_EXTRACT_I]], <2 x i32> [[DOTFCA_3_EXTRACT_I]], <2 x i32> [[DOTFCA_2_EXTRACT21_I]], <2 x i32> [[DOTFCA_3_EXTRACT23_I]], <2 x i32> [[DOTFCA_4_EXTRACT_I]], <2 x i32> [[DOTFCA_5_EXTRACT_I]], <2 x i32> [[DOTFCA_4_EXTRACT25_I]], <2 x i32> [[DOTFCA_5_EXTRACT27_I]], <64 x float> [[ACC]], i32 [[OR25_I_I]])
+// CHECK-NEXT:    ret <64 x float> [[TMP5]]
 //
 v64accfloat test_msc_4x16_16x16T_conf(v64mx9 a, v256mx9 b, v64accfloat acc,
                                       int zero_acc, int sub_mul, int sub_acc1) {
@@ -38648,21 +38679,23 @@ v64accfloat test_msc_4x16_16x16T_conf(v64mx9 a, v256mx9 b, v64accfloat acc,
 // CHECK-LABEL: define dso_local inreg noundef <64 x float> @_Z28test_addmac_4x16_16x16T_conf6v64mx97v256mx9Dv64_u10__accfloatS1_iiii(
 // CHECK-SAME: [[STRUCT_V64MX9:%.*]] [[A_COERCE:%.*]], [[STRUCT_V256MX9:%.*]] [[B_COERCE:%.*]], <64 x float> inreg noundef [[ACC1:%.*]], <64 x float> inreg noundef [[ACC2:%.*]], i32 noundef [[ZERO_ACC1:%.*]], i32 noundef [[SUB_MUL:%.*]], i32 noundef [[SUB_ACC1:%.*]], i32 noundef [[SUB_ACC2:%.*]]) local_unnamed_addr #[[ATTR1]] {
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[TMP0:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 0
-// CHECK-NEXT:    [[TMP1:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 1
-// CHECK-NEXT:    [[TMP2:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 2
-// CHECK-NEXT:    [[TMP3:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 0
-// CHECK-NEXT:    [[TMP4:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 1
-// CHECK-NEXT:    [[TMP5:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 2
-// CHECK-NEXT:    [[TMP6:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 3
-// CHECK-NEXT:    [[TMP7:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 4
-// CHECK-NEXT:    [[TMP8:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 5
-// CHECK-NEXT:    [[TMP9:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 6
-// CHECK-NEXT:    [[TMP10:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 7
-// CHECK-NEXT:    [[TMP11:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 8
-// CHECK-NEXT:    [[TMP12:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 9
-// CHECK-NEXT:    [[TMP13:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 10
-// CHECK-NEXT:    [[TMP14:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 11
+// CHECK-NEXT:    [[TMP0:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 0
+// CHECK-NEXT:    [[TMP1:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 1
+// CHECK-NEXT:    [[TMP2:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 0
+// CHECK-NEXT:    [[TMP3:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 1
+// CHECK-NEXT:    [[TMP4:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 2
+// CHECK-NEXT:    [[DOTFCA_0_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9:%.*]] [[TMP0]], 0
+// CHECK-NEXT:    [[DOTFCA_1_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 1
+// CHECK-NEXT:    [[DOTFCA_2_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 2
+// CHECK-NEXT:    [[DOTFCA_3_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 3
+// CHECK-NEXT:    [[DOTFCA_4_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 4
+// CHECK-NEXT:    [[DOTFCA_5_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 5
+// CHECK-NEXT:    [[DOTFCA_0_EXTRACT17_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 0
+// CHECK-NEXT:    [[DOTFCA_1_EXTRACT19_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 1
+// CHECK-NEXT:    [[DOTFCA_2_EXTRACT21_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 2
+// CHECK-NEXT:    [[DOTFCA_3_EXTRACT23_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 3
+// CHECK-NEXT:    [[DOTFCA_4_EXTRACT25_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 4
+// CHECK-NEXT:    [[DOTFCA_5_EXTRACT27_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 5
 // CHECK-NEXT:    [[SHL2_I_I:%.*]] = shl i32 [[SUB_MUL]], 11
 // CHECK-NEXT:    [[SHL4_I_I:%.*]] = shl i32 [[SUB_ACC1]], 12
 // CHECK-NEXT:    [[SHL6_I_I:%.*]] = shl i32 [[SUB_ACC2]], 13
@@ -38670,8 +38703,8 @@ v64accfloat test_msc_4x16_16x16T_conf(v64mx9 a, v256mx9 b, v64accfloat acc,
 // CHECK-NEXT:    [[OR5_I_I:%.*]] = or i32 [[OR3_I_I]], [[SHL4_I_I]]
 // CHECK-NEXT:    [[OR9_I_I:%.*]] = or i32 [[OR5_I_I]], [[SHL6_I_I]]
 // CHECK-NEXT:    [[OR25_I_I:%.*]] = or i32 [[OR9_I_I]], 972
-// CHECK-NEXT:    [[TMP15:%.*]] = tail call noundef <64 x float> @llvm.aie2ps.BFP640.BFP2560.ACC2048.bf.addmac.conf(<16 x i32> [[TMP0]], <2 x i32> [[TMP1]], <2 x i32> [[TMP2]], <16 x i32> [[TMP3]], <16 x i32> [[TMP4]], <16 x i32> [[TMP5]], <16 x i32> [[TMP6]], <2 x i32> [[TMP7]], <2 x i32> [[TMP8]], <2 x i32> [[TMP9]], <2 x i32> [[TMP10]], <2 x i32> [[TMP11]], <2 x i32> [[TMP12]], <2 x i32> [[TMP13]], <2 x i32> [[TMP14]], <64 x float> [[ACC1]], <64 x float> [[ACC2]], i32 [[OR25_I_I]])
-// CHECK-NEXT:    ret <64 x float> [[TMP15]]
+// CHECK-NEXT:    [[TMP5:%.*]] = tail call noundef <64 x float> @llvm.aie2ps.BFP640.BFP2560.ACC2048.bf.addmac.conf(<16 x i32> [[TMP2]], <2 x i32> [[TMP3]], <2 x i32> [[TMP4]], <16 x i32> [[DOTFCA_0_EXTRACT_I]], <16 x i32> [[DOTFCA_1_EXTRACT_I]], <16 x i32> [[DOTFCA_0_EXTRACT17_I]], <16 x i32> [[DOTFCA_1_EXTRACT19_I]], <2 x i32> [[DOTFCA_2_EXTRACT_I]], <2 x i32> [[DOTFCA_3_EXTRACT_I]], <2 x i32> [[DOTFCA_2_EXTRACT21_I]], <2 x i32> [[DOTFCA_3_EXTRACT23_I]], <2 x i32> [[DOTFCA_4_EXTRACT_I]], <2 x i32> [[DOTFCA_5_EXTRACT_I]], <2 x i32> [[DOTFCA_4_EXTRACT25_I]], <2 x i32> [[DOTFCA_5_EXTRACT27_I]], <64 x float> [[ACC1]], <64 x float> [[ACC2]], i32 [[OR25_I_I]])
+// CHECK-NEXT:    ret <64 x float> [[TMP5]]
 //
 v64accfloat test_addmac_4x16_16x16T_conf(v64mx9 a, v256mx9 b, v64accfloat acc1,
                                          v64accfloat acc2, int zero_acc1,
@@ -38683,21 +38716,23 @@ v64accfloat test_addmac_4x16_16x16T_conf(v64mx9 a, v256mx9 b, v64accfloat acc1,
 // CHECK-LABEL: define dso_local inreg noundef <64 x float> @_Z28test_addmsc_4x16_16x16T_conf6v64mx97v256mx9Dv64_u10__accfloatS1_iiii(
 // CHECK-SAME: [[STRUCT_V64MX9:%.*]] [[A_COERCE:%.*]], [[STRUCT_V256MX9:%.*]] [[B_COERCE:%.*]], <64 x float> inreg noundef [[ACC1:%.*]], <64 x float> inreg noundef [[ACC2:%.*]], i32 noundef [[ZERO_ACC1:%.*]], i32 noundef [[SUB_MUL:%.*]], i32 noundef [[SUB_ACC1:%.*]], i32 noundef [[SUB_ACC2:%.*]]) local_unnamed_addr #[[ATTR1]] {
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[TMP0:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 0
-// CHECK-NEXT:    [[TMP1:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 1
-// CHECK-NEXT:    [[TMP2:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 2
-// CHECK-NEXT:    [[TMP3:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 0
-// CHECK-NEXT:    [[TMP4:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 1
-// CHECK-NEXT:    [[TMP5:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 2
-// CHECK-NEXT:    [[TMP6:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 3
-// CHECK-NEXT:    [[TMP7:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 4
-// CHECK-NEXT:    [[TMP8:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 5
-// CHECK-NEXT:    [[TMP9:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 6
-// CHECK-NEXT:    [[TMP10:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 7
-// CHECK-NEXT:    [[TMP11:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 8
-// CHECK-NEXT:    [[TMP12:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 9
-// CHECK-NEXT:    [[TMP13:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 10
-// CHECK-NEXT:    [[TMP14:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 11
+// CHECK-NEXT:    [[TMP0:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 0
+// CHECK-NEXT:    [[TMP1:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 1
+// CHECK-NEXT:    [[TMP2:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 0
+// CHECK-NEXT:    [[TMP3:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 1
+// CHECK-NEXT:    [[TMP4:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 2
+// CHECK-NEXT:    [[DOTFCA_0_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9:%.*]] [[TMP0]], 0
+// CHECK-NEXT:    [[DOTFCA_1_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 1
+// CHECK-NEXT:    [[DOTFCA_2_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 2
+// CHECK-NEXT:    [[DOTFCA_3_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 3
+// CHECK-NEXT:    [[DOTFCA_4_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 4
+// CHECK-NEXT:    [[DOTFCA_5_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 5
+// CHECK-NEXT:    [[DOTFCA_0_EXTRACT17_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 0
+// CHECK-NEXT:    [[DOTFCA_1_EXTRACT19_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 1
+// CHECK-NEXT:    [[DOTFCA_2_EXTRACT21_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 2
+// CHECK-NEXT:    [[DOTFCA_3_EXTRACT23_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 3
+// CHECK-NEXT:    [[DOTFCA_4_EXTRACT25_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 4
+// CHECK-NEXT:    [[DOTFCA_5_EXTRACT27_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 5
 // CHECK-NEXT:    [[SHL2_I_I:%.*]] = shl i32 [[SUB_MUL]], 11
 // CHECK-NEXT:    [[SHL4_I_I:%.*]] = shl i32 [[SUB_ACC1]], 12
 // CHECK-NEXT:    [[SHL6_I_I:%.*]] = shl i32 [[SUB_ACC2]], 13
@@ -38705,8 +38740,8 @@ v64accfloat test_addmac_4x16_16x16T_conf(v64mx9 a, v256mx9 b, v64accfloat acc1,
 // CHECK-NEXT:    [[OR5_I_I:%.*]] = or i32 [[OR3_I_I]], [[SHL4_I_I]]
 // CHECK-NEXT:    [[OR9_I_I:%.*]] = or i32 [[OR5_I_I]], [[SHL6_I_I]]
 // CHECK-NEXT:    [[OR25_I_I:%.*]] = or i32 [[OR9_I_I]], 972
-// CHECK-NEXT:    [[TMP15:%.*]] = tail call noundef <64 x float> @llvm.aie2ps.BFP640.BFP2560.ACC2048.bf.addmsc.conf(<16 x i32> [[TMP0]], <2 x i32> [[TMP1]], <2 x i32> [[TMP2]], <16 x i32> [[TMP3]], <16 x i32> [[TMP4]], <16 x i32> [[TMP5]], <16 x i32> [[TMP6]], <2 x i32> [[TMP7]], <2 x i32> [[TMP8]], <2 x i32> [[TMP9]], <2 x i32> [[TMP10]], <2 x i32> [[TMP11]], <2 x i32> [[TMP12]], <2 x i32> [[TMP13]], <2 x i32> [[TMP14]], <64 x float> [[ACC1]], <64 x float> [[ACC2]], i32 [[OR25_I_I]])
-// CHECK-NEXT:    ret <64 x float> [[TMP15]]
+// CHECK-NEXT:    [[TMP5:%.*]] = tail call noundef <64 x float> @llvm.aie2ps.BFP640.BFP2560.ACC2048.bf.addmsc.conf(<16 x i32> [[TMP2]], <2 x i32> [[TMP3]], <2 x i32> [[TMP4]], <16 x i32> [[DOTFCA_0_EXTRACT_I]], <16 x i32> [[DOTFCA_1_EXTRACT_I]], <16 x i32> [[DOTFCA_0_EXTRACT17_I]], <16 x i32> [[DOTFCA_1_EXTRACT19_I]], <2 x i32> [[DOTFCA_2_EXTRACT_I]], <2 x i32> [[DOTFCA_3_EXTRACT_I]], <2 x i32> [[DOTFCA_2_EXTRACT21_I]], <2 x i32> [[DOTFCA_3_EXTRACT23_I]], <2 x i32> [[DOTFCA_4_EXTRACT_I]], <2 x i32> [[DOTFCA_5_EXTRACT_I]], <2 x i32> [[DOTFCA_4_EXTRACT25_I]], <2 x i32> [[DOTFCA_5_EXTRACT27_I]], <64 x float> [[ACC1]], <64 x float> [[ACC2]], i32 [[OR25_I_I]])
+// CHECK-NEXT:    ret <64 x float> [[TMP5]]
 //
 v64accfloat test_addmsc_4x16_16x16T_conf(v64mx9 a, v256mx9 b, v64accfloat acc1,
                                          v64accfloat acc2, int zero_acc1,
@@ -38718,29 +38753,31 @@ v64accfloat test_addmsc_4x16_16x16T_conf(v64mx9 a, v256mx9 b, v64accfloat acc1,
 // CHECK-LABEL: define dso_local inreg noundef <64 x float> @_Z25test_mul_4x16_16x16T_conf6v64mx9i7v256mx9ii(
 // CHECK-SAME: [[STRUCT_V64MX9:%.*]] [[A_COERCE:%.*]], i32 noundef [[SGN_X:%.*]], [[STRUCT_V256MX9:%.*]] [[B_COERCE:%.*]], i32 noundef [[SGN_Y:%.*]], i32 noundef [[SUB_MUL:%.*]]) local_unnamed_addr #[[ATTR1]] {
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[TMP0:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 0
-// CHECK-NEXT:    [[TMP1:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 1
-// CHECK-NEXT:    [[TMP2:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 2
-// CHECK-NEXT:    [[TMP3:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 0
-// CHECK-NEXT:    [[TMP4:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 1
-// CHECK-NEXT:    [[TMP5:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 2
-// CHECK-NEXT:    [[TMP6:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 3
-// CHECK-NEXT:    [[TMP7:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 4
-// CHECK-NEXT:    [[TMP8:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 5
-// CHECK-NEXT:    [[TMP9:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 6
-// CHECK-NEXT:    [[TMP10:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 7
-// CHECK-NEXT:    [[TMP11:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 8
-// CHECK-NEXT:    [[TMP12:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 9
-// CHECK-NEXT:    [[TMP13:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 10
-// CHECK-NEXT:    [[TMP14:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 11
+// CHECK-NEXT:    [[TMP0:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 0
+// CHECK-NEXT:    [[TMP1:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 1
+// CHECK-NEXT:    [[TMP2:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 0
+// CHECK-NEXT:    [[TMP3:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 1
+// CHECK-NEXT:    [[TMP4:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 2
+// CHECK-NEXT:    [[DOTFCA_0_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9:%.*]] [[TMP0]], 0
+// CHECK-NEXT:    [[DOTFCA_1_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 1
+// CHECK-NEXT:    [[DOTFCA_2_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 2
+// CHECK-NEXT:    [[DOTFCA_3_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 3
+// CHECK-NEXT:    [[DOTFCA_4_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 4
+// CHECK-NEXT:    [[DOTFCA_5_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 5
+// CHECK-NEXT:    [[DOTFCA_0_EXTRACT17_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 0
+// CHECK-NEXT:    [[DOTFCA_1_EXTRACT19_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 1
+// CHECK-NEXT:    [[DOTFCA_2_EXTRACT21_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 2
+// CHECK-NEXT:    [[DOTFCA_3_EXTRACT23_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 3
+// CHECK-NEXT:    [[DOTFCA_4_EXTRACT25_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 4
+// CHECK-NEXT:    [[DOTFCA_5_EXTRACT27_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 5
 // CHECK-NEXT:    [[SHL2_I_I:%.*]] = shl i32 [[SUB_MUL]], 11
 // CHECK-NEXT:    [[SHL20_I_I:%.*]] = shl i32 [[SGN_X]], 9
 // CHECK-NEXT:    [[SHL21_I_I:%.*]] = shl i32 [[SGN_Y]], 8
 // CHECK-NEXT:    [[OR12_I_I:%.*]] = or i32 [[SHL20_I_I]], [[SHL21_I_I]]
 // CHECK-NEXT:    [[OR15_I_I:%.*]] = or i32 [[OR12_I_I]], [[SHL2_I_I]]
 // CHECK-NEXT:    [[OR25_I_I:%.*]] = or disjoint i32 [[OR15_I_I]], 204
-// CHECK-NEXT:    [[TMP15:%.*]] = tail call noundef <64 x float> @llvm.aie2ps.BFP640.BFP2560.ACC2048.bf.mul.conf(<16 x i32> [[TMP0]], <2 x i32> [[TMP1]], <2 x i32> [[TMP2]], <16 x i32> [[TMP3]], <16 x i32> [[TMP4]], <16 x i32> [[TMP5]], <16 x i32> [[TMP6]], <2 x i32> [[TMP7]], <2 x i32> [[TMP8]], <2 x i32> [[TMP9]], <2 x i32> [[TMP10]], <2 x i32> [[TMP11]], <2 x i32> [[TMP12]], <2 x i32> [[TMP13]], <2 x i32> [[TMP14]], i32 [[OR25_I_I]])
-// CHECK-NEXT:    ret <64 x float> [[TMP15]]
+// CHECK-NEXT:    [[TMP5:%.*]] = tail call noundef <64 x float> @llvm.aie2ps.BFP640.BFP2560.ACC2048.bf.mul.conf(<16 x i32> [[TMP2]], <2 x i32> [[TMP3]], <2 x i32> [[TMP4]], <16 x i32> [[DOTFCA_0_EXTRACT_I]], <16 x i32> [[DOTFCA_1_EXTRACT_I]], <16 x i32> [[DOTFCA_0_EXTRACT17_I]], <16 x i32> [[DOTFCA_1_EXTRACT19_I]], <2 x i32> [[DOTFCA_2_EXTRACT_I]], <2 x i32> [[DOTFCA_3_EXTRACT_I]], <2 x i32> [[DOTFCA_2_EXTRACT21_I]], <2 x i32> [[DOTFCA_3_EXTRACT23_I]], <2 x i32> [[DOTFCA_4_EXTRACT_I]], <2 x i32> [[DOTFCA_5_EXTRACT_I]], <2 x i32> [[DOTFCA_4_EXTRACT25_I]], <2 x i32> [[DOTFCA_5_EXTRACT27_I]], i32 [[OR25_I_I]])
+// CHECK-NEXT:    ret <64 x float> [[TMP5]]
 //
 v64accfloat test_mul_4x16_16x16T_conf(v64mx9 a, int sgn_x, v256mx9 b, int sgn_y,
                                       int sub_mul) {
@@ -38749,29 +38786,31 @@ v64accfloat test_mul_4x16_16x16T_conf(v64mx9 a, int sgn_x, v256mx9 b, int sgn_y,
 // CHECK-LABEL: define dso_local inreg noundef <64 x float> @_Z28test_negmul_4x16_16x16T_conf6v64mx9i7v256mx9ii(
 // CHECK-SAME: [[STRUCT_V64MX9:%.*]] [[A_COERCE:%.*]], i32 noundef [[SGN_X:%.*]], [[STRUCT_V256MX9:%.*]] [[B_COERCE:%.*]], i32 noundef [[SGN_Y:%.*]], i32 noundef [[SUB_MUL:%.*]]) local_unnamed_addr #[[ATTR1]] {
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[TMP0:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 0
-// CHECK-NEXT:    [[TMP1:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 1
-// CHECK-NEXT:    [[TMP2:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 2
-// CHECK-NEXT:    [[TMP3:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 0
-// CHECK-NEXT:    [[TMP4:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 1
-// CHECK-NEXT:    [[TMP5:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 2
-// CHECK-NEXT:    [[TMP6:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 3
-// CHECK-NEXT:    [[TMP7:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 4
-// CHECK-NEXT:    [[TMP8:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 5
-// CHECK-NEXT:    [[TMP9:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 6
-// CHECK-NEXT:    [[TMP10:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 7
-// CHECK-NEXT:    [[TMP11:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 8
-// CHECK-NEXT:    [[TMP12:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 9
-// CHECK-NEXT:    [[TMP13:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 10
-// CHECK-NEXT:    [[TMP14:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 11
+// CHECK-NEXT:    [[TMP0:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 0
+// CHECK-NEXT:    [[TMP1:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 1
+// CHECK-NEXT:    [[TMP2:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 0
+// CHECK-NEXT:    [[TMP3:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 1
+// CHECK-NEXT:    [[TMP4:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 2
+// CHECK-NEXT:    [[DOTFCA_0_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9:%.*]] [[TMP0]], 0
+// CHECK-NEXT:    [[DOTFCA_1_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 1
+// CHECK-NEXT:    [[DOTFCA_2_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 2
+// CHECK-NEXT:    [[DOTFCA_3_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 3
+// CHECK-NEXT:    [[DOTFCA_4_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 4
+// CHECK-NEXT:    [[DOTFCA_5_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 5
+// CHECK-NEXT:    [[DOTFCA_0_EXTRACT17_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 0
+// CHECK-NEXT:    [[DOTFCA_1_EXTRACT19_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 1
+// CHECK-NEXT:    [[DOTFCA_2_EXTRACT21_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 2
+// CHECK-NEXT:    [[DOTFCA_3_EXTRACT23_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 3
+// CHECK-NEXT:    [[DOTFCA_4_EXTRACT25_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 4
+// CHECK-NEXT:    [[DOTFCA_5_EXTRACT27_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 5
 // CHECK-NEXT:    [[SHL2_I_I:%.*]] = shl i32 [[SUB_MUL]], 11
 // CHECK-NEXT:    [[SHL20_I_I:%.*]] = shl i32 [[SGN_X]], 9
 // CHECK-NEXT:    [[SHL21_I_I:%.*]] = shl i32 [[SGN_Y]], 8
 // CHECK-NEXT:    [[OR12_I_I:%.*]] = or i32 [[SHL20_I_I]], [[SHL21_I_I]]
 // CHECK-NEXT:    [[OR15_I_I:%.*]] = or i32 [[OR12_I_I]], [[SHL2_I_I]]
 // CHECK-NEXT:    [[OR25_I_I:%.*]] = or disjoint i32 [[OR15_I_I]], 204
-// CHECK-NEXT:    [[TMP15:%.*]] = tail call noundef <64 x float> @llvm.aie2ps.BFP640.BFP2560.ACC2048.bf.negmul.conf(<16 x i32> [[TMP0]], <2 x i32> [[TMP1]], <2 x i32> [[TMP2]], <16 x i32> [[TMP3]], <16 x i32> [[TMP4]], <16 x i32> [[TMP5]], <16 x i32> [[TMP6]], <2 x i32> [[TMP7]], <2 x i32> [[TMP8]], <2 x i32> [[TMP9]], <2 x i32> [[TMP10]], <2 x i32> [[TMP11]], <2 x i32> [[TMP12]], <2 x i32> [[TMP13]], <2 x i32> [[TMP14]], i32 [[OR25_I_I]])
-// CHECK-NEXT:    ret <64 x float> [[TMP15]]
+// CHECK-NEXT:    [[TMP5:%.*]] = tail call noundef <64 x float> @llvm.aie2ps.BFP640.BFP2560.ACC2048.bf.negmul.conf(<16 x i32> [[TMP2]], <2 x i32> [[TMP3]], <2 x i32> [[TMP4]], <16 x i32> [[DOTFCA_0_EXTRACT_I]], <16 x i32> [[DOTFCA_1_EXTRACT_I]], <16 x i32> [[DOTFCA_0_EXTRACT17_I]], <16 x i32> [[DOTFCA_1_EXTRACT19_I]], <2 x i32> [[DOTFCA_2_EXTRACT_I]], <2 x i32> [[DOTFCA_3_EXTRACT_I]], <2 x i32> [[DOTFCA_2_EXTRACT21_I]], <2 x i32> [[DOTFCA_3_EXTRACT23_I]], <2 x i32> [[DOTFCA_4_EXTRACT_I]], <2 x i32> [[DOTFCA_5_EXTRACT_I]], <2 x i32> [[DOTFCA_4_EXTRACT25_I]], <2 x i32> [[DOTFCA_5_EXTRACT27_I]], i32 [[OR25_I_I]])
+// CHECK-NEXT:    ret <64 x float> [[TMP5]]
 //
 v64accfloat test_negmul_4x16_16x16T_conf(v64mx9 a, int sgn_x, v256mx9 b,
                                          int sgn_y, int sub_mul) {
@@ -38780,21 +38819,23 @@ v64accfloat test_negmul_4x16_16x16T_conf(v64mx9 a, int sgn_x, v256mx9 b,
 // CHECK-LABEL: define dso_local inreg noundef <64 x float> @_Z25test_mac_4x16_16x16T_conf6v64mx9i7v256mx9iDv64_u10__accfloatiii(
 // CHECK-SAME: [[STRUCT_V64MX9:%.*]] [[A_COERCE:%.*]], i32 noundef [[SGN_X:%.*]], [[STRUCT_V256MX9:%.*]] [[B_COERCE:%.*]], i32 noundef [[SGN_Y:%.*]], <64 x float> inreg noundef [[ACC:%.*]], i32 noundef [[ZERO_ACC:%.*]], i32 noundef [[SUB_MUL:%.*]], i32 noundef [[SUB_ACC1:%.*]]) local_unnamed_addr #[[ATTR1]] {
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[TMP0:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 0
-// CHECK-NEXT:    [[TMP1:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 1
-// CHECK-NEXT:    [[TMP2:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 2
-// CHECK-NEXT:    [[TMP3:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 0
-// CHECK-NEXT:    [[TMP4:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 1
-// CHECK-NEXT:    [[TMP5:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 2
-// CHECK-NEXT:    [[TMP6:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 3
-// CHECK-NEXT:    [[TMP7:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 4
-// CHECK-NEXT:    [[TMP8:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 5
-// CHECK-NEXT:    [[TMP9:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 6
-// CHECK-NEXT:    [[TMP10:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 7
-// CHECK-NEXT:    [[TMP11:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 8
-// CHECK-NEXT:    [[TMP12:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 9
-// CHECK-NEXT:    [[TMP13:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 10
-// CHECK-NEXT:    [[TMP14:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 11
+// CHECK-NEXT:    [[TMP0:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 0
+// CHECK-NEXT:    [[TMP1:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 1
+// CHECK-NEXT:    [[TMP2:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 0
+// CHECK-NEXT:    [[TMP3:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 1
+// CHECK-NEXT:    [[TMP4:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 2
+// CHECK-NEXT:    [[DOTFCA_0_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9:%.*]] [[TMP0]], 0
+// CHECK-NEXT:    [[DOTFCA_1_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 1
+// CHECK-NEXT:    [[DOTFCA_2_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 2
+// CHECK-NEXT:    [[DOTFCA_3_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 3
+// CHECK-NEXT:    [[DOTFCA_4_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 4
+// CHECK-NEXT:    [[DOTFCA_5_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 5
+// CHECK-NEXT:    [[DOTFCA_0_EXTRACT17_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 0
+// CHECK-NEXT:    [[DOTFCA_1_EXTRACT19_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 1
+// CHECK-NEXT:    [[DOTFCA_2_EXTRACT21_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 2
+// CHECK-NEXT:    [[DOTFCA_3_EXTRACT23_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 3
+// CHECK-NEXT:    [[DOTFCA_4_EXTRACT25_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 4
+// CHECK-NEXT:    [[DOTFCA_5_EXTRACT27_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 5
 // CHECK-NEXT:    [[SHL2_I_I:%.*]] = shl i32 [[SUB_MUL]], 11
 // CHECK-NEXT:    [[SHL4_I_I:%.*]] = shl i32 [[SUB_ACC1]], 12
 // CHECK-NEXT:    [[SHL20_I_I:%.*]] = shl i32 [[SGN_X]], 9
@@ -38804,8 +38845,8 @@ v64accfloat test_negmul_4x16_16x16T_conf(v64mx9 a, int sgn_x, v256mx9 b,
 // CHECK-NEXT:    [[OR12_I_I:%.*]] = or i32 [[OR9_I_I]], [[SHL2_I_I]]
 // CHECK-NEXT:    [[OR15_I_I:%.*]] = or i32 [[OR12_I_I]], [[SHL4_I_I]]
 // CHECK-NEXT:    [[OR25_I_I:%.*]] = or i32 [[OR15_I_I]], 204
-// CHECK-NEXT:    [[TMP15:%.*]] = tail call noundef <64 x float> @llvm.aie2ps.BFP640.BFP2560.ACC2048.bf.mac.conf(<16 x i32> [[TMP0]], <2 x i32> [[TMP1]], <2 x i32> [[TMP2]], <16 x i32> [[TMP3]], <16 x i32> [[TMP4]], <16 x i32> [[TMP5]], <16 x i32> [[TMP6]], <2 x i32> [[TMP7]], <2 x i32> [[TMP8]], <2 x i32> [[TMP9]], <2 x i32> [[TMP10]], <2 x i32> [[TMP11]], <2 x i32> [[TMP12]], <2 x i32> [[TMP13]], <2 x i32> [[TMP14]], <64 x float> [[ACC]], i32 [[OR25_I_I]])
-// CHECK-NEXT:    ret <64 x float> [[TMP15]]
+// CHECK-NEXT:    [[TMP5:%.*]] = tail call noundef <64 x float> @llvm.aie2ps.BFP640.BFP2560.ACC2048.bf.mac.conf(<16 x i32> [[TMP2]], <2 x i32> [[TMP3]], <2 x i32> [[TMP4]], <16 x i32> [[DOTFCA_0_EXTRACT_I]], <16 x i32> [[DOTFCA_1_EXTRACT_I]], <16 x i32> [[DOTFCA_0_EXTRACT17_I]], <16 x i32> [[DOTFCA_1_EXTRACT19_I]], <2 x i32> [[DOTFCA_2_EXTRACT_I]], <2 x i32> [[DOTFCA_3_EXTRACT_I]], <2 x i32> [[DOTFCA_2_EXTRACT21_I]], <2 x i32> [[DOTFCA_3_EXTRACT23_I]], <2 x i32> [[DOTFCA_4_EXTRACT_I]], <2 x i32> [[DOTFCA_5_EXTRACT_I]], <2 x i32> [[DOTFCA_4_EXTRACT25_I]], <2 x i32> [[DOTFCA_5_EXTRACT27_I]], <64 x float> [[ACC]], i32 [[OR25_I_I]])
+// CHECK-NEXT:    ret <64 x float> [[TMP5]]
 //
 v64accfloat test_mac_4x16_16x16T_conf(v64mx9 a, int sgn_x, v256mx9 b, int sgn_y,
                                       v64accfloat acc, int zero_acc,
@@ -38816,21 +38857,23 @@ v64accfloat test_mac_4x16_16x16T_conf(v64mx9 a, int sgn_x, v256mx9 b, int sgn_y,
 // CHECK-LABEL: define dso_local inreg noundef <64 x float> @_Z25test_msc_4x16_16x16T_conf6v64mx9i7v256mx9iDv64_u10__accfloatiii(
 // CHECK-SAME: [[STRUCT_V64MX9:%.*]] [[A_COERCE:%.*]], i32 noundef [[SGN_X:%.*]], [[STRUCT_V256MX9:%.*]] [[B_COERCE:%.*]], i32 noundef [[SGN_Y:%.*]], <64 x float> inreg noundef [[ACC:%.*]], i32 noundef [[ZERO_ACC:%.*]], i32 noundef [[SUB_MUL:%.*]], i32 noundef [[SUB_ACC1:%.*]]) local_unnamed_addr #[[ATTR1]] {
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[TMP0:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 0
-// CHECK-NEXT:    [[TMP1:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 1
-// CHECK-NEXT:    [[TMP2:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 2
-// CHECK-NEXT:    [[TMP3:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 0
-// CHECK-NEXT:    [[TMP4:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 1
-// CHECK-NEXT:    [[TMP5:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 2
-// CHECK-NEXT:    [[TMP6:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 3
-// CHECK-NEXT:    [[TMP7:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 4
-// CHECK-NEXT:    [[TMP8:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 5
-// CHECK-NEXT:    [[TMP9:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 6
-// CHECK-NEXT:    [[TMP10:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 7
-// CHECK-NEXT:    [[TMP11:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 8
-// CHECK-NEXT:    [[TMP12:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 9
-// CHECK-NEXT:    [[TMP13:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 10
-// CHECK-NEXT:    [[TMP14:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 11
+// CHECK-NEXT:    [[TMP0:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 0
+// CHECK-NEXT:    [[TMP1:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 1
+// CHECK-NEXT:    [[TMP2:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 0
+// CHECK-NEXT:    [[TMP3:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 1
+// CHECK-NEXT:    [[TMP4:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 2
+// CHECK-NEXT:    [[DOTFCA_0_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9:%.*]] [[TMP0]], 0
+// CHECK-NEXT:    [[DOTFCA_1_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 1
+// CHECK-NEXT:    [[DOTFCA_2_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 2
+// CHECK-NEXT:    [[DOTFCA_3_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 3
+// CHECK-NEXT:    [[DOTFCA_4_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 4
+// CHECK-NEXT:    [[DOTFCA_5_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 5
+// CHECK-NEXT:    [[DOTFCA_0_EXTRACT17_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 0
+// CHECK-NEXT:    [[DOTFCA_1_EXTRACT19_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 1
+// CHECK-NEXT:    [[DOTFCA_2_EXTRACT21_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 2
+// CHECK-NEXT:    [[DOTFCA_3_EXTRACT23_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 3
+// CHECK-NEXT:    [[DOTFCA_4_EXTRACT25_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 4
+// CHECK-NEXT:    [[DOTFCA_5_EXTRACT27_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 5
 // CHECK-NEXT:    [[SHL2_I_I:%.*]] = shl i32 [[SUB_MUL]], 11
 // CHECK-NEXT:    [[SHL4_I_I:%.*]] = shl i32 [[SUB_ACC1]], 12
 // CHECK-NEXT:    [[SHL20_I_I:%.*]] = shl i32 [[SGN_X]], 9
@@ -38840,8 +38883,8 @@ v64accfloat test_mac_4x16_16x16T_conf(v64mx9 a, int sgn_x, v256mx9 b, int sgn_y,
 // CHECK-NEXT:    [[OR12_I_I:%.*]] = or i32 [[OR9_I_I]], [[SHL2_I_I]]
 // CHECK-NEXT:    [[OR15_I_I:%.*]] = or i32 [[OR12_I_I]], [[SHL4_I_I]]
 // CHECK-NEXT:    [[OR25_I_I:%.*]] = or i32 [[OR15_I_I]], 204
-// CHECK-NEXT:    [[TMP15:%.*]] = tail call noundef <64 x float> @llvm.aie2ps.BFP640.BFP2560.ACC2048.bf.msc.conf(<16 x i32> [[TMP0]], <2 x i32> [[TMP1]], <2 x i32> [[TMP2]], <16 x i32> [[TMP3]], <16 x i32> [[TMP4]], <16 x i32> [[TMP5]], <16 x i32> [[TMP6]], <2 x i32> [[TMP7]], <2 x i32> [[TMP8]], <2 x i32> [[TMP9]], <2 x i32> [[TMP10]], <2 x i32> [[TMP11]], <2 x i32> [[TMP12]], <2 x i32> [[TMP13]], <2 x i32> [[TMP14]], <64 x float> [[ACC]], i32 [[OR25_I_I]])
-// CHECK-NEXT:    ret <64 x float> [[TMP15]]
+// CHECK-NEXT:    [[TMP5:%.*]] = tail call noundef <64 x float> @llvm.aie2ps.BFP640.BFP2560.ACC2048.bf.msc.conf(<16 x i32> [[TMP2]], <2 x i32> [[TMP3]], <2 x i32> [[TMP4]], <16 x i32> [[DOTFCA_0_EXTRACT_I]], <16 x i32> [[DOTFCA_1_EXTRACT_I]], <16 x i32> [[DOTFCA_0_EXTRACT17_I]], <16 x i32> [[DOTFCA_1_EXTRACT19_I]], <2 x i32> [[DOTFCA_2_EXTRACT_I]], <2 x i32> [[DOTFCA_3_EXTRACT_I]], <2 x i32> [[DOTFCA_2_EXTRACT21_I]], <2 x i32> [[DOTFCA_3_EXTRACT23_I]], <2 x i32> [[DOTFCA_4_EXTRACT_I]], <2 x i32> [[DOTFCA_5_EXTRACT_I]], <2 x i32> [[DOTFCA_4_EXTRACT25_I]], <2 x i32> [[DOTFCA_5_EXTRACT27_I]], <64 x float> [[ACC]], i32 [[OR25_I_I]])
+// CHECK-NEXT:    ret <64 x float> [[TMP5]]
 //
 v64accfloat test_msc_4x16_16x16T_conf(v64mx9 a, int sgn_x, v256mx9 b, int sgn_y,
                                       v64accfloat acc, int zero_acc,
@@ -38852,21 +38895,23 @@ v64accfloat test_msc_4x16_16x16T_conf(v64mx9 a, int sgn_x, v256mx9 b, int sgn_y,
 // CHECK-LABEL: define dso_local inreg noundef <64 x float> @_Z28test_addmac_4x16_16x16T_conf6v64mx9i7v256mx9iDv64_u10__accfloatS1_iiii(
 // CHECK-SAME: [[STRUCT_V64MX9:%.*]] [[A_COERCE:%.*]], i32 noundef [[SGN_X:%.*]], [[STRUCT_V256MX9:%.*]] [[B_COERCE:%.*]], i32 noundef [[SGN_Y:%.*]], <64 x float> inreg noundef [[ACC1:%.*]], <64 x float> inreg noundef [[ACC2:%.*]], i32 noundef [[ZERO_ACC1:%.*]], i32 noundef [[SUB_MUL:%.*]], i32 noundef [[SUB_ACC1:%.*]], i32 noundef [[SUB_ACC2:%.*]]) local_unnamed_addr #[[ATTR1]] {
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[TMP0:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 0
-// CHECK-NEXT:    [[TMP1:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 1
-// CHECK-NEXT:    [[TMP2:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 2
-// CHECK-NEXT:    [[TMP3:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 0
-// CHECK-NEXT:    [[TMP4:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 1
-// CHECK-NEXT:    [[TMP5:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 2
-// CHECK-NEXT:    [[TMP6:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 3
-// CHECK-NEXT:    [[TMP7:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 4
-// CHECK-NEXT:    [[TMP8:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 5
-// CHECK-NEXT:    [[TMP9:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 6
-// CHECK-NEXT:    [[TMP10:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 7
-// CHECK-NEXT:    [[TMP11:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 8
-// CHECK-NEXT:    [[TMP12:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 9
-// CHECK-NEXT:    [[TMP13:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 10
-// CHECK-NEXT:    [[TMP14:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 11
+// CHECK-NEXT:    [[TMP0:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 0
+// CHECK-NEXT:    [[TMP1:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 1
+// CHECK-NEXT:    [[TMP2:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 0
+// CHECK-NEXT:    [[TMP3:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 1
+// CHECK-NEXT:    [[TMP4:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 2
+// CHECK-NEXT:    [[DOTFCA_0_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9:%.*]] [[TMP0]], 0
+// CHECK-NEXT:    [[DOTFCA_1_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 1
+// CHECK-NEXT:    [[DOTFCA_2_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 2
+// CHECK-NEXT:    [[DOTFCA_3_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 3
+// CHECK-NEXT:    [[DOTFCA_4_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 4
+// CHECK-NEXT:    [[DOTFCA_5_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 5
+// CHECK-NEXT:    [[DOTFCA_0_EXTRACT17_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 0
+// CHECK-NEXT:    [[DOTFCA_1_EXTRACT19_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 1
+// CHECK-NEXT:    [[DOTFCA_2_EXTRACT21_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 2
+// CHECK-NEXT:    [[DOTFCA_3_EXTRACT23_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 3
+// CHECK-NEXT:    [[DOTFCA_4_EXTRACT25_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 4
+// CHECK-NEXT:    [[DOTFCA_5_EXTRACT27_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 5
 // CHECK-NEXT:    [[SHL2_I_I:%.*]] = shl i32 [[SUB_MUL]], 11
 // CHECK-NEXT:    [[SHL4_I_I:%.*]] = shl i32 [[SUB_ACC1]], 12
 // CHECK-NEXT:    [[SHL6_I_I:%.*]] = shl i32 [[SUB_ACC2]], 13
@@ -38878,8 +38923,8 @@ v64accfloat test_msc_4x16_16x16T_conf(v64mx9 a, int sgn_x, v256mx9 b, int sgn_y,
 // CHECK-NEXT:    [[OR12_I_I:%.*]] = or i32 [[OR9_I_I]], [[SHL4_I_I]]
 // CHECK-NEXT:    [[OR15_I_I:%.*]] = or i32 [[OR12_I_I]], [[SHL6_I_I]]
 // CHECK-NEXT:    [[OR25_I_I:%.*]] = or i32 [[OR15_I_I]], 204
-// CHECK-NEXT:    [[TMP15:%.*]] = tail call noundef <64 x float> @llvm.aie2ps.BFP640.BFP2560.ACC2048.bf.addmac.conf(<16 x i32> [[TMP0]], <2 x i32> [[TMP1]], <2 x i32> [[TMP2]], <16 x i32> [[TMP3]], <16 x i32> [[TMP4]], <16 x i32> [[TMP5]], <16 x i32> [[TMP6]], <2 x i32> [[TMP7]], <2 x i32> [[TMP8]], <2 x i32> [[TMP9]], <2 x i32> [[TMP10]], <2 x i32> [[TMP11]], <2 x i32> [[TMP12]], <2 x i32> [[TMP13]], <2 x i32> [[TMP14]], <64 x float> [[ACC1]], <64 x float> [[ACC2]], i32 [[OR25_I_I]])
-// CHECK-NEXT:    ret <64 x float> [[TMP15]]
+// CHECK-NEXT:    [[TMP5:%.*]] = tail call noundef <64 x float> @llvm.aie2ps.BFP640.BFP2560.ACC2048.bf.addmac.conf(<16 x i32> [[TMP2]], <2 x i32> [[TMP3]], <2 x i32> [[TMP4]], <16 x i32> [[DOTFCA_0_EXTRACT_I]], <16 x i32> [[DOTFCA_1_EXTRACT_I]], <16 x i32> [[DOTFCA_0_EXTRACT17_I]], <16 x i32> [[DOTFCA_1_EXTRACT19_I]], <2 x i32> [[DOTFCA_2_EXTRACT_I]], <2 x i32> [[DOTFCA_3_EXTRACT_I]], <2 x i32> [[DOTFCA_2_EXTRACT21_I]], <2 x i32> [[DOTFCA_3_EXTRACT23_I]], <2 x i32> [[DOTFCA_4_EXTRACT_I]], <2 x i32> [[DOTFCA_5_EXTRACT_I]], <2 x i32> [[DOTFCA_4_EXTRACT25_I]], <2 x i32> [[DOTFCA_5_EXTRACT27_I]], <64 x float> [[ACC1]], <64 x float> [[ACC2]], i32 [[OR25_I_I]])
+// CHECK-NEXT:    ret <64 x float> [[TMP5]]
 //
 v64accfloat test_addmac_4x16_16x16T_conf(v64mx9 a, int sgn_x, v256mx9 b,
                                          int sgn_y, v64accfloat acc1,
@@ -38892,21 +38937,23 @@ v64accfloat test_addmac_4x16_16x16T_conf(v64mx9 a, int sgn_x, v256mx9 b,
 // CHECK-LABEL: define dso_local inreg noundef <64 x float> @_Z28test_addmsc_4x16_16x16T_conf6v64mx9i7v256mx9iDv64_u10__accfloatS1_iiii(
 // CHECK-SAME: [[STRUCT_V64MX9:%.*]] [[A_COERCE:%.*]], i32 noundef [[SGN_X:%.*]], [[STRUCT_V256MX9:%.*]] [[B_COERCE:%.*]], i32 noundef [[SGN_Y:%.*]], <64 x float> inreg noundef [[ACC1:%.*]], <64 x float> inreg noundef [[ACC2:%.*]], i32 noundef [[ZERO_ACC1:%.*]], i32 noundef [[SUB_MUL:%.*]], i32 noundef [[SUB_ACC1:%.*]], i32 noundef [[SUB_ACC2:%.*]]) local_unnamed_addr #[[ATTR1]] {
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[TMP0:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 0
-// CHECK-NEXT:    [[TMP1:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 1
-// CHECK-NEXT:    [[TMP2:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 2
-// CHECK-NEXT:    [[TMP3:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 0
-// CHECK-NEXT:    [[TMP4:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 1
-// CHECK-NEXT:    [[TMP5:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 2
-// CHECK-NEXT:    [[TMP6:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 3
-// CHECK-NEXT:    [[TMP7:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 4
-// CHECK-NEXT:    [[TMP8:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 5
-// CHECK-NEXT:    [[TMP9:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 6
-// CHECK-NEXT:    [[TMP10:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 7
-// CHECK-NEXT:    [[TMP11:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 8
-// CHECK-NEXT:    [[TMP12:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 9
-// CHECK-NEXT:    [[TMP13:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 10
-// CHECK-NEXT:    [[TMP14:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 11
+// CHECK-NEXT:    [[TMP0:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 0
+// CHECK-NEXT:    [[TMP1:%.*]] = extractvalue [[STRUCT_V256MX9]] [[B_COERCE]], 1
+// CHECK-NEXT:    [[TMP2:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 0
+// CHECK-NEXT:    [[TMP3:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 1
+// CHECK-NEXT:    [[TMP4:%.*]] = extractvalue [[STRUCT_V64MX9]] [[A_COERCE]], 2
+// CHECK-NEXT:    [[DOTFCA_0_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9:%.*]] [[TMP0]], 0
+// CHECK-NEXT:    [[DOTFCA_1_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 1
+// CHECK-NEXT:    [[DOTFCA_2_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 2
+// CHECK-NEXT:    [[DOTFCA_3_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 3
+// CHECK-NEXT:    [[DOTFCA_4_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 4
+// CHECK-NEXT:    [[DOTFCA_5_EXTRACT_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP0]], 5
+// CHECK-NEXT:    [[DOTFCA_0_EXTRACT17_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 0
+// CHECK-NEXT:    [[DOTFCA_1_EXTRACT19_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 1
+// CHECK-NEXT:    [[DOTFCA_2_EXTRACT21_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 2
+// CHECK-NEXT:    [[DOTFCA_3_EXTRACT23_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 3
+// CHECK-NEXT:    [[DOTFCA_4_EXTRACT25_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 4
+// CHECK-NEXT:    [[DOTFCA_5_EXTRACT27_I:%.*]] = extractvalue [[STRUCT_V128MX9]] [[TMP1]], 5
 // CHECK-NEXT:    [[SHL2_I_I:%.*]] = shl i32 [[SUB_MUL]], 11
 // CHECK-NEXT:    [[SHL4_I_I:%.*]] = shl i32 [[SUB_ACC1]], 12
 // CHECK-NEXT:    [[SHL6_I_I:%.*]] = shl i32 [[SUB_ACC2]], 13
@@ -38918,8 +38965,8 @@ v64accfloat test_addmac_4x16_16x16T_conf(v64mx9 a, int sgn_x, v256mx9 b,
 // CHECK-NEXT:    [[OR12_I_I:%.*]] = or i32 [[OR9_I_I]], [[SHL4_I_I]]
 // CHECK-NEXT:    [[OR15_I_I:%.*]] = or i32 [[OR12_I_I]], [[SHL6_I_I]]
 // CHECK-NEXT:    [[OR25_I_I:%.*]] = or i32 [[OR15_I_I]], 204
-// CHECK-NEXT:    [[TMP15:%.*]] = tail call noundef <64 x float> @llvm.aie2ps.BFP640.BFP2560.ACC2048.bf.addmsc.conf(<16 x i32> [[TMP0]], <2 x i32> [[TMP1]], <2 x i32> [[TMP2]], <16 x i32> [[TMP3]], <16 x i32> [[TMP4]], <16 x i32> [[TMP5]], <16 x i32> [[TMP6]], <2 x i32> [[TMP7]], <2 x i32> [[TMP8]], <2 x i32> [[TMP9]], <2 x i32> [[TMP10]], <2 x i32> [[TMP11]], <2 x i32> [[TMP12]], <2 x i32> [[TMP13]], <2 x i32> [[TMP14]], <64 x float> [[ACC1]], <64 x float> [[ACC2]], i32 [[OR25_I_I]])
-// CHECK-NEXT:    ret <64 x float> [[TMP15]]
+// CHECK-NEXT:    [[TMP5:%.*]] = tail call noundef <64 x float> @llvm.aie2ps.BFP640.BFP2560.ACC2048.bf.addmsc.conf(<16 x i32> [[TMP2]], <2 x i32> [[TMP3]], <2 x i32> [[TMP4]], <16 x i32> [[DOTFCA_0_EXTRACT_I]], <16 x i32> [[DOTFCA_1_EXTRACT_I]], <16 x i32> [[DOTFCA_0_EXTRACT17_I]], <16 x i32> [[DOTFCA_1_EXTRACT19_I]], <2 x i32> [[DOTFCA_2_EXTRACT_I]], <2 x i32> [[DOTFCA_3_EXTRACT_I]], <2 x i32> [[DOTFCA_2_EXTRACT21_I]], <2 x i32> [[DOTFCA_3_EXTRACT23_I]], <2 x i32> [[DOTFCA_4_EXTRACT_I]], <2 x i32> [[DOTFCA_5_EXTRACT_I]], <2 x i32> [[DOTFCA_4_EXTRACT25_I]], <2 x i32> [[DOTFCA_5_EXTRACT27_I]], <64 x float> [[ACC1]], <64 x float> [[ACC2]], i32 [[OR25_I_I]])
+// CHECK-NEXT:    ret <64 x float> [[TMP5]]
 //
 v64accfloat test_addmsc_4x16_16x16T_conf(v64mx9 a, int sgn_x, v256mx9 b,
                                          int sgn_y, v64accfloat acc1,


### PR DESCRIPTION
Change the definition of v256mx9 into two v128mx9 fields instead of decomposed mattisa, sign, shift and exp fields.