### PR TITLE
[AIEX] Support ZOL jump to LEND distance

### DIFF
--- a/llvm/lib/Target/AIE/AIEBaseInstrInfo.cpp
+++ b/llvm/lib/Target/AIE/AIEBaseInstrInfo.cpp
@@ -325,6 +325,17 @@ bool AIEBaseInstrInfo::isCallBundle(MachineBasicBlock::iterator MII) const {
   return IsReturnAddr;
 }
 
+bool AIEBaseInstrInfo::isJumpBundle(MachineBasicBlock::iterator MII) const {
+  MachineBasicBlock::const_instr_iterator I = ++MII->getIterator();
+  MachineBasicBlock::instr_iterator E = MII->getParent()->instr_end();
+  while (I != E && I->isInsideBundle()) {
+    if (I->hasDelaySlot())
+      return true;
+    ++I;
+  }
+  return false;
+}
+
 bool AIEBaseInstrInfo::isZOLTripCountDef(const MachineInstr &MI,
                                          bool Pristine) const {
   auto ZOLSupport = getZOLSupport();
@@ -463,8 +474,7 @@ unsigned AIEBaseInstrInfo::getRegionSizeInBytes(
     Size += getAIEMachineBundleSize(It);
   }
   LLVM_DEBUG(dbgs() << "---Region End---\n");
-  LLVM_DEBUG(dbgs() << "Region Size"
-                    << " " << Size << "\n");
+  LLVM_DEBUG(dbgs() << "Region Size" << " " << Size << "\n");
   return Size;
 }
 
@@ -1219,17 +1229,61 @@ AIEBaseInstrInfo::getAlignmentBoundaries(MachineBasicBlock &MBB) const {
   std::vector<MachineBasicBlock::iterator> AlignmentBoundaries;
 
   unsigned DelaySlot = 0;
-  // LoopSetupDistance will be set to number of instructions (7). In
-  // PostRAScheduler, this is enforced by setting the exit latency in the
+  // LoopSetupDistance is the number of bundles between setup and LEND.
+  // In PostRAScheduler, this is enforced by setting the exit latency in the
   // scheduler dag mutator.
   int LoopPaddingInBytes = 0;
   bool IsCall = false;
   auto ZOLSupport = getZOLSupport();
   const unsigned ZOLSetupToLoopEndDist =
       ZOLSupport.has_value() ? ZOLSupport->LoopSetupDistance : 0;
+  const bool LoopSetupRequiresByteDistance =
+      ZOLSupport && ZOLSupport->LoopSetupRequiresByteDistance;
   const unsigned LoopSetupSizeInBytes =
-      getMachineBlockAlignmentBytes() * ZOLSetupToLoopEndDist;
+      LoopSetupRequiresByteDistance
+          ? getMachineBlockAlignmentBytes() * ZOLSetupToLoopEndDist
+          : 0;
   const unsigned MBBAlignment = getMachineBlockAlignmentBytes();
+
+  const unsigned JumpToLENDBytes =
+      ZOLSupport ? ZOLSupport->JumpToLoopEndDistanceInBytes : 0;
+
+  // Byte-based counter for padding delay slot bundles of branches near
+  // ZOL. Works like LoopPaddingInBytes: each bundle absorbs up to
+  // (MBBAlignment - BundleSize) bytes until the deficit is covered.
+  int JumpPaddingInBytes = 0;
+
+  // Check if this MBB can have a branch that reaches a ZOL body within
+  // JumpToLoopEndDistanceInBytes. Scan forward in layout order; any block
+  // whose single successor is a ZOL body is a candidate preheader. This
+  // handles jumps not only in the immediate predecessor of the preheader
+  // but in any block within range of LEND.
+  bool IsGuardOfZOL = false;
+  MachineBasicBlock *GuardPreheader = nullptr;
+  MachineBasicBlock *GuardZOLBody = nullptr;
+  unsigned GuardIntermediateBlocksSize = 0;
+  if (JumpToLENDBytes > 0) {
+    unsigned AccumulatedSize = 0;
+    for (auto NextIt = std::next(MBB.getIterator()),
+              EndIt = MBB.getParent()->end();
+         NextIt != EndIt; ++NextIt) {
+      MachineBasicBlock &NextMBB = *NextIt;
+      if (NextMBB.succ_size() == 1 &&
+          NextMBB.getFirstTerminator() == NextMBB.end()) {
+        MachineBasicBlock *PossibleBody = *NextMBB.successors().begin();
+        if (isZOLBody(*PossibleBody)) {
+          IsGuardOfZOL = true;
+          GuardPreheader = &NextMBB;
+          GuardZOLBody = PossibleBody;
+          GuardIntermediateBlocksSize = AccumulatedSize;
+          break;
+        }
+      }
+      AccumulatedSize += getMBBSizeInBytes(NextMBB);
+      if (AccumulatedSize >= JumpToLENDBytes)
+        break;
+    }
+  }
 
   auto GetPostZOLSetupRegionSize =
       [this](MachineBasicBlock &LoopMBB) -> std::pair<unsigned, unsigned> {
@@ -1297,9 +1351,36 @@ AIEBaseInstrInfo::getAlignmentBoundaries(MachineBasicBlock &MBB) const {
         LoopPaddingInBytes -= (MBBAlignment - BundleSize);
       }
 
+      // Pad delay slot bundles of branches near ZOL to meet the
+      // jump-to-LEND byte distance. Only pads as many bundles as needed.
+      if (JumpPaddingInBytes > 0) {
+        AlignmentBoundaries.emplace_back(MI);
+        const int BundleSize = getAIEMachineBundleSize(MI);
+        JumpPaddingInBytes -= (MBBAlignment - BundleSize);
+      }
+
       if (IsCall)
         DelaySlot = getNumDelaySlots(*MI);
 
+      // When a branch is found and there is a ZOL body within
+      // JumpToLENDBytes (possibly with intermediate blocks), compute
+      // the distance from this branch to LEND and pad delay slots to
+      // cover the deficit.
+      if (IsGuardOfZOL && isJumpBundle(MI)) {
+        unsigned DistToEnd =
+            getRegionSizeInBytes(llvm::make_range(MI, MBB.end()));
+        unsigned PreheaderSize = getMBBSizeInBytes(*GuardPreheader);
+        unsigned LoopBodySize = LoopSizeExcludingLastBundle(*GuardZOLBody);
+        int Deficit = static_cast<int>(JumpToLENDBytes) -
+                      static_cast<int>(DistToEnd + GuardIntermediateBlocksSize +
+                                       PreheaderSize + LoopBodySize);
+        if (Deficit > 0) {
+          JumpPaddingInBytes = Deficit;
+          AlignmentBoundaries.emplace_back(MI);
+          const int BundleSize = getAIEMachineBundleSize(MI);
+          JumpPaddingInBytes -= (MBBAlignment - BundleSize);
+        }
+      }
       // Distance in terms of fully-expanded bundles that loop setup should
       // maintain. We force each of these bundles to an alignment boundary.
       if (ZOLSupport && isZOLSetupBundle(MI) && isLastZOLSetupBundleInMBB(MI)) {

--- a/llvm/lib/Target/AIE/AIEBaseInstrInfo.cpp
+++ b/llvm/lib/Target/AIE/AIEBaseInstrInfo.cpp
@@ -1216,7 +1216,7 @@ AIEBaseInstrInfo::getSlotOpcode(const MCSlotKind Slot,
 
 std::vector<MachineBasicBlock::iterator>
 AIEBaseInstrInfo::getAlignmentBoundaries(MachineBasicBlock &MBB) const {
-  std::vector<MachineBasicBlock::iterator> AlignCandidates;
+  std::vector<MachineBasicBlock::iterator> AlignmentBoundaries;
 
   unsigned DelaySlot = 0;
   // LoopSetupDistance will be set to number of instructions (7). In
@@ -1285,14 +1285,14 @@ AIEBaseInstrInfo::getAlignmentBoundaries(MachineBasicBlock &MBB) const {
         DelaySlot--;
         if (DelaySlot == 0)
           /* Region + 1 => RegionEnd */
-          AlignCandidates.emplace_back(std::next(MI));
+          AlignmentBoundaries.emplace_back(std::next(MI));
       }
 
       // Create regions of singleton bundle for schedule margin bundles,
       // alignment algorithm will force fill each bundle to the correct number
       // of bits to fulfill the alignment requirement of the region.
       if (LoopPaddingInBytes > 0) {
-        AlignCandidates.emplace_back(MI);
+        AlignmentBoundaries.emplace_back(MI);
         const int BundleSize = getAIEMachineBundleSize(MI);
         LoopPaddingInBytes -= (MBBAlignment - BundleSize);
       }
@@ -1334,7 +1334,7 @@ AIEBaseInstrInfo::getAlignmentBoundaries(MachineBasicBlock &MBB) const {
       while (PrevNonMetaMI->isMetaInstruction())
         PrevNonMetaMI = std::prev(PrevNonMetaMI);
 
-      AlignCandidates.emplace_back(PrevNonMetaMI);
+      AlignmentBoundaries.emplace_back(PrevNonMetaMI);
     } else if (!MI->isMetaInstruction()) {
       // Single instruction, there should not be any
       // after Bundle Finalization Pass.
@@ -1345,8 +1345,8 @@ AIEBaseInstrInfo::getAlignmentBoundaries(MachineBasicBlock &MBB) const {
   if (LoopPaddingInBytes > 0)
     llvm_unreachable("LoopStart/LoopBody: insufficient padding!\n");
 
-  AlignCandidates.emplace_back(MBB.end());
-  return AlignCandidates;
+  AlignmentBoundaries.emplace_back(MBB.end());
+  return AlignmentBoundaries;
 }
 
 bool AIEBaseInstrInfo::isNativeS20Consumer(

--- a/llvm/lib/Target/AIE/AIEBaseInstrInfo.h
+++ b/llvm/lib/Target/AIE/AIEBaseInstrInfo.h
@@ -60,6 +60,16 @@ struct AIEBaseInstrInfo : public TargetInstrInfo {
     // The distance between setup and the start of the loop, in units
     // of bundles.
     unsigned LoopSetupDistance;
+    // Minimum distance in bytes from any JUMP instruction to the
+    // end-of-loop label. 0 means no additional constraint beyond
+    // LoopSetupDistance. When set, delay slot bundles of branches
+    // preceding a ZOL preheader are forced to full alignment boundaries.
+    // Any remaining gap could be padded in the preheader but that is not needed
+    // at the moment since the last bundle of the loop body is always aligned.
+    unsigned JumpToLoopEndDistanceInBytes = 0;
+    // If true, the loop setup distance is enforced as a byte distance:
+    // bundles between setup and LEND are elongated to alignment boundaries.
+    bool LoopSetupRequiresByteDistance = true;
   };
 
   class JNZDSupport {
@@ -342,6 +352,9 @@ struct AIEBaseInstrInfo : public TargetInstrInfo {
 
   /// Check whether Opc represents a JL/JAL instruction.
   virtual bool isCall(unsigned Opc) const { return false; }
+
+  // Check if the MII points to a BUNDLE which contains a branch instruction
+  bool isJumpBundle(MachineBasicBlock::iterator MII) const;
 
   // Detect instructions that induce control flow to unknown targets,
   // in particular after pseudo expansion, where they are no longer

--- a/llvm/lib/Target/AIE/AIEMachineAlignment.cpp
+++ b/llvm/lib/Target/AIE/AIEMachineAlignment.cpp
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// (c) Copyright 2023-2025 Advanced Micro Devices, Inc. or its affiliates
+// (c) Copyright 2023-2026 Advanced Micro Devices, Inc. or its affiliates
 //
 //===----------------------------------------------------------------------===//
 
@@ -179,7 +179,8 @@ unsigned tryRegionAlignment(MultiBlockRegion &PadRegion, unsigned PadBytes,
   return PadBytes;
 }
 
-void padRegion(MultiBlockRegion &PadRegion, const unsigned AlignOffset) {
+void padRegionForAlignment(MultiBlockRegion &PadRegion,
+                           const unsigned AlignOffset) {
   const AIEBaseInstrInfo &TII = PadRegion.getTII();
 
   const unsigned MachineBlockAlignment = TII.getMachineBlockAlignmentBytes();
@@ -248,8 +249,9 @@ void verifyAlignment(MachineFunction &MF) {
 
 void padRegions(std::vector<MultiBlockRegion> &AllRegions) {
   for (auto [Idx, Region] : enumerate(AllRegions)) {
-    LLVM_DEBUG(dbgs() << "Aligning Region " << Idx << "\n");
-    padRegion(Region, Region.getRegionSize());
+    LLVM_DEBUG(dbgs() << "Padding Region " << Idx << " to align the next"
+                      << "\n");
+    padRegionForAlignment(Region, Region.getRegionSize());
   }
 }
 


### PR DESCRIPTION
This allows the target to specify a ZOL setup distance in either cycles or a concrete byte distance. Also, this allows the target to opt to keep jump instructions away from ZOL LEND at a particular distance in bytes.