### PR TITLE
[AIE2PS] enable floating conversion between 16-bit floating point

### DIFF
--- a/clang/lib/Sema/SemaOverload.cpp
+++ b/clang/lib/Sema/SemaOverload.cpp
@@ -4,6 +4,9 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// Modifications (c) Copyright 2026 Advanced Micro Devices, Inc. or its
+// affiliates
+//
 //===----------------------------------------------------------------------===//
 //
 // This file provides Sema routines for C++ overloading.
@@ -1996,12 +1999,17 @@ static bool IsFloatingPointConversion(Sema &S, QualType FromType,
   // if their representation is different until there is back end support
   // We of course allow this conversion if long double is really double.
 
-  // Conversions between bfloat16 and float16 are currently not supported.
-  if ((FromType->isBFloat16Type() &&
-       (ToType->isFloat16Type() || ToType->isHalfType())) ||
-      (ToType->isBFloat16Type() &&
-       (FromType->isFloat16Type() || FromType->isHalfType())))
-    return false;
+  // Conversions between bfloat16 and float16 are currently not supported,
+  // except for aie2ps target which has hardware support for these conversions.
+  llvm::Triple::ArchType Arch = S.Context.getTargetInfo().getTriple().getArch();
+  bool AllowBF16FP16Conversion = (Arch == llvm::Triple::aie2ps);
+  if (!AllowBF16FP16Conversion) {
+    if ((FromType->isBFloat16Type() &&
+         (ToType->isFloat16Type() || ToType->isHalfType())) ||
+        (ToType->isBFloat16Type() &&
+         (FromType->isFloat16Type() || FromType->isHalfType())))
+      return false;
+  }
 
   // Conversions between IEEE-quad and IBM-extended semantics are not
   // permitted.

--- a/clang/test/CodeGen/aie/aie2ps/test-Float16.cpp
+++ b/clang/test/CodeGen/aie/aie2ps/test-Float16.cpp
@@ -36,3 +36,25 @@ float16 test_minus_const() {
 float16 test_minus_variable(float16 a) {
     return -a;
 }
+
+// CHECK-LABEL: define dso_local noundef half @_Z16test_bf16_to_f168bfloat16(
+// CHECK-SAME: bfloat noundef [[A:%.*]]) local_unnamed_addr #[[ATTR0]] {
+// CHECK-NEXT:  [[ENTRY:.*:]]
+// CHECK-NEXT:    [[FPEXT:%.*]] = fpext bfloat [[A]] to float
+// CHECK-NEXT:    [[FPTRUNC:%.*]] = fptrunc float [[FPEXT]] to half
+// CHECK-NEXT:    ret half [[FPTRUNC]]
+//
+float16 test_bf16_to_f16(bfloat16 a) {
+  return a;
+}
+
+// CHECK-LABEL: define dso_local noundef bfloat @_Z16test_f16_to_bf16DF16_(
+// CHECK-SAME: half noundef [[A:%.*]]) local_unnamed_addr #[[ATTR0]] {
+// CHECK-NEXT:  [[ENTRY:.*:]]
+// CHECK-NEXT:    [[FPEXT:%.*]] = fpext half [[A]] to float
+// CHECK-NEXT:    [[FPTRUNC:%.*]] = fptrunc float [[FPEXT]] to bfloat
+// CHECK-NEXT:    ret bfloat [[FPTRUNC]]
+//
+bfloat16 test_f16_to_bf16(float16 a) {
+  return a;
+}


### PR DESCRIPTION
Enable conversion between bfloat16 and float16 for AIE2PS.