### PR TITLE
[AIE] Add TTI overrides to prevent sub-512-bit vector arithmetic

### DIFF
--- a/llvm/lib/Target/AIE/AIEBaseTargetTransformInfo.h
+++ b/llvm/lib/Target/AIE/AIEBaseTargetTransformInfo.h
@@ -104,6 +104,61 @@ public:
                                 AssumptionCache &AC, TargetLibraryInfo *LibInfo,
                                 HardwareLoopInfo &HWLoopInfo);
 
+  // AIE vector arithmetic operates on 512-bit registers. The default
+  // getRegisterBitWidth returns 32 (scalar width), which causes the loop
+  // vectorizer to choose VF=4 for i8, creating <4 x i8> vectors. The
+  // GlobalISel Legalizer only has rules for 512-bit vector arithmetic
+  // (V64S8, V32S16, V16S32), so sub-512-bit vector ops are illegal.
+  // Return 512 for vector register kinds to match the legal types.
+  //
+  // See {AIE1,AIE2,AIE2P,AIE2PS}LegalizerInfo.cpp for the authoritative
+  // legal-types list (search for `legalFor({V16S32, V32S16, V64S8})` on the
+  // G_ADD/G_SUB/G_XOR rules; AIE1 has no legal vector arithmetic). If a
+  // future target legalizes additional widths, the three TTI overrides
+  // below must be revisited.
+  TypeSize getRegisterBitWidth(TargetTransformInfo::RegisterKind K) const {
+    switch (K) {
+    case TargetTransformInfo::RGK_Scalar:
+      return TypeSize::getFixed(32);
+    case TargetTransformInfo::RGK_FixedWidthVector:
+      return TypeSize::getFixed(512);
+    case TargetTransformInfo::RGK_ScalableVector:
+      // Use a scalable TypeSize to represent "no scalable vector registers".
+      return TypeSize::getScalable(0);
+    }
+    llvm_unreachable("Unsupported register kind");
+  }
+
+  // Minimum vector width for the SLP vectorizer and VectorCombine.
+  // Must match the Legalizer's supported vector arithmetic widths (512-bit).
+  unsigned getMinVectorRegisterBitWidth() const { return 512; }
+
+  // AIE vector arithmetic only supports 512-bit operations (V64S8, V32S16,
+  // V16S32). Sub-512-bit vector ops like <8 x i8> are illegal in the
+  // GlobalISel Legalizer and would crash during code generation. Return
+  // Invalid cost to prevent vectorizers (especially SLP) from creating them.
+  //
+  // The < 512 width filter is conservative on the upper end: a 512-bit
+  // vector that is not in the legal-arithmetic list (e.g. V8S64) would also
+  // be illegal, but no current vectorizer pass produces such types from AIE
+  // workloads in practice. Querying LegalizerInfo directly from TTI would be
+  // the precise solution but is a cross-layer violation -- TTI operates on
+  // LLVM IR types during mid-level optimization, while LegalizerInfo uses
+  // LLT machine types and is only initialized when GlobalISel is active.
+  // No upstream LLVM target queries LegalizerInfo from TTI.
+  InstructionCost getArithmeticInstrCost(
+      unsigned Opcode, Type *Ty, TTI::TargetCostKind CostKind,
+      TTI::OperandValueInfo Opd1Info = {TTI::OK_AnyValue, TTI::OP_None},
+      TTI::OperandValueInfo Opd2Info = {TTI::OK_AnyValue, TTI::OP_None},
+      ArrayRef<const Value *> Args = {}, const Instruction *CxtI = nullptr) {
+    if (auto *VTy = dyn_cast<FixedVectorType>(Ty)) {
+      if (VTy->getPrimitiveSizeInBits() < 512)
+        return InstructionCost::getInvalid();
+    }
+    return BaseT::getArithmeticInstrCost(Opcode, Ty, CostKind, Opd1Info,
+                                         Opd2Info, Args, CxtI);
+  }
+
   // We define a store vector factor of  4 for 8-bit and 2 for 16-bit. This
   // allows combining 2 16-bit stores or 4 8-bit stores into a single 32-bit
   // vector store. This is deemed beneficial because of the LMS nature of

--- a/llvm/test/CodeGen/AIE/opt/no-subregister-vectorize-arithmetic.ll
+++ b/llvm/test/CodeGen/AIE/opt/no-subregister-vectorize-arithmetic.ll
@@ -1,0 +1,144 @@
+; This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+; See https://llvm.org/LICENSE.txt for license information.
+; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+;
+; (c) Copyright 2025-2026 Advanced Micro Devices, Inc. or its affiliates
+;
+; Pre-commit test for llvm-aie#480. Documents the current status quo on
+; AIE2: under -O2, the LoopVectorizer and SLP create sub-512-bit vector
+; arithmetic ops (e.g., <4 x i8>, <2 x i16>) without target guidance.
+; The AIE2 GlobalISel Legalizer only has rules for 512-bit vector
+; arithmetic (V64S8, V32S16, V16S32), so the resulting IR cannot be
+; legalized and llc aborts with a fatal error.
+;
+; The first RUN line captures the sub-512-bit vectorization in the
+; optimizer output. The second RUN line confirms the legalization crash
+; via `not --crash` plus a FileCheck on the error message.
+;
+; A subsequent commit adds TTI overrides that change this behavior and
+; updates both RUN lines and CHECK patterns to match the fixed state.
+
+; RUN: opt -mtriple=aie2 -O2 -S < %s | FileCheck %s
+; RUN: opt -mtriple=aie2 -O2 -S < %s 2>/dev/null | \
+; RUN:   not --crash llc --march=aie2 -O2 --function-sections --filetype=obj -o /dev/null 2>&1 | \
+; RUN:   FileCheck %s --check-prefix=CRASH
+
+; --------------------------------------------------------------------------
+; Test 1: Large trip count loop (vectorized by LoopVectorize).
+; Without getRegisterBitWidth = 512, the vectorizer picks VF=4 for i8 and
+; emits <4 x i8> adds rather than the V64S8 width AIE2 can legalize.
+
+; CHECK-LABEL: @add_i8_kernel
+; CHECK: add <4 x i8>
+; CHECK-NOT: add <64 x i8>
+
+@buf_in = external global [4096 x i8]
+@buf_out = external global [4096 x i8]
+
+define void @add_i8_kernel() {
+  br label %outer
+
+outer:
+  %i = phi i64 [ %i.next, %inner.exit ], [ 0, %0 ]
+  %cmp.outer = icmp slt i64 %i, 64
+  br i1 %cmp.outer, label %inner, label %done
+
+inner:
+  %j = phi i64 [ %j.next, %inner.body ], [ 0, %outer ]
+  %cmp.inner = icmp slt i64 %j, 64
+  br i1 %cmp.inner, label %inner.body, label %inner.exit
+
+inner.body:
+  %idx = mul nuw nsw i64 %i, 64
+  %off = add nuw nsw i64 %idx, %j
+  %in.ptr = getelementptr inbounds nuw i8, ptr @buf_in, i64 %off
+  %val = load i8, ptr %in.ptr, align 1
+  %add = add i8 %val, 12
+  %out.ptr = getelementptr inbounds nuw i8, ptr @buf_out, i64 %off
+  store i8 %add, ptr %out.ptr, align 1
+  %j.next = add i64 %j, 1
+  br label %inner
+
+inner.exit:
+  %i.next = add i64 %i, 1
+  br label %outer
+
+done:
+  ret void
+}
+
+; --------------------------------------------------------------------------
+; Test 2: Small trip count loop (unrolled, then SLP attempts to vectorize).
+; After unrolling, SLP finds adjacent scalar adds. Without the
+; getArithmeticInstrCost override returning Invalid for sub-512-bit vectors,
+; SLP's cost model treats sub-512-bit vector adds as profitable and emits
+; <4 x i8> adds (32-bit, illegal on AIE2).
+
+; CHECK-LABEL: @add_i8_small_kernel
+; CHECK: add <4 x i8>
+; CHECK-NOT: add <64 x i8>
+
+@small_in = external global [8 x i8]
+@small_out = external global [8 x i8]
+
+declare void @llvm.aie2.acquire(i32, i32)
+declare void @llvm.aie2.release(i32, i32)
+
+define void @add_i8_small_kernel() {
+  call void @llvm.aie2.acquire(i32 49, i32 -1)
+  call void @llvm.aie2.acquire(i32 50, i32 -1)
+  br label %loop
+
+loop:
+  %i = phi i64 [ %i.next, %loop ], [ 0, %0 ]
+  %in.ptr = getelementptr inbounds nuw i8, ptr @small_in, i64 %i
+  %val = load i8, ptr %in.ptr, align 1
+  %add = add i8 %val, 21
+  %out.ptr = getelementptr inbounds nuw i8, ptr @small_out, i64 %i
+  store i8 %add, ptr %out.ptr, align 1
+  %i.next = add i64 %i, 1
+  %done = icmp eq i64 %i.next, 8
+  br i1 %done, label %exit, label %loop
+
+exit:
+  call void @llvm.aie2.release(i32 49, i32 1)
+  call void @llvm.aie2.release(i32 50, i32 1)
+  ret void
+}
+
+; --------------------------------------------------------------------------
+; Test 3: i16 variant. Without the override, VF=2 produces <2 x i16> adds
+; instead of the V32S16 width AIE2 can legalize.
+
+; CHECK-LABEL: @add_i16_kernel
+; CHECK: add <2 x i16>
+; CHECK-NOT: add <32 x i16>
+
+@buf_in_i16 = external global [1024 x i16]
+@buf_out_i16 = external global [1024 x i16]
+
+define void @add_i16_kernel() {
+  br label %loop
+
+loop:
+  %i = phi i64 [ %i.next, %loop ], [ 0, %0 ]
+  %in.ptr = getelementptr inbounds nuw i16, ptr @buf_in_i16, i64 %i
+  %val = load i16, ptr %in.ptr, align 2
+  %add = add i16 %val, 42
+  %out.ptr = getelementptr inbounds nuw i16, ptr @buf_out_i16, i64 %i
+  store i16 %add, ptr %out.ptr, align 2
+  %i.next = add i64 %i, 1
+  %done = icmp eq i64 %i.next, 1024
+  br i1 %done, label %exit, label %loop
+
+exit:
+  ret void
+}
+
+; --------------------------------------------------------------------------
+; CRASH-prefix checks: full-pipeline `llc` aborts at GlobalISel legalization
+; on the sub-512-bit G_ADD produced by Test 1's vectorized loop.
+
+; CRASH: LLVM ERROR: unable to legalize instruction
+; CRASH-SAME: G_ADD
+; CRASH-SAME: in function: add_i8_kernel

--- a/llvm/test/CodeGen/AIE/opt/no-subregister-vectorize-arithmetic.ll
+++ b/llvm/test/CodeGen/AIE/opt/no-subregister-vectorize-arithmetic.ll
@@ -2,35 +2,39 @@
 ; See https://llvm.org/LICENSE.txt for license information.
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 ;
-; (c) Copyright 2025-2026 Advanced Micro Devices, Inc. or its affiliates
+; (c) Copyright 2025 Advanced Micro Devices, Inc. or its affiliates
 ;
-; Pre-commit test for llvm-aie#480. Documents the current status quo on
-; AIE2: under -O2, the LoopVectorizer and SLP create sub-512-bit vector
-; arithmetic ops (e.g., <4 x i8>, <2 x i16>) without target guidance.
-; The AIE2 GlobalISel Legalizer only has rules for 512-bit vector
-; arithmetic (V64S8, V32S16, V16S32), so the resulting IR cannot be
-; legalized and llc aborts with a fatal error.
+; Regression test for llvm-aie#480: vectorizers must not create sub-512-bit
+; vector arithmetic on AIE2. The GlobalISel Legalizer only has rules for
+; 512-bit vector arithmetic (V64S8, V32S16, V16S32).
 ;
-; The first RUN line captures the sub-512-bit vectorization in the
-; optimizer output. The second RUN line confirms the legalization crash
-; via `not --crash` plus a FileCheck on the error message.
+; Three TTI overrides prevent this:
+;   - getRegisterBitWidth(RGK_FixedWidthVector) = 512: prevents the loop
+;     vectorizer from choosing sub-512-bit VF (e.g., VF=4 -> <4 x i8>).
+;   - getMinVectorRegisterBitWidth() = 512: prevents the SLP vectorizer
+;     from creating sub-512-bit vectors via its minimum size check.
+;   - getArithmeticInstrCost() = Invalid for sub-512-bit: prevents the SLP
+;     vectorizer's cost model from treating <8 x i8> adds as profitable
+;     (after loop unrolling, SLP may find adjacent scalar ops to vectorize).
 ;
-; A subsequent commit adds TTI overrides that change this behavior and
-; updates both RUN lines and CHECK patterns to match the fixed state.
+; The first RUN line verifies the optimizer creates 512-bit vectors (V64S8),
+; not sub-512-bit ones. The second RUN line verifies the full pipeline compiles.
 
 ; RUN: opt -mtriple=aie2 -O2 -S < %s | FileCheck %s
-; RUN: opt -mtriple=aie2 -O2 -S < %s 2>/dev/null | \
-; RUN:   not --crash llc --march=aie2 -O2 --function-sections --filetype=obj -o /dev/null 2>&1 | \
-; RUN:   FileCheck %s --check-prefix=CRASH
+; RUN: opt -mtriple=aie2 -O2 -S < %s | \
+; RUN:   llc --march=aie2 -O2 --function-sections --filetype=obj -o /dev/null
 
 ; --------------------------------------------------------------------------
 ; Test 1: Large trip count loop (vectorized by LoopVectorize).
-; Without getRegisterBitWidth = 512, the vectorizer picks VF=4 for i8 and
-; emits <4 x i8> adds rather than the V64S8 width AIE2 can legalize.
+; Without getRegisterBitWidth = 512, the vectorizer creates <4 x i8> adds.
+; With the fix, it creates <64 x i8> adds (512-bit, matching V64S8).
 
 ; CHECK-LABEL: @add_i8_kernel
-; CHECK: add <4 x i8>
-; CHECK-NOT: add <64 x i8>
+; CHECK: add <64 x i8>
+; CHECK-NOT: add <4 x i8>
+; CHECK-NOT: add <8 x i8>
+; CHECK-NOT: add <16 x i8>
+; CHECK-NOT: add <32 x i8>
 
 @buf_in = external global [4096 x i8]
 @buf_out = external global [4096 x i8]
@@ -69,14 +73,14 @@ done:
 
 ; --------------------------------------------------------------------------
 ; Test 2: Small trip count loop (unrolled, then SLP attempts to vectorize).
-; After unrolling, SLP finds adjacent scalar adds. Without the
+; After unrolling, SLP finds 8 adjacent scalar adds. Without the
 ; getArithmeticInstrCost override returning Invalid for sub-512-bit vectors,
-; SLP's cost model treats sub-512-bit vector adds as profitable and emits
-; <4 x i8> adds (32-bit, illegal on AIE2).
+; SLP would create <8 x i8> adds (64-bit, illegal) because its cost model
+; thinks vector add costs 1 vs scalar cost 8.
 
 ; CHECK-LABEL: @add_i8_small_kernel
-; CHECK: add <4 x i8>
-; CHECK-NOT: add <64 x i8>
+; CHECK-NOT: add <8 x i8>
+; CHECK-NOT: add <4 x i8>
 
 @small_in = external global [8 x i8]
 @small_out = external global [8 x i8]
@@ -107,12 +111,12 @@ exit:
 }
 
 ; --------------------------------------------------------------------------
-; Test 3: i16 variant. Without the override, VF=2 produces <2 x i16> adds
-; instead of the V32S16 width AIE2 can legalize.
+; Test 3: i16 variant to verify 512-bit vectorization (V32S16).
 
 ; CHECK-LABEL: @add_i16_kernel
-; CHECK: add <2 x i16>
-; CHECK-NOT: add <32 x i16>
+; CHECK: add <32 x i16>
+; CHECK-NOT: add <2 x i16>
+; CHECK-NOT: add <4 x i16>
 
 @buf_in_i16 = external global [1024 x i16]
 @buf_out_i16 = external global [1024 x i16]
@@ -134,11 +138,3 @@ loop:
 exit:
   ret void
 }
-
-; --------------------------------------------------------------------------
-; CRASH-prefix checks: full-pipeline `llc` aborts at GlobalISel legalization
-; on the sub-512-bit G_ADD produced by Test 1's vectorized loop.
-
-; CRASH: LLVM ERROR: unable to legalize instruction
-; CRASH-SAME: G_ADD
-; CRASH-SAME: in function: add_i8_kernel

--- a/llvm/test/CodeGen/AIE/opt/vector-combine-widen-subvector-load.ll
+++ b/llvm/test/CodeGen/AIE/opt/vector-combine-widen-subvector-load.ll
@@ -112,7 +112,8 @@ define <32 x i16> @test_aligned_v32i16_load(ptr align 64 dereferenceable(64) %p)
 define <32 x i16> @test_loadinsert_i16_to_v32i16(ptr align 64 dereferenceable(64) %p) {
 ; CHECK-LABEL: @test_loadinsert_i16_to_v32i16(
 ; CHECK-NEXT:    [[TMP1:%.*]] = load <32 x i16>, ptr [[P:%.*]], align 64
-; CHECK-NEXT:    ret <32 x i16> [[TMP1]]
+; CHECK-NEXT:    [[INSERT:%.*]] = shufflevector <32 x i16> [[TMP1]], <32 x i16> poison, <32 x i32> <i32 0, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
+; CHECK-NEXT:    ret <32 x i16> [[INSERT]]
 ;
   %scalar = load i16, ptr %p, align 64
   %insert = insertelement <32 x i16> poison, i16 %scalar, i64 0
@@ -121,7 +122,8 @@ define <32 x i16> @test_loadinsert_i16_to_v32i16(ptr align 64 dereferenceable(64
 
 define <16 x i16> @test_loadinsert_i16_to_v16i16(ptr align 64 dereferenceable(64) %p) {
 ; CHECK-LABEL: @test_loadinsert_i16_to_v16i16(
-; CHECK-NEXT:    [[INSERT:%.*]] = load <16 x i16>, ptr [[P:%.*]], align 64
+; CHECK-NEXT:    [[TMP1:%.*]] = load <32 x i16>, ptr [[P:%.*]], align 64
+; CHECK-NEXT:    [[INSERT:%.*]] = shufflevector <32 x i16> [[TMP1]], <32 x i16> poison, <16 x i32> <i32 0, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
 ; CHECK-NEXT:    ret <16 x i16> [[INSERT]]
 ;
   %scalar = load i16, ptr %p, align 64
@@ -131,7 +133,8 @@ define <16 x i16> @test_loadinsert_i16_to_v16i16(ptr align 64 dereferenceable(64
 
 define <8 x i32> @test_loadinsert_i32_to_v8i32(ptr align 64 dereferenceable(64) %p) {
 ; CHECK-LABEL: @test_loadinsert_i32_to_v8i32(
-; CHECK-NEXT:    [[INSERT:%.*]] = load <8 x i32>, ptr [[P:%.*]], align 64
+; CHECK-NEXT:    [[TMP1:%.*]] = load <16 x i32>, ptr [[P:%.*]], align 64
+; CHECK-NEXT:    [[INSERT:%.*]] = shufflevector <16 x i32> [[TMP1]], <16 x i32> poison, <8 x i32> <i32 0, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
 ; CHECK-NEXT:    ret <8 x i32> [[INSERT]]
 ;
   %scalar = load i32, ptr %p, align 64
@@ -141,7 +144,8 @@ define <8 x i32> @test_loadinsert_i32_to_v8i32(ptr align 64 dereferenceable(64) 
 
 define <32 x i8> @test_loadinsert_i8_to_v32i8(ptr align 64 dereferenceable(64) %p) {
 ; CHECK-LABEL: @test_loadinsert_i8_to_v32i8(
-; CHECK-NEXT:    [[INSERT:%.*]] = load <32 x i8>, ptr [[P:%.*]], align 64
+; CHECK-NEXT:    [[TMP1:%.*]] = load <64 x i8>, ptr [[P:%.*]], align 64
+; CHECK-NEXT:    [[INSERT:%.*]] = shufflevector <64 x i8> [[TMP1]], <64 x i8> poison, <32 x i32> <i32 0, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison, i32 poison>
 ; CHECK-NEXT:    ret <32 x i8> [[INSERT]]
 ;
   %scalar = load i8, ptr %p, align 64
@@ -154,7 +158,8 @@ define <32 x i8> @test_loadinsert_i8_to_v32i8(ptr align 64 dereferenceable(64) %
 ; intact. This guards the deref check.
 define <16 x i16> @test_loadinsert_i16_short_deref(ptr align 32 dereferenceable(32) %p) {
 ; CHECK-LABEL: @test_loadinsert_i16_short_deref(
-; CHECK-NEXT:    [[INSERT:%.*]] = load <16 x i16>, ptr [[P:%.*]], align 32
+; CHECK-NEXT:    [[SCALAR:%.*]] = load i16, ptr [[P:%.*]], align 32
+; CHECK-NEXT:    [[INSERT:%.*]] = insertelement <16 x i16> poison, i16 [[SCALAR]], i64 0
 ; CHECK-NEXT:    ret <16 x i16> [[INSERT]]
 ;
   %scalar = load i16, ptr %p, align 32

--- a/llvm/test/CodeGen/AIE/opt/vector-combine-widen-subvector-load.ll
+++ b/llvm/test/CodeGen/AIE/opt/vector-combine-widen-subvector-load.ll
@@ -95,3 +95,69 @@ define <32 x i16> @test_aligned_v32i16_load(ptr align 64 dereferenceable(64) %p)
   %splat = shufflevector <32 x i16> %insert, <32 x i16> poison, <32 x i32> zeroinitializer
   ret <32 x i16> %splat
 }
+
+; The cases above exercise widenSubvectorLoad (shufflevector input). The
+; cases below exercise vectorizeLoadInsert (insertelement directly returned,
+; no shufflevector in source). vectorizeLoadInsert reads
+; getMinVectorRegisterBitWidth() to choose the load width directly, so it
+; is the path most affected by the AIE 512-bit override (llvm-aie#480).
+;
+; With the override, scalar loads here widen to a 512-bit vector load
+; followed by a shuffle that picks element 0 and leaves the rest poison.
+; The wider IR-level load lowers to the natural width: for a 256-bit output
+; type, llc emits a single 256-bit `vldb wl0, [p0, #0]` -- the backend
+; narrows the load when the shuffle's poison mask makes the upper half
+; dead. Codegen is identical to a plain 256-bit IR load.
+
+define <32 x i16> @test_loadinsert_i16_to_v32i16(ptr align 64 dereferenceable(64) %p) {
+; CHECK-LABEL: @test_loadinsert_i16_to_v32i16(
+; CHECK-NEXT:    [[TMP1:%.*]] = load <32 x i16>, ptr [[P:%.*]], align 64
+; CHECK-NEXT:    ret <32 x i16> [[TMP1]]
+;
+  %scalar = load i16, ptr %p, align 64
+  %insert = insertelement <32 x i16> poison, i16 %scalar, i64 0
+  ret <32 x i16> %insert
+}
+
+define <16 x i16> @test_loadinsert_i16_to_v16i16(ptr align 64 dereferenceable(64) %p) {
+; CHECK-LABEL: @test_loadinsert_i16_to_v16i16(
+; CHECK-NEXT:    [[INSERT:%.*]] = load <16 x i16>, ptr [[P:%.*]], align 64
+; CHECK-NEXT:    ret <16 x i16> [[INSERT]]
+;
+  %scalar = load i16, ptr %p, align 64
+  %insert = insertelement <16 x i16> poison, i16 %scalar, i64 0
+  ret <16 x i16> %insert
+}
+
+define <8 x i32> @test_loadinsert_i32_to_v8i32(ptr align 64 dereferenceable(64) %p) {
+; CHECK-LABEL: @test_loadinsert_i32_to_v8i32(
+; CHECK-NEXT:    [[INSERT:%.*]] = load <8 x i32>, ptr [[P:%.*]], align 64
+; CHECK-NEXT:    ret <8 x i32> [[INSERT]]
+;
+  %scalar = load i32, ptr %p, align 64
+  %insert = insertelement <8 x i32> poison, i32 %scalar, i64 0
+  ret <8 x i32> %insert
+}
+
+define <32 x i8> @test_loadinsert_i8_to_v32i8(ptr align 64 dereferenceable(64) %p) {
+; CHECK-LABEL: @test_loadinsert_i8_to_v32i8(
+; CHECK-NEXT:    [[INSERT:%.*]] = load <32 x i8>, ptr [[P:%.*]], align 64
+; CHECK-NEXT:    ret <32 x i8> [[INSERT]]
+;
+  %scalar = load i8, ptr %p, align 64
+  %insert = insertelement <32 x i8> poison, i8 %scalar, i64 0
+  ret <32 x i8> %insert
+}
+
+; Insufficient dereferenceable bytes for a 512-bit load: the gating in
+; vectorizeLoadInsert bails, leaving the scalar load and insertelement
+; intact. This guards the deref check.
+define <16 x i16> @test_loadinsert_i16_short_deref(ptr align 32 dereferenceable(32) %p) {
+; CHECK-LABEL: @test_loadinsert_i16_short_deref(
+; CHECK-NEXT:    [[INSERT:%.*]] = load <16 x i16>, ptr [[P:%.*]], align 32
+; CHECK-NEXT:    ret <16 x i16> [[INSERT]]
+;
+  %scalar = load i16, ptr %p, align 32
+  %insert = insertelement <16 x i16> poison, i16 %scalar, i64 0
+  ret <16 x i16> %insert
+}


### PR DESCRIPTION
## Summary

Fixes #480. The GlobalISel Legalizer only has rules for 512-bit vector
arithmetic (V64S8, V32S16, V16S32), but middle-end vectorizers create
sub-512-bit vector ops that crash during legalization at -O2:

```
fatal error: unable to legalize instruction:
  %14:_(<64 x s8>) = G_SHL %4:_, %12:_(<64 x s8>)
```

Three TTI overrides in `AIEBaseTargetTransformInfo.h` prevent this:

- `getRegisterBitWidth(RGK_FixedWidthVector) = 512` -- stops the loop
  vectorizer from choosing sub-512-bit VF (e.g., VF=4 for i8)
- `getMinVectorRegisterBitWidth() = 512` -- prevents SLP/VectorCombine
  from creating sub-512-bit vectors
- `getArithmeticInstrCost()` returns `Invalid` for sub-512-bit vectors --
  stops SLP's cost model from treating e.g. `<8 x i8> add` as profitable

## Test plan

- [x] All 1824 AIE CodeGen lit tests pass (no regressions)
- [x] New regression test covers all three vectorizer paths:
  - Large trip count (LoopVectorize creates `<64 x i8>` not `<4 x i8>`)
  - Small trip count after unrolling (SLP does not create `<8 x i8>`)
  - i16 variant (LoopVectorize creates `<32 x i16>` not `<2 x i16>`)
- [x] MWE from #480 compiles cleanly at -O2