### PR TITLE
Remove loops from aie2ps upd headers

### DIFF
--- a/clang/lib/Headers/aie2ps/aie2ps_upd_ext.h
+++ b/clang/lib/Headers/aie2ps/aie2ps_upd_ext.h
@@ -2629,11 +2629,8 @@ INTRINSIC(v128uint4) extract_v128uint4(v256mx6 v, int idx) {
     temp0 = v.mantissaX2;
     temp1 = v.mantissaX3;
   }
-  for (int i = 0; i < 8; i++) {
-    res[i] = temp0[i];
-    res[i + 8] = temp1[i];
-  }
 
+  res = concat(temp0, temp1);
   return (v128uint4)res;
 }
 
@@ -2662,28 +2659,18 @@ INTRINSIC(v128uint4) extract_v128uint4(v256mx4 v, int idx) {
     temp0 = v.mantissaX2;
     temp1 = v.mantissaX3;
   }
-  for (int i = 0; i < 8; i++) {
-    res[i] = temp0[i];
-    res[i + 8] = temp1[i];
-  }
+  res = concat(temp0, temp1);
 
   return (v128uint4)res;
 }
 
 INTRINSIC(v256mx6) update(v256mx6 s, int idx, v128uint4 m) {
-  v8int32 temp0;
-  v8int32 temp1;
-  for (int i = 0; i < 8; i++) {
-    temp0[i] = ((v16int32)m)[i];
-    temp1[i] = ((v16int32)m)[i + 8];
-  }
-  if (idx == 0) {
-    s.mantissaX0 = temp0;
-    s.mantissaX1 = temp1;
-  } else {
-    s.mantissaX2 = temp0;
-    s.mantissaX3 = temp1;
-  }
+  v8int32 temp0 = extract_256_512((v16int32)m, 0);
+  v8int32 temp1 = extract_256_512((v16int32)m, 1);
+  s.mantissaX0 = idx == 0 ? temp0 : s.mantissaX0;
+  s.mantissaX1 = idx == 0 ? temp1 : s.mantissaX1;
+  s.mantissaX2 = idx == 0 ? s.mantissaX2 : temp0;
+  s.mantissaX3 = idx == 0 ? s.mantissaX3 : temp1;
   return s;
 }
 
@@ -2701,19 +2688,12 @@ INTRINSIC(v256mx6) update(v256mx6 s, int idx, v64uint4 m) {
 }
 
 INTRINSIC(v256mx4) update(v256mx4 s, int idx, v128uint4 m) {
-  v8int32 temp0;
-  v8int32 temp1;
-  for (int i = 0; i < 8; i++) {
-    temp0[i] = ((v16int32)m)[i];
-    temp1[i] = ((v16int32)m)[i + 8];
-  }
-  if (idx == 0) {
-    s.mantissaX0 = temp0;
-    s.mantissaX1 = temp1;
-  } else {
-    s.mantissaX2 = temp0;
-    s.mantissaX3 = temp1;
-  }
+  v8int32 temp0 = extract_256_512((v16int32)m, 0);
+  v8int32 temp1 = extract_256_512((v16int32)m, 1);
+  s.mantissaX0 = idx == 0 ? temp0 : s.mantissaX0;
+  s.mantissaX1 = idx == 0 ? temp1 : s.mantissaX1;
+  s.mantissaX2 = idx == 0 ? s.mantissaX2 : temp0;
+  s.mantissaX3 = idx == 0 ? s.mantissaX3 : temp1;
   return s;
 }
 

--- a/clang/test/CodeGen/aie/aie2ps/aie2ps-upd-ext-intrinsic.cpp
+++ b/clang/test/CodeGen/aie/aie2ps/aie2ps-upd-ext-intrinsic.cpp
@@ -2017,8 +2017,20 @@ v64uint4 test_extract_v64uint4 (v256mx6 m, int idx) { return extract_v64uint4(m,
 // CHECK-NEXT:    [[TMP3:%.*]] = extractvalue [[STRUCT_V256MX6]] [[M_COERCE]], 2
 // CHECK-NEXT:    [[TEMP0_0_I:%.*]] = select i1 [[CMP_I]], <8 x i32> [[TMP1]], <8 x i32> [[TMP3]]
 // CHECK-NEXT:    [[TEMP1_0_I:%.*]] = select i1 [[CMP_I]], <8 x i32> [[TMP0]], <8 x i32> [[TMP2]]
-// CHECK-NEXT:    [[VECINS3_7_I:%.*]] = shufflevector <8 x i32> [[TEMP0_0_I]], <8 x i32> [[TEMP1_0_I]], <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
-// CHECK-NEXT:    [[TMP4:%.*]] = bitcast <16 x i32> [[VECINS3_7_I]] to <64 x i8>
+// CHECK-NEXT:    br label [[FOR_BODY_I:%.*]]
+// CHECK:       for.body.i:
+// CHECK-NEXT:    [[I_012_I:%.*]] = phi i32 [ 0, [[ENTRY:%.*]] ], [ [[INC_I:%.*]], [[FOR_BODY_I]] ]
+// CHECK-NEXT:    [[RES_011_I:%.*]] = phi <16 x i32> [ undef, [[ENTRY]] ], [ [[VECINS3_I:%.*]], [[FOR_BODY_I]] ]
+// CHECK-NEXT:    [[VECEXT_I:%.*]] = extractelement <8 x i32> [[TEMP0_0_I]], i32 [[I_012_I]]
+// CHECK-NEXT:    [[VECINS_I:%.*]] = insertelement <16 x i32> [[RES_011_I]], i32 [[VECEXT_I]], i32 [[I_012_I]]
+// CHECK-NEXT:    [[VECEXT2_I:%.*]] = extractelement <8 x i32> [[TEMP1_0_I]], i32 [[I_012_I]]
+// CHECK-NEXT:    [[ADD_I:%.*]] = or disjoint i32 [[I_012_I]], 8
+// CHECK-NEXT:    [[VECINS3_I]] = insertelement <16 x i32> [[VECINS_I]], i32 [[VECEXT2_I]], i32 [[ADD_I]]
+// CHECK-NEXT:    [[INC_I]] = add nuw nsw i32 [[I_012_I]], 1
+// CHECK-NEXT:    [[EXITCOND_NOT_I:%.*]] = icmp eq i32 [[INC_I]], 8
+// CHECK-NEXT:    br i1 [[EXITCOND_NOT_I]], label [[_ZL17EXTRACT_V128UINT47V256MX6I_EXIT:%.*]], label [[FOR_BODY_I]], !llvm.loop [[LOOP113:![0-9]+]]
+// CHECK:       _ZL17extract_v128uint47v256mx6i.exit:
+// CHECK-NEXT:    [[TMP4:%.*]] = bitcast <16 x i32> [[VECINS3_I]] to <64 x i8>
 // CHECK-NEXT:    ret <64 x i8> [[TMP4]]
 //
 v128uint4 test_extract_v128uint4 (v256mx6 m, int idx) { return extract_v128uint4(m, idx); }
@@ -2079,17 +2091,29 @@ v256mx6 test_update (v256mx6 s, int idx, v64uint4 m) { return update(s, idx, m);
 // CHECK-LABEL: @_Z11test_update7v256mx6iDv64_DU8_(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[TMP0:%.*]] = bitcast <64 x i8> [[M:%.*]] to <16 x i32>
-// CHECK-NEXT:    [[VECINS_7_I:%.*]] = shufflevector <16 x i32> [[TMP0]], <16 x i32> poison, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
-// CHECK-NEXT:    [[VECINS3_7_I:%.*]] = shufflevector <16 x i32> [[TMP0]], <16 x i32> poison, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
+// CHECK-NEXT:    br label [[FOR_BODY_I:%.*]]
+// CHECK:       for.body.i:
+// CHECK-NEXT:    [[I_017_I:%.*]] = phi i32 [ 0, [[ENTRY:%.*]] ], [ [[INC_I:%.*]], [[FOR_BODY_I]] ]
+// CHECK-NEXT:    [[TEMP1_016_I:%.*]] = phi <8 x i32> [ undef, [[ENTRY]] ], [ [[VECINS3_I:%.*]], [[FOR_BODY_I]] ]
+// CHECK-NEXT:    [[TEMP0_015_I:%.*]] = phi <8 x i32> [ undef, [[ENTRY]] ], [ [[VECINS_I:%.*]], [[FOR_BODY_I]] ]
+// CHECK-NEXT:    [[VECEXT_I:%.*]] = extractelement <16 x i32> [[TMP0]], i32 [[I_017_I]]
+// CHECK-NEXT:    [[VECINS_I]] = insertelement <8 x i32> [[TEMP0_015_I]], i32 [[VECEXT_I]], i32 [[I_017_I]]
+// CHECK-NEXT:    [[ADD_I:%.*]] = or disjoint i32 [[I_017_I]], 8
+// CHECK-NEXT:    [[VECEXT2_I:%.*]] = extractelement <16 x i32> [[TMP0]], i32 [[ADD_I]]
+// CHECK-NEXT:    [[VECINS3_I]] = insertelement <8 x i32> [[TEMP1_016_I]], i32 [[VECEXT2_I]], i32 [[I_017_I]]
+// CHECK-NEXT:    [[INC_I]] = add nuw nsw i32 [[I_017_I]], 1
+// CHECK-NEXT:    [[EXITCOND_NOT_I:%.*]] = icmp eq i32 [[INC_I]], 8
+// CHECK-NEXT:    br i1 [[EXITCOND_NOT_I]], label [[_ZL6UPDATE7V256MX6IDV64_DU8__EXIT:%.*]], label [[FOR_BODY_I]], !llvm.loop [[LOOP115:![0-9]+]]
+// CHECK:       _ZL6update7v256mx6iDv64_DU8_.exit:
 // CHECK-NEXT:    [[TMP1:%.*]] = extractvalue [[STRUCT_V256MX6:%.*]] [[S_COERCE:%.*]], 3
 // CHECK-NEXT:    [[TMP2:%.*]] = extractvalue [[STRUCT_V256MX6]] [[S_COERCE]], 2
 // CHECK-NEXT:    [[TMP3:%.*]] = extractvalue [[STRUCT_V256MX6]] [[S_COERCE]], 1
 // CHECK-NEXT:    [[TMP4:%.*]] = extractvalue [[STRUCT_V256MX6]] [[S_COERCE]], 0
 // CHECK-NEXT:    [[CMP4_I:%.*]] = icmp eq i32 [[IDX:%.*]], 0
-// CHECK-NEXT:    [[TEMP0_0__I:%.*]] = select i1 [[CMP4_I]], <8 x i32> [[VECINS_7_I]], <8 x i32> [[TMP4]]
-// CHECK-NEXT:    [[TEMP1_0__I:%.*]] = select i1 [[CMP4_I]], <8 x i32> [[VECINS3_7_I]], <8 x i32> [[TMP3]]
-// CHECK-NEXT:    [[DOTTEMP0_0_I:%.*]] = select i1 [[CMP4_I]], <8 x i32> [[TMP2]], <8 x i32> [[VECINS_7_I]]
-// CHECK-NEXT:    [[DOTTEMP1_0_I:%.*]] = select i1 [[CMP4_I]], <8 x i32> [[TMP1]], <8 x i32> [[VECINS3_7_I]]
+// CHECK-NEXT:    [[TEMP0_0__I:%.*]] = select i1 [[CMP4_I]], <8 x i32> [[VECINS_I]], <8 x i32> [[TMP4]]
+// CHECK-NEXT:    [[TEMP1_0__I:%.*]] = select i1 [[CMP4_I]], <8 x i32> [[VECINS3_I]], <8 x i32> [[TMP3]]
+// CHECK-NEXT:    [[DOTTEMP0_0_I:%.*]] = select i1 [[CMP4_I]], <8 x i32> [[TMP2]], <8 x i32> [[VECINS_I]]
+// CHECK-NEXT:    [[DOTTEMP1_0_I:%.*]] = select i1 [[CMP4_I]], <8 x i32> [[TMP1]], <8 x i32> [[VECINS3_I]]
 // CHECK-NEXT:    [[TMP5:%.*]] = extractvalue [[STRUCT_V256MX6]] [[S_COERCE]], 15
 // CHECK-NEXT:    [[TMP6:%.*]] = extractvalue [[STRUCT_V256MX6]] [[S_COERCE]], 14
 // CHECK-NEXT:    [[TMP7:%.*]] = extractvalue [[STRUCT_V256MX6]] [[S_COERCE]], 13
@@ -2866,8 +2890,20 @@ v64uint4 test_extract_v64uint4 (v256mx4 m, int idx) { return extract_v64uint4(m,
 // CHECK-NEXT:    [[TMP3:%.*]] = extractvalue [[STRUCT_V256MX4]] [[M_COERCE]], 2
 // CHECK-NEXT:    [[TEMP0_0_I:%.*]] = select i1 [[CMP_I]], <8 x i32> [[TMP1]], <8 x i32> [[TMP3]]
 // CHECK-NEXT:    [[TEMP1_0_I:%.*]] = select i1 [[CMP_I]], <8 x i32> [[TMP0]], <8 x i32> [[TMP2]]
-// CHECK-NEXT:    [[VECINS3_7_I:%.*]] = shufflevector <8 x i32> [[TEMP0_0_I]], <8 x i32> [[TEMP1_0_I]], <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
-// CHECK-NEXT:    [[TMP4:%.*]] = bitcast <16 x i32> [[VECINS3_7_I]] to <64 x i8>
+// CHECK-NEXT:    br label [[FOR_BODY_I:%.*]]
+// CHECK:       for.body.i:
+// CHECK-NEXT:    [[I_012_I:%.*]] = phi i32 [ 0, [[ENTRY:%.*]] ], [ [[INC_I:%.*]], [[FOR_BODY_I]] ]
+// CHECK-NEXT:    [[RES_011_I:%.*]] = phi <16 x i32> [ undef, [[ENTRY]] ], [ [[VECINS3_I:%.*]], [[FOR_BODY_I]] ]
+// CHECK-NEXT:    [[VECEXT_I:%.*]] = extractelement <8 x i32> [[TEMP0_0_I]], i32 [[I_012_I]]
+// CHECK-NEXT:    [[VECINS_I:%.*]] = insertelement <16 x i32> [[RES_011_I]], i32 [[VECEXT_I]], i32 [[I_012_I]]
+// CHECK-NEXT:    [[VECEXT2_I:%.*]] = extractelement <8 x i32> [[TEMP1_0_I]], i32 [[I_012_I]]
+// CHECK-NEXT:    [[ADD_I:%.*]] = or disjoint i32 [[I_012_I]], 8
+// CHECK-NEXT:    [[VECINS3_I]] = insertelement <16 x i32> [[VECINS_I]], i32 [[VECEXT2_I]], i32 [[ADD_I]]
+// CHECK-NEXT:    [[INC_I]] = add nuw nsw i32 [[I_012_I]], 1
+// CHECK-NEXT:    [[EXITCOND_NOT_I:%.*]] = icmp eq i32 [[INC_I]], 8
+// CHECK-NEXT:    br i1 [[EXITCOND_NOT_I]], label [[_ZL17EXTRACT_V128UINT47V256MX4I_EXIT:%.*]], label [[FOR_BODY_I]], !llvm.loop [[LOOP116:![0-9]+]]
+// CHECK:       _ZL17extract_v128uint47v256mx4i.exit:
+// CHECK-NEXT:    [[TMP4:%.*]] = bitcast <16 x i32> [[VECINS3_I]] to <64 x i8>
 // CHECK-NEXT:    ret <64 x i8> [[TMP4]]
 //
 v128uint4 test_extract_v128uint4 (v256mx4 m, int idx) { return extract_v128uint4(m, idx); }
@@ -2928,17 +2964,29 @@ v256mx4 test_update (v256mx4 s, int idx, v64uint4 m) { return update(s, idx, m);
 // CHECK-LABEL: @_Z11test_update7v256mx4iDv64_DU8_(
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[TMP0:%.*]] = bitcast <64 x i8> [[M:%.*]] to <16 x i32>
-// CHECK-NEXT:    [[VECINS_7_I:%.*]] = shufflevector <16 x i32> [[TMP0]], <16 x i32> poison, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
-// CHECK-NEXT:    [[VECINS3_7_I:%.*]] = shufflevector <16 x i32> [[TMP0]], <16 x i32> poison, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
+// CHECK-NEXT:    br label [[FOR_BODY_I:%.*]]
+// CHECK:       for.body.i:
+// CHECK-NEXT:    [[I_017_I:%.*]] = phi i32 [ 0, [[ENTRY:%.*]] ], [ [[INC_I:%.*]], [[FOR_BODY_I]] ]
+// CHECK-NEXT:    [[TEMP1_016_I:%.*]] = phi <8 x i32> [ undef, [[ENTRY]] ], [ [[VECINS3_I:%.*]], [[FOR_BODY_I]] ]
+// CHECK-NEXT:    [[TEMP0_015_I:%.*]] = phi <8 x i32> [ undef, [[ENTRY]] ], [ [[VECINS_I:%.*]], [[FOR_BODY_I]] ]
+// CHECK-NEXT:    [[VECEXT_I:%.*]] = extractelement <16 x i32> [[TMP0]], i32 [[I_017_I]]
+// CHECK-NEXT:    [[VECINS_I]] = insertelement <8 x i32> [[TEMP0_015_I]], i32 [[VECEXT_I]], i32 [[I_017_I]]
+// CHECK-NEXT:    [[ADD_I:%.*]] = or disjoint i32 [[I_017_I]], 8
+// CHECK-NEXT:    [[VECEXT2_I:%.*]] = extractelement <16 x i32> [[TMP0]], i32 [[ADD_I]]
+// CHECK-NEXT:    [[VECINS3_I]] = insertelement <8 x i32> [[TEMP1_016_I]], i32 [[VECEXT2_I]], i32 [[I_017_I]]
+// CHECK-NEXT:    [[INC_I]] = add nuw nsw i32 [[I_017_I]], 1
+// CHECK-NEXT:    [[EXITCOND_NOT_I:%.*]] = icmp eq i32 [[INC_I]], 8
+// CHECK-NEXT:    br i1 [[EXITCOND_NOT_I]], label [[_ZL6UPDATE7V256MX4IDV64_DU8__EXIT:%.*]], label [[FOR_BODY_I]], !llvm.loop [[LOOP117:![0-9]+]]
+// CHECK:       _ZL6update7v256mx4iDv64_DU8_.exit:
 // CHECK-NEXT:    [[TMP1:%.*]] = extractvalue [[STRUCT_V256MX4:%.*]] [[S_COERCE:%.*]], 3
 // CHECK-NEXT:    [[TMP2:%.*]] = extractvalue [[STRUCT_V256MX4]] [[S_COERCE]], 2
 // CHECK-NEXT:    [[TMP3:%.*]] = extractvalue [[STRUCT_V256MX4]] [[S_COERCE]], 1
 // CHECK-NEXT:    [[TMP4:%.*]] = extractvalue [[STRUCT_V256MX4]] [[S_COERCE]], 0
 // CHECK-NEXT:    [[CMP4_I:%.*]] = icmp eq i32 [[IDX:%.*]], 0
-// CHECK-NEXT:    [[TEMP0_0__I:%.*]] = select i1 [[CMP4_I]], <8 x i32> [[VECINS_7_I]], <8 x i32> [[TMP4]]
-// CHECK-NEXT:    [[TEMP1_0__I:%.*]] = select i1 [[CMP4_I]], <8 x i32> [[VECINS3_7_I]], <8 x i32> [[TMP3]]
-// CHECK-NEXT:    [[DOTTEMP0_0_I:%.*]] = select i1 [[CMP4_I]], <8 x i32> [[TMP2]], <8 x i32> [[VECINS_7_I]]
-// CHECK-NEXT:    [[DOTTEMP1_0_I:%.*]] = select i1 [[CMP4_I]], <8 x i32> [[TMP1]], <8 x i32> [[VECINS3_7_I]]
+// CHECK-NEXT:    [[TEMP0_0__I:%.*]] = select i1 [[CMP4_I]], <8 x i32> [[VECINS_I]], <8 x i32> [[TMP4]]
+// CHECK-NEXT:    [[TEMP1_0__I:%.*]] = select i1 [[CMP4_I]], <8 x i32> [[VECINS3_I]], <8 x i32> [[TMP3]]
+// CHECK-NEXT:    [[DOTTEMP0_0_I:%.*]] = select i1 [[CMP4_I]], <8 x i32> [[TMP2]], <8 x i32> [[VECINS_I]]
+// CHECK-NEXT:    [[DOTTEMP1_0_I:%.*]] = select i1 [[CMP4_I]], <8 x i32> [[TMP1]], <8 x i32> [[VECINS3_I]]
 // CHECK-NEXT:    [[TMP5:%.*]] = extractvalue [[STRUCT_V256MX4]] [[S_COERCE]], 15
 // CHECK-NEXT:    [[TMP6:%.*]] = extractvalue [[STRUCT_V256MX4]] [[S_COERCE]], 14
 // CHECK-NEXT:    [[TMP7:%.*]] = extractvalue [[STRUCT_V256MX4]] [[S_COERCE]], 13

--- a/clang/test/CodeGen/aie/aie2ps/aie2ps-upd-ext-intrinsic.cpp
+++ b/clang/test/CodeGen/aie/aie2ps/aie2ps-upd-ext-intrinsic.cpp
@@ -2015,22 +2015,10 @@ v64uint4 test_extract_v64uint4 (v256mx6 m, int idx) { return extract_v64uint4(m,
 // CHECK-NEXT:    [[TMP1:%.*]] = extractvalue [[STRUCT_V256MX6]] [[M_COERCE]], 0
 // CHECK-NEXT:    [[TMP2:%.*]] = extractvalue [[STRUCT_V256MX6]] [[M_COERCE]], 3
 // CHECK-NEXT:    [[TMP3:%.*]] = extractvalue [[STRUCT_V256MX6]] [[M_COERCE]], 2
-// CHECK-NEXT:    [[TEMP0_0_I:%.*]] = select i1 [[CMP_I]], <8 x i32> [[TMP1]], <8 x i32> [[TMP3]]
 // CHECK-NEXT:    [[TEMP1_0_I:%.*]] = select i1 [[CMP_I]], <8 x i32> [[TMP0]], <8 x i32> [[TMP2]]
-// CHECK-NEXT:    br label [[FOR_BODY_I:%.*]]
-// CHECK:       for.body.i:
-// CHECK-NEXT:    [[I_012_I:%.*]] = phi i32 [ 0, [[ENTRY:%.*]] ], [ [[INC_I:%.*]], [[FOR_BODY_I]] ]
-// CHECK-NEXT:    [[RES_011_I:%.*]] = phi <16 x i32> [ undef, [[ENTRY]] ], [ [[VECINS3_I:%.*]], [[FOR_BODY_I]] ]
-// CHECK-NEXT:    [[VECEXT_I:%.*]] = extractelement <8 x i32> [[TEMP0_0_I]], i32 [[I_012_I]]
-// CHECK-NEXT:    [[VECINS_I:%.*]] = insertelement <16 x i32> [[RES_011_I]], i32 [[VECEXT_I]], i32 [[I_012_I]]
-// CHECK-NEXT:    [[VECEXT2_I:%.*]] = extractelement <8 x i32> [[TEMP1_0_I]], i32 [[I_012_I]]
-// CHECK-NEXT:    [[ADD_I:%.*]] = or disjoint i32 [[I_012_I]], 8
-// CHECK-NEXT:    [[VECINS3_I]] = insertelement <16 x i32> [[VECINS_I]], i32 [[VECEXT2_I]], i32 [[ADD_I]]
-// CHECK-NEXT:    [[INC_I]] = add nuw nsw i32 [[I_012_I]], 1
-// CHECK-NEXT:    [[EXITCOND_NOT_I:%.*]] = icmp eq i32 [[INC_I]], 8
-// CHECK-NEXT:    br i1 [[EXITCOND_NOT_I]], label [[_ZL17EXTRACT_V128UINT47V256MX6I_EXIT:%.*]], label [[FOR_BODY_I]], !llvm.loop [[LOOP113:![0-9]+]]
-// CHECK:       _ZL17extract_v128uint47v256mx6i.exit:
-// CHECK-NEXT:    [[TMP4:%.*]] = bitcast <16 x i32> [[VECINS3_I]] to <64 x i8>
+// CHECK-NEXT:    [[TEMP0_0_I:%.*]] = select i1 [[CMP_I]], <8 x i32> [[TMP1]], <8 x i32> [[TMP3]]
+// CHECK-NEXT:    [[SHUFFLE_I_I_I:%.*]] = shufflevector <8 x i32> [[TEMP0_0_I]], <8 x i32> [[TEMP1_0_I]], <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
+// CHECK-NEXT:    [[TMP4:%.*]] = bitcast <16 x i32> [[SHUFFLE_I_I_I]] to <64 x i8>
 // CHECK-NEXT:    ret <64 x i8> [[TMP4]]
 //
 v128uint4 test_extract_v128uint4 (v256mx6 m, int idx) { return extract_v128uint4(m, idx); }
@@ -2090,30 +2078,18 @@ v128uint4 test_extract_v128uint4 (v256mx6 m, int idx) { return extract_v128uint4
 v256mx6 test_update (v256mx6 s, int idx, v64uint4 m) { return update(s, idx, m); }
 // CHECK-LABEL: @_Z11test_update7v256mx6iDv64_DU8_(
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[TMP0:%.*]] = bitcast <64 x i8> [[M:%.*]] to <16 x i32>
-// CHECK-NEXT:    br label [[FOR_BODY_I:%.*]]
-// CHECK:       for.body.i:
-// CHECK-NEXT:    [[I_017_I:%.*]] = phi i32 [ 0, [[ENTRY:%.*]] ], [ [[INC_I:%.*]], [[FOR_BODY_I]] ]
-// CHECK-NEXT:    [[TEMP1_016_I:%.*]] = phi <8 x i32> [ undef, [[ENTRY]] ], [ [[VECINS3_I:%.*]], [[FOR_BODY_I]] ]
-// CHECK-NEXT:    [[TEMP0_015_I:%.*]] = phi <8 x i32> [ undef, [[ENTRY]] ], [ [[VECINS_I:%.*]], [[FOR_BODY_I]] ]
-// CHECK-NEXT:    [[VECEXT_I:%.*]] = extractelement <16 x i32> [[TMP0]], i32 [[I_017_I]]
-// CHECK-NEXT:    [[VECINS_I]] = insertelement <8 x i32> [[TEMP0_015_I]], i32 [[VECEXT_I]], i32 [[I_017_I]]
-// CHECK-NEXT:    [[ADD_I:%.*]] = or disjoint i32 [[I_017_I]], 8
-// CHECK-NEXT:    [[VECEXT2_I:%.*]] = extractelement <16 x i32> [[TMP0]], i32 [[ADD_I]]
-// CHECK-NEXT:    [[VECINS3_I]] = insertelement <8 x i32> [[TEMP1_016_I]], i32 [[VECEXT2_I]], i32 [[I_017_I]]
-// CHECK-NEXT:    [[INC_I]] = add nuw nsw i32 [[I_017_I]], 1
-// CHECK-NEXT:    [[EXITCOND_NOT_I:%.*]] = icmp eq i32 [[INC_I]], 8
-// CHECK-NEXT:    br i1 [[EXITCOND_NOT_I]], label [[_ZL6UPDATE7V256MX6IDV64_DU8__EXIT:%.*]], label [[FOR_BODY_I]], !llvm.loop [[LOOP115:![0-9]+]]
-// CHECK:       _ZL6update7v256mx6iDv64_DU8_.exit:
-// CHECK-NEXT:    [[TMP1:%.*]] = extractvalue [[STRUCT_V256MX6:%.*]] [[S_COERCE:%.*]], 3
-// CHECK-NEXT:    [[TMP2:%.*]] = extractvalue [[STRUCT_V256MX6]] [[S_COERCE]], 2
-// CHECK-NEXT:    [[TMP3:%.*]] = extractvalue [[STRUCT_V256MX6]] [[S_COERCE]], 1
+// CHECK-NEXT:    [[TMP0:%.*]] = extractvalue [[STRUCT_V256MX6:%.*]] [[S_COERCE:%.*]], 1
+// CHECK-NEXT:    [[TMP1:%.*]] = extractvalue [[STRUCT_V256MX6]] [[S_COERCE]], 2
+// CHECK-NEXT:    [[TMP2:%.*]] = extractvalue [[STRUCT_V256MX6]] [[S_COERCE]], 3
+// CHECK-NEXT:    [[TMP3:%.*]] = bitcast <64 x i8> [[M:%.*]] to <16 x i32>
+// CHECK-NEXT:    [[SHUFFLE_I_I:%.*]] = shufflevector <16 x i32> [[TMP3]], <16 x i32> poison, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+// CHECK-NEXT:    [[SHUFFLE1_I_I:%.*]] = shufflevector <16 x i32> [[TMP3]], <16 x i32> poison, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
+// CHECK-NEXT:    [[CMP_I:%.*]] = icmp eq i32 [[IDX:%.*]], 0
 // CHECK-NEXT:    [[TMP4:%.*]] = extractvalue [[STRUCT_V256MX6]] [[S_COERCE]], 0
-// CHECK-NEXT:    [[CMP4_I:%.*]] = icmp eq i32 [[IDX:%.*]], 0
-// CHECK-NEXT:    [[TEMP0_0__I:%.*]] = select i1 [[CMP4_I]], <8 x i32> [[VECINS_I]], <8 x i32> [[TMP4]]
-// CHECK-NEXT:    [[TEMP1_0__I:%.*]] = select i1 [[CMP4_I]], <8 x i32> [[VECINS3_I]], <8 x i32> [[TMP3]]
-// CHECK-NEXT:    [[DOTTEMP0_0_I:%.*]] = select i1 [[CMP4_I]], <8 x i32> [[TMP2]], <8 x i32> [[VECINS_I]]
-// CHECK-NEXT:    [[DOTTEMP1_0_I:%.*]] = select i1 [[CMP4_I]], <8 x i32> [[TMP1]], <8 x i32> [[VECINS3_I]]
+// CHECK-NEXT:    [[COND_I:%.*]] = select i1 [[CMP_I]], <8 x i32> [[SHUFFLE_I_I]], <8 x i32> [[TMP4]]
+// CHECK-NEXT:    [[COND7_I:%.*]] = select i1 [[CMP_I]], <8 x i32> [[SHUFFLE1_I_I]], <8 x i32> [[TMP0]]
+// CHECK-NEXT:    [[COND13_I:%.*]] = select i1 [[CMP_I]], <8 x i32> [[TMP1]], <8 x i32> [[SHUFFLE_I_I]]
+// CHECK-NEXT:    [[COND19_I:%.*]] = select i1 [[CMP_I]], <8 x i32> [[TMP2]], <8 x i32> [[SHUFFLE1_I_I]]
 // CHECK-NEXT:    [[TMP5:%.*]] = extractvalue [[STRUCT_V256MX6]] [[S_COERCE]], 15
 // CHECK-NEXT:    [[TMP6:%.*]] = extractvalue [[STRUCT_V256MX6]] [[S_COERCE]], 14
 // CHECK-NEXT:    [[TMP7:%.*]] = extractvalue [[STRUCT_V256MX6]] [[S_COERCE]], 13
@@ -2126,10 +2102,10 @@ v256mx6 test_update (v256mx6 s, int idx, v64uint4 m) { return update(s, idx, m);
 // CHECK-NEXT:    [[TMP14:%.*]] = extractvalue [[STRUCT_V256MX6]] [[S_COERCE]], 6
 // CHECK-NEXT:    [[TMP15:%.*]] = extractvalue [[STRUCT_V256MX6]] [[S_COERCE]], 5
 // CHECK-NEXT:    [[TMP16:%.*]] = extractvalue [[STRUCT_V256MX6]] [[S_COERCE]], 4
-// CHECK-NEXT:    [[DOTFCA_0_INSERT_I:%.*]] = insertvalue [[STRUCT_V256MX6]] poison, <8 x i32> [[TEMP0_0__I]], 0
-// CHECK-NEXT:    [[DOTFCA_1_INSERT_I:%.*]] = insertvalue [[STRUCT_V256MX6]] [[DOTFCA_0_INSERT_I]], <8 x i32> [[TEMP1_0__I]], 1
-// CHECK-NEXT:    [[DOTFCA_2_INSERT_I:%.*]] = insertvalue [[STRUCT_V256MX6]] [[DOTFCA_1_INSERT_I]], <8 x i32> [[DOTTEMP0_0_I]], 2
-// CHECK-NEXT:    [[DOTFCA_3_INSERT_I:%.*]] = insertvalue [[STRUCT_V256MX6]] [[DOTFCA_2_INSERT_I]], <8 x i32> [[DOTTEMP1_0_I]], 3
+// CHECK-NEXT:    [[DOTFCA_0_INSERT_I:%.*]] = insertvalue [[STRUCT_V256MX6]] poison, <8 x i32> [[COND_I]], 0
+// CHECK-NEXT:    [[DOTFCA_1_INSERT_I:%.*]] = insertvalue [[STRUCT_V256MX6]] [[DOTFCA_0_INSERT_I]], <8 x i32> [[COND7_I]], 1
+// CHECK-NEXT:    [[DOTFCA_2_INSERT_I:%.*]] = insertvalue [[STRUCT_V256MX6]] [[DOTFCA_1_INSERT_I]], <8 x i32> [[COND13_I]], 2
+// CHECK-NEXT:    [[DOTFCA_3_INSERT_I:%.*]] = insertvalue [[STRUCT_V256MX6]] [[DOTFCA_2_INSERT_I]], <8 x i32> [[COND19_I]], 3
 // CHECK-NEXT:    [[DOTFCA_4_INSERT_I:%.*]] = insertvalue [[STRUCT_V256MX6]] [[DOTFCA_3_INSERT_I]], <2 x i32> [[TMP16]], 4
 // CHECK-NEXT:    [[DOTFCA_5_INSERT_I:%.*]] = insertvalue [[STRUCT_V256MX6]] [[DOTFCA_4_INSERT_I]], <2 x i32> [[TMP15]], 5
 // CHECK-NEXT:    [[DOTFCA_6_INSERT_I:%.*]] = insertvalue [[STRUCT_V256MX6]] [[DOTFCA_5_INSERT_I]], <2 x i32> [[TMP14]], 6
@@ -2888,22 +2864,10 @@ v64uint4 test_extract_v64uint4 (v256mx4 m, int idx) { return extract_v64uint4(m,
 // CHECK-NEXT:    [[TMP1:%.*]] = extractvalue [[STRUCT_V256MX4]] [[M_COERCE]], 0
 // CHECK-NEXT:    [[TMP2:%.*]] = extractvalue [[STRUCT_V256MX4]] [[M_COERCE]], 3
 // CHECK-NEXT:    [[TMP3:%.*]] = extractvalue [[STRUCT_V256MX4]] [[M_COERCE]], 2
-// CHECK-NEXT:    [[TEMP0_0_I:%.*]] = select i1 [[CMP_I]], <8 x i32> [[TMP1]], <8 x i32> [[TMP3]]
 // CHECK-NEXT:    [[TEMP1_0_I:%.*]] = select i1 [[CMP_I]], <8 x i32> [[TMP0]], <8 x i32> [[TMP2]]
-// CHECK-NEXT:    br label [[FOR_BODY_I:%.*]]
-// CHECK:       for.body.i:
-// CHECK-NEXT:    [[I_012_I:%.*]] = phi i32 [ 0, [[ENTRY:%.*]] ], [ [[INC_I:%.*]], [[FOR_BODY_I]] ]
-// CHECK-NEXT:    [[RES_011_I:%.*]] = phi <16 x i32> [ undef, [[ENTRY]] ], [ [[VECINS3_I:%.*]], [[FOR_BODY_I]] ]
-// CHECK-NEXT:    [[VECEXT_I:%.*]] = extractelement <8 x i32> [[TEMP0_0_I]], i32 [[I_012_I]]
-// CHECK-NEXT:    [[VECINS_I:%.*]] = insertelement <16 x i32> [[RES_011_I]], i32 [[VECEXT_I]], i32 [[I_012_I]]
-// CHECK-NEXT:    [[VECEXT2_I:%.*]] = extractelement <8 x i32> [[TEMP1_0_I]], i32 [[I_012_I]]
-// CHECK-NEXT:    [[ADD_I:%.*]] = or disjoint i32 [[I_012_I]], 8
-// CHECK-NEXT:    [[VECINS3_I]] = insertelement <16 x i32> [[VECINS_I]], i32 [[VECEXT2_I]], i32 [[ADD_I]]
-// CHECK-NEXT:    [[INC_I]] = add nuw nsw i32 [[I_012_I]], 1
-// CHECK-NEXT:    [[EXITCOND_NOT_I:%.*]] = icmp eq i32 [[INC_I]], 8
-// CHECK-NEXT:    br i1 [[EXITCOND_NOT_I]], label [[_ZL17EXTRACT_V128UINT47V256MX4I_EXIT:%.*]], label [[FOR_BODY_I]], !llvm.loop [[LOOP116:![0-9]+]]
-// CHECK:       _ZL17extract_v128uint47v256mx4i.exit:
-// CHECK-NEXT:    [[TMP4:%.*]] = bitcast <16 x i32> [[VECINS3_I]] to <64 x i8>
+// CHECK-NEXT:    [[TEMP0_0_I:%.*]] = select i1 [[CMP_I]], <8 x i32> [[TMP1]], <8 x i32> [[TMP3]]
+// CHECK-NEXT:    [[SHUFFLE_I_I_I:%.*]] = shufflevector <8 x i32> [[TEMP0_0_I]], <8 x i32> [[TEMP1_0_I]], <16 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
+// CHECK-NEXT:    [[TMP4:%.*]] = bitcast <16 x i32> [[SHUFFLE_I_I_I]] to <64 x i8>
 // CHECK-NEXT:    ret <64 x i8> [[TMP4]]
 //
 v128uint4 test_extract_v128uint4 (v256mx4 m, int idx) { return extract_v128uint4(m, idx); }
@@ -2963,30 +2927,18 @@ v128uint4 test_extract_v128uint4 (v256mx4 m, int idx) { return extract_v128uint4
 v256mx4 test_update (v256mx4 s, int idx, v64uint4 m) { return update(s, idx, m); }
 // CHECK-LABEL: @_Z11test_update7v256mx4iDv64_DU8_(
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[TMP0:%.*]] = bitcast <64 x i8> [[M:%.*]] to <16 x i32>
-// CHECK-NEXT:    br label [[FOR_BODY_I:%.*]]
-// CHECK:       for.body.i:
-// CHECK-NEXT:    [[I_017_I:%.*]] = phi i32 [ 0, [[ENTRY:%.*]] ], [ [[INC_I:%.*]], [[FOR_BODY_I]] ]
-// CHECK-NEXT:    [[TEMP1_016_I:%.*]] = phi <8 x i32> [ undef, [[ENTRY]] ], [ [[VECINS3_I:%.*]], [[FOR_BODY_I]] ]
-// CHECK-NEXT:    [[TEMP0_015_I:%.*]] = phi <8 x i32> [ undef, [[ENTRY]] ], [ [[VECINS_I:%.*]], [[FOR_BODY_I]] ]
-// CHECK-NEXT:    [[VECEXT_I:%.*]] = extractelement <16 x i32> [[TMP0]], i32 [[I_017_I]]
-// CHECK-NEXT:    [[VECINS_I]] = insertelement <8 x i32> [[TEMP0_015_I]], i32 [[VECEXT_I]], i32 [[I_017_I]]
-// CHECK-NEXT:    [[ADD_I:%.*]] = or disjoint i32 [[I_017_I]], 8
-// CHECK-NEXT:    [[VECEXT2_I:%.*]] = extractelement <16 x i32> [[TMP0]], i32 [[ADD_I]]
-// CHECK-NEXT:    [[VECINS3_I]] = insertelement <8 x i32> [[TEMP1_016_I]], i32 [[VECEXT2_I]], i32 [[I_017_I]]
-// CHECK-NEXT:    [[INC_I]] = add nuw nsw i32 [[I_017_I]], 1
-// CHECK-NEXT:    [[EXITCOND_NOT_I:%.*]] = icmp eq i32 [[INC_I]], 8
-// CHECK-NEXT:    br i1 [[EXITCOND_NOT_I]], label [[_ZL6UPDATE7V256MX4IDV64_DU8__EXIT:%.*]], label [[FOR_BODY_I]], !llvm.loop [[LOOP117:![0-9]+]]
-// CHECK:       _ZL6update7v256mx4iDv64_DU8_.exit:
-// CHECK-NEXT:    [[TMP1:%.*]] = extractvalue [[STRUCT_V256MX4:%.*]] [[S_COERCE:%.*]], 3
-// CHECK-NEXT:    [[TMP2:%.*]] = extractvalue [[STRUCT_V256MX4]] [[S_COERCE]], 2
-// CHECK-NEXT:    [[TMP3:%.*]] = extractvalue [[STRUCT_V256MX4]] [[S_COERCE]], 1
+// CHECK-NEXT:    [[TMP0:%.*]] = extractvalue [[STRUCT_V256MX4:%.*]] [[S_COERCE:%.*]], 1
+// CHECK-NEXT:    [[TMP1:%.*]] = extractvalue [[STRUCT_V256MX4]] [[S_COERCE]], 2
+// CHECK-NEXT:    [[TMP2:%.*]] = extractvalue [[STRUCT_V256MX4]] [[S_COERCE]], 3
+// CHECK-NEXT:    [[TMP3:%.*]] = bitcast <64 x i8> [[M:%.*]] to <16 x i32>
+// CHECK-NEXT:    [[SHUFFLE_I_I:%.*]] = shufflevector <16 x i32> [[TMP3]], <16 x i32> poison, <8 x i32> <i32 0, i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7>
+// CHECK-NEXT:    [[SHUFFLE1_I_I:%.*]] = shufflevector <16 x i32> [[TMP3]], <16 x i32> poison, <8 x i32> <i32 8, i32 9, i32 10, i32 11, i32 12, i32 13, i32 14, i32 15>
+// CHECK-NEXT:    [[CMP_I:%.*]] = icmp eq i32 [[IDX:%.*]], 0
 // CHECK-NEXT:    [[TMP4:%.*]] = extractvalue [[STRUCT_V256MX4]] [[S_COERCE]], 0
-// CHECK-NEXT:    [[CMP4_I:%.*]] = icmp eq i32 [[IDX:%.*]], 0
-// CHECK-NEXT:    [[TEMP0_0__I:%.*]] = select i1 [[CMP4_I]], <8 x i32> [[VECINS_I]], <8 x i32> [[TMP4]]
-// CHECK-NEXT:    [[TEMP1_0__I:%.*]] = select i1 [[CMP4_I]], <8 x i32> [[VECINS3_I]], <8 x i32> [[TMP3]]
-// CHECK-NEXT:    [[DOTTEMP0_0_I:%.*]] = select i1 [[CMP4_I]], <8 x i32> [[TMP2]], <8 x i32> [[VECINS_I]]
-// CHECK-NEXT:    [[DOTTEMP1_0_I:%.*]] = select i1 [[CMP4_I]], <8 x i32> [[TMP1]], <8 x i32> [[VECINS3_I]]
+// CHECK-NEXT:    [[COND_I:%.*]] = select i1 [[CMP_I]], <8 x i32> [[SHUFFLE_I_I]], <8 x i32> [[TMP4]]
+// CHECK-NEXT:    [[COND7_I:%.*]] = select i1 [[CMP_I]], <8 x i32> [[SHUFFLE1_I_I]], <8 x i32> [[TMP0]]
+// CHECK-NEXT:    [[COND13_I:%.*]] = select i1 [[CMP_I]], <8 x i32> [[TMP1]], <8 x i32> [[SHUFFLE_I_I]]
+// CHECK-NEXT:    [[COND19_I:%.*]] = select i1 [[CMP_I]], <8 x i32> [[TMP2]], <8 x i32> [[SHUFFLE1_I_I]]
 // CHECK-NEXT:    [[TMP5:%.*]] = extractvalue [[STRUCT_V256MX4]] [[S_COERCE]], 15
 // CHECK-NEXT:    [[TMP6:%.*]] = extractvalue [[STRUCT_V256MX4]] [[S_COERCE]], 14
 // CHECK-NEXT:    [[TMP7:%.*]] = extractvalue [[STRUCT_V256MX4]] [[S_COERCE]], 13
@@ -2999,10 +2951,10 @@ v256mx4 test_update (v256mx4 s, int idx, v64uint4 m) { return update(s, idx, m);
 // CHECK-NEXT:    [[TMP14:%.*]] = extractvalue [[STRUCT_V256MX4]] [[S_COERCE]], 6
 // CHECK-NEXT:    [[TMP15:%.*]] = extractvalue [[STRUCT_V256MX4]] [[S_COERCE]], 5
 // CHECK-NEXT:    [[TMP16:%.*]] = extractvalue [[STRUCT_V256MX4]] [[S_COERCE]], 4
-// CHECK-NEXT:    [[DOTFCA_0_INSERT_I:%.*]] = insertvalue [[STRUCT_V256MX4]] poison, <8 x i32> [[TEMP0_0__I]], 0
-// CHECK-NEXT:    [[DOTFCA_1_INSERT_I:%.*]] = insertvalue [[STRUCT_V256MX4]] [[DOTFCA_0_INSERT_I]], <8 x i32> [[TEMP1_0__I]], 1
-// CHECK-NEXT:    [[DOTFCA_2_INSERT_I:%.*]] = insertvalue [[STRUCT_V256MX4]] [[DOTFCA_1_INSERT_I]], <8 x i32> [[DOTTEMP0_0_I]], 2
-// CHECK-NEXT:    [[DOTFCA_3_INSERT_I:%.*]] = insertvalue [[STRUCT_V256MX4]] [[DOTFCA_2_INSERT_I]], <8 x i32> [[DOTTEMP1_0_I]], 3
+// CHECK-NEXT:    [[DOTFCA_0_INSERT_I:%.*]] = insertvalue [[STRUCT_V256MX4]] poison, <8 x i32> [[COND_I]], 0
+// CHECK-NEXT:    [[DOTFCA_1_INSERT_I:%.*]] = insertvalue [[STRUCT_V256MX4]] [[DOTFCA_0_INSERT_I]], <8 x i32> [[COND7_I]], 1
+// CHECK-NEXT:    [[DOTFCA_2_INSERT_I:%.*]] = insertvalue [[STRUCT_V256MX4]] [[DOTFCA_1_INSERT_I]], <8 x i32> [[COND13_I]], 2
+// CHECK-NEXT:    [[DOTFCA_3_INSERT_I:%.*]] = insertvalue [[STRUCT_V256MX4]] [[DOTFCA_2_INSERT_I]], <8 x i32> [[COND19_I]], 3
 // CHECK-NEXT:    [[DOTFCA_4_INSERT_I:%.*]] = insertvalue [[STRUCT_V256MX4]] [[DOTFCA_3_INSERT_I]], <2 x i32> [[TMP16]], 4
 // CHECK-NEXT:    [[DOTFCA_5_INSERT_I:%.*]] = insertvalue [[STRUCT_V256MX4]] [[DOTFCA_4_INSERT_I]], <2 x i32> [[TMP15]], 5
 // CHECK-NEXT:    [[DOTFCA_6_INSERT_I:%.*]] = insertvalue [[STRUCT_V256MX4]] [[DOTFCA_5_INSERT_I]], <2 x i32> [[TMP14]], 6

--- a/llvm/lib/Target/AIE/AIEBaseTargetTransformInfo.cpp
+++ b/llvm/lib/Target/AIE/AIEBaseTargetTransformInfo.cpp
@@ -185,12 +185,9 @@ void AIETTICommon::adjustUnrollingPreferences(Loop *L, ScalarEvolution &SE,
   }
 }
 
-static bool isVectorReshuffleLoop(const Loop *L);
-
 void AIETTICommon::applyLoopIdiomUnrolling(
     Loop *L, TTI::UnrollingPreferences &UP) const {
-  if (isScalarizedVectorOpIdiomLoop(L) || isScalarLoop(L) ||
-      isVectorReshuffleLoop(L)) {
+  if (isScalarizedVectorOpIdiomLoop(L) || isScalarLoop(L)) {
     UP.Threshold = LoopIdiomUnrollingThreshold;
   } else if (UnrollOnlyLoopsWithPragma && !AIELoopUtils::hasUnrollPragma(L)) {
     UP.Threshold = 0;
@@ -250,54 +247,6 @@ bool AIETTICommon::isScalarizedVectorOpIdiomLoop(const Loop *L) const {
   }
 
   return IsVectorLoopIdiom;
-}
-
-// Detects pure vector element reshuffling loops whose bodies collapse
-// entirely after full unrolling (extractelement/insertelement become
-// shufflevector, index math gets constant-folded, loop control is
-// eliminated). Any instruction not on the whitelist below disqualifies
-// the loop to avoid unrolling arithmetic-heavy bodies.
-//
-// Whitelisted instructions (potentially zero cost):
-//   - PHINode           : IV and vector accumulators
-//   - Terminator        : loop back-edge (br)
-//   - ExtractElementInst: reading source vector elements
-//   - InsertElementInst : writing destination vector elements
-//   - BinaryOperator<i> : integer index arithmetic (add, or, shl, ...)
-//   - ICmpInst          : loop exit condition
-//   - CastInst<i>       : integer index casts (zext, sext, trunc)
-//   - BitCastInst       : zero-cost type reinterpretation on any type
-static bool isVectorReshuffleLoop(const Loop *L) {
-  if (L->getNumBlocks() != 1)
-    return false;
-
-  const BasicBlock *LoopBlock = L->getHeader();
-  bool HasExtractInsertPair = false;
-
-  for (const auto &I : *LoopBlock) {
-    if (isa<PHINode>(I) || I.isTerminator())
-      continue;
-    if (isa<ExtractElementInst>(I))
-      continue;
-    if (const auto *Ins = dyn_cast<InsertElementInst>(&I)) {
-      const Value *Val = Ins->getOperand(1);
-      if (const auto *BC = dyn_cast<BitCastInst>(Val))
-        Val = BC->getOperand(0);
-      HasExtractInsertPair |= isa<ExtractElementInst>(Val);
-      continue;
-    }
-    if (isa<BinaryOperator>(I) && I.getType()->isIntegerTy())
-      continue;
-    if (isa<ICmpInst>(I))
-      continue;
-    if (isa<BitCastInst>(I))
-      continue;
-    if (isa<CastInst>(I) && I.getType()->isIntegerTy())
-      continue;
-    return false;
-  }
-
-  return HasExtractInsertPair;
 }
 
 bool AIETTICommon::isScalarLoop(const Loop *L) {


### PR DESCRIPTION
Revert Loop Unrolling whitelist in favor of removing the loops in the aie2ps headers.