### PR TITLE
CI: artifact collision fix

### DIFF
--- a/.github/workflows/amd-aie-distro.yml
+++ b/.github/workflows/amd-aie-distro.yml
@@ -331,7 +331,8 @@ jobs:
       uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # 4.6.0
       with:
         path: ${{ steps.setup_base.outputs.WORKSPACE_ROOT }}/wheelhouse/*.whl
-        name: build_artifact
+        # Matrix legs must upload to unique artifact names
+        name: build_artifact-${{ matrix.OS }}-${{ matrix.ARCH }}
 
   upload_distro_wheels:
 
@@ -348,10 +349,11 @@ jobs:
     steps:
       - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # 4.1.8
         with:
-          # unpacks default artifact into dist/
-          # if `name: artifact` is omitted, the action will create extra parent dir
-          name: build_artifact
+          # Unpacks all per-platform artifacts into dist/
+          pattern: build_artifact-*
           path: dist
+          # If omitted, the action will create extra parent dirs
+          merge-multiple: true
 
       - name: Release current commit
         uses: ncipollo/release-action@v1.12.0


### PR DESCRIPTION
This is a follow-up to #809. As promised, I monitored the CI for remaining issues publishing the Windows wheel.

The distro workflow was uploading Linux and Windows wheel artifacts under the same artifact name, `build_artifact`, and the Linux build (which finishes first) preempted the Windows artifact, tripping a `409 Conflict` and failing publication.

This tiny patch fixes the collision by giving each matrix leg its own artifact name and then downloading all matching artifacts into the same `dist/` directory for release.