### PR TITLE
[AIEX][NFC] Fix 6 failing lit tests for macOS compatibility and updated codegen

### DIFF
--- a/llvm/test/CodeGen/AIE/GlobalISel/xfail-irtranslator-formal-arguments-vect.ll
+++ b/llvm/test/CodeGen/AIE/GlobalISel/xfail-irtranslator-formal-arguments-vect.ll
@@ -8,7 +8,7 @@
 
 ; REQUIRES: asserts
 
-; CHECK: Assertion `LocVT == MVT::i32 && "VT should be split in 32-bits chunks"' failed.
+; CHECK: VT should be split in 32-bits chunks
 define <16 x i64> @arg_v16int64(<16 x i64> %a) {
   ret <16 x i64> %a
 }

--- a/llvm/test/CodeGen/AIE/aie2/hardware-loops/multi-use.mir
+++ b/llvm/test/CodeGen/AIE/aie2/hardware-loops/multi-use.mir
@@ -8,7 +8,7 @@
 # RUN: not --crash llc -O2 -mtriple=aie2 -run-pass=aie-hardware-loops %s -o - 2>&1 | FileCheck %s
 # requires: asserts
 
-# CHECK: Assertion `0 && "AIE Loops: Wrong/multiple use of LoopDec result!.\n"' failed.
+# CHECK: AIE Loops: Wrong/multiple use of LoopDec result!
 ---
 name:            multi_use
 alignment:       16

--- a/llvm/test/CodeGen/AIE/aie2/hardware-loops/overwritten-use.mir
+++ b/llvm/test/CodeGen/AIE/aie2/hardware-loops/overwritten-use.mir
@@ -8,7 +8,7 @@
 # RUN: not --crash llc -O2 -mtriple=aie2 -run-pass=aie-hardware-loops %s -o - 2>&1 | FileCheck %s
 # requires: asserts
 
-# CHECK: Assertion `0 && "AIE Loops: Wrong/multiple use of LoopDec result!.\n"' failed.
+# CHECK: AIE Loops: Wrong/multiple use of LoopDec result!
 ---
 name:            overwritten
 alignment:       16

--- a/llvm/test/CodeGen/AIE/aie2/schedule/interblock/order.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/interblock/order.mir
@@ -5,7 +5,7 @@
 #
 # (c) Copyright 2023-2024 Advanced Micro Devices, Inc. or its affiliates
 # RUN: llc --mtriple=aie2 --start-before=postmisched --debug-only=sched-blocks \
-# RUN: --aie-loop-aware=1 %s -o /dev/null |& FileCheck %s
+# RUN: --aie-loop-aware=1 %s -o /dev/null 2>&1 | FileCheck %s
 # REQUIRES: asserts
 
 # Check post-order scheduling of blocks. This mainly follows the flow

--- a/llvm/test/CodeGen/AIE/aie2/schedule/loopaware/loop-classify.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/loopaware/loop-classify.mir
@@ -5,7 +5,7 @@
 # (c) Copyright 2023-2024 Advanced Micro Devices, Inc. or its affiliates
 #
 # RUN: llc --mtriple=aie2 --start-before=postmisched --debug-only=sched-blocks \
-# RUN: --aie-loop-aware=1 %s -o /dev/null |& FileCheck %s
+# RUN: --aie-loop-aware=1 %s -o /dev/null 2>&1 | FileCheck %s
 # REQUIRES: asserts
 
 # Check that a loop that has a loop as epilogue isn't considered a loop

--- a/llvm/test/CodeGen/AIE/aie2p/ra/waw_reg_renaming_swpaware.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/ra/waw_reg_renaming_swpaware.mir
@@ -55,28 +55,28 @@ body:             |
   ; CHECK-NEXT:   successors: %bb.2(0x7c000000), %bb.3(0x04000000)
   ; CHECK-NEXT:   liveins: $dc0, $dc1, $dc4, $dj0, $dj1, $dj4, $dm2:0x000000001800000C, $dm4:0x000000001800000C, $dn0, $dn1, $dn4, $m0, $m1, $p0, $p1, $p2, $r0, $r2, $r3, $r4, $r5, $x0
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT:   $x2, $p2, $dc1 = VLD_2D_x_pseudo_split killed $p2, $m1, $dn1, $dj1, killed $dc1 :: (load (<16 x s32>), addrspace 6)
-  ; CHECK-NEXT:   renamable $x4, renamable $p1 = VLD_x_pstm_nrm_imm_pseudo killed renamable $p1, 64 :: (load (<32 x s16>), addrspace 5)
-  ; CHECK-NEXT:   renamable $x6, renamable $p1 = VLD_x_pstm_nrm_imm_pseudo killed renamable $p1, 64 :: (load (<32 x s16>), addrspace 5)
-  ; CHECK-NEXT:   $x8, $p1, $dc0, $dc4 = VLD_3D_x_pseudo_split killed $p1, $m0, $dn0, $dj0, killed $dc0, undef $m4, $dn4, $dj4, killed $dc4 :: (load (<32 x s16>), addrspace 5)
-  ; CHECK-NEXT:   renamable $x10 = VEXTBCST_128_vec_extract_broadcast_imm renamable $x2, 0
-  ; CHECK-NEXT:   renamable $x1 = VSHIFT renamable $x4, renamable $x6, renamable $r0
-  ; CHECK-NEXT:   renamable $dm3 = VMAC_f_vmac_bf_vmul_bf_core_X_X killed renamable $dm2, renamable $x4, renamable $x10, renamable $r5, implicit-def dead $srfpflags, implicit $crfpmask
-  ; CHECK-NEXT:   renamable $x3 = VEXTBCST_128_vec_extract_broadcast_imm renamable $x2, 1
-  ; CHECK-NEXT:   renamable $dm4 = VMAC_f_vmac_bf_vmul_bf_core_X_X killed renamable $dm4, renamable $x6, killed renamable $x10, renamable $r5, implicit-def dead $srfpflags, implicit $crfpmask
-  ; CHECK-NEXT:   renamable $x7 = VSHIFT renamable $x6, renamable $x8, renamable $r0
-  ; CHECK-NEXT:   renamable $x5 = VSHIFT renamable $x4, renamable $x6, renamable $r3
-  ; CHECK-NEXT:   renamable $dm3 = VMAC_f_vmac_bf_vmul_bf_core_X_X killed renamable $dm3, killed renamable $x1, renamable $x3, renamable $r5, implicit-def dead $srfpflags, implicit $crfpmask
-  ; CHECK-NEXT:   renamable $x9 = VEXTBCST_128_vec_extract_broadcast_imm renamable $x2, 2
-  ; CHECK-NEXT:   renamable $dm1 = VMAC_f_vmac_bf_vmul_bf_core_X_X killed renamable $dm4, killed renamable $x7, killed renamable $x3, renamable $r5, implicit-def dead $srfpflags, implicit $crfpmask
-  ; CHECK-NEXT:   renamable $x10 = VSHIFT renamable $x6, renamable $x8, renamable $r3
-  ; CHECK-NEXT:   renamable $x4 = VSHIFT killed renamable $x4, renamable $x6, renamable $r4
-  ; CHECK-NEXT:   renamable $dm0 = VMAC_f_vmac_bf_vmul_bf_core_X_X killed renamable $dm3, killed renamable $x5, renamable $x9, renamable $r5, implicit-def dead $srfpflags, implicit $crfpmask
-  ; CHECK-NEXT:   renamable $x11 = VEXTBCST_128_vec_extract_broadcast_imm killed renamable $x2, 3
-  ; CHECK-NEXT:   renamable $dm1 = VMAC_f_vmac_bf_vmul_bf_core_X_X killed renamable $dm1, killed renamable $x10, killed renamable $x9, renamable $r5, implicit-def dead $srfpflags, implicit $crfpmask
-  ; CHECK-NEXT:   renamable $x6 = VSHIFT killed renamable $x6, killed renamable $x8, renamable $r4
-  ; CHECK-NEXT:   renamable $dm2 = VMAC_f_vmac_bf_vmul_bf_core_X_X killed renamable $dm0, killed renamable $x4, renamable $x11, renamable $r5, implicit-def dead $srfpflags, implicit $crfpmask
-  ; CHECK-NEXT:   renamable $dm4 = VMAC_f_vmac_bf_vmul_bf_core_X_X killed renamable $dm1, killed renamable $x6, killed renamable $x11, renamable $r5, implicit-def dead $srfpflags, implicit $crfpmask
+  ; CHECK-NEXT:   $x8, $p2, $dc1 = VLD_2D_x_pseudo_split killed $p2, $m1, $dn1, $dj1, killed $dc1 :: (load (<16 x s32>), addrspace 6)
+  ; CHECK-NEXT:   renamable $x10, renamable $p1 = VLD_x_pstm_nrm_imm_pseudo killed renamable $p1, 64 :: (load (<32 x s16>), addrspace 5)
+  ; CHECK-NEXT:   renamable $x1, renamable $p1 = VLD_x_pstm_nrm_imm_pseudo killed renamable $p1, 64 :: (load (<32 x s16>), addrspace 5)
+  ; CHECK-NEXT:   $x6, $p1, $dc0, $dc4 = VLD_3D_x_pseudo_split killed $p1, $m0, $dn0, $dj0, killed $dc0, undef $m4, $dn4, $dj4, killed $dc4 :: (load (<32 x s16>), addrspace 5)
+  ; CHECK-NEXT:   renamable $x9 = VEXTBCST_128_vec_extract_broadcast_imm renamable $x8, 0
+  ; CHECK-NEXT:   renamable $x5 = VSHIFT renamable $x10, renamable $x1, renamable $r0
+  ; CHECK-NEXT:   renamable $dm3 = VMAC_f_vmac_bf_vmul_bf_core_X_X killed renamable $dm2, renamable $x10, renamable $x9, renamable $r5, implicit-def dead $srfpflags, implicit $crfpmask
+  ; CHECK-NEXT:   renamable $x11 = VEXTBCST_128_vec_extract_broadcast_imm renamable $x8, 1
+  ; CHECK-NEXT:   renamable $dm4 = VMAC_f_vmac_bf_vmul_bf_core_X_X killed renamable $dm4, renamable $x1, killed renamable $x9, renamable $r5, implicit-def dead $srfpflags, implicit $crfpmask
+  ; CHECK-NEXT:   renamable $x3 = VSHIFT renamable $x1, renamable $x6, renamable $r0
+  ; CHECK-NEXT:   renamable $x7 = VSHIFT renamable $x10, renamable $x1, renamable $r3
+  ; CHECK-NEXT:   renamable $dm3 = VMAC_f_vmac_bf_vmul_bf_core_X_X killed renamable $dm3, killed renamable $x5, renamable $x11, renamable $r5, implicit-def dead $srfpflags, implicit $crfpmask
+  ; CHECK-NEXT:   renamable $x2 = VEXTBCST_128_vec_extract_broadcast_imm renamable $x8, 2
+  ; CHECK-NEXT:   renamable $dm1 = VMAC_f_vmac_bf_vmul_bf_core_X_X killed renamable $dm4, killed renamable $x3, killed renamable $x11, renamable $r5, implicit-def dead $srfpflags, implicit $crfpmask
+  ; CHECK-NEXT:   renamable $x5 = VSHIFT renamable $x1, renamable $x6, renamable $r3
+  ; CHECK-NEXT:   renamable $x10 = VSHIFT killed renamable $x10, renamable $x1, renamable $r4
+  ; CHECK-NEXT:   renamable $dm0 = VMAC_f_vmac_bf_vmul_bf_core_X_X killed renamable $dm3, killed renamable $x7, renamable $x2, renamable $r5, implicit-def dead $srfpflags, implicit $crfpmask
+  ; CHECK-NEXT:   renamable $x4 = VEXTBCST_128_vec_extract_broadcast_imm killed renamable $x8, 3
+  ; CHECK-NEXT:   renamable $dm1 = VMAC_f_vmac_bf_vmul_bf_core_X_X killed renamable $dm1, killed renamable $x5, killed renamable $x2, renamable $r5, implicit-def dead $srfpflags, implicit $crfpmask
+  ; CHECK-NEXT:   renamable $x7 = VSHIFT killed renamable $x1, killed renamable $x6, renamable $r4
+  ; CHECK-NEXT:   renamable $dm2 = VMAC_f_vmac_bf_vmul_bf_core_X_X killed renamable $dm0, killed renamable $x10, renamable $x4, renamable $r5, implicit-def dead $srfpflags, implicit $crfpmask
+  ; CHECK-NEXT:   renamable $dm4 = VMAC_f_vmac_bf_vmul_bf_core_X_X killed renamable $dm1, killed renamable $x7, killed renamable $x4, renamable $r5, implicit-def dead $srfpflags, implicit $crfpmask
   ; CHECK-NEXT:   PseudoLoopEnd <mcsymbol .L_LEnd0>, %bb.2
   ; CHECK-NEXT:   PseudoJ_jump_imm %bb.3
   ; CHECK-NEXT: {{  $}}


### PR DESCRIPTION
- Use portable assertion message matching in CHECK lines to work on both macOS and Linux (3 tests)
- Replace bash-specific |& with portable 2>&1 | in RUN lines (2 tests)
- Update expected register assignments in waw_reg_renaming_swpaware to match current SWP-aware allocator output (1 test)