### PR TITLE
fixup! [AIEX] Support ZOL jump to LEND distance

### DIFF
--- a/llvm/lib/Target/AIE/AIEBaseInstrInfo.cpp
+++ b/llvm/lib/Target/AIE/AIEBaseInstrInfo.cpp
@@ -1376,9 +1376,6 @@ AIEBaseInstrInfo::getAlignmentBoundaries(MachineBasicBlock &MBB) const {
                                        PreheaderSize + LoopBodySize);
         if (Deficit > 0) {
           JumpPaddingInBytes = Deficit;
-          AlignmentBoundaries.emplace_back(MI);
-          const int BundleSize = getAIEMachineBundleSize(MI);
-          JumpPaddingInBytes -= (MBBAlignment - BundleSize);
         }
       }
       // Distance in terms of fully-expanded bundles that loop setup should


### PR DESCRIPTION
We don't need to elongate the jump bundle since there we will be at least 4 full delay slot bundles, at least a full bundle in the preheader and at least a full one in the loop. 