### PR TITLE
[AIEX] Fix RegionEndEdges DAG mutator to lower hwloop setup latency and padd the setup instruction instead 

### DIFF
--- a/llvm/lib/Target/AIE/AIEBaseInstrInfo.cpp
+++ b/llvm/lib/Target/AIE/AIEBaseInstrInfo.cpp
@@ -431,8 +431,12 @@ AIEBaseInstrInfo::getPostZOLRegionSizeInfo(MachineBasicBlock &MBB) const {
     if (MI.isDebugInstr())
       continue;
 
-    if (isZOLSetupBundle(&MI) && isLastZOLSetupBundleInMBB(&MI))
+    // We iterate backwards so this is the last setup bundle in the block.
+    if (isZOLSetupBundle(&MI)) {
+      BundleCount++;
+      Size += getAIEMachineBundleSize(MI);
       break;
+    }
 
     if (MI.isBundle())
       BundleCount++;
@@ -1403,6 +1407,13 @@ AIEBaseInstrInfo::getAlignmentBoundaries(MachineBasicBlock &MBB) const {
           const int NeededPadding =
               LoopSetupSizeInBytes - LoopSize - PostZOLSize;
           LoopPaddingInBytes = std::min(AvailablePaddingSpace, NeededPadding);
+          // Align the last setup bundle. Given the minimum LoopSetupDistance
+          // number of bundles afterwards, sufficient padding is guaranteed.
+          if (LoopPaddingInBytes > 0) {
+            AlignmentBoundaries.emplace_back(MI);
+            const int BundleSize = getAIEMachineBundleSize(MI);
+            LoopPaddingInBytes -= (MBBAlignment - BundleSize);
+          }
         }
       }
     } else if (isHardwareLoopEnd(MI->getOpcode())) {

--- a/llvm/lib/Target/AIE/AIEBaseSubtarget.cpp
+++ b/llvm/lib/Target/AIE/AIEBaseSubtarget.cpp
@@ -312,8 +312,8 @@ class RegionEndEdges : public ScheduleDAGMutation {
           ZOLBundlesCount = TII->getZOLBundlesCount(*LoopSucc) - 1;
         }
         if (ZOLBundlesCount < ZOLSupport->LoopSetupDistance)
-          EdgeLatency = std::max(EdgeLatency, ZOLSupport->LoopSetupDistance +
-                                                  1 - ZOLBundlesCount);
+          EdgeLatency = std::max(EdgeLatency, ZOLSupport->LoopSetupDistance -
+                                                  ZOLBundlesCount);
       }
       ExitDep.setLatency(EdgeLatency);
       DAG->ExitSU.addPred(ExitDep, /*Required=*/true);

--- a/llvm/lib/Target/AIE/AIEMachineAlignment.cpp
+++ b/llvm/lib/Target/AIE/AIEMachineAlignment.cpp
@@ -282,8 +282,6 @@ void verifyDistanceToLoopEnd(MachineFunction &MF) {
       continue;
 
     auto LastInstr = MBB.getLastNonDebugInstr();
-    if (LastInstr == MBB.end())
-      continue;
     unsigned BytesToLoopEndStart = 0;
     for (auto MI = MBB.begin(); MI != LastInstr; ++MI)
       BytesToLoopEndStart += TII.getAIEMachineBundleSize(MI);
@@ -330,7 +328,7 @@ void verifyDistanceToLoopEnd(MachineFunction &MF) {
         }
         if (!HasLoopAsSuccessor)
           continue;
-        unsigned BytesToLastJumpStart = 0;
+        unsigned BytesToClosestJumpStart = 0;
         bool FoundJump = false;
         unsigned CurrentOffset = 0;
         for (auto MI = OtherMBB.begin(), E = OtherMBB.end(); MI != E; ++MI) {
@@ -338,13 +336,13 @@ void verifyDistanceToLoopEnd(MachineFunction &MF) {
             unsigned JumpPC = MBBStartOffset[&OtherMBB] + CurrentOffset;
             if (JumpPC < LoopEndPC) {
               FoundJump = true;
-              BytesToLastJumpStart = CurrentOffset;
+              BytesToClosestJumpStart = CurrentOffset;
             }
           }
           CurrentOffset += TII.getAIEMachineBundleSize(MI);
         }
         if (FoundJump) {
-          unsigned JumpPC = MBBStartOffset[&OtherMBB] + BytesToLastJumpStart;
+          unsigned JumpPC = MBBStartOffset[&OtherMBB] + BytesToClosestJumpStart;
           unsigned JumpToLoopEndDist = LoopEndPC - JumpPC;
           LLVM_DEBUG(dbgs() << "jump-to-loopend distance (ZOL body MBB "
                             << MBB.getNumber() << ", jump in MBB "

--- a/llvm/test/CodeGen/AIE/aie2/elongate/elongate_loopstart.mir
+++ b/llvm/test/CodeGen/AIE/aie2/elongate/elongate_loopstart.mir
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2024-2026 Advanced Micro Devices, Inc. or its affiliates
 # RUN: llc -mtriple aie2 -run-pass=postmisched %topdown-multi %s -verify-machineinstrs -o - | FileCheck %s
 # The test is adding scheduler margin of 7-cycles afer the start block
 
@@ -22,7 +22,6 @@ body:             |
     ; CHECK-NEXT: $ls = MOVXM_lng_cg 0
     ; CHECK-NEXT: $le = MOVXM_lng_cg <mcsymbol .L_1120>
     ; CHECK-NEXT: renamable $r3 = MOV_mv_cg 2
-    ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP

--- a/llvm/test/CodeGen/AIE/aie2/elongate/elongate_loopstart_schedule.mir
+++ b/llvm/test/CodeGen/AIE/aie2/elongate/elongate_loopstart_schedule.mir
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2024-2026 Advanced Micro Devices, Inc. or its affiliates
 # RUN: llc -mtriple aie2 -run-pass=postmisched %topdown-multi %s -verify-machineinstrs -o - | FileCheck %s
 # The test is adding scheduler margin of 7-cycles afer the start block
 
@@ -28,7 +28,6 @@ body:             |
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: renamable $r1 = nsw ADD killed renamable $r2, killed renamable $r1, implicit-def $srcarry
-    ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
       renamable $r1 = LDA_dms_lda_idx_imm renamable $p0, 0
       $le = MOVXM_lng_cg <mcsymbol .L_1120>

--- a/llvm/test/CodeGen/AIE/aie2/elongate/zol_112bytes_elongate.mir
+++ b/llvm/test/CodeGen/AIE/aie2/elongate/zol_112bytes_elongate.mir
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2024-2026 Advanced Micro Devices, Inc. or its affiliates
 
 # RUN: llc -mtriple aie2 -run-pass=aie-machine-alignment %s -verify-machineinstrs -o - | FileCheck %s
 ---
@@ -14,19 +14,19 @@ body:             |
 
     ; CHECK-LABEL: name: zol_112bytes_constraint
     ; CHECK: BUNDLE implicit-def $r1, implicit-def $r2, implicit-def $lc, implicit $p0, implicit $r0 {
-    ; CHECK-NEXT:   NOPB
     ; CHECK-NEXT:   renamable $r1 = LDA_dms_lda_idx_imm renamable $p0, 0
-    ; CHECK-NEXT:   NOPS
     ; CHECK-NEXT:   renamable $r2 = MOVX_alu_cg 0
     ; CHECK-NEXT:   $lc = MOV_mv_scl $r0
-    ; CHECK-NEXT:   NOPV
     ; CHECK-NEXT: }
     ; CHECK-NEXT: BUNDLE implicit-def $ls {
-    ; CHECK-NEXT:   NOPA
     ; CHECK-NEXT:   $ls = MOVXM_lng_cg 0
     ; CHECK-NEXT: }
     ; CHECK-NEXT: BUNDLE implicit-def $le {
+    ; CHECK-NEXT:   NOPB
+    ; CHECK-NEXT:   NOPA
+    ; CHECK-NEXT:   NOPS
     ; CHECK-NEXT:   $le = MOVXM_lng_cg <mcsymbol .L_1120>
+    ; CHECK-NEXT:   NOPV
     ; CHECK-NEXT: }
     ; CHECK-NEXT: BUNDLE implicit-def $r3 {
     ; CHECK-NEXT:   NOPB
@@ -65,18 +65,13 @@ body:             |
     ; CHECK-NEXT:   NOPV
     ; CHECK-NEXT: }
     ; CHECK-NEXT: BUNDLE {
-    ; CHECK-NEXT:   NOPB
     ; CHECK-NEXT:   NOPA
-    ; CHECK-NEXT:   NOPS
+    ; CHECK-NEXT:   NOPB
     ; CHECK-NEXT:   NOPXM
-    ; CHECK-NEXT:   NOPV
+    ; CHECK-NEXT:   NOPS
     ; CHECK-NEXT: }
     ; CHECK-NEXT: BUNDLE {
-    ; CHECK-NEXT:   NOPB
-    ; CHECK-NEXT:   NOPA
-    ; CHECK-NEXT:   NOPS
-    ; CHECK-NEXT:   NOPXM
-    ; CHECK-NEXT:   NOPV
+    ; CHECK-NEXT:   NOP
     ; CHECK-NEXT: }
     BUNDLE implicit-def $r1, implicit-def $r2, implicit-def $lc, implicit $p0, implicit $r0 {
       renamable $r1 = LDA_dms_lda_idx_imm renamable $p0, 0

--- a/llvm/test/CodeGen/AIE/aie2/elongate/zol_112bytes_elongate1.mir
+++ b/llvm/test/CodeGen/AIE/aie2/elongate/zol_112bytes_elongate1.mir
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2024-2026 Advanced Micro Devices, Inc. or its affiliates
 
 # RUN: llc -mtriple aie2 -run-pass=aie-machine-alignment %s -verify-machineinstrs -o - | FileCheck %s
 
@@ -15,13 +15,15 @@ body:             |
 
     ; CHECK-LABEL: name: LoopStartBlock_Different_Insns_Order
     ; CHECK: BUNDLE implicit-def $r1, implicit-def $r2, implicit-def $lc, implicit $p0, implicit $r0 {
-    ; CHECK-NEXT:   renamable $r1 = LDA_dms_lda_idx_imm renamable $p0, 0
     ; CHECK-NEXT:   NOPB
+    ; CHECK-NEXT:   renamable $r1 = LDA_dms_lda_idx_imm renamable $p0, 0
+    ; CHECK-NEXT:   NOPS
     ; CHECK-NEXT:   renamable $r2 = MOVX_alu_cg 0
     ; CHECK-NEXT:   $lc = MOV_mv_scl $r0
-    ; CHECK-NEXT:   NOPS
+    ; CHECK-NEXT:   NOPV
     ; CHECK-NEXT: }
     ; CHECK-NEXT: BUNDLE implicit-def $r3 {
+    ; CHECK-NEXT:   NOPX
     ; CHECK-NEXT:   renamable $r3 = MOV_mv_cg 2
     ; CHECK-NEXT: }
     ; CHECK-NEXT: BUNDLE implicit-def $le {
@@ -31,13 +33,10 @@ body:             |
     ; CHECK-NEXT:   NOP
     ; CHECK-NEXT: }
     ; CHECK-NEXT: BUNDLE implicit-def $ls {
+    ; CHECK-NEXT:   NOPB
+    ; CHECK-NEXT:   NOPA
+    ; CHECK-NEXT:   NOPS
     ; CHECK-NEXT:   $ls = MOVXM_lng_cg 0
-    ; CHECK-NEXT: }
-    ; CHECK-NEXT: BUNDLE {
-    ; CHECK-NEXT:   NOPB
-    ; CHECK-NEXT:   NOPA
-    ; CHECK-NEXT:   NOPS
-    ; CHECK-NEXT:   NOPXM
     ; CHECK-NEXT:   NOPV
     ; CHECK-NEXT: }
     ; CHECK-NEXT: BUNDLE {
@@ -76,11 +75,13 @@ body:             |
     ; CHECK-NEXT:   NOPV
     ; CHECK-NEXT: }
     ; CHECK-NEXT: BUNDLE {
-    ; CHECK-NEXT:   NOPB
     ; CHECK-NEXT:   NOPA
-    ; CHECK-NEXT:   NOPS
+    ; CHECK-NEXT:   NOPB
     ; CHECK-NEXT:   NOPXM
-    ; CHECK-NEXT:   NOPV
+    ; CHECK-NEXT:   NOPS
+    ; CHECK-NEXT: }
+    ; CHECK-NEXT: BUNDLE {
+    ; CHECK-NEXT:   NOP
     ; CHECK-NEXT: }
     BUNDLE implicit-def $r1, implicit-def $r2, implicit-def $lc, implicit $p0, implicit $r0 {
       renamable $r1 = LDA_dms_lda_idx_imm renamable $p0, 0

--- a/llvm/test/CodeGen/AIE/aie2/elongate/zol_112bytes_elongate2.mir
+++ b/llvm/test/CodeGen/AIE/aie2/elongate/zol_112bytes_elongate2.mir
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2024-2025 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2024-2026 Advanced Micro Devices, Inc. or its affiliates
 
 # RUN: llc -mtriple aie2 -run-pass=aie-machine-alignment %s -verify-machineinstrs -o - | FileCheck %s
 
@@ -17,8 +17,11 @@ body:             |
   ; CHECK-NEXT:   successors: %bb.1(0x80000000)
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   BUNDLE implicit-def $le {
+  ; CHECK-NEXT:     NOPB
   ; CHECK-NEXT:     NOPA
+  ; CHECK-NEXT:     NOPS
   ; CHECK-NEXT:     $le = MOVXM_lng_cg <mcsymbol .L_1120>
+  ; CHECK-NEXT:     NOPV
   ; CHECK-NEXT:   }
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT: bb.1 (align 16):
@@ -37,13 +40,10 @@ body:             |
   ; CHECK-NEXT:     NOP
   ; CHECK-NEXT:   }
   ; CHECK-NEXT:   BUNDLE implicit-def $ls {
+  ; CHECK-NEXT:     NOPB
+  ; CHECK-NEXT:     NOPA
+  ; CHECK-NEXT:     NOPS
   ; CHECK-NEXT:     $ls = MOVXM_lng_cg %bb.1
-  ; CHECK-NEXT:   }
-  ; CHECK-NEXT:   BUNDLE {
-  ; CHECK-NEXT:     NOPB
-  ; CHECK-NEXT:     NOPA
-  ; CHECK-NEXT:     NOPS
-  ; CHECK-NEXT:     NOPXM
   ; CHECK-NEXT:     NOPV
   ; CHECK-NEXT:   }
   ; CHECK-NEXT:   BUNDLE {
@@ -78,7 +78,9 @@ body:             |
   ; CHECK-NEXT:     NOPA
   ; CHECK-NEXT:     NOPB
   ; CHECK-NEXT:     NOPXM
-  ; CHECK-NEXT:     NOPS
+  ; CHECK-NEXT:   }
+  ; CHECK-NEXT:   BUNDLE {
+  ; CHECK-NEXT:     NOP
   ; CHECK-NEXT:   }
   ; CHECK-NEXT:   BUNDLE {
   ; CHECK-NEXT:     NOP

--- a/llvm/test/CodeGen/AIE/aie2/elongate/zol_elongate2.mir
+++ b/llvm/test/CodeGen/AIE/aie2/elongate/zol_elongate2.mir
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2023-2025 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2023-2026 Advanced Micro Devices, Inc. or its affiliates
 
 # RUN: llc -mtriple aie2 -run-pass=aie-machine-alignment %s -verify-machineinstrs -o - | FileCheck %s
 --- |
@@ -549,14 +549,11 @@ body:             |
   ; CHECK-NEXT:   liveins: $p0, $p1, $r1, $r2, $r3, $r4, $r7
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   BUNDLE implicit $r3 {
-  ; CHECK-NEXT:     NOPB
-  ; CHECK-NEXT:     NOPA
-  ; CHECK-NEXT:     NOPS
+  ; CHECK-NEXT:     NOP
   ; CHECK-NEXT:     JZ renamable $r3, %bb.8
-  ; CHECK-NEXT:     NOPV
   ; CHECK-NEXT:   }
   ; CHECK-NEXT:   BUNDLE {
-  ; CHECK-NEXT:     NOPX
+  ; CHECK-NEXT:     NOP
   ; CHECK-NEXT:   }
   ; CHECK-NEXT:   BUNDLE {
   ; CHECK-NEXT:     NOP
@@ -586,13 +583,10 @@ body:             |
   ; CHECK-NEXT:     $ls = MOVXM_lng_cg %bb.7
   ; CHECK-NEXT:   }
   ; CHECK-NEXT:   BUNDLE {
+  ; CHECK-NEXT:     NOPB
+  ; CHECK-NEXT:     NOPA
+  ; CHECK-NEXT:     NOPS
   ; CHECK-NEXT:     $le = MOVXM_lng_cg <mcsymbol .L_1120>
-  ; CHECK-NEXT:   }
-  ; CHECK-NEXT:   BUNDLE {
-  ; CHECK-NEXT:     NOPB
-  ; CHECK-NEXT:     NOPA
-  ; CHECK-NEXT:     NOPS
-  ; CHECK-NEXT:     NOPXM
   ; CHECK-NEXT:     NOPV
   ; CHECK-NEXT:   }
   ; CHECK-NEXT:   BUNDLE {
@@ -618,8 +612,10 @@ body:             |
   ; CHECK-NEXT:   }
   ; CHECK-NEXT:   BUNDLE {
   ; CHECK-NEXT:     NOPA
-  ; CHECK-NEXT:     NOPB
   ; CHECK-NEXT:     NOPXM
+  ; CHECK-NEXT:   }
+  ; CHECK-NEXT:   BUNDLE {
+  ; CHECK-NEXT:     NOP
   ; CHECK-NEXT:   }
   ; CHECK-NEXT:   BUNDLE {
   ; CHECK-NEXT:     NOP

--- a/llvm/test/CodeGen/AIE/aie2/elongate/zol_elongate3.mir
+++ b/llvm/test/CodeGen/AIE/aie2/elongate/zol_elongate3.mir
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2023-2024 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2023-2026 Advanced Micro Devices, Inc. or its affiliates
 
 # RUN: llc -mtriple aie2 -run-pass=aie-machine-alignment %s -verify-machineinstrs -o - | FileCheck %s
 --- |
@@ -48,19 +48,18 @@ body:             |
   ; CHECK-NEXT:   liveins: $r0
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   BUNDLE {
+  ; CHECK-NEXT:     NOPA
+  ; CHECK-NEXT:     NOPX
   ; CHECK-NEXT:     $lc = MOV_mv_scl $r0
   ; CHECK-NEXT:   }
   ; CHECK-NEXT:   BUNDLE {
   ; CHECK-NEXT:     $ls = MOVXM_lng_cg %bb.1
   ; CHECK-NEXT:   }
   ; CHECK-NEXT:   BUNDLE {
+  ; CHECK-NEXT:     NOPB
+  ; CHECK-NEXT:     NOPA
+  ; CHECK-NEXT:     NOPS
   ; CHECK-NEXT:     $le = MOVXM_lng_cg <mcsymbol .L_1120>
-  ; CHECK-NEXT:   }
-  ; CHECK-NEXT:   BUNDLE {
-  ; CHECK-NEXT:     NOPB
-  ; CHECK-NEXT:     NOPA
-  ; CHECK-NEXT:     NOPS
-  ; CHECK-NEXT:     NOPXM
   ; CHECK-NEXT:     NOPV
   ; CHECK-NEXT:   }
   ; CHECK-NEXT:   BUNDLE {
@@ -99,11 +98,13 @@ body:             |
   ; CHECK-NEXT:     NOPV
   ; CHECK-NEXT:   }
   ; CHECK-NEXT:   BUNDLE {
-  ; CHECK-NEXT:     NOPB
   ; CHECK-NEXT:     NOPA
-  ; CHECK-NEXT:     NOPS
+  ; CHECK-NEXT:     NOPB
   ; CHECK-NEXT:     NOPXM
-  ; CHECK-NEXT:     NOPV
+  ; CHECK-NEXT:     NOPS
+  ; CHECK-NEXT:   }
+  ; CHECK-NEXT:   BUNDLE {
+  ; CHECK-NEXT:     NOP
   ; CHECK-NEXT:   }
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT: bb.1.for.body (align 16):

--- a/llvm/test/CodeGen/AIE/aie2/end-to-end/Add2D-red.ll
+++ b/llvm/test/CodeGen/AIE/aie2/end-to-end/Add2D-red.ll
@@ -77,7 +77,7 @@ define void @add2d(ptr noalias %params, ptr noalias %ifm1_data, ptr noalias %ifm
 ; ASM-NEXT:    mova r1, #0 // Delay Slot 1
 ; ASM-NEXT:  .LBB0_2: // %entry.new
 ; ASM-NEXT:    nopb ; vlda.ups.s32.d8 cm0, s1, [p1], m1; nops ; nopx ; mov dc0, #0; nopv
-; ASM-NEXT:    vlda.ups.s32.d8 cm2, s1, [p1], m1; mov dc4, dc0
+; ASM-NEXT:    vlda.ups.s32.d8 cm2, s1, [p1], m1; nopx ; mov dc4, dc0
 ; ASM-NEXT:    vlda.3d.ups.s32.d8 cm8, s1, [p2], d0
 ; ASM-NEXT:    vlda.ups.s32.d8 cm3, s1, [p1], m1
 ; ASM-NEXT:    vlda.3d.ups.s32.d8 cm6, s1, [p2], d0; mov crUPSSign, r4
@@ -89,15 +89,15 @@ define void @add2d(ptr noalias %params, ptr noalias %ifm1_data, ptr noalias %ifm
 ; ASM-NEXT:    mova r2, #-2; add r0, r0, #-4
 ; ASM-NEXT:    lshl r0, r0, r2; mov crSRSSign, r6
 ; ASM-NEXT:    add r0, r0, #1; mov s0, r5
-; ASM-NEXT:    add.nc lc, r0, #-1
+; ASM-NEXT:    nopb ; nopa ; nops ; nopx ; add.nc lc, r0, #-1; nopv
 ; ASM-NEXT:  .LBB0_3: // %for.body
 ; ASM-NEXT:    // =>This Inner Loop Header: Depth=1
 ; ASM-NEXT:    nopb ; nopa ; nops ; nopxm ; vadd cm0, cm8, cm0, r1
 ; ASM-NEXT:    nopb ; nopa ; nops ; nopxm ; nopv
 ; ASM-NEXT:    nopb ; vlda.3d.ups.s32.d8 cm8, s1, [p2], d0; nops ; nopxm ; vadd cm2, cm6, cm2, r1
-; ASM-NEXT:    nopb ; vlda.3d.ups.s32.d8 cm6, s1, [p2], d0; nops ; nopxm ; nopv
-; ASM-NEXT:    nopb ; vlda.ups.s32.d8 cm0, s1, [p1], m1; nops ; nopxm ; vadd cm3, cm5, cm3, r1
-; ASM-NEXT:    vlda.3d.ups.s32.d8 cm5, s1, [p2], d0; vst.srs.d8.s32 cm0, s0, [p3], #32; nopx ; vadd cm7, cm1, cm4, r1
+; ASM-NEXT:    vlda.3d.ups.s32.d8 cm6, s1, [p2], d0; nopxm
+; ASM-NEXT:    vlda.ups.s32.d8 cm0, s1, [p1], m1; vadd cm3, cm5, cm3, r1
+; ASM-NEXT:    vlda.3d.ups.s32.d8 cm5, s1, [p2], d0; vst.srs.d8.s32 cm0, s0, [p3], #32; vadd cm7, cm1, cm4, r1
 ; ASM-NEXT:    vlda.ups.s32.d8 cm2, s1, [p1], m1
 ; ASM-NEXT:    vlda.3d.ups.s32.d8 cm1, s1, [p2], d0
 ; ASM-NEXT:    vlda.ups.s32.d8 cm3, s1, [p1], m1; vst.srs.d8.s32 cm2, s0, [p3], #32

--- a/llvm/test/CodeGen/AIE/aie2/end-to-end/Conv2D-red-swp.ll
+++ b/llvm/test/CodeGen/AIE/aie2/end-to-end/Conv2D-red-swp.ll
@@ -216,7 +216,7 @@ define dso_local void @conv2d.loop.nest(ptr %add.ptr6.i51, ptr %add.ptr5, ptr %c
 ; ZOL-NEXT:  .LBB0_1: // %outer.loop.header
 ; ZOL-NEXT:    // =>This Loop Header: Depth=1
 ; ZOL-NEXT:    // Child Loop BB0_2 Depth 2
-; ZOL-NEXT:    vlda.ups.s32.s16 bmh0, s0, [p2, #32]; nopb ; nopxm ; nops
+; ZOL-NEXT:    vlda.ups.s32.s16 bmh0, s0, [p2, #32]; nopx
 ; ZOL-NEXT:    vlda.ups.s32.s16 bml0, s0, [p2], m5
 ; ZOL-NEXT:    vlda.ups.s32.s16 bmh1, s0, [p2, #32]; mov m7, p5
 ; ZOL-NEXT:    vlda.ups.s32.s16 bml1, s0, [p2], m7
@@ -239,15 +239,15 @@ define dso_local void @conv2d.loop.nest(ptr %add.ptr6.i51, ptr %add.ptr5, ptr %c
 ; ZOL-NEXT:    vldb wh1, [p1], #32; add r0, r1, #33; mov r1, p0
 ; ZOL-NEXT:    vldb wl10, [p1], #32; vshuffle x7, x4, x2, r2
 ; ZOL-NEXT:    vldb wh10, [p1], #32; vshuffle x9, x7, x0, r8
-; ZOL-NEXT:    and r1, r1, r9; add.nc lc, r5, #-2
+; ZOL-NEXT:    nopb ; nopa ; nops ; and r1, r1, r9; add.nc lc, r5, #-2; nopv
 ; ZOL-NEXT:  .LBB0_2: // %inner.loop
 ; ZOL-NEXT:    // Parent Loop BB0_1 Depth=1
 ; ZOL-NEXT:    // => This Inner Loop Header: Depth=2
 ; ZOL-NEXT:    nopb ; nopa ; nops ; nopx ; vshuffle x9, x4, x2, r3; vmac cm1, cm1, x9, x6, r4
 ; ZOL-NEXT:    vldb wl5, [p0], m6; nopa ; nops ; nopx ; vshift.align x4, x4, s1, x5, r0; vmac cm7, cm7, x9, x8, r4
-; ZOL-NEXT:    vldb wh5, [p0], m6; nopa ; nops ; nopx ; vshift.align x2, x2, s1, x3, r0; nopv
-; ZOL-NEXT:    nopb ; vlda wl3, [p0], m6; nops ; nopx ; vshuffle x11, x9, x0, r8; vmac cm0, cm0, x7, x6, r4
-; ZOL-NEXT:    nopb ; vlda.3d wh3, [p0], d0; nops ; nopx ; vshuffle x7, x4, x2, r2; vmac cm4, cm4, x7, x8, r4
+; ZOL-NEXT:    nopa ; vldb wh5, [p0], m6; nopx ; vshift.align x2, x2, s1, x3, r0
+; ZOL-NEXT:    vlda wl3, [p0], m6; vshuffle x11, x9, x0, r8; vmac cm0, cm0, x7, x6, r4
+; ZOL-NEXT:    vlda.3d wh3, [p0], d0; vshuffle x7, x4, x2, r2; vmac cm4, cm4, x7, x8, r4
 ; ZOL-NEXT:    vldb wl1, [p1], #32; vshuffle x9, x7, x0, r8; vmac cm2, cm2, x9, x6, r4
 ; ZOL-NEXT:    vldb wh1, [p1], #32; vmov x6, x1; vmac cm5, cm5, x9, x8, r4
 ; ZOL-NEXT:    vldb wl10, [p1], #32; add r0, r1, #33; mov r1, p0; vmac cm3, cm3, x11, x6, r4

--- a/llvm/test/CodeGen/AIE/aie2/end-to-end/Conv2D-red.ll
+++ b/llvm/test/CodeGen/AIE/aie2/end-to-end/Conv2D-red.ll
@@ -73,7 +73,7 @@ define dso_local void @conv2d.loop.nest(ptr %add.ptr6.i51, ptr %add.ptr5, ptr %c
 ; ASM-NEXT:  .LBB0_1: // %outer.loop.header
 ; ASM-NEXT:    // =>This Loop Header: Depth=1
 ; ASM-NEXT:    // Child Loop BB0_2 Depth 2
-; ASM-NEXT:    vlda.ups.s32.s16 bmh7, s0, [p2, #32]; nopxm
+; ASM-NEXT:    vlda.ups.s32.s16 bmh7, s0, [p2, #32]
 ; ASM-NEXT:    vlda.ups.s32.s16 bml7, s0, [p2], m7
 ; ASM-NEXT:    vlda.ups.s32.s16 bmh6, s0, [p2, #32]; mov m2, p5
 ; ASM-NEXT:    vlda.ups.s32.s16 bml6, s0, [p2], m2
@@ -88,12 +88,12 @@ define dso_local void @conv2d.loop.nest(ptr %add.ptr6.i51, ptr %add.ptr5, ptr %c
 ; ASM-NEXT:    vlda.ups.s32.s16 bmh1, s0, [p2, #32]; movxm ls, #.LBB0_2
 ; ASM-NEXT:    vlda.ups.s32.s16 bml1, s0, [p2], m7; movxm le, #.L_LEnd0
 ; ASM-NEXT:    vlda.ups.s32.s16 bmh0, s0, [p2, #32]; and r0, r0, r9
-; ASM-NEXT:    vlda.ups.s32.s16 bml0, s0, [p2, #0]; add r0, r0, #33; add.nc lc, r5, #0
+; ASM-NEXT:    nopb ; vlda.ups.s32.s16 bml0, s0, [p2, #0]; nops ; add r0, r0, #33; add.nc lc, r5, #0; nopv
 ; ASM-NEXT:  .LBB0_2: // %inner.loop
 ; ASM-NEXT:    // Parent Loop BB0_1 Depth=1
 ; ASM-NEXT:    // => This Inner Loop Header: Depth=2
-; ASM-NEXT:    vldb wl10, [p0], m6; nopa ; nops ; nopxm ; nopv
-; ASM-NEXT:    vldb wh10, [p0], m6; nopxm
+; ASM-NEXT:    vldb wl10, [p0], m6; nopx
+; ASM-NEXT:    vldb wh10, [p0], m6
 ; ASM-NEXT:    vldb wl8, [p0], m6
 ; ASM-NEXT:    vldb.3d wh8, [p0], d0
 ; ASM-NEXT:    nop

--- a/llvm/test/CodeGen/AIE/aie2/hardware-loops/noduplication.mir
+++ b/llvm/test/CodeGen/AIE/aie2/hardware-loops/noduplication.mir
@@ -126,9 +126,6 @@ body:             |
   ; CHECK-NEXT:   BUNDLE {
   ; CHECK-NEXT:     NOP
   ; CHECK-NEXT:   }
-  ; CHECK-NEXT:   BUNDLE {
-  ; CHECK-NEXT:     NOP
-  ; CHECK-NEXT:   }
   ; CHECK-NEXT:   BUNDLE implicit-def $r0 {
   ; CHECK-NEXT:     renamable $r0 = MOVA_lda_cg 0
   ; CHECK-NEXT:   }

--- a/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/add-store-notc.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/add-store-notc.mir
@@ -3,7 +3,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2024-2026 Advanced Micro Devices, Inc. or its affiliates
 
 # RUN: llc --mtriple=aie2 -O2 --start-before=postmisched %s -o - | FileCheck %s
 
@@ -15,8 +15,8 @@
   ; CHECK-LABEL: addStore:
   ; CHECK:         .p2align 4
   ; CHECK-NEXT:  // %bb.0: // %entry
-  ; CHECK-NEXT:    mova r1, #0; nopb ; nopxm
-  ; CHECK-NEXT:    ge r1, r1, r0
+  ; CHECK-NEXT:    nopb ; mova r1, #0; nops ; nopxm ; nopv
+  ; CHECK-NEXT:    nopa ; ge r1, r1, r0
   ; CHECK-NEXT:    jnz r1, #.LBB0_3
   ; CHECK-NEXT:    nop // Delay Slot 5
   ; CHECK-NEXT:    nop // Delay Slot 4
@@ -26,8 +26,7 @@
   ; CHECK-NEXT:  // %bb.1: // %for.body.preheader
   ; CHECK-NEXT:    add.nc lc, r0, #0
   ; CHECK-NEXT:    movxm ls, #.LBB0_2
-  ; CHECK-NEXT:    movxm le, #.L_LEnd0
-  ; CHECK-NEXT:    nopb ; nopa ; nops ; nopxm ; nopv
+  ; CHECK-NEXT:    nopb ; nopa ; nops ; movxm le, #.L_LEnd0; nopv
   ; CHECK-NEXT:    nopb ; nopa ; nops ; nopxm ; nopv
   ; CHECK-NEXT:    nopb ; nopa ; nops ; nopxm ; nopv
   ; CHECK-NEXT:    nopb ; nopa ; nops ; nopxm ; nopv

--- a/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/add-store-tc1.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/add-store-tc1.mir
@@ -3,7 +3,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2024-2026 Advanced Micro Devices, Inc. or its affiliates
 
 # RUN: llc --mtriple=aie2 -O2 --start-before=postmisched %s -o - | FileCheck %s
 
@@ -15,8 +15,8 @@
   ; CHECK-LABEL: addStore:
   ; CHECK:         .p2align 4
   ; CHECK-NEXT:  // %bb.0: // %entry
-  ; CHECK-NEXT:    mova r1, #0; nopb ; nopxm
-  ; CHECK-NEXT:    ge r1, r1, r0
+  ; CHECK-NEXT:    nopb ; mova r1, #0; nops ; nopxm ; nopv
+  ; CHECK-NEXT:    nopa ; ge r1, r1, r0
   ; CHECK-NEXT:    jnz r1, #.LBB0_3
   ; CHECK-NEXT:    nop // Delay Slot 5
   ; CHECK-NEXT:    nop // Delay Slot 4
@@ -26,8 +26,7 @@
   ; CHECK-NEXT:  // %bb.1: // %for.body.preheader
   ; CHECK-NEXT:    add.nc lc, r0, #0
   ; CHECK-NEXT:    movxm ls, #.LBB0_2
-  ; CHECK-NEXT:    movxm le, #.L_LEnd0
-  ; CHECK-NEXT:    nopb ; nopa ; nops ; nopxm ; nopv
+  ; CHECK-NEXT:    nopb ; nopa ; nops ; movxm le, #.L_LEnd0; nopv
   ; CHECK-NEXT:    nopb ; nopa ; nops ; nopxm ; nopv
   ; CHECK-NEXT:    nopb ; nopa ; nops ; nopxm ; nopv
   ; CHECK-NEXT:    nopb ; nopa ; nops ; nopxm ; nopv

--- a/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/add-store-updated.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/add-store-updated.mir
@@ -3,7 +3,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2024-2026 Advanced Micro Devices, Inc. or its affiliates
 
 # RUN: llc --mtriple=aie2 -O2 --start-before=postmisched %s -o - | FileCheck %s
 
@@ -16,8 +16,8 @@
   ; CHECK-LABEL: addStore:
   ; CHECK:         .p2align 4
   ; CHECK-NEXT:  // %bb.0: // %entry
-  ; CHECK-NEXT:    mova r1, #0; nopb ; nopxm
-  ; CHECK-NEXT:    ge r1, r1, r0
+  ; CHECK-NEXT:    nopb ; mova r1, #0; nops ; nopxm ; nopv
+  ; CHECK-NEXT:    nopa ; ge r1, r1, r0
   ; CHECK-NEXT:    jnz r1, #.LBB0_3
   ; CHECK-NEXT:    nop // Delay Slot 5
   ; CHECK-NEXT:    nop // Delay Slot 4
@@ -27,8 +27,7 @@
   ; CHECK-NEXT:  // %bb.1: // %for.body.preheader
   ; CHECK-NEXT:    add.nc lc, r0, #-1
   ; CHECK-NEXT:    movxm ls, #.LBB0_2
-  ; CHECK-NEXT:    movxm le, #.L_LEnd0
-  ; CHECK-NEXT:    nopb ; nopa ; nops ; nopxm ; nopv
+  ; CHECK-NEXT:    nopb ; nopa ; nops ; movxm le, #.L_LEnd0; nopv
   ; CHECK-NEXT:    nopb ; nopa ; nops ; nopxm ; nopv
   ; CHECK-NEXT:    nopb ; nopa ; nops ; nopxm ; nopv
   ; CHECK-NEXT:    nopb ; nopa ; nops ; nopxm ; nopv

--- a/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/add-store.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/add-store.mir
@@ -15,8 +15,8 @@
   ; CHECK-LABEL: addStore:
   ; CHECK:         .p2align 4
   ; CHECK-NEXT:  // %bb.0: // %entry
-  ; CHECK-NEXT:    mova r1, #0; nopb ; nopxm
-  ; CHECK-NEXT:    ge r1, r1, r0
+  ; CHECK-NEXT:    nopb ; mova r1, #0; nops ; nopxm ; nopv
+  ; CHECK-NEXT:    nopa ; ge r1, r1, r0
   ; CHECK-NEXT:    jnz r1, #.LBB0_4
   ; CHECK-NEXT:    nop // Delay Slot 5
   ; CHECK-NEXT:    nop // Delay Slot 4
@@ -26,8 +26,7 @@
   ; CHECK-NEXT:  // %bb.1: // %for.body.preheader
   ; CHECK-NEXT:    add.nc lc, r0, #-1
   ; CHECK-NEXT:    movxm ls, #.LBB0_2
-  ; CHECK-NEXT:    movxm le, #.L_LEnd0
-  ; CHECK-NEXT:    nopb ; nopa ; nops ; nopxm ; nopv
+  ; CHECK-NEXT:    nopb ; nopa ; nops ; movxm le, #.L_LEnd0; nopv
   ; CHECK-NEXT:    nopb ; nopa ; nops ; nopxm ; nopv
   ; CHECK-NEXT:    nopb ; nopa ; nops ; nopxm ; nopv
   ; CHECK-NEXT:    nopb ; nopa ; nops ; nopxm ; nopv
@@ -38,9 +37,9 @@
   ; CHECK-NEXT:  .LBB0_2: // %for.body
   ; CHECK-NEXT:    // =>This Inner Loop Header: Depth=1
   ; CHECK-NEXT:  .L_LEnd0:
-  ; CHECK-NEXT:    nopa ; st r1, [p0], #4; add r1, r1, #1
+  ; CHECK-NEXT:    nopb ; nopa ; st r1, [p0], #4; add r1, r1, #1; nopm ; nopv
   ; CHECK-NEXT:  // %bb.3: // %for.cond.cleanup
-  ; CHECK-NEXT:    st r1, [p0], #4
+  ; CHECK-NEXT:    nopa ; nopb ; nopxm ; st r1, [p0], #4
   ; CHECK-NEXT:    nop
   ; CHECK-NEXT:    nop
   ; CHECK-NEXT:    nop

--- a/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/bitwisenot.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/bitwisenot.mir
@@ -3,7 +3,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2024-2026 Advanced Micro Devices, Inc. or its affiliates
 
 # RUN: llc --mtriple=aie2 -O2 --start-before=postmisched %s -o - | FileCheck %s
 
@@ -13,11 +13,11 @@
   define dso_local void @bitNot(ptr addrspace(5) noalias nocapture writeonly %d, ptr addrspace(6) noalias nocapture readonly %s, i32 noundef %n) local_unnamed_addr #0 {
   ; CHECK-LABEL: bitNot:
   ; CHECK:       // %bb.0:
-  ; CHECK-NEXT:    vldb wh0, [p0, #32]; nopx
-  ; CHECK-NEXT:    vldb wl0, [p0], #64; add.nc lc, r0, #-5
-  ; CHECK-NEXT:    vldb wh0, [p0, #32]; movxm ls, #.LBB0_2
-  ; CHECK-NEXT:    vldb wl0, [p0], #64; movxm le, #.L_LEnd0
-  ; CHECK-NEXT:    vldb wh0, [p0, #32]; nopa ; nops ; nopxm ; nopv
+  ; CHECK-NEXT:    nopa ; vldb wh0, [p0, #32]; nopxm
+  ; CHECK-NEXT:    vldb wl0, [p0], #64
+  ; CHECK-NEXT:    vldb wh0, [p0, #32]; add.nc lc, r0, #-5
+  ; CHECK-NEXT:    vldb wl0, [p0], #64; movxm ls, #.LBB0_2
+  ; CHECK-NEXT:    vldb wh0, [p0, #32]; nopa ; nops ; movxm le, #.L_LEnd0; nopv
   ; CHECK-NEXT:    vldb wl0, [p0], #64; nopa ; nops ; nopxm ; nopv
   ; CHECK-NEXT:    vldb wh0, [p0, #32]; nopa ; nops ; nopxm ; nopv
   ; CHECK-NEXT:    vldb wl0, [p0], #64; nopa ; nops ; nopxm ; nopv

--- a/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/bitwisexor.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/bitwisexor.mir
@@ -3,7 +3,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2024-2025 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2024-2026 Advanced Micro Devices, Inc. or its affiliates
 
 # RUN: llc --mtriple=aie2 -O2 --start-before=postmisched %s -o - | FileCheck %s
 
@@ -17,7 +17,7 @@
   ; CHECK-LABEL: bitXor:
   ; CHECK:         .p2align 4
   ; CHECK-NEXT:  // %bb.0: // %entry
-  ; CHECK-NEXT:    mova r1, #0; nopb ; nopxm ; nops
+  ; CHECK-NEXT:    mova r1, #0
   ; CHECK-NEXT:    ge r1, r1, r0
   ; CHECK-NEXT:    jnz r1, #.LBB0_4
   ; CHECK-NEXT:    nop // Delay Slot 5
@@ -33,11 +33,11 @@
   ; CHECK-NEXT:    nop
   ; CHECK-NEXT:    vlda wh1, [p0, #32]; vldb wh0, [p1, #32]; add.nc lc, r0, #-3
   ; CHECK-NEXT:    vlda wl1, [p0], #64; vldb wl0, [p1], #64; movxm ls, #.LBB0_2
-  ; CHECK-NEXT:    movxm le, #.L_LEnd0
+  ; CHECK-NEXT:    nopb ; nopa ; nops ; movxm le, #.L_LEnd0; nopv
   ; CHECK-NEXT:    nopb ; nopa ; nops ; nopx ; vbneg_ltz.s8 x2, r25:r24, x0; nopv
-  ; CHECK-NEXT:    nopb ; nopa ; nops ; nopx ; vbneg_ltz.s8 x3, r25:r24, x1; nopv
-  ; CHECK-NEXT:    vldb wh0, [p1, #32]; vlda wh1, [p0, #32]; nops ; nopx ; vband x4, x0, x3; nopv
-  ; CHECK-NEXT:    vldb wl0, [p1], #64; vlda wl1, [p0], #64; nops ; nopx ; vband x5, x1, x2; nopv
+  ; CHECK-NEXT:    nopa ; nopb ; nopx ; vbneg_ltz.s8 x3, r25:r24, x1
+  ; CHECK-NEXT:    vlda wh1, [p0, #32]; vldb wh0, [p1, #32]; vband x4, x0, x3
+  ; CHECK-NEXT:    vlda wl1, [p0], #64; vldb wl0, [p1], #64; vband x5, x1, x2
   ; CHECK-NEXT:    vbor x6, x4, x5
   ; CHECK-NEXT:    vbneg_ltz.s8 x2, r25:r24, x0
   ; CHECK-NEXT:    vst wh6, [p2, #32]; vbneg_ltz.s8 x3, r25:r24, x1

--- a/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/crash.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/crash.mir
@@ -3,7 +3,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2024-2026 Advanced Micro Devices, Inc. or its affiliates
 
 # RUN: llc --mtriple=aie2 -O2 --start-before=postmisched %s -o - | FileCheck %s
 
@@ -17,9 +17,9 @@
   ; CHECK:         .p2align 4
   ; CHECK-NEXT:  // %bb.0: // %entry
   ; CHECK-NEXT:    nopb ; nopa ; nops ; movxm ls, #.LBB0_1; nopv
-  ; CHECK-NEXT:    movxm le, #.L_LEnd0
+  ; CHECK-NEXT:    nopa ; movxm le, #.L_LEnd0
   ; CHECK-NEXT:    mova r0, #8; mov p2, p0
-  ; CHECK-NEXT:    add.nc lc, r0, #0
+  ; CHECK-NEXT:    nopb ; nopa ; nops ; nopx ; add.nc lc, r0, #0; nopv
   ; CHECK-NEXT:    .p2align 4
   ; CHECK-NEXT:  .LBB0_1: // %for.body
   ; CHECK-NEXT:    // =>This Inner Loop Header: Depth=1
@@ -28,8 +28,8 @@
   ; CHECK-NEXT:    nopb ; nopa ; nops ; nopxm ; nopv
   ; CHECK-NEXT:    nopb ; nopa ; nops ; nopxm ; nopv
   ; CHECK-NEXT:    nopb ; nopa ; nops ; nopxm ; nopv
-  ; CHECK-NEXT:    nopb ; nopa ; nops ; nopxm ; nopv
-  ; CHECK-NEXT:    nopb ; nopa ; nops ; nopxm ; nopv
+  ; CHECK-NEXT:    nopa ; nopb ; nopxm ; nops
+  ; CHECK-NEXT:    nop
   ; CHECK-NEXT:  .L_LEnd0:
   ; CHECK-NEXT:    nopb ; nopa ; st r0, [p0, #0]; nopxm ; nopv
   ; CHECK-NEXT:  // %bb.2: // %for.cond.cleanup

--- a/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/hardsigmoid-templated-double.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/hardsigmoid-templated-double.mir
@@ -3,7 +3,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2024-2025 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2024-2026 Advanced Micro Devices, Inc. or its affiliates
 
 # RUN: llc --mtriple=aie2 -O2 --start-before=postmisched %s -o - | FileCheck %s
 
@@ -16,19 +16,19 @@
   define dso_local void @kernel(ptr addrspace(5) noalias nocapture writeonly %d, ptr addrspace(6) noalias nocapture readonly %s, i32 noundef %n) local_unnamed_addr #0 {
   ; CHECK-LABEL: kernel:
   ; CHECK:       // %bb.0:
-  ; CHECK-NEXT:    vldb.unpack.s16.s8 x6, [p0], m0; nopa ; nops ; nopxm ; nopv
-  ; CHECK-NEXT:    nopx
+  ; CHECK-NEXT:    nopa ; vldb.unpack.s16.s8 x6, [p0], m0; nopxm
+  ; CHECK-NEXT:    nop
   ; CHECK-NEXT:    vldb.unpack.s16.s8 x6, [p0], m0
   ; CHECK-NEXT:    nop
   ; CHECK-NEXT:    vldb.unpack.s16.s8 x6, [p0], m0; add.nc lc, r0, #-7
   ; CHECK-NEXT:    movxm ls, #.LBB0_2
-  ; CHECK-NEXT:    vldb.unpack.s16.s8 x6, [p0], m0; movxm le, #.L_LEnd0
+  ; CHECK-NEXT:    vldb.unpack.s16.s8 x6, [p0], m0; nopa ; nops ; movxm le, #.L_LEnd0; nopv
   ; CHECK-NEXT:    nopb ; nopa ; nops ; nopx ; vmin_ge.s16 x8, r16, x6, x0; nopv
   ; CHECK-NEXT:    vldb.unpack.s16.s8 x6, [p0], m0; nopa ; nops ; nopx ; vmax_lt.s16 x10, r16, x8, x2; nopv
   ; CHECK-NEXT:    nopb ; nopa ; nops ; nopx ; vmin_ge.s16 x8, r16, x6, x0; nopv
-  ; CHECK-NEXT:    vldb.unpack.s16.s8 x6, [p0], m0; nopa ; nops ; nopx ; vmax_lt.s16 x10, r16, x8, x2; vmac cm1, cm0, x10, x4, r0
-  ; CHECK-NEXT:    nopb ; nopa ; nops ; nopx ; vmin_ge.s16 x8, r16, x6, x0; nopv
-  ; CHECK-NEXT:    vldb.unpack.s16.s8 x6, [p0], m0; nopx ; vmax_lt.s16 x10, r16, x8, x2; vmac cm1, cm0, x10, x4, r0
+  ; CHECK-NEXT:    nopa ; vldb.unpack.s16.s8 x6, [p0], m0; nopx ; vmax_lt.s16 x10, r16, x8, x2; vmac cm1, cm0, x10, x4, r0
+  ; CHECK-NEXT:    vmin_ge.s16 x8, r16, x6, x0
+  ; CHECK-NEXT:    vldb.unpack.s16.s8 x6, [p0], m0; vmax_lt.s16 x10, r16, x8, x2; vmac cm1, cm0, x10, x4, r0
   ; CHECK-NEXT:    vmin_ge.s16 x8, r16, x6, x0
   ; CHECK-NEXT:  .LBB0_1: // %for.body
   ; CHECK-NEXT:    // =>This Inner Loop Header: Depth=1
@@ -36,8 +36,8 @@
   ; CHECK-NEXT:  .L_LEnd0:
   ; CHECK-NEXT:    nopb ; nopa ; vst.srs.s8.s32 cm1, s0, [p1], #32; nopx ; vmin_ge.s16 x8, r16, x6, x0; nopv
   ; CHECK-NEXT:  .LBB0_2:
-  ; CHECK-NEXT:    nopb ; nopa ; nops ; nopx ; vmax_lt.s16 x10, r16, x8, x2; vmac cm1, cm0, x10, x4, r0
-  ; CHECK-NEXT:    nopa ; vst.srs.s8.s32 cm1, s0, [p1], #32; nopx ; vmin_ge.s16 x8, r16, x6, x0
+  ; CHECK-NEXT:    nopx ; vmax_lt.s16 x10, r16, x8, x2; vmac cm1, cm0, x10, x4, r0
+  ; CHECK-NEXT:    vst.srs.s8.s32 cm1, s0, [p1], #32; vmin_ge.s16 x8, r16, x6, x0
   ; CHECK-NEXT:    vmax_lt.s16 x10, r16, x8, x2; vmac cm1, cm0, x10, x4, r0
   ; CHECK-NEXT:    vst.srs.s8.s32 cm1, s0, [p1], #32; vmin_ge.s16 x8, r16, x6, x0
   ; CHECK-NEXT:    vmax_lt.s16 x10, r16, x8, x2; vmac cm1, cm0, x10, x4, r0
@@ -46,9 +46,9 @@
   ; CHECK-NEXT:    vst.srs.s8.s32 cm1, s0, [p1], #32
   ; CHECK-NEXT:    add.nc lc, r0, #-7; vmac cm1, cm0, x10, x4, r0
   ; CHECK-NEXT:    vst.srs.s8.s32 cm1, s0, [p1], #32; movxm ls, #.LBB0_2
-  ; CHECK-NEXT:    movxm le, #.L_LEnd0
-  ; CHECK-NEXT:    nopb ; nopa ; vst.srs.s8.s32 cm1, s0, [p1], #32; nopxm ; nopv
-  ; CHECK-NEXT:    nopa ; nopb ; nopxm
+  ; CHECK-NEXT:    nopb ; nopa ; nops ; movxm le, #.L_LEnd0; nopv
+  ; CHECK-NEXT:    nopa ; vst.srs.s8.s32 cm1, s0, [p1], #32; nopx
+  ; CHECK-NEXT:    nop
   ; CHECK-NEXT:    vst.srs.s8.s32 cm1, s0, [p1], #32
   ; CHECK-NEXT:    vldb.unpack.s16.s8 x6, [p0], m0
   ; CHECK-NEXT:    nop

--- a/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/hardsigmoid-templated.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/hardsigmoid-templated.mir
@@ -3,7 +3,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2024-2026 Advanced Micro Devices, Inc. or its affiliates
 
 # RUN: llc --mtriple=aie2 -O2 --start-before=postmisched %s -o - | FileCheck %s
 
@@ -13,19 +13,19 @@
   define dso_local void @kernel(ptr addrspace(5) noalias nocapture writeonly %d, ptr addrspace(6) noalias nocapture readonly %s, i32 noundef %n) local_unnamed_addr #0 {
   ; CHECK-LABEL: kernel:
   ; CHECK:       // %bb.0:
-  ; CHECK-NEXT:    vldb.unpack.s16.s8 x6, [p0], m0; nopa ; nops ; nopxm ; nopv
-  ; CHECK-NEXT:    nopx
+  ; CHECK-NEXT:    nopa ; vldb.unpack.s16.s8 x6, [p0], m0; nopxm
+  ; CHECK-NEXT:    nop
   ; CHECK-NEXT:    vldb.unpack.s16.s8 x6, [p0], m0
   ; CHECK-NEXT:    nop
   ; CHECK-NEXT:    vldb.unpack.s16.s8 x6, [p0], m0; add.nc lc, r0, #-7
   ; CHECK-NEXT:    movxm ls, #.LBB0_2
-  ; CHECK-NEXT:    vldb.unpack.s16.s8 x6, [p0], m0; movxm le, #.L_LEnd0
+  ; CHECK-NEXT:    vldb.unpack.s16.s8 x6, [p0], m0; nopa ; nops ; movxm le, #.L_LEnd0; nopv
   ; CHECK-NEXT:    nopb ; nopa ; nops ; nopx ; vmin_ge.s16 x8, r16, x6, x0; nopv
   ; CHECK-NEXT:    vldb.unpack.s16.s8 x6, [p0], m0; nopa ; nops ; nopx ; vmax_lt.s16 x10, r16, x8, x2; nopv
   ; CHECK-NEXT:    nopb ; nopa ; nops ; nopx ; vmin_ge.s16 x8, r16, x6, x0; nopv
-  ; CHECK-NEXT:    vldb.unpack.s16.s8 x6, [p0], m0; nopa ; nops ; nopx ; vmax_lt.s16 x10, r16, x8, x2; vmac cm1, cm0, x10, x4, r0
-  ; CHECK-NEXT:    nopb ; nopa ; nops ; nopx ; vmin_ge.s16 x8, r16, x6, x0; nopv
-  ; CHECK-NEXT:    vldb.unpack.s16.s8 x6, [p0], m0; nopx ; vmax_lt.s16 x10, r16, x8, x2; vmac cm1, cm0, x10, x4, r0
+  ; CHECK-NEXT:    nopa ; vldb.unpack.s16.s8 x6, [p0], m0; nopx ; vmax_lt.s16 x10, r16, x8, x2; vmac cm1, cm0, x10, x4, r0
+  ; CHECK-NEXT:    vmin_ge.s16 x8, r16, x6, x0
+  ; CHECK-NEXT:    vldb.unpack.s16.s8 x6, [p0], m0; vmax_lt.s16 x10, r16, x8, x2; vmac cm1, cm0, x10, x4, r0
   ; CHECK-NEXT:    vmin_ge.s16 x8, r16, x6, x0
   ; CHECK-NEXT:  .LBB0_1: // %for.body
   ; CHECK-NEXT:    // =>This Inner Loop Header: Depth=1

--- a/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/interleave-prologue.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/interleave-prologue.mir
@@ -3,7 +3,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2024-2026 Advanced Micro Devices, Inc. or its affiliates
 
 # RUN: llc --mtriple=aie2 -O2 --run-pass=postmisched --aie-loop-min-tripcount=16 --aie-addrspace-none-is-safe %s -o - | FileCheck %s
 
@@ -21,8 +21,10 @@ body:             |
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   $lc = ADD_NC $r0, -7
   ; CHECK-NEXT:   $ls = MOVXM_lng_cg %bb.2
-  ; CHECK-NEXT:   $le = MOVXM_lng_cg <mcsymbol .L_LEnd0>
-  ; CHECK-NEXT:   $x6, $p0 = VLDB_UNPACK_S16_S8_ag_pstm_nrm killed $p0, $m0
+  ; CHECK-NEXT:   BUNDLE implicit-def $x6, implicit-def $wl6, implicit-def $wh6, implicit-def $p0, implicit-def $le, implicit killed $p0, implicit $m0 {
+  ; CHECK-NEXT:     $x6, $p0 = VLDB_UNPACK_S16_S8_ag_pstm_nrm killed $p0, $m0
+  ; CHECK-NEXT:     $le = MOVXM_lng_cg <mcsymbol .L_LEnd0>
+  ; CHECK-NEXT:   }
   ; CHECK-NEXT:   $x6, $p0 = VLDB_UNPACK_S16_S8_ag_pstm_nrm killed $p0, $m0
   ; CHECK-NEXT:   $x6, $p0 = VLDB_UNPACK_S16_S8_ag_pstm_nrm killed $p0, $m0
   ; CHECK-NEXT:   $x6, $p0 = VLDB_UNPACK_S16_S8_ag_pstm_nrm killed $p0, $m0
@@ -104,14 +106,14 @@ body:             |
   ; CHECK-NEXT:   liveins: $p0, $p1, $r0
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   $lc = ADD_NC $r0, -8
-  ; CHECK-NEXT:   $ls = MOVXM_lng_cg %bb.2
-  ; CHECK-NEXT:   BUNDLE implicit-def $wl4, implicit-def $p0, implicit-def $le, implicit killed $p0, implicit $m0 {
+  ; CHECK-NEXT:   BUNDLE implicit-def $wl4, implicit-def $p0, implicit-def $ls, implicit killed $p0, implicit $m0 {
   ; CHECK-NEXT:     $wl4, $p0 = VLDA_dmw_lda_w_ag_pstm_nrm_imm killed $p0, $m0
-  ; CHECK-NEXT:     $le = MOVXM_lng_cg <mcsymbol .L_LEnd0>
+  ; CHECK-NEXT:     $ls = MOVXM_lng_cg %bb.2
   ; CHECK-NEXT:   }
-  ; CHECK-NEXT:   BUNDLE implicit-def $wl4, implicit-def $p0, implicit-def $x6, implicit-def $wl6, implicit-def $wh6, implicit killed $p0, implicit $m0 {
+  ; CHECK-NEXT:   BUNDLE implicit-def $wl4, implicit-def $p0, implicit-def $x6, implicit-def $wl6, implicit-def $wh6, implicit-def $le, implicit killed $p0, implicit $m0 {
   ; CHECK-NEXT:     $wl4, $p0 = VLDA_dmw_lda_w_ag_pstm_nrm_imm killed $p0, $m0
   ; CHECK-NEXT:     $x6 = VUNPACK_S16_S8 internal $wl4
+  ; CHECK-NEXT:     $le = MOVXM_lng_cg <mcsymbol .L_LEnd0>
   ; CHECK-NEXT:   }
   ; CHECK-NEXT:   BUNDLE implicit-def $wl4, implicit-def $p0, implicit-def $x6, implicit-def $wl6, implicit-def $wh6, implicit killed $p0, implicit $m0 {
   ; CHECK-NEXT:     $wl4, $p0 = VLDA_dmw_lda_w_ag_pstm_nrm_imm killed $p0, $m0
@@ -215,10 +217,10 @@ body:             |
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   $lc = ADD_NC $r0, -7
   ; CHECK-NEXT:   $ls = MOVXM_lng_cg %bb.2
-  ; CHECK-NEXT:   $le = MOVXM_lng_cg <mcsymbol .L_LEnd0>
-  ; CHECK-NEXT:   BUNDLE implicit-def $wh6, implicit-def $wl6, implicit-def $p0, implicit killed $p0 {
+  ; CHECK-NEXT:   BUNDLE implicit-def $wh6, implicit-def $wl6, implicit-def $p0, implicit-def $le, implicit killed $p0 {
   ; CHECK-NEXT:     $wh6 = VLDA_dmw_lda_w_ag_idx_imm $p0, 32 :: (load (<16 x s16>))
   ; CHECK-NEXT:     $wl6, $p0 = VLDB_dmw_ldb_ag_pstm_nrm_imm killed $p0, 64 :: (load (<16 x s16>))
+  ; CHECK-NEXT:     $le = MOVXM_lng_cg <mcsymbol .L_LEnd0>
   ; CHECK-NEXT:   }
   ; CHECK-NEXT:   BUNDLE implicit-def $wh6, implicit-def $wl6, implicit-def $p0, implicit killed $p0 {
   ; CHECK-NEXT:     $wh6 = VLDA_dmw_lda_w_ag_idx_imm $p0, 32 :: (load (<16 x s16>))
@@ -321,19 +323,19 @@ body:             |
   ; CHECK-NEXT:   $bmh2 = VLDA_UPS_S32_S16_ag_idx_imm $s0, $p2, 32, implicit-def $srups_of, implicit $crsat
   ; CHECK-NEXT:   $bml2 = VLDA_UPS_S32_S16_ag_idx_imm $s0, killed $p2, 0, implicit-def $srups_of, implicit $crsat
   ; CHECK-NEXT:   $wh6 = VLDA_dmw_lda_w_ag_idx_imm $p0, 32
-  ; CHECK-NEXT:   BUNDLE implicit-def $wl6, implicit-def $p0, implicit-def $lc, implicit killed $p0, implicit $m0, implicit killed $r0 {
-  ; CHECK-NEXT:     $wl6, $p0 = VLDA_dmw_lda_w_ag_pstm_nrm_imm killed $p0, $m0
+  ; CHECK-NEXT:   $wl6, $p0 = VLDA_dmw_lda_w_ag_pstm_nrm_imm killed $p0, $m0
+  ; CHECK-NEXT:   BUNDLE implicit-def $wh6, implicit-def $lc, implicit $p0, implicit killed $r0 {
+  ; CHECK-NEXT:     $wh6 = VLDA_dmw_lda_w_ag_idx_imm $p0, 32
   ; CHECK-NEXT:     $lc = ADD_NC killed $r0, -5
   ; CHECK-NEXT:   }
-  ; CHECK-NEXT:   BUNDLE implicit-def $wh6, implicit-def $ls, implicit $p0 {
-  ; CHECK-NEXT:     $wh6 = VLDA_dmw_lda_w_ag_idx_imm $p0, 32
+  ; CHECK-NEXT:   BUNDLE implicit-def $wl6, implicit-def $p0, implicit-def $ls, implicit killed $p0, implicit $m0 {
+  ; CHECK-NEXT:     $wl6, $p0 = VLDA_dmw_lda_w_ag_pstm_nrm_imm killed $p0, $m0
   ; CHECK-NEXT:     $ls = MOVXM_lng_cg %bb.2
   ; CHECK-NEXT:   }
-  ; CHECK-NEXT:   BUNDLE implicit-def $wl6, implicit-def $p0, implicit-def $le, implicit killed $p0, implicit $m0 {
-  ; CHECK-NEXT:     $wl6, $p0 = VLDA_dmw_lda_w_ag_pstm_nrm_imm killed $p0, $m0
+  ; CHECK-NEXT:   BUNDLE implicit-def $wh6, implicit-def $le, implicit $p0 {
+  ; CHECK-NEXT:     $wh6 = VLDA_dmw_lda_w_ag_idx_imm $p0, 32
   ; CHECK-NEXT:     $le = MOVXM_lng_cg <mcsymbol .L_LEnd0>
   ; CHECK-NEXT:   }
-  ; CHECK-NEXT:   $wh6 = VLDA_dmw_lda_w_ag_idx_imm $p0, 32
   ; CHECK-NEXT:   $wl6, $p0 = VLDA_dmw_lda_w_ag_pstm_nrm_imm killed $p0, $m0
   ; CHECK-NEXT:   BUNDLE implicit-def $wh6, implicit-def $x1, implicit-def $wl1, implicit-def $wh1, implicit $p0, implicit killed $r1 {
   ; CHECK-NEXT:     $wh6 = VLDA_dmw_lda_w_ag_idx_imm $p0, 32
@@ -450,10 +452,13 @@ body:             |
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   ACQ_mLockId_imm 49, killed renamable $r18
   ; CHECK-NEXT:   NOP
+  ; CHECK-NEXT:   NOP
   ; CHECK-NEXT:   $lc = ADD_NC $r0, -7
   ; CHECK-NEXT:   $ls = MOVXM_lng_cg %bb.2
-  ; CHECK-NEXT:   $le = MOVXM_lng_cg <mcsymbol .L_LEnd0>
-  ; CHECK-NEXT:   $x6, $p0 = VLDB_UNPACK_S16_S8_ag_pstm_nrm killed $p0, $m0
+  ; CHECK-NEXT:   BUNDLE implicit-def $x6, implicit-def $wl6, implicit-def $wh6, implicit-def $p0, implicit-def $le, implicit killed $p0, implicit $m0 {
+  ; CHECK-NEXT:     $x6, $p0 = VLDB_UNPACK_S16_S8_ag_pstm_nrm killed $p0, $m0
+  ; CHECK-NEXT:     $le = MOVXM_lng_cg <mcsymbol .L_LEnd0>
+  ; CHECK-NEXT:   }
   ; CHECK-NEXT:   $x6, $p0 = VLDB_UNPACK_S16_S8_ag_pstm_nrm killed $p0, $m0
   ; CHECK-NEXT:   $x6, $p0 = VLDB_UNPACK_S16_S8_ag_pstm_nrm killed $p0, $m0
   ; CHECK-NEXT:   $x6, $p0 = VLDB_UNPACK_S16_S8_ag_pstm_nrm killed $p0, $m0

--- a/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/large-II.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/large-II.mir
@@ -19,7 +19,7 @@
   ; CHECK-LABEL: rotatepermute:
   ; CHECK:         .p2align 4
   ; CHECK-NEXT:  // %bb.0: // %entry
-  ; CHECK-NEXT:    mova r1, #0; nopb ; nopxm
+  ; CHECK-NEXT:    mova r1, #0; nopb ; nopx
   ; CHECK-NEXT:    ge r1, r1, r0
   ; CHECK-NEXT:    jnz r1, #.LBB0_4
   ; CHECK-NEXT:    nop // Delay Slot 5
@@ -35,7 +35,7 @@
   ; CHECK-NEXT:    lda r4, [p0], #4
   ; CHECK-NEXT:    lda r5, [p0], #4; add.nc lc, r0, #-1
   ; CHECK-NEXT:    lda r6, [p0], #4; movxm ls, #.LBB0_2
-  ; CHECK-NEXT:    lda r7, [p0], #4; st r0, [p1], #4; movxm le, #.L_LEnd0
+  ; CHECK-NEXT:    nopb ; lda r7, [p0], #4; st r0, [p1], #4; movxm le, #.L_LEnd0; nopv
   ; CHECK-NEXT:    .p2align 4
   ; CHECK-NEXT:  .LBB0_2: // %for.body
   ; CHECK-NEXT:    // =>This Inner Loop Header: Depth=1
@@ -44,8 +44,8 @@
   ; CHECK-NEXT:    nopb ; lda r2, [p0], #4; st r3, [p1], #4; nopxm ; nopv
   ; CHECK-NEXT:    nopb ; lda r3, [p0], #4; st r4, [p1], #4; nopxm ; nopv
   ; CHECK-NEXT:    nopb ; lda r4, [p0], #4; st r5, [p1], #4; nopxm ; nopv
-  ; CHECK-NEXT:    nopb ; lda r5, [p0], #4; st r6, [p1], #4; nopxm ; nopv
-  ; CHECK-NEXT:    nopb ; lda r6, [p0], #4; st r7, [p1], #4; nopxm ; nopv
+  ; CHECK-NEXT:    lda r5, [p0], #4; st r6, [p1], #4; nopx
+  ; CHECK-NEXT:    lda r6, [p0], #4; st r7, [p1], #4
   ; CHECK-NEXT:  .L_LEnd0:
   ; CHECK-NEXT:    nopb ; lda r7, [p0], #4; st r0, [p1], #4; nopxm ; nopv
   ; CHECK-NEXT:  // %bb.3: // %for.cond.cleanup

--- a/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/ld2-mv-mac2-st2.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/ld2-mv-mac2-st2.mir
@@ -25,16 +25,16 @@
   ; CHECK-NEXT:  // %bb.1: // %for.body.preheader
   ; CHECK-NEXT:    vldb wl4, [p0], m2
   ; CHECK-NEXT:    vlda.2d wl4, [p0], d0
-  ; CHECK-NEXT:    vldb wl4, [p0], m2; add.nc lc, r0, #-6
-  ; CHECK-NEXT:    vlda.2d wl4, [p0], d0; movxm ls, #.LBB0_2
-  ; CHECK-NEXT:    vldb wl4, [p0], m2; movxm le, #.L_LEnd0
-  ; CHECK-NEXT:    nopb ; vlda.2d wl4, [p0], d0; nops ; nopx ; vmov wh4, wl0; nopv
-  ; CHECK-NEXT:    vldb wl4, [p0], m2; nopa ; nops ; nopxm ; nopv
+  ; CHECK-NEXT:    vldb wl4, [p0], m2
+  ; CHECK-NEXT:    vlda.2d wl4, [p0], d0; add.nc lc, r0, #-6
+  ; CHECK-NEXT:    vldb wl4, [p0], m2; movxm ls, #.LBB0_2
+  ; CHECK-NEXT:    vlda.2d wl4, [p0], d0; vmov wh4, wl0
+  ; CHECK-NEXT:    vldb wl4, [p0], m2; nopa ; nops ; movxm le, #.L_LEnd0; nopv
   ; CHECK-NEXT:    nopb ; vlda.2d wl4, [p0], d0; nops ; nopx ; vmov wh4, wl0; vmac cm1, cm0, x4, x2, r0
   ; CHECK-NEXT:    vldb wl4, [p0], m2; nopa ; nops ; nopxm ; vmac cm2, cm0, x4, x2, r0
-  ; CHECK-NEXT:    vlda.2d wl4, [p0], d0; nopb ; nopx ; vmov wh4, wl0; vmac cm1, cm0, x4, x2, r0
-  ; CHECK-NEXT:    vldb wl4, [p0], m2; vmac cm2, cm0, x4, x2, r0
-  ; CHECK-NEXT:    vlda.2d wl4, [p0], d0; vmov wh4, wl0; vmac cm1, cm0, x4, x2, r0
+  ; CHECK-NEXT:    nopb ; vlda.2d wl4, [p0], d0; nops ; nopx ; vmov wh4, wl0; vmac cm1, cm0, x4, x2, r0
+  ; CHECK-NEXT:    vldb wl4, [p0], m2; nopa ; nops ; nopxm ; vmac cm2, cm0, x4, x2, r0
+  ; CHECK-NEXT:    nopb ; vlda.2d wl4, [p0], d0; nops ; nopx ; vmov wh4, wl0; vmac cm1, cm0, x4, x2, r0
   ; CHECK-NEXT:    .p2align 4
   ; CHECK-NEXT:  .LBB0_2: // %for.body
   ; CHECK-NEXT:    // =>This Inner Loop Header: Depth=1

--- a/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/load-add-or-store.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/load-add-or-store.mir
@@ -3,7 +3,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2024-2026 Advanced Micro Devices, Inc. or its affiliates
 
 # RUN: llc --mtriple=aie2 -O2 --start-before=postmisched %s -o - | FileCheck %s
 
@@ -16,7 +16,7 @@
   ; CHECK-LABEL: loadAddOrStore:
   ; CHECK:         .p2align 4
   ; CHECK-NEXT:  // %bb.0: // %entry
-  ; CHECK-NEXT:    mova r1, #0; nopb ; nopx
+  ; CHECK-NEXT:    nopb ; mova r1, #0; nops ; nopxm ; nopv
   ; CHECK-NEXT:    ge r1, r1, r0
   ; CHECK-NEXT:    jnz r1, #.LBB0_4
   ; CHECK-NEXT:    nop // Delay Slot 5
@@ -25,10 +25,9 @@
   ; CHECK-NEXT:    nop // Delay Slot 2
   ; CHECK-NEXT:    nop // Delay Slot 1
   ; CHECK-NEXT:  // %bb.1: // %for.body.preheader
-  ; CHECK-NEXT:    add.nc lc, r0, #-4
-  ; CHECK-NEXT:    lda r0, [p1], #4; movxm ls, #.LBB0_2
-  ; CHECK-NEXT:    movxm le, #.L_LEnd0
-  ; CHECK-NEXT:    nopb ; lda r0, [p1], #4; nops ; nopxm ; nopv
+  ; CHECK-NEXT:    lda r0, [p1], #4; add.nc lc, r0, #-4
+  ; CHECK-NEXT:    movxm ls, #.LBB0_2
+  ; CHECK-NEXT:    nopb ; lda r0, [p1], #4; nops ; movxm le, #.L_LEnd0; nopv
   ; CHECK-NEXT:    nopb ; nopa ; nops ; nopxm ; nopv
   ; CHECK-NEXT:    nopb ; lda r0, [p1], #4; nops ; nopxm ; nopv
   ; CHECK-NEXT:    nopb ; nopa ; nops ; nopxm ; nopv

--- a/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/load-add-store-renamed.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/load-add-store-renamed.mir
@@ -15,7 +15,7 @@
   ; CHECK-LABEL: loadAddStore:
   ; CHECK:         .p2align 4
   ; CHECK-NEXT:  // %bb.0: // %entry
-  ; CHECK-NEXT:    mova r1, #0; nopb ; nopx
+  ; CHECK-NEXT:    mova r1, #0; nopb ; nopxm ; nops
   ; CHECK-NEXT:    ge r1, r1, r0
   ; CHECK-NEXT:    jnz r1, #.LBB0_4
   ; CHECK-NEXT:    nop // Delay Slot 5
@@ -25,9 +25,8 @@
   ; CHECK-NEXT:    nop // Delay Slot 1
   ; CHECK-NEXT:  // %bb.1: // %for.body.preheader
   ; CHECK-NEXT:    add.nc lc, r0, #-8
-  ; CHECK-NEXT:    movxm ls, #.LBB0_2
-  ; CHECK-NEXT:    lda r0, [p1], #4; movxm le, #.L_LEnd0
-  ; CHECK-NEXT:    nopb ; lda r0, [p1], #4; nops ; nopxm ; nopv
+  ; CHECK-NEXT:    lda r0, [p1], #4; movxm ls, #.LBB0_2
+  ; CHECK-NEXT:    nopb ; lda r0, [p1], #4; nops ; movxm le, #.L_LEnd0; nopv
   ; CHECK-NEXT:    nopb ; lda r0, [p1], #4; nops ; nopxm ; nopv
   ; CHECK-NEXT:    nopb ; lda r0, [p1], #4; nops ; nopxm ; nopv
   ; CHECK-NEXT:    nopb ; lda r0, [p1], #4; nops ; nopxm ; nopv

--- a/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/load-add-store-renamed.prepiplined.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/load-add-store-renamed.prepiplined.mir
@@ -3,7 +3,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2024-2026 Advanced Micro Devices, Inc. or its affiliates
 
 # RUN: llc --mtriple=aie2 -O2 --start-before=postmisched %s -o - | FileCheck %s
 
@@ -16,8 +16,8 @@
   ; CHECK-LABEL: loadAddStore:
   ; CHECK:         .p2align 4
   ; CHECK-NEXT:  // %bb.0: // %entry
-  ; CHECK-NEXT:    mova r1, #0; nopb ; nopxm
-  ; CHECK-NEXT:    ge r1, r1, r0
+  ; CHECK-NEXT:    nopb ; mova r1, #0; nops ; nopxm ; nopv
+  ; CHECK-NEXT:    nopa ; ge r1, r1, r0
   ; CHECK-NEXT:    jnz r1, #.LBB0_3
   ; CHECK-NEXT:    nop // Delay Slot 5
   ; CHECK-NEXT:    nop // Delay Slot 4
@@ -27,7 +27,7 @@
   ; CHECK-NEXT:  // %bb.1: // %for.body.preheader
   ; CHECK-NEXT:    add.nc lc, r0, #-1
   ; CHECK-NEXT:    movxm ls, #.LBB0_2
-  ; CHECK-NEXT:    movxm le, #.L_LEnd0
+  ; CHECK-NEXT:    nopb ; nopa ; nops ; movxm le, #.L_LEnd0; nopv
   ; CHECK-NEXT:    .p2align 4
   ; CHECK-NEXT:  .LBB0_2: // %for.body
   ; CHECK-NEXT:    // =>This Inner Loop Header: Depth=1
@@ -36,8 +36,8 @@
   ; CHECK-NEXT:    nopb ; nopa ; nops ; nopxm ; nopv
   ; CHECK-NEXT:    nopb ; nopa ; nops ; nopxm ; nopv
   ; CHECK-NEXT:    nopb ; nopa ; nops ; nopxm ; nopv
-  ; CHECK-NEXT:    nopb ; nopa ; nops ; nopxm ; nopv
-  ; CHECK-NEXT:    nopa ; nopb ; nopxm
+  ; CHECK-NEXT:    nopa ; nopxm
+  ; CHECK-NEXT:    nop
   ; CHECK-NEXT:    add r1, r0, #1
   ; CHECK-NEXT:  .L_LEnd0:
   ; CHECK-NEXT:    nopb ; nopa ; st r1, [p0], #4; nopxm ; nopv

--- a/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/load-add-store.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/load-add-store.mir
@@ -3,7 +3,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2024-2026 Advanced Micro Devices, Inc. or its affiliates
 
 # RUN: llc --mtriple=aie2 -O2 --start-before=postmisched %s -o - | FileCheck %s
 
@@ -16,7 +16,7 @@
   ; CHECK-LABEL: loadAddStore:
   ; CHECK:         .p2align 4
   ; CHECK-NEXT:  // %bb.0: // %entry
-  ; CHECK-NEXT:    mova r1, #0; nopb ; nopx
+  ; CHECK-NEXT:    nopb ; mova r1, #0; nops ; nopxm ; nopv
   ; CHECK-NEXT:    ge r1, r1, r0
   ; CHECK-NEXT:    jnz r1, #.LBB0_4
   ; CHECK-NEXT:    nop // Delay Slot 5
@@ -25,10 +25,9 @@
   ; CHECK-NEXT:    nop // Delay Slot 2
   ; CHECK-NEXT:    nop // Delay Slot 1
   ; CHECK-NEXT:  // %bb.1: // %for.body.preheader
-  ; CHECK-NEXT:    add.nc lc, r0, #-4
-  ; CHECK-NEXT:    lda r0, [p1], #4; movxm ls, #.LBB0_2
-  ; CHECK-NEXT:    movxm le, #.L_LEnd0
-  ; CHECK-NEXT:    nopb ; lda r0, [p1], #4; nops ; nopxm ; nopv
+  ; CHECK-NEXT:    lda r0, [p1], #4; add.nc lc, r0, #-4
+  ; CHECK-NEXT:    movxm ls, #.LBB0_2
+  ; CHECK-NEXT:    nopb ; lda r0, [p1], #4; nops ; movxm le, #.L_LEnd0; nopv
   ; CHECK-NEXT:    nopb ; nopa ; nops ; nopxm ; nopv
   ; CHECK-NEXT:    nopb ; lda r0, [p1], #4; nops ; nopxm ; nopv
   ; CHECK-NEXT:    nopb ; nopa ; nops ; nopxm ; nopv

--- a/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/load-mac-store.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/load-mac-store.mir
@@ -3,7 +3,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2024-2026 Advanced Micro Devices, Inc. or its affiliates
 
 # RUN: llc --mtriple=aie2 -O2 --start-before=postmisched %s -o - | FileCheck %s
 
@@ -16,7 +16,7 @@
   ; CHECK-LABEL: loadAddStore:
   ; CHECK:         .p2align 4
   ; CHECK-NEXT:  // %bb.0: // %entry
-  ; CHECK-NEXT:    mova r1, #0; nopb ; nopx
+  ; CHECK-NEXT:    nopb ; mova r1, #0; nops ; nopxm ; nopv
   ; CHECK-NEXT:    ge r1, r1, r0
   ; CHECK-NEXT:    jnz r1, #.LBB0_4
   ; CHECK-NEXT:    nop // Delay Slot 5
@@ -25,10 +25,9 @@
   ; CHECK-NEXT:    nop // Delay Slot 2
   ; CHECK-NEXT:    nop // Delay Slot 1
   ; CHECK-NEXT:  // %bb.1: // %for.body.preheader
-  ; CHECK-NEXT:    add.nc lc, r0, #-4
-  ; CHECK-NEXT:    lda r0, [p1], #4; movxm ls, #.LBB0_2
-  ; CHECK-NEXT:    movxm le, #.L_LEnd0
-  ; CHECK-NEXT:    nopb ; lda r0, [p1], #4; nops ; nopxm ; nopv
+  ; CHECK-NEXT:    lda r0, [p1], #4; add.nc lc, r0, #-4
+  ; CHECK-NEXT:    movxm ls, #.LBB0_2
+  ; CHECK-NEXT:    nopb ; lda r0, [p1], #4; nops ; movxm le, #.L_LEnd0; nopv
   ; CHECK-NEXT:    nopb ; nopa ; nops ; nopxm ; nopv
   ; CHECK-NEXT:    nopb ; lda r0, [p1], #4; nops ; nopxm ; nopv
   ; CHECK-NEXT:    nopb ; nopa ; nops ; nopxm ; nopv

--- a/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/round-memdep.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/round-memdep.mir
@@ -3,7 +3,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2024-2025 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2024-2026 Advanced Micro Devices, Inc. or its affiliates
 
 # RUN: llc --mtriple=aie2 -O2 --start-before=postmisched %s -o - | FileCheck %s
 
@@ -20,7 +20,7 @@
   ; CHECK-LABEL: round:
   ; CHECK:         .p2align 4
   ; CHECK-NEXT:  // %bb.0: // %entry
-  ; CHECK-NEXT:    mova r1, #0
+  ; CHECK-NEXT:    mova r1, #0; nopb ; nopx
   ; CHECK-NEXT:    ge r1, r1, r0
   ; CHECK-NEXT:    jnz r1, #.LBB0_4
   ; CHECK-NEXT:    nop // Delay Slot 5
@@ -35,10 +35,10 @@
   ; CHECK-NEXT:    nop
   ; CHECK-NEXT:    vlda.ups.s32.s8 cm0, s0, [p0], #32
   ; CHECK-NEXT:    vlda.ups.s32.s8 cm1, s0, [p0], #32
+  ; CHECK-NEXT:    nop
   ; CHECK-NEXT:    add.nc lc, r0, #-4
-  ; CHECK-NEXT:    movxm ls, #.LBB0_2
-  ; CHECK-NEXT:    vlda.ups.s32.s8 cm0, s0, [p0], #32; movxm le, #.L_LEnd0
-  ; CHECK-NEXT:    nopb ; vlda.ups.s32.s8 cm1, s0, [p0], #32; vsrs.s8.s32 wh0, cm0, s1; nopxm ; nopv
+  ; CHECK-NEXT:    vlda.ups.s32.s8 cm0, s0, [p0], #32; movxm ls, #.LBB0_2
+  ; CHECK-NEXT:    nopb ; vlda.ups.s32.s8 cm1, s0, [p0], #32; vsrs.s8.s32 wh0, cm0, s1; movxm le, #.L_LEnd0; nopv
   ; CHECK-NEXT:    nopb ; nopa ; nops ; nopxm ; nopv
   ; CHECK-NEXT:    nopb ; nopa ; vsrs.s8.s32 wh2, cm1, s1; nopxm ; nopv
   ; CHECK-NEXT:    nopb ; vlda.ups.s32.s8 cm0, s0, [p0], #32; nops ; nopxm ; nopv

--- a/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/round-war.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/round-war.mir
@@ -3,7 +3,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2024-2026 Advanced Micro Devices, Inc. or its affiliates
 
 # RUN: llc --mtriple=aie2 -O2 --start-before=postmisched %s -o - | FileCheck %s
 
@@ -19,7 +19,7 @@
   ; CHECK-LABEL: round:
   ; CHECK:         .p2align 4
   ; CHECK-NEXT:  // %bb.0: // %entry
-  ; CHECK-NEXT:    mova r1, #0; nopb ; nopx
+  ; CHECK-NEXT:    mova r1, #0; nopb ; nopxm ; nops
   ; CHECK-NEXT:    ge r1, r1, r0
   ; CHECK-NEXT:    jnz r1, #.LBB0_4
   ; CHECK-NEXT:    nop // Delay Slot 5
@@ -37,10 +37,10 @@
   ; CHECK-NEXT:    nop
   ; CHECK-NEXT:    vlda.ups.s32.s8 cm1, s0, [p0], #32
   ; CHECK-NEXT:    vlda.ups.s32.s8 cm0, s0, [p0], #32
-  ; CHECK-NEXT:    vsrs.s8.s32 wh0, cm0, s1; add.nc lc, r0, #-4
-  ; CHECK-NEXT:    movxm ls, #.LBB0_2
-  ; CHECK-NEXT:    vlda.ups.s32.s8 cm1, s0, [p0], #32; movxm le, #.L_LEnd0
-  ; CHECK-NEXT:    nopb ; vlda.ups.s32.s8 cm0, s0, [p0], #32; vsrs.s8.s32 wh2, cm1, s1; nopxm ; nopv
+  ; CHECK-NEXT:    vsrs.s8.s32 wh0, cm0, s1
+  ; CHECK-NEXT:    add.nc lc, r0, #-4
+  ; CHECK-NEXT:    vlda.ups.s32.s8 cm1, s0, [p0], #32; movxm ls, #.LBB0_2
+  ; CHECK-NEXT:    nopb ; vlda.ups.s32.s8 cm0, s0, [p0], #32; vsrs.s8.s32 wh2, cm1, s1; movxm le, #.L_LEnd0; nopv
   ; CHECK-NEXT:    nopb ; nopa ; vsrs.s8.s32 wh0, cm0, s1; nopxm ; nopv
   ; CHECK-NEXT:    nopb ; nopa ; nops ; nopx ; mov crSRSSign, r0; nopv
   ; CHECK-NEXT:    nopb ; vlda.ups.s32.s8 cm1, s0, [p0], #32; nops ; nopx ; vups.s32.s8 cm2, wh0, s1; nopv

--- a/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/round.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/round.mir
@@ -25,7 +25,7 @@
   ; CHECK-LABEL: round:
   ; CHECK:         .p2align 4
   ; CHECK-NEXT:  // %bb.0: // %entry
-  ; CHECK-NEXT:    mova r1, #0; nopb ; nopx
+  ; CHECK-NEXT:    mova r1, #0; nopb ; nopxm ; nops
   ; CHECK-NEXT:    ge r1, r1, r0
   ; CHECK-NEXT:    jnz r1, #.LBB0_4
   ; CHECK-NEXT:    nop // Delay Slot 5
@@ -43,10 +43,10 @@
   ; CHECK-NEXT:    nop
   ; CHECK-NEXT:    vlda.ups.s32.s8 cm1, s0, [p0], #32
   ; CHECK-NEXT:    vlda.ups.s32.s8 cm0, s0, [p0], #32
-  ; CHECK-NEXT:    vsrs.s8.s32 wh0, cm0, s1; add.nc lc, r0, #-4
-  ; CHECK-NEXT:    movxm ls, #.LBB0_2
-  ; CHECK-NEXT:    vlda.ups.s32.s8 cm1, s0, [p0], #32; movxm le, #.L_LEnd0
-  ; CHECK-NEXT:    nopb ; vlda.ups.s32.s8 cm0, s0, [p0], #32; vsrs.s8.s32 wh2, cm1, s1; nopxm ; nopv
+  ; CHECK-NEXT:    vsrs.s8.s32 wh0, cm0, s1
+  ; CHECK-NEXT:    add.nc lc, r0, #-4
+  ; CHECK-NEXT:    vlda.ups.s32.s8 cm1, s0, [p0], #32; movxm ls, #.LBB0_2
+  ; CHECK-NEXT:    nopb ; vlda.ups.s32.s8 cm0, s0, [p0], #32; vsrs.s8.s32 wh2, cm1, s1; movxm le, #.L_LEnd0; nopv
   ; CHECK-NEXT:    nopb ; nopa ; vsrs.s8.s32 wh0, cm0, s1; nopxm ; nopv
   ; CHECK-NEXT:    nopb ; nopa ; nops ; nopxm ; nopv
   ; CHECK-NEXT:    nopb ; vlda.ups.s32.s8 cm1, s0, [p0], #32; nops ; nopx ; vups.s32.s8 cm2, wh0, s1; nopv

--- a/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/small-II.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/small-II.mir
@@ -19,7 +19,7 @@
   ; CHECK-LABEL: rotatepermute:
   ; CHECK:         .p2align 4
   ; CHECK-NEXT:  // %bb.0: // %entry
-  ; CHECK-NEXT:    mova r1, #0; nopb ; nopxm ; nops
+  ; CHECK-NEXT:    mova r1, #0
   ; CHECK-NEXT:    ge r1, r1, r0
   ; CHECK-NEXT:    jnz r1, #.LBB0_4
   ; CHECK-NEXT:    nop // Delay Slot 5
@@ -29,10 +29,10 @@
   ; CHECK-NEXT:    nop // Delay Slot 1
   ; CHECK-NEXT:  // %bb.1: // %for.body.preheader
   ; CHECK-NEXT:    lda r0, [p0], #4
-  ; CHECK-NEXT:    lda r1, [p0], #4; add.nc lc, r0, #-2
-  ; CHECK-NEXT:    lda r2, [p0], #4; movxm ls, #.LBB0_2
-  ; CHECK-NEXT:    lda r3, [p0], #4; movxm le, #.L_LEnd0
-  ; CHECK-NEXT:    nopb ; lda r0, [p0], #4; nops ; nopxm ; nopv
+  ; CHECK-NEXT:    lda r1, [p0], #4
+  ; CHECK-NEXT:    lda r2, [p0], #4; add.nc lc, r0, #-2
+  ; CHECK-NEXT:    lda r3, [p0], #4; movxm ls, #.LBB0_2
+  ; CHECK-NEXT:    nopb ; lda r0, [p0], #4; nops ; movxm le, #.L_LEnd0; nopv
   ; CHECK-NEXT:    nopb ; lda r1, [p0], #4; nops ; nopxm ; nopv
   ; CHECK-NEXT:    nopb ; lda r2, [p0], #4; nops ; nopxm ; nopv
   ; CHECK-NEXT:    nopb ; lda r3, [p0], #4; st r0, [p1], #4; nopxm ; nopv

--- a/llvm/test/CodeGen/AIE/aie2p/AA-unroll-iterations.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/AA-unroll-iterations.mir
@@ -21,10 +21,10 @@
   ; CHECK-NEXT:    mova dc1, #0; movs p1, p0; mov dn1, dn0
   ; CHECK-NEXT:    movs dj1, m0; mov dc0, dc1
   ; CHECK-NEXT:    lda.2d r1, [p1], d1
-  ; CHECK-NEXT:    movxm ls, #.LBB0_1
-  ; CHECK-NEXT:    mova r1, #4; movxm le, #.L_LEnd0
-  ; CHECK-NEXT:    lda.2d r1, [p1], d1; add.nc lc, r1, #-3
-  ; CHECK-NEXT:    nopa ; nopb ; nops ; nopxm ; nopv
+  ; CHECK-NEXT:    nop
+  ; CHECK-NEXT:    mova r1, #4; movxm ls, #.LBB0_1
+  ; CHECK-NEXT:    lda.2d r1, [p1], d1; movxm le, #.L_LEnd0
+  ; CHECK-NEXT:    nopa ; nopb ; nops ; nopx ; add.nc lc, r1, #-3; nopv
   ; CHECK-NEXT:    nopa ; nopb ; nops ; nopxm ; nopv
   ; CHECK-NEXT:    lda.2d r1, [p1], d1; nopb ; nops ; movx r0, #10; nopm ; nopv
   ; CHECK-NEXT:    nopa ; nopb ; nops ; mul r1, r1, r0; nopm ; nopv

--- a/llvm/test/CodeGen/AIE/aie2p/align-fallthrough-mbb-jump-table.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/align-fallthrough-mbb-jump-table.mir
@@ -105,9 +105,10 @@ body:             |
   ; CHECK-NEXT:   BUNDLE implicit-def $r27, implicit $r1, implicit $r0 {
   ; CHECK-NEXT:     NOPA
   ; CHECK-NEXT:     NOPB
+  ; CHECK-NEXT:     NOPS
   ; CHECK-NEXT:     renamable $r27 = LTU renamable $r1, renamable $r0
   ; CHECK-NEXT:     NOPM
-  ; CHECK-NEXT:     NOPS
+  ; CHECK-NEXT:     NOPV
   ; CHECK-NEXT:   }
   ; CHECK-NEXT:   BUNDLE implicit-def $ls {
   ; CHECK-NEXT:     $ls = MOVXM %bb.3
@@ -116,6 +117,7 @@ body:             |
   ; CHECK-NEXT:     $le = MOVXM <mcsymbol .L_LEnd3>
   ; CHECK-NEXT:   }
   ; CHECK-NEXT:   BUNDLE implicit-def $r0, implicit killed $r0, implicit killed $r1, implicit killed $r27 {
+  ; CHECK-NEXT:     NOPA
   ; CHECK-NEXT:     renamable $r0 = SEL_NEZ killed renamable $r0, killed renamable $r1, killed renamable $r27
   ; CHECK-NEXT:   }
   ; CHECK-NEXT:   BUNDLE implicit-def $r1, implicit-def $r0, implicit-def dead $srcarry, implicit killed $r0 {
@@ -129,7 +131,12 @@ body:             |
   ; CHECK-NEXT:     renamable $r0 = nuw nsw ADD_add_r_ri killed renamable $r0, 1, implicit-def dead $srcarry
   ; CHECK-NEXT:   }
   ; CHECK-NEXT:   BUNDLE implicit-def $lc, implicit killed $r0 {
+  ; CHECK-NEXT:     NOPA
+  ; CHECK-NEXT:     NOPB
+  ; CHECK-NEXT:     NOPS
+  ; CHECK-NEXT:     NOPX
   ; CHECK-NEXT:     $lc = ADD_NC_mv_add_ri killed $r0, 0
+  ; CHECK-NEXT:     NOPV
   ; CHECK-NEXT:   }
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT: bb.3:
@@ -174,13 +181,10 @@ body:             |
   ; CHECK-NEXT:   BUNDLE {
   ; CHECK-NEXT:     NOPA
   ; CHECK-NEXT:     NOPB
-  ; CHECK-NEXT:     NOPS
-  ; CHECK-NEXT:     NOPXM
-  ; CHECK-NEXT:     NOPV
+  ; CHECK-NEXT:     NOPX
   ; CHECK-NEXT:   }
   ; CHECK-NEXT:   BUNDLE {
-  ; CHECK-NEXT:     NOPA
-  ; CHECK-NEXT:     NOPXM
+  ; CHECK-NEXT:     NOP
   ; CHECK-NEXT:   }
   ; CHECK-NEXT:   BUNDLE implicit-def $x4, implicit-def $wl4, implicit-def $wh4, implicit-def dead $l8, implicit $x0, implicit killed $x2, implicit $vaddsign0 {
   ; CHECK-NEXT:     renamable $x4, dead renamable $l8 = VMIN_GE_8_vaddSign0 renamable $x0, killed renamable $x2, implicit $vaddsign0
@@ -227,8 +231,10 @@ body:             |
   ; CHECK-NEXT:   BUNDLE implicit-def $r27, implicit $r1, implicit $r0 {
   ; CHECK-NEXT:     NOPA
   ; CHECK-NEXT:     NOPB
+  ; CHECK-NEXT:     NOPS
   ; CHECK-NEXT:     renamable $r27 = LTU renamable $r1, renamable $r0
   ; CHECK-NEXT:     NOPM
+  ; CHECK-NEXT:     NOPV
   ; CHECK-NEXT:   }
   ; CHECK-NEXT:   BUNDLE implicit-def $ls {
   ; CHECK-NEXT:     $ls = MOVXM %bb.6
@@ -251,7 +257,12 @@ body:             |
   ; CHECK-NEXT:     renamable $x4 = VBCST_8 killed renamable $r2
   ; CHECK-NEXT:   }
   ; CHECK-NEXT:   BUNDLE implicit-def $lc, implicit killed $r0 {
+  ; CHECK-NEXT:     NOPA
+  ; CHECK-NEXT:     NOPB
+  ; CHECK-NEXT:     NOPS
+  ; CHECK-NEXT:     NOPX
   ; CHECK-NEXT:     $lc = ADD_NC_mv_add_ri killed $r0, 0
+  ; CHECK-NEXT:     NOPV
   ; CHECK-NEXT:   }
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT: bb.6:
@@ -294,14 +305,10 @@ body:             |
   ; CHECK-NEXT:     NOPV
   ; CHECK-NEXT:   }
   ; CHECK-NEXT:   BUNDLE {
-  ; CHECK-NEXT:     NOPA
-  ; CHECK-NEXT:     NOPB
-  ; CHECK-NEXT:     NOPS
-  ; CHECK-NEXT:     NOPXM
-  ; CHECK-NEXT:     NOPV
+  ; CHECK-NEXT:     NOP
   ; CHECK-NEXT:   }
   ; CHECK-NEXT:   BUNDLE {
-  ; CHECK-NEXT:     NOPX
+  ; CHECK-NEXT:     NOP
   ; CHECK-NEXT:   }
   ; CHECK-NEXT:   BUNDLE implicit-def $l0, implicit-def $r0, implicit-def $r1, implicit $x0, implicit killed $x6, implicit $vaddsign0 {
   ; CHECK-NEXT:     renamable $l0 = VLT_8_vaddSign0 renamable $x0, killed renamable $x6, implicit $vaddsign0

--- a/llvm/test/CodeGen/AIE/aie2p/align-zol-empty-branch-target.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/align-zol-empty-branch-target.mir
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2025 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2025-2026 Advanced Micro Devices, Inc. or its affiliates
 
 # RUN: llc -mtriple=aie2p %s --run-pass=aie-machine-alignment -o - -verify-machineinstrs | FileCheck %s
 
@@ -43,9 +43,12 @@ body:             |
   ; CHECK-NEXT:     NOPV
   ; CHECK-NEXT:   }
   ; CHECK-NEXT:   BUNDLE implicit-def $r0, implicit-def $r8, implicit killed $r8, implicit $sp, implicit killed $r1, implicit killed $r0 {
+  ; CHECK-NEXT:     NOPA
+  ; CHECK-NEXT:     NOPB
   ; CHECK-NEXT:     ST_dms_sts_spill killed $r8, -56, implicit $sp :: (store (s32) into %stack.1)
   ; CHECK-NEXT:     renamable $r0 = GE killed renamable $r1, killed $r0
   ; CHECK-NEXT:     $r8 = MOV_alu_mv_mv_mv_scl internal $r0
+  ; CHECK-NEXT:     NOPV
   ; CHECK-NEXT:   }
   ; CHECK-NEXT:   BUNDLE implicit killed $r0 {
   ; CHECK-NEXT:     JNZ killed renamable $r0, %bb.3
@@ -78,13 +81,10 @@ body:             |
   ; CHECK-NEXT:     $ls = MOVXM %bb.2
   ; CHECK-NEXT:   }
   ; CHECK-NEXT:   BUNDLE implicit-def $le {
+  ; CHECK-NEXT:     NOPA
+  ; CHECK-NEXT:     NOPB
+  ; CHECK-NEXT:     NOPS
   ; CHECK-NEXT:     $le = MOVXM <mcsymbol .L_LEnd0>
-  ; CHECK-NEXT:   }
-  ; CHECK-NEXT:   BUNDLE {
-  ; CHECK-NEXT:     NOPA
-  ; CHECK-NEXT:     NOPB
-  ; CHECK-NEXT:     NOPS
-  ; CHECK-NEXT:     NOPXM
   ; CHECK-NEXT:     NOPV
   ; CHECK-NEXT:   }
   ; CHECK-NEXT:   BUNDLE {
@@ -118,9 +118,11 @@ body:             |
   ; CHECK-NEXT:   BUNDLE {
   ; CHECK-NEXT:     NOPA
   ; CHECK-NEXT:     NOPB
-  ; CHECK-NEXT:     NOPS
   ; CHECK-NEXT:     NOPXM
-  ; CHECK-NEXT:     NOPV
+  ; CHECK-NEXT:     NOPS
+  ; CHECK-NEXT:   }
+  ; CHECK-NEXT:   BUNDLE {
+  ; CHECK-NEXT:     NOP
   ; CHECK-NEXT:   }
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT: bb.2 (align 16):

--- a/llvm/test/CodeGen/AIE/aie2p/align-zol-meta-before-lend.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/align-zol-meta-before-lend.mir
@@ -24,9 +24,12 @@ body:             |
   ; CHECK-NEXT:   BUNDLE implicit-def $r1 {
   ; CHECK-NEXT:     $r1 = MOVA 0
   ; CHECK-NEXT:     NOPB
+  ; CHECK-NEXT:     NOPS
   ; CHECK-NEXT:     NOPXM
+  ; CHECK-NEXT:     NOPV
   ; CHECK-NEXT:   }
   ; CHECK-NEXT:   BUNDLE implicit-def $r1, implicit killed $r1, implicit $r0 {
+  ; CHECK-NEXT:     NOPA
   ; CHECK-NEXT:     $r1 = GE killed $r1, $r0
   ; CHECK-NEXT:   }
   ; CHECK-NEXT:   BUNDLE implicit killed $r1 {
@@ -60,13 +63,10 @@ body:             |
   ; CHECK-NEXT:     $ls = MOVXM %bb.2
   ; CHECK-NEXT:   }
   ; CHECK-NEXT:   BUNDLE implicit-def $le {
+  ; CHECK-NEXT:     NOPA
+  ; CHECK-NEXT:     NOPB
+  ; CHECK-NEXT:     NOPS
   ; CHECK-NEXT:     $le = MOVXM <mcsymbol .L_LEnd0>
-  ; CHECK-NEXT:   }
-  ; CHECK-NEXT:   BUNDLE {
-  ; CHECK-NEXT:     NOPA
-  ; CHECK-NEXT:     NOPB
-  ; CHECK-NEXT:     NOPS
-  ; CHECK-NEXT:     NOPXM
   ; CHECK-NEXT:     NOPV
   ; CHECK-NEXT:   }
   ; CHECK-NEXT:   BUNDLE {
@@ -100,9 +100,11 @@ body:             |
   ; CHECK-NEXT:   BUNDLE {
   ; CHECK-NEXT:     NOPA
   ; CHECK-NEXT:     NOPB
-  ; CHECK-NEXT:     NOPS
   ; CHECK-NEXT:     NOPXM
-  ; CHECK-NEXT:     NOPV
+  ; CHECK-NEXT:     NOPS
+  ; CHECK-NEXT:   }
+  ; CHECK-NEXT:   BUNDLE {
+  ; CHECK-NEXT:     NOP
   ; CHECK-NEXT:   }
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT: bb.2 (align 16):

--- a/llvm/test/CodeGen/AIE/aie2p/align-zol-with-branch.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/align-zol-with-branch.mir
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2025 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2025-2026 Advanced Micro Devices, Inc. or its affiliates
 
 # RUN: llc -mtriple=aie2p %s --run-pass=aie-machine-alignment -o - | FileCheck %s
 
@@ -20,9 +20,12 @@ body:             |
   ; CHECK-NEXT:   BUNDLE implicit-def $r1 {
   ; CHECK-NEXT:     $r1 = MOVA 0
   ; CHECK-NEXT:     NOPB
+  ; CHECK-NEXT:     NOPS
   ; CHECK-NEXT:     NOPXM
+  ; CHECK-NEXT:     NOPV
   ; CHECK-NEXT:   }
   ; CHECK-NEXT:   BUNDLE implicit-def $r1, implicit killed $r1, implicit $r0 {
+  ; CHECK-NEXT:     NOPA
   ; CHECK-NEXT:     $r1 = GE killed $r1, $r0
   ; CHECK-NEXT:   }
   ; CHECK-NEXT:   BUNDLE implicit killed $r1 {
@@ -56,13 +59,10 @@ body:             |
   ; CHECK-NEXT:     $ls = MOVXM %bb.2
   ; CHECK-NEXT:   }
   ; CHECK-NEXT:   BUNDLE implicit-def $le {
+  ; CHECK-NEXT:     NOPA
+  ; CHECK-NEXT:     NOPB
+  ; CHECK-NEXT:     NOPS
   ; CHECK-NEXT:     $le = MOVXM <mcsymbol .L_LEnd0>
-  ; CHECK-NEXT:   }
-  ; CHECK-NEXT:   BUNDLE {
-  ; CHECK-NEXT:     NOPA
-  ; CHECK-NEXT:     NOPB
-  ; CHECK-NEXT:     NOPS
-  ; CHECK-NEXT:     NOPXM
   ; CHECK-NEXT:     NOPV
   ; CHECK-NEXT:   }
   ; CHECK-NEXT:   BUNDLE {
@@ -96,9 +96,11 @@ body:             |
   ; CHECK-NEXT:   BUNDLE {
   ; CHECK-NEXT:     NOPA
   ; CHECK-NEXT:     NOPB
-  ; CHECK-NEXT:     NOPS
   ; CHECK-NEXT:     NOPXM
-  ; CHECK-NEXT:     NOPV
+  ; CHECK-NEXT:     NOPS
+  ; CHECK-NEXT:   }
+  ; CHECK-NEXT:   BUNDLE {
+  ; CHECK-NEXT:     NOP
   ; CHECK-NEXT:   }
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT: bb.2 (align 16):

--- a/llvm/test/CodeGen/AIE/aie2p/align-zol.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/align-zol.mir
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2025 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2025-2026 Advanced Micro Devices, Inc. or its affiliates
 
 # RUN: llc -mtriple=aie2p %s --run-pass=aie-machine-alignment -o - | FileCheck %s
 
@@ -20,9 +20,12 @@ body:             |
   ; CHECK-NEXT:   BUNDLE implicit-def $r1 {
   ; CHECK-NEXT:     $r1 = MOVA 0
   ; CHECK-NEXT:     NOPB
+  ; CHECK-NEXT:     NOPS
   ; CHECK-NEXT:     NOPXM
+  ; CHECK-NEXT:     NOPV
   ; CHECK-NEXT:   }
   ; CHECK-NEXT:   BUNDLE implicit-def $r1, implicit killed $r1, implicit $r0 {
+  ; CHECK-NEXT:     NOPA
   ; CHECK-NEXT:     $r1 = GE killed $r1, $r0
   ; CHECK-NEXT:   }
   ; CHECK-NEXT:   BUNDLE implicit killed $r1 {
@@ -56,13 +59,10 @@ body:             |
   ; CHECK-NEXT:     $ls = MOVXM %bb.2
   ; CHECK-NEXT:   }
   ; CHECK-NEXT:   BUNDLE implicit-def $le {
+  ; CHECK-NEXT:     NOPA
+  ; CHECK-NEXT:     NOPB
+  ; CHECK-NEXT:     NOPS
   ; CHECK-NEXT:     $le = MOVXM <mcsymbol .L_LEnd0>
-  ; CHECK-NEXT:   }
-  ; CHECK-NEXT:   BUNDLE {
-  ; CHECK-NEXT:     NOPA
-  ; CHECK-NEXT:     NOPB
-  ; CHECK-NEXT:     NOPS
-  ; CHECK-NEXT:     NOPXM
   ; CHECK-NEXT:     NOPV
   ; CHECK-NEXT:   }
   ; CHECK-NEXT:   BUNDLE {
@@ -96,9 +96,11 @@ body:             |
   ; CHECK-NEXT:   BUNDLE {
   ; CHECK-NEXT:     NOPA
   ; CHECK-NEXT:     NOPB
-  ; CHECK-NEXT:     NOPS
   ; CHECK-NEXT:     NOPXM
-  ; CHECK-NEXT:     NOPV
+  ; CHECK-NEXT:     NOPS
+  ; CHECK-NEXT:   }
+  ; CHECK-NEXT:   BUNDLE {
+  ; CHECK-NEXT:     NOP
   ; CHECK-NEXT:   }
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT: bb.2 (align 16):

--- a/llvm/test/CodeGen/AIE/aie2p/elongate/zol_112bytes_elongate.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/elongate/zol_112bytes_elongate.mir
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2024-2026 Advanced Micro Devices, Inc. or its affiliates
 
 # RUN: llc -mtriple aie2p -run-pass=aie-machine-alignment %s -verify-machineinstrs -o - | FileCheck %s
 ---
@@ -15,18 +15,18 @@ body:             |
     ; CHECK-LABEL: name: zol_112bytes_constraint
     ; CHECK: BUNDLE implicit-def $r1, implicit-def $r2, implicit-def $lc, implicit $p0, implicit $r0 {
     ; CHECK-NEXT:   renamable $r1 = LDA_dms_lda_idx_imm renamable $p0, 0
-    ; CHECK-NEXT:   NOPB
-    ; CHECK-NEXT:   NOPS
     ; CHECK-NEXT:   renamable $r2 = MOVX_alu_cg 0
     ; CHECK-NEXT:   $lc = MOV_alu_mv_mv_mv_scl $r0
-    ; CHECK-NEXT:   NOPV
     ; CHECK-NEXT: }
     ; CHECK-NEXT: BUNDLE implicit-def $ls {
-    ; CHECK-NEXT:   NOPA
     ; CHECK-NEXT:   $ls = MOVXM 0
     ; CHECK-NEXT: }
     ; CHECK-NEXT: BUNDLE implicit-def $le {
+    ; CHECK-NEXT:   NOPA
+    ; CHECK-NEXT:   NOPB
+    ; CHECK-NEXT:   NOPS
     ; CHECK-NEXT:   $le = MOVXM <mcsymbol .L_1120>
+    ; CHECK-NEXT:   NOPV
     ; CHECK-NEXT: }
     ; CHECK-NEXT: BUNDLE implicit-def $r3 {
     ; CHECK-NEXT:   NOPA
@@ -67,16 +67,11 @@ body:             |
     ; CHECK-NEXT: BUNDLE {
     ; CHECK-NEXT:   NOPA
     ; CHECK-NEXT:   NOPB
-    ; CHECK-NEXT:   NOPS
     ; CHECK-NEXT:   NOPXM
-    ; CHECK-NEXT:   NOPV
+    ; CHECK-NEXT:   NOPS
     ; CHECK-NEXT: }
     ; CHECK-NEXT: BUNDLE {
-    ; CHECK-NEXT:   NOPA
-    ; CHECK-NEXT:   NOPB
-    ; CHECK-NEXT:   NOPS
-    ; CHECK-NEXT:   NOPXM
-    ; CHECK-NEXT:   NOPV
+    ; CHECK-NEXT:   NOP
     ; CHECK-NEXT: }
     BUNDLE implicit-def $r1, implicit-def $r2, implicit-def $lc, implicit $p0, implicit $r0 {
       renamable $r1 = LDA_dms_lda_idx_imm renamable $p0, 0

--- a/llvm/test/CodeGen/AIE/aie2p/elongate/zol_112bytes_elongate1.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/elongate/zol_112bytes_elongate1.mir
@@ -6,14 +6,8 @@
 #
 # (c) Copyright 2025-2026 Advanced Micro Devices, Inc. or its affiliates
 
-# RUN: llc -mtriple=aie2p -run-pass=aie-machine-alignment -debug-only=aie-machine-alignment -verify-machineinstrs -o - %s 2>%t.dbg \
-# RUN:   | FileCheck %s
-# RUN: FileCheck %s --check-prefix=DBG < %t.dbg
-#
-# zol_elongated_preheader_plus_1_LoopBundles_ge112bytes
-# DBG: setup-to-loopend distance (MBB 1): 138 bytes
-# empty_MBB_After_zol_elongated_preheader_plus_1_LoopBundles_ge112bytes
-# DBG: setup-to-loopend distance (MBB 1): 138 bytes
+# RUN: llc -mtriple aie2p -run-pass=aie-machine-alignment %s -verify-machineinstrs -o - | FileCheck %s
+
 ---
 name:            zol_elongated_preheader_plus_1_LoopBundles_ge112bytes
 alignment:       16
@@ -24,9 +18,8 @@ body:             |
   ; CHECK-NEXT:   liveins: $p0, $r0
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   BUNDLE implicit-def $x6, implicit-def $wl6, implicit-def $wh6, implicit-def $p0, implicit killed $p0 {
-  ; CHECK-NEXT:     NOPA
   ; CHECK-NEXT:     renamable $x6, renamable $p0 = VLDB_dmx_ldb_x_pstm_nrm_imm killed renamable $p0, 0 :: (load (<32 x s16>))
-  ; CHECK-NEXT:     NOPXM
+  ; CHECK-NEXT:     NOPX
   ; CHECK-NEXT:   }
   ; CHECK-NEXT:   BUNDLE implicit-def $r0, implicit-def dead $srcarry, implicit killed $r0 {
   ; CHECK-NEXT:     renamable $r0 = ADD_add_r_ri killed renamable $r0, -1, implicit-def dead $srcarry
@@ -44,8 +37,11 @@ body:             |
   ; CHECK-NEXT:     $ls = MOVXM %bb.1
   ; CHECK-NEXT:   }
   ; CHECK-NEXT:   BUNDLE implicit-def $x1, implicit-def $wl1, implicit-def $wh1, implicit-def $p0, implicit-def $le, implicit killed $p0 {
+  ; CHECK-NEXT:     NOPA
   ; CHECK-NEXT:     renamable $x1, renamable $p0 = VLDB_dmx_ldb_x_pstm_nrm_imm killed renamable $p0, 128 :: (load (<32 x s16>))
+  ; CHECK-NEXT:     NOPS
   ; CHECK-NEXT:     $le = MOVXM <mcsymbol .L_LEnd0>
+  ; CHECK-NEXT:     NOPV
   ; CHECK-NEXT:   }
   ; CHECK-NEXT:   BUNDLE implicit-def $x0, implicit-def $wl0, implicit-def $wh0, implicit-def $p0, implicit-def $r0, implicit-def dead $srcarry, implicit killed $p0, implicit killed $r0 {
   ; CHECK-NEXT:     NOPA
@@ -70,20 +66,13 @@ body:             |
   ; CHECK-NEXT:     NOPV
   ; CHECK-NEXT:   }
   ; CHECK-NEXT:   BUNDLE implicit-def $x0, implicit-def $wl0, implicit-def $wh0, implicit-def $p0, implicit-def $r0, implicit-def dead $srcarry, implicit killed $p0, implicit killed $r0 {
-  ; CHECK-NEXT:     NOPA
   ; CHECK-NEXT:     renamable $x0, renamable $p0 = VLDB_dmx_ldb_x_pstm_nrm_imm killed renamable $p0, 64 :: (load (<32 x s16>))
-  ; CHECK-NEXT:     NOPS
   ; CHECK-NEXT:     renamable $r0 = ADD_add_r_ri killed renamable $r0, -1, implicit-def dead $srcarry
   ; CHECK-NEXT:     NOPM
-  ; CHECK-NEXT:     NOPV
   ; CHECK-NEXT:   }
   ; CHECK-NEXT:   BUNDLE implicit-def $x2, implicit-def $wl2, implicit-def $wh2, implicit-def $p0, implicit-def $x4, implicit-def $wl4, implicit-def $wh4, implicit killed $p0, implicit $x6, implicit killed $x0 {
-  ; CHECK-NEXT:     NOPA
   ; CHECK-NEXT:     renamable $x2, renamable $p0 = VLDB_dmx_ldb_x_pstm_nrm_imm killed renamable $p0, 64 :: (load (<32 x s16>))
-  ; CHECK-NEXT:     NOPS
-  ; CHECK-NEXT:     NOPX
   ; CHECK-NEXT:     renamable $x4 = VADD_16 renamable $x6, killed renamable $x0
-  ; CHECK-NEXT:     NOPV
   ; CHECK-NEXT:   }
   ; CHECK-NEXT:   BUNDLE implicit-def $x1, implicit-def $wl1, implicit-def $wh1, implicit-def $p0, implicit killed $p0 {
   ; CHECK-NEXT:     renamable $x1, renamable $p0 = VLDB_dmx_ldb_x_pstm_nrm_imm killed renamable $p0, 128 :: (load (<32 x s16>))
@@ -219,9 +208,8 @@ body:             |
   ; CHECK-NEXT:   liveins: $p0, $r0
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   BUNDLE implicit-def $x6, implicit-def $wl6, implicit-def $wh6, implicit-def $p0, implicit killed $p0 {
-  ; CHECK-NEXT:     NOPA
   ; CHECK-NEXT:     renamable $x6, renamable $p0 = VLDB_dmx_ldb_x_pstm_nrm_imm killed renamable $p0, 0 :: (load (<32 x s16>))
-  ; CHECK-NEXT:     NOPXM
+  ; CHECK-NEXT:     NOPX
   ; CHECK-NEXT:   }
   ; CHECK-NEXT:   BUNDLE implicit-def $r0, implicit-def dead $srcarry, implicit killed $r0 {
   ; CHECK-NEXT:     renamable $r0 = ADD_add_r_ri killed renamable $r0, -1, implicit-def dead $srcarry
@@ -239,8 +227,11 @@ body:             |
   ; CHECK-NEXT:     $ls = MOVXM %bb.1
   ; CHECK-NEXT:   }
   ; CHECK-NEXT:   BUNDLE implicit-def $x1, implicit-def $wl1, implicit-def $wh1, implicit-def $p0, implicit-def $le, implicit killed $p0 {
+  ; CHECK-NEXT:     NOPA
   ; CHECK-NEXT:     renamable $x1, renamable $p0 = VLDB_dmx_ldb_x_pstm_nrm_imm killed renamable $p0, 128 :: (load (<32 x s16>))
+  ; CHECK-NEXT:     NOPS
   ; CHECK-NEXT:     $le = MOVXM <mcsymbol .L_LEnd0>
+  ; CHECK-NEXT:     NOPV
   ; CHECK-NEXT:   }
   ; CHECK-NEXT:   BUNDLE implicit-def $x0, implicit-def $wl0, implicit-def $wh0, implicit-def $p0, implicit-def $r0, implicit-def dead $srcarry, implicit killed $p0, implicit killed $r0 {
   ; CHECK-NEXT:     NOPA
@@ -265,20 +256,13 @@ body:             |
   ; CHECK-NEXT:     NOPV
   ; CHECK-NEXT:   }
   ; CHECK-NEXT:   BUNDLE implicit-def $x0, implicit-def $wl0, implicit-def $wh0, implicit-def $p0, implicit-def $r0, implicit-def dead $srcarry, implicit killed $p0, implicit killed $r0 {
-  ; CHECK-NEXT:     NOPA
   ; CHECK-NEXT:     renamable $x0, renamable $p0 = VLDB_dmx_ldb_x_pstm_nrm_imm killed renamable $p0, 64 :: (load (<32 x s16>))
-  ; CHECK-NEXT:     NOPS
   ; CHECK-NEXT:     renamable $r0 = ADD_add_r_ri killed renamable $r0, -1, implicit-def dead $srcarry
   ; CHECK-NEXT:     NOPM
-  ; CHECK-NEXT:     NOPV
   ; CHECK-NEXT:   }
   ; CHECK-NEXT:   BUNDLE implicit-def $x2, implicit-def $wl2, implicit-def $wh2, implicit-def $p0, implicit-def $x4, implicit-def $wl4, implicit-def $wh4, implicit killed $p0, implicit $x6, implicit killed $x0 {
-  ; CHECK-NEXT:     NOPA
   ; CHECK-NEXT:     renamable $x2, renamable $p0 = VLDB_dmx_ldb_x_pstm_nrm_imm killed renamable $p0, 64 :: (load (<32 x s16>))
-  ; CHECK-NEXT:     NOPS
-  ; CHECK-NEXT:     NOPX
   ; CHECK-NEXT:     renamable $x4 = VADD_16 renamable $x6, killed renamable $x0
-  ; CHECK-NEXT:     NOPV
   ; CHECK-NEXT:   }
   ; CHECK-NEXT:   BUNDLE implicit-def $x1, implicit-def $wl1, implicit-def $wh1, implicit-def $p0, implicit killed $p0 {
   ; CHECK-NEXT:     renamable $x1, renamable $p0 = VLDB_dmx_ldb_x_pstm_nrm_imm killed renamable $p0, 128 :: (load (<32 x s16>))

--- a/llvm/test/CodeGen/AIE/aie2p/elongate/zol_112bytes_elongate2.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/elongate/zol_112bytes_elongate2.mir
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2025 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2025-2026 Advanced Micro Devices, Inc. or its affiliates
 
 # RUN: llc -mtriple aie2p -run-pass=aie-machine-alignment %s -verify-machineinstrs -o - | FileCheck %s
 
@@ -19,26 +19,19 @@ body:             |
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   BUNDLE {
   ; CHECK-NEXT:     NOPA
-  ; CHECK-NEXT:     NOPB
-  ; CHECK-NEXT:     NOPS
   ; CHECK-NEXT:     $ls = MOVXM %bb.1
-  ; CHECK-NEXT:     NOPV
   ; CHECK-NEXT:   }
   ; CHECK-NEXT:   BUNDLE {
-  ; CHECK-NEXT:     NOPA
   ; CHECK-NEXT:     $le = MOVXM <mcsymbol .L_LEnd0>
   ; CHECK-NEXT:   }
   ; CHECK-NEXT:   BUNDLE {
+  ; CHECK-NEXT:     NOPA
   ; CHECK-NEXT:     $x3, $p0, $dc0, $dc4 = VLDB_3D_UNPACK_dmw_ldb_unpack_unpackSign1 killed $p0, $d0_3d, implicit $crunpacksize, implicit $unpacksign1 :: (load (<32 x s8>))
+  ; CHECK-NEXT:     NOPX
   ; CHECK-NEXT:     $lc = ADD_NC_mv_add_ri killed $r7, -3
   ; CHECK-NEXT:   }
   ; CHECK-NEXT:   BUNDLE {
-  ; CHECK-NEXT:     NOPA
-  ; CHECK-NEXT:     NOPB
-  ; CHECK-NEXT:     NOPS
-  ; CHECK-NEXT:     NOPX
   ; CHECK-NEXT:     $crunpacksize = MOV_alu_mv_mv_mv_cg 1
-  ; CHECK-NEXT:     NOPV
   ; CHECK-NEXT:   }
   ; CHECK-NEXT:   BUNDLE {
   ; CHECK-NEXT:     $x1, $p3, $dc2 = VLDA_2D_dmx_lda_x killed $p3, $d2 :: (load (<32 x s16>))

--- a/llvm/test/CodeGen/AIE/aie2p/elongate/zol_phdr_loopbundles_112bytes.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/elongate/zol_phdr_loopbundles_112bytes.mir
@@ -24,10 +24,10 @@
   ; CHECK-NEXT:    nopa ; nopb ; nops ; add r0, r0, #-1; nopm ; nopv
   ; CHECK-NEXT:    vldb x6, [p0], #0; add.nc lc, r0, #-3
   ; CHECK-NEXT:    vldb x0, [p0], #64; add r0, r0, #-1
-  ; CHECK-NEXT:    vlda x2, [p0], #64; movxm ls, #.LBB0_1
-  ; CHECK-NEXT:    vldb x1, [p0], #128; movxm le, #.L_LEnd0
-  ; CHECK-NEXT:    nopa ; vldb x0, [p0], #64; nops ; add r0, r0, #-1; nopm ; nopv
-  ; CHECK-NEXT:    vlda x2, [p0], #64; nopb ; nops ; nopxm ; nopv
+  ; CHECK-NEXT:    vlda x2, [p0], #64
+  ; CHECK-NEXT:    vldb x1, [p0], #128; movxm ls, #.LBB0_1
+  ; CHECK-NEXT:    vldb x0, [p0], #64; add r0, r0, #-1
+  ; CHECK-NEXT:    vlda x2, [p0], #64; nopb ; nops ; movxm le, #.L_LEnd0; nopv
   ; CHECK-NEXT:    nopa ; vldb x1, [p0], #128; nops ; nopxm ; nopv
   ; CHECK-NEXT:    nopa ; vldb x0, [p0], #64; nops ; add r0, r0, #-1; nopm ; nopv
   ; CHECK-NEXT:    vlda x2, [p0], #64; nopb ; nops ; nopx ; vadd.16 x4, x6, x0; nopv
@@ -35,8 +35,8 @@
   ; CHECK-NEXT:    .p2align 4
   ; CHECK-NEXT:  .LBB0_1: // %for.body
   ; CHECK-NEXT:    // =>This Inner Loop Header: Depth=1
-  ; CHECK-NEXT:    vldb x0, [p0], #64; add r0, r0, #-1; vadd.16 x6, x4, x1
-  ; CHECK-NEXT:    vlda x2, [p0], #64; vadd.16 x4, x6, x0
+  ; CHECK-NEXT:    nopa ; vldb x0, [p0], #64; nops ; add r0, r0, #-1; vadd.16 x6, x4, x1; nopv
+  ; CHECK-NEXT:    vlda x2, [p0], #64; nopb ; nops ; nopx ; vadd.16 x4, x6, x0; nopv
   ; CHECK-NEXT:  .L_LEnd0:
   ; CHECK-NEXT:    nopa ; vldb x1, [p0], #128; nops ; nopxm ; nopv
   ; CHECK-NEXT:  // %bb.2: // %for.cond.cleanup

--- a/llvm/test/CodeGen/AIE/aie2p/end-to-end/add-att-broadcasting-aa.ll
+++ b/llvm/test/CodeGen/AIE/aie2p/end-to-end/add-att-broadcasting-aa.ll
@@ -27,16 +27,16 @@ declare <32 x bfloat> @llvm.aie2p.v32accfloat.to.v32bf16(<32 x float>) #1
 define dso_local void @add_attribute_bcast_prologue1(ptr %ifm2, ptr %ifm1, i32 %div16, ptr noalias %ofm, ptr noalias %targetptr, ptr %targetptrmayalias) {
 ; CHECK-LABEL: add_attribute_bcast_prologue1:
 ; CHECK:       // %bb.0: // %newFuncRoot
-; CHECK-NEXT:    mova m0, #32; nopb ; st r0, [p4, #0]
+; CHECK-NEXT:    mova m0, #32; nopb ; nopx ; st r0, [p4, #0]
 ; CHECK-NEXT:    vlda.conv.fp32.bf16 cml1, [p1], m0
 ; CHECK-NEXT:    vlda.conv.fp32.bf16 cml2, [p0], m0
 ; CHECK-NEXT:    vlda.conv.fp32.bf16 cml0, [p0], m0
 ; CHECK-NEXT:    vlda.conv.fp32.bf16 cml3, [p1], m0
 ; CHECK-NEXT:    vlda.conv.fp32.bf16 cml1, [p1], m0; movx r1, #60
-; CHECK-NEXT:    vlda.conv.fp32.bf16 cml2, [p0], m0; add.nc lc, r0, #-3; vadd.f dm4, dm1, dm2, r1
-; CHECK-NEXT:    vlda.conv.fp32.bf16 cml0, [p0], m0; st r0, [p3, #0]; movxm ls, #.LBB0_1
-; CHECK-NEXT:    vlda.conv.fp32.bf16 cml3, [p1], m0; movxm le, #.L_LEnd0; vadd.f dm3, dm3, dm0, r1
-; CHECK-NEXT:    vlda.conv.fp32.bf16 cml1, [p1], m0; nopb ; nops ; nopxm ; nopv
+; CHECK-NEXT:    vlda.conv.fp32.bf16 cml2, [p0], m0; vadd.f dm4, dm1, dm2, r1
+; CHECK-NEXT:    vlda.conv.fp32.bf16 cml0, [p0], m0; st r0, [p3, #0]; add.nc lc, r0, #-3
+; CHECK-NEXT:    vlda.conv.fp32.bf16 cml3, [p1], m0; movxm ls, #.LBB0_1; vadd.f dm3, dm3, dm0, r1
+; CHECK-NEXT:    vlda.conv.fp32.bf16 cml1, [p1], m0; nopb ; nops ; movxm le, #.L_LEnd0; nopv
 ; CHECK-NEXT:    vlda.conv.fp32.bf16 cml2, [p0], m0; nopb ; nops ; nopxm ; vadd.f dm4, dm1, dm2, r1
 ; CHECK-NEXT:    vlda.conv.fp32.bf16 cml0, [p0], m0; nopb ; nops ; nopxm ; nopv
 ; CHECK-NEXT:    vlda.conv.fp32.bf16 cml3, [p1], m0; nopb ; vst.conv.bf16.fp32 cml4, [p2], #64; nopxm ; vadd.f dm3, dm3, dm0, r1
@@ -144,8 +144,8 @@ for.cond.cleanup.ret.exitStub:                    ; preds = %for.cond.cleanup
 define dso_local void @add_attribute_bcast_prologue2(ptr %ifm2, ptr %ifm1, i32 %div16, ptr noalias %ofm, ptr noalias %targetptr) {
 ; CHECK-LABEL: add_attribute_bcast_prologue2:
 ; CHECK:       // %bb.0: // %newFuncRoot
-; CHECK-NEXT:    st.s16 r0, [p3, #0]; nopb ; nopxm
-; CHECK-NEXT:    nop
+; CHECK-NEXT:    st.s16 r0, [p3, #0]; nopb ; nops ; nopxm ; nopv
+; CHECK-NEXT:    nopx
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
@@ -156,10 +156,10 @@ define dso_local void @add_attribute_bcast_prologue2(ptr %ifm2, ptr %ifm1, i32 %
 ; CHECK-NEXT:    vlda.conv.fp32.bf16 cml0, [p0], m0
 ; CHECK-NEXT:    vlda.conv.fp32.bf16 cml3, [p1], m0
 ; CHECK-NEXT:    vlda.conv.fp32.bf16 cml1, [p1], m0; movx r1, #60
-; CHECK-NEXT:    vlda.conv.fp32.bf16 cml2, [p0], m0; add.nc lc, r0, #-3; vadd.f dm4, dm1, dm2, r1
-; CHECK-NEXT:    vlda.conv.fp32.bf16 cml0, [p0], m0; movxm ls, #.LBB1_1
-; CHECK-NEXT:    vlda.conv.fp32.bf16 cml3, [p1], m0; movxm le, #.L_LEnd1; vadd.f dm3, dm3, dm0, r1
-; CHECK-NEXT:    vlda.conv.fp32.bf16 cml1, [p1], m0; nopb ; nops ; nopxm ; nopv
+; CHECK-NEXT:    vlda.conv.fp32.bf16 cml2, [p0], m0; vadd.f dm4, dm1, dm2, r1
+; CHECK-NEXT:    vlda.conv.fp32.bf16 cml0, [p0], m0; add.nc lc, r0, #-3
+; CHECK-NEXT:    vlda.conv.fp32.bf16 cml3, [p1], m0; movxm ls, #.LBB1_1; vadd.f dm3, dm3, dm0, r1
+; CHECK-NEXT:    vlda.conv.fp32.bf16 cml1, [p1], m0; nopb ; nops ; movxm le, #.L_LEnd1; nopv
 ; CHECK-NEXT:    vlda.conv.fp32.bf16 cml2, [p0], m0; nopb ; nops ; nopxm ; vadd.f dm4, dm1, dm2, r1
 ; CHECK-NEXT:    vlda.conv.fp32.bf16 cml0, [p0], m0; nopb ; nops ; nopxm ; nopv
 ; CHECK-NEXT:    vlda.conv.fp32.bf16 cml3, [p1], m0; nopb ; vst.conv.bf16.fp32 cml4, [p2], #64; nopxm ; vadd.f dm3, dm3, dm0, r1
@@ -267,16 +267,16 @@ for.cond.cleanup.ret.exitStub:                    ; preds = %for.cond.cleanup
 define dso_local void @add_attribute_bcast_epilogue1(ptr noalias %ifm2, ptr noalias %ifm1, i32 %div16, ptr %ofm, ptr noalias %targetptr, ptr %targetptrmayalias) {
 ; CHECK-LABEL: add_attribute_bcast_epilogue1:
 ; CHECK:       // %bb.0: // %newFuncRoot
-; CHECK-NEXT:    mova m0, #32; nopxm
+; CHECK-NEXT:    mova m0, #32; nopb ; nops ; nopxm ; nopv
 ; CHECK-NEXT:    vlda.conv.fp32.bf16 cml1, [p1], m0
 ; CHECK-NEXT:    vlda.conv.fp32.bf16 cml2, [p0], m0
 ; CHECK-NEXT:    vlda.conv.fp32.bf16 cml0, [p0], m0
 ; CHECK-NEXT:    vlda.conv.fp32.bf16 cml3, [p1], m0
 ; CHECK-NEXT:    vlda.conv.fp32.bf16 cml1, [p1], m0; movx r1, #60
-; CHECK-NEXT:    vlda.conv.fp32.bf16 cml2, [p0], m0; add.nc lc, r0, #-3; vadd.f dm4, dm1, dm2, r1
-; CHECK-NEXT:    vlda.conv.fp32.bf16 cml0, [p0], m0; movxm ls, #.LBB2_1
-; CHECK-NEXT:    vlda.conv.fp32.bf16 cml3, [p1], m0; movxm le, #.L_LEnd2; vadd.f dm3, dm3, dm0, r1
-; CHECK-NEXT:    vlda.conv.fp32.bf16 cml1, [p1], m0; nopb ; nops ; nopxm ; nopv
+; CHECK-NEXT:    vlda.conv.fp32.bf16 cml2, [p0], m0; vadd.f dm4, dm1, dm2, r1
+; CHECK-NEXT:    vlda.conv.fp32.bf16 cml0, [p0], m0; add.nc lc, r0, #-3
+; CHECK-NEXT:    vlda.conv.fp32.bf16 cml3, [p1], m0; movxm ls, #.LBB2_1; vadd.f dm3, dm3, dm0, r1
+; CHECK-NEXT:    vlda.conv.fp32.bf16 cml1, [p1], m0; nopb ; nops ; movxm le, #.L_LEnd2; nopv
 ; CHECK-NEXT:    vlda.conv.fp32.bf16 cml2, [p0], m0; nopb ; nops ; nopxm ; vadd.f dm4, dm1, dm2, r1
 ; CHECK-NEXT:    vlda.conv.fp32.bf16 cml0, [p0], m0; nopb ; nops ; nopxm ; nopv
 ; CHECK-NEXT:    vlda.conv.fp32.bf16 cml3, [p1], m0; nopb ; vst.conv.bf16.fp32 cml4, [p2], #64; nopxm ; vadd.f dm3, dm3, dm0, r1
@@ -385,16 +385,16 @@ for.cond.cleanup.ret.exitStub:                    ; preds = %for.cond.cleanup
 define dso_local void @add_attribute_bcast_epilogue2(ptr noalias %ifm2, ptr noalias %ifm1, i32 %div16, ptr %ofm, ptr noalias %targetptr) {
 ; CHECK-LABEL: add_attribute_bcast_epilogue2:
 ; CHECK:       // %bb.0: // %newFuncRoot
-; CHECK-NEXT:    mova m0, #32; nopxm
+; CHECK-NEXT:    mova m0, #32; nopb ; nops ; nopxm ; nopv
 ; CHECK-NEXT:    vlda.conv.fp32.bf16 cml1, [p1], m0
 ; CHECK-NEXT:    vlda.conv.fp32.bf16 cml2, [p0], m0
 ; CHECK-NEXT:    vlda.conv.fp32.bf16 cml0, [p0], m0
 ; CHECK-NEXT:    vlda.conv.fp32.bf16 cml3, [p1], m0
 ; CHECK-NEXT:    vlda.conv.fp32.bf16 cml1, [p1], m0; movx r1, #60
-; CHECK-NEXT:    vlda.conv.fp32.bf16 cml2, [p0], m0; add.nc lc, r0, #-3; vadd.f dm4, dm1, dm2, r1
-; CHECK-NEXT:    vlda.conv.fp32.bf16 cml0, [p0], m0; movxm ls, #.LBB3_1
-; CHECK-NEXT:    vlda.conv.fp32.bf16 cml3, [p1], m0; movxm le, #.L_LEnd3; vadd.f dm3, dm3, dm0, r1
-; CHECK-NEXT:    vlda.conv.fp32.bf16 cml1, [p1], m0; nopb ; nops ; nopxm ; nopv
+; CHECK-NEXT:    vlda.conv.fp32.bf16 cml2, [p0], m0; vadd.f dm4, dm1, dm2, r1
+; CHECK-NEXT:    vlda.conv.fp32.bf16 cml0, [p0], m0; add.nc lc, r0, #-3
+; CHECK-NEXT:    vlda.conv.fp32.bf16 cml3, [p1], m0; movxm ls, #.LBB3_1; vadd.f dm3, dm3, dm0, r1
+; CHECK-NEXT:    vlda.conv.fp32.bf16 cml1, [p1], m0; nopb ; nops ; movxm le, #.L_LEnd3; nopv
 ; CHECK-NEXT:    vlda.conv.fp32.bf16 cml2, [p0], m0; nopb ; nops ; nopxm ; vadd.f dm4, dm1, dm2, r1
 ; CHECK-NEXT:    vlda.conv.fp32.bf16 cml0, [p0], m0; nopb ; nops ; nopxm ; nopv
 ; CHECK-NEXT:    vlda.conv.fp32.bf16 cml3, [p1], m0; nopb ; vst.conv.bf16.fp32 cml4, [p2], #64; nopxm ; vadd.f dm3, dm3, dm0, r1
@@ -504,16 +504,16 @@ for.cond.cleanup.ret.exitStub:                    ; preds = %for.cond.cleanup
 define dso_local void @add_attribute_bcast_epilogue3(ptr noalias %ifm2, ptr noalias %ifm1, i32 %div16, ptr %ofm, ptr noalias %targetptr, ptr %targetptrmayalias) {
 ; CHECK-LABEL: add_attribute_bcast_epilogue3:
 ; CHECK:       // %bb.0: // %newFuncRoot
-; CHECK-NEXT:    mova m0, #32; nopxm
+; CHECK-NEXT:    mova m0, #32; nopb ; nops ; nopxm ; nopv
 ; CHECK-NEXT:    vlda.conv.fp32.bf16 cml1, [p1], m0
 ; CHECK-NEXT:    vlda.conv.fp32.bf16 cml2, [p0], m0
 ; CHECK-NEXT:    vlda.conv.fp32.bf16 cml0, [p0], m0
 ; CHECK-NEXT:    vlda.conv.fp32.bf16 cml3, [p1], m0
 ; CHECK-NEXT:    vlda.conv.fp32.bf16 cml1, [p1], m0; movx r1, #60
-; CHECK-NEXT:    vlda.conv.fp32.bf16 cml2, [p0], m0; add.nc lc, r0, #-3; vadd.f dm4, dm1, dm2, r1
-; CHECK-NEXT:    vlda.conv.fp32.bf16 cml0, [p0], m0; movxm ls, #.LBB4_1
-; CHECK-NEXT:    vlda.conv.fp32.bf16 cml3, [p1], m0; movxm le, #.L_LEnd4; vadd.f dm3, dm3, dm0, r1
-; CHECK-NEXT:    vlda.conv.fp32.bf16 cml1, [p1], m0; nopb ; nops ; nopxm ; nopv
+; CHECK-NEXT:    vlda.conv.fp32.bf16 cml2, [p0], m0; vadd.f dm4, dm1, dm2, r1
+; CHECK-NEXT:    vlda.conv.fp32.bf16 cml0, [p0], m0; add.nc lc, r0, #-3
+; CHECK-NEXT:    vlda.conv.fp32.bf16 cml3, [p1], m0; movxm ls, #.LBB4_1; vadd.f dm3, dm3, dm0, r1
+; CHECK-NEXT:    vlda.conv.fp32.bf16 cml1, [p1], m0; nopb ; nops ; movxm le, #.L_LEnd4; nopv
 ; CHECK-NEXT:    vlda.conv.fp32.bf16 cml2, [p0], m0; nopb ; nops ; nopxm ; vadd.f dm4, dm1, dm2, r1
 ; CHECK-NEXT:    vlda.conv.fp32.bf16 cml0, [p0], m0; nopb ; nops ; nopxm ; nopv
 ; CHECK-NEXT:    vlda.conv.fp32.bf16 cml3, [p1], m0; nopb ; vst.conv.bf16.fp32 cml4, [p2], #64; nopxm ; vadd.f dm3, dm3, dm0, r1

--- a/llvm/test/CodeGen/AIE/aie2p/end-to-end/add-att-broadcasting.ll
+++ b/llvm/test/CodeGen/AIE/aie2p/end-to-end/add-att-broadcasting.ll
@@ -4,7 +4,7 @@
 ; See https://llvm.org/LICENSE.txt for license information.
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 ;
-; (c) Copyright 2025 Advanced Micro Devices, Inc. or its affiliates
+; (c) Copyright 2025-2026 Advanced Micro Devices, Inc. or its affiliates
 ; RUN: llc -mtriple=aie2p --aie-reg-rewrite-mode=latencyaware %s -o - | FileCheck %s
 
 ; Test postSWP capabilities related to AddAttributeBroadcasting
@@ -22,7 +22,7 @@ declare <32 x bfloat> @llvm.aie2p.v32accfloat.to.v32bf16(<32 x float>) #1
 define dso_local void @add_attribute_bcast(ptr noalias %ifm2, ptr noalias %ifm1, ptr noalias %params, i32 %div16, ptr noalias %ofm) {
 ; CHECK-LABEL: add_attribute_bcast:
 ; CHECK:       // %bb.0: // %newFuncRoot
-; CHECK-NEXT:    mova dj0, #32
+; CHECK-NEXT:    mova dj0, #32; nopxm
 ; CHECK-NEXT:    lda m0, [p2, dj0]
 ; CHECK-NEXT:    mova dj0, #36
 ; CHECK-NEXT:    lda m1, [p2, dj0]
@@ -36,10 +36,10 @@ define dso_local void @add_attribute_bcast(ptr noalias %ifm2, ptr noalias %ifm1,
 ; CHECK-NEXT:    vlda.conv.fp32.bf16 cml0, [p0], m1
 ; CHECK-NEXT:    vlda.conv.fp32.bf16 cml3, [p1], m0
 ; CHECK-NEXT:    vlda.conv.fp32.bf16 cml1, [p1], m0; movx r1, #60
-; CHECK-NEXT:    vlda.conv.fp32.bf16 cml2, [p0], m1; add.nc lc, r0, #-3; vadd.f dm4, dm1, dm2, r1
-; CHECK-NEXT:    vlda.conv.fp32.bf16 cml0, [p0], m1; movxm ls, #.LBB0_1
-; CHECK-NEXT:    vlda.conv.fp32.bf16 cml3, [p1], m0; movxm le, #.L_LEnd0; vadd.f dm3, dm3, dm0, r1
-; CHECK-NEXT:    vlda.conv.fp32.bf16 cml1, [p1], m0; nopb ; nops ; nopxm ; nopv
+; CHECK-NEXT:    vlda.conv.fp32.bf16 cml2, [p0], m1; vadd.f dm4, dm1, dm2, r1
+; CHECK-NEXT:    vlda.conv.fp32.bf16 cml0, [p0], m1; add.nc lc, r0, #-3
+; CHECK-NEXT:    vlda.conv.fp32.bf16 cml3, [p1], m0; movxm ls, #.LBB0_1; vadd.f dm3, dm3, dm0, r1
+; CHECK-NEXT:    vlda.conv.fp32.bf16 cml1, [p1], m0; nopb ; nops ; movxm le, #.L_LEnd0; nopv
 ; CHECK-NEXT:    vlda.conv.fp32.bf16 cml2, [p0], m1; nopb ; nops ; nopxm ; vadd.f dm4, dm1, dm2, r1
 ; CHECK-NEXT:    vlda.conv.fp32.bf16 cml0, [p0], m1; nopb ; nops ; nopxm ; nopv
 ; CHECK-NEXT:    vlda.conv.fp32.bf16 cml3, [p1], m0; nopb ; vst.conv.bf16.fp32 cml4, [p3], #64; nopxm ; vadd.f dm3, dm3, dm0, r1

--- a/llvm/test/CodeGen/AIE/aie2p/end-to-end/conv2d_bfp16_convert.ll
+++ b/llvm/test/CodeGen/AIE/aie2p/end-to-end/conv2d_bfp16_convert.ll
@@ -15,8 +15,8 @@
 define weak_odr dso_local void @convert_bf16_to_bfp16(ptr noalias %in, ptr noalias %out, ptr nonnull align 64 dereferenceable(64) %params) local_unnamed_addr #0 {
 ; CHECK-LABEL: convert_bf16_to_bfp16:
 ; CHECK:       // %bb.0: // %entry
-; CHECK-NEXT:    lda r0, [p2, #0]; nopb ; nops ; nopx ; mov m0, #4; nopv
-; CHECK-NEXT:    padda [p2], m0; nopx
+; CHECK-NEXT:    lda r0, [p2, #0]; mov m0, #4
+; CHECK-NEXT:    padda [p2], m0
 ; CHECK-NEXT:    lda dn0, [p2], #4
 ; CHECK-NEXT:    lda m1, [p2, #0]
 ; CHECK-NEXT:    nop
@@ -28,10 +28,10 @@ define weak_odr dso_local void @convert_bf16_to_bfp16(ptr noalias %in, ptr noali
 ; CHECK-NEXT:    vldb.pop.512.2d x4, [p0, lf0, r24, d1]
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    lda m0, [p2, #4]; vldb.fill.512 [p0, lf0, r24]
-; CHECK-NEXT:    vlda.pop.512 x6, [p0, lf0, r24]; movxm ls, #.LBB0_1
-; CHECK-NEXT:    vldb.pop.512.2d x4, [p0, lf0, r24, d1]; movxm le, #.L_LEnd0
-; CHECK-NEXT:    add.nc lc, r0, #-3
-; CHECK-NEXT:    nopa ; vldb.fill.512 [p0, lf0, r24]; nops ; nopxm ; nopv
+; CHECK-NEXT:    vlda.pop.512 x6, [p0, lf0, r24]
+; CHECK-NEXT:    vldb.pop.512.2d x4, [p0, lf0, r24, d1]; movxm ls, #.LBB0_1
+; CHECK-NEXT:    movxm le, #.L_LEnd0
+; CHECK-NEXT:    nopa ; vldb.fill.512 [p0, lf0, r24]; nops ; nopx ; add.nc lc, r0, #-3; nopv
 ; CHECK-NEXT:    vlda.pop.512 x6, [p0, lf0, r24]; nopb ; nops ; nopx ; vconv.fp32.bf16 cml1, x6; nopv
 ; CHECK-NEXT:    nopa ; vldb.pop.512.2d x4, [p0, lf0, r24, d1]; nops ; nopx ; vconv.fp32.bf16 cmh1, x4; nopv
 ; CHECK-NEXT:    nopa ; nopb ; movs dc0, dj0; nopx ; mov p2, p1; nopv

--- a/llvm/test/CodeGen/AIE/aie2p/end-to-end/conv2d_bfp16_kernel_red.ll
+++ b/llvm/test/CodeGen/AIE/aie2p/end-to-end/conv2d_bfp16_kernel_red.ll
@@ -18,7 +18,7 @@
 define dso_local void @conv2d_bfp16.for.body90.i(<32 x i32> %fW.sroa.0.1489.i, i32 %fW.sroa.14.1488.i, <32 x i32> %fA.sroa.0.1487.i, i32 %fA.sroa.18.1486.i, ptr addrspace(6) %pW.1485.i, ptr addrspace(5) %pA.1484.i, <64 x i32> %0, <64 x i32> %1, <64 x i32> %2, <64 x i32> %3, i32 %4, i32 %5, i20 %6, i20 %7, i20 %8, i20 %9, i20 %10, i20 %11, i32 %12, i32 %13, i32 %14, ptr %.out, ptr %.out1, ptr %.out2, ptr %.out3, ptr %.out4, ptr %.out5, ptr %pA.1.i.out, ptr %pW.1.i.out, ptr %fA.sroa.18.1.i.out, ptr %fA.sroa.0.1.i.out, ptr %fW.sroa.14.1.i.out, ptr %fW.sroa.0.1.i.out) #3 {
 ; CHECK-LABEL: conv2d_bfp16.for.body90.i:
 ; CHECK:       // %bb.0: // %newFuncRoot
-; CHECK-NEXT:    paddxm [sp], #64
+; CHECK-NEXT:    nopa ; paddxm [sp], #64
 ; CHECK-NEXT:    st p6, [sp, #-64] // 4-byte Folded Spill
 ; CHECK-NEXT:    mov p6, sp
 ; CHECK-NEXT:    padda [p6], #-320
@@ -47,11 +47,11 @@ define dso_local void @conv2d_bfp16.for.body90.i(<32 x i32> %fW.sroa.0.1489.i, i
 ; CHECK-NEXT:    lda r3, [p6], #-4; vldb.pop.576 ex9, [p1, lf1, r25]; movs dc0, dc4; mov m0, p2
 ; CHECK-NEXT:    lda r2, [p6, #0]; vldb.pop.576.3d ex7, [p1, lf1, r25, d0]; movx r24, #0
 ; CHECK-NEXT:    vlda.fill.512 [p0, lf0, r24]; vldb.fill.512 [p1, lf1, r25]
-; CHECK-NEXT:    vlda.pop.576 ex5, [p0, lf0, r24]; vldb.fill.512 [p1, lf1, r25]; add r1, r6, #-1
-; CHECK-NEXT:    lda p6, [p6, #-4]; vldb.pop.576 ex9, [p1, lf1, r25]; movxm ls, #.LBB0_1
-; CHECK-NEXT:    vlda.pop.576 ex3, [p0, lf0, r24, m1]; vldb.pop.576.3d ex7, [p1, lf1, r25, d0]; movxm le, #.L_LEnd0
-; CHECK-NEXT:    vlda.fill.512 [p0, lf0, r24]; vldb.fill.512 [p1, lf1, r25]; add.nc lc, r1, #-4
-; CHECK-NEXT:    vlda.pop.576 ex5, [p0, lf0, r24]; vldb.fill.512 [p1, lf1, r25]; nops ; nopxm ; nopv
+; CHECK-NEXT:    vlda.pop.576 ex5, [p0, lf0, r24]; vldb.fill.512 [p1, lf1, r25]
+; CHECK-NEXT:    lda p6, [p6, #-4]; vldb.pop.576 ex9, [p1, lf1, r25]; add r1, r6, #-1
+; CHECK-NEXT:    vlda.pop.576 ex3, [p0, lf0, r24, m1]; vldb.pop.576.3d ex7, [p1, lf1, r25, d0]; movxm ls, #.LBB0_1
+; CHECK-NEXT:    vlda.fill.512 [p0, lf0, r24]; vldb.fill.512 [p1, lf1, r25]; movxm le, #.L_LEnd0
+; CHECK-NEXT:    vlda.pop.576 ex5, [p0, lf0, r24]; vldb.fill.512 [p1, lf1, r25]; nops ; nopx ; add.nc lc, r1, #-4; nopv
 ; CHECK-NEXT:    nopa ; vldb.pop.576 ex9, [p1, lf1, r25]; nops ; nopxm ; nopv
 ; CHECK-NEXT:    vlda.pop.576 ex3, [p0, lf0, r24, m1]; vldb.pop.576.3d ex7, [p1, lf1, r25, d0]; nops ; nopx ; vshuffle ex11, ex9, ex7, r4; nopv
 ; CHECK-NEXT:    vlda.fill.512 [p0, lf0, r24]; vldb.fill.512 [p1, lf1, r25]; nops ; movx r0, #780; vshuffle ex1, ex9, ex7, r5; nopv

--- a/llvm/test/CodeGen/AIE/aie2p/end-to-end/gelu-templated.ll
+++ b/llvm/test/CodeGen/AIE/aie2p/end-to-end/gelu-templated.ll
@@ -4,7 +4,7 @@
 ; See https://llvm.org/LICENSE.txt for license information.
 ; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 ;
-; (c) Copyright 2025 Advanced Micro Devices, Inc. or its affiliates
+; (c) Copyright 2025-2026 Advanced Micro Devices, Inc. or its affiliates
 ; RUN: llc -mtriple=aie2p %s -o - | FileCheck %s
 
 ; Test that the use of llvm.loop.pipeline.initiationinterval can force pre-swp to accepted
@@ -17,7 +17,7 @@
 define void @gelu_fn(ptr noalias %ifm, ptr noalias %ofm, ptr nonnull align 64 dereferenceable(64) %params) {
 ; CHECK-LABEL: gelu_fn:
 ; CHECK:       // %bb.0: // %entry
-; CHECK-NEXT:    vlda.conv.fp32.bf16 cml1, [p0], #64; nopb ; nopxm
+; CHECK-NEXT:    vlda.conv.fp32.bf16 cml1, [p0], #64; nopb ; nopx
 ; CHECK-NEXT:    movxm r0, #16544
 ; CHECK-NEXT:    vbcst.16 x6, r0
 ; CHECK-NEXT:    lda r1, [p2, #0]; movxm r0, #17280
@@ -51,20 +51,20 @@ define void @gelu_fn(ptr noalias %ifm, ptr noalias %ofm, ptr nonnull align 64 de
 ; CHECK-NEXT:    vconv.bf16.fp32 x5, cml3; vmul.f dm4, x5, x4, r2
 ; CHECK-NEXT:    vconv.bf16.fp32 x7, cml1; movxm ls, #.LBB0_1; vadd.f dm2, dm2, dm0, r0
 ; CHECK-NEXT:    mova r4, #-5; nopb ; vfloor.s32.bf16 x3, wh8, s0; movxm le, #.L_LEnd0; vmul.f dm3, x5, x4, r2
-; CHECK-NEXT:    mova r1, #2; nopb ; vconv.bf16.fp32 x10, cml4; lshl r4, r1, r4; vbcst.16 x6, r3; vmul.f dm4, x7, x2, r2
+; CHECK-NEXT:    mova r1, #2; vconv.bf16.fp32 x10, cml4; lshl r4, r1, r4; vmul.f dm4, x7, x2, r2
 ; CHECK-NEXT:    vlda.conv.fp32.bf16 cml1, [p0], #64; vshuffle x1, x1, x3, r1
 ; CHECK-NEXT:    vfloor.s32.bf16 x9, wl10, s0; vmin_ge.16 x3, r16, x1, x0, vaddsign1
-; CHECK-NEXT:    vfloor.s32.bf16 x3, wh10, s0; add.nc lc, r4, #-7
-; CHECK-NEXT:    nopa ; nopb ; vconv.bf16.fp32 x8, cml4; nopx ; vmax_lt.16 x11, r16, x3, x6, vaddsign1; nopv
-; CHECK-NEXT:    padda [p1], m0; nopb ; nops ; nopxm ; nopv
+; CHECK-NEXT:    vfloor.s32.bf16 x3, wh10, s0; vbcst.16 x6, r3
+; CHECK-NEXT:    vconv.bf16.fp32 x8, cml4; vmax_lt.16 x11, r16, x3, x6, vaddsign1
+; CHECK-NEXT:    padda [p1], m0; nopb ; nops ; nopx ; add.nc lc, r4, #-7; nopv
 ; CHECK-NEXT:  .LBB0_1: // %for.body
 ; CHECK-NEXT:    // =>This Inner Loop Header: Depth=1
 ; CHECK-NEXT:    nopa ; nopb ; vconv.bf16.fp32 x10, cml2; nopxm ; nopv
 ; CHECK-NEXT:    nopa ; nopb ; nops ; nopxm ; vadd.f dm2, dm4, dm0, r0
 ; CHECK-NEXT:    vlda.conv.fp32.bf16 cml1, [p0], #64; nopb ; vconv.bf16.fp32 x7, cml4; nopx ; vmov cml4, cml1; vmul.f dm4, x10, x2, r2
 ; CHECK-NEXT:    nopa ; nopb ; vst x11, [p1], #64; nopx ; vshuffle x1, x9, x3, r1; nopv
-; CHECK-NEXT:    vfloor.s32.bf16 x3, wh8, s0; vmin_ge.16 x5, r16, x1, x0, vaddsign1
-; CHECK-NEXT:    vfloor.s32.bf16 x9, wl8, s0; vmax_lt.16 x11, r16, x5, x6, vaddsign1
+; CHECK-NEXT:    nopa ; nopb ; vfloor.s32.bf16 x3, wh8, s0; nopx ; vmin_ge.16 x5, r16, x1, x0, vaddsign1; nopv
+; CHECK-NEXT:    nopa ; nopb ; vfloor.s32.bf16 x9, wl8, s0; nopx ; vmax_lt.16 x11, r16, x5, x6, vaddsign1; nopv
 ; CHECK-NEXT:  .L_LEnd0:
 ; CHECK-NEXT:    nopa ; nopb ; vconv.bf16.fp32 x8, cml3; nopxm ; vmul.f dm3, x7, x4, r2
 ; CHECK-NEXT:  // %bb.2:

--- a/llvm/test/CodeGen/AIE/aie2p/end-to-end/ore-hardware-loops.ll
+++ b/llvm/test/CodeGen/AIE/aie2p/end-to-end/ore-hardware-loops.ll
@@ -32,7 +32,7 @@ define weak_odr dso_local void @convert_bf16_to_bfp16(ptr noalias %in, ptr noali
 ; REMARKS-NEXT: Args:
 ; REMARKS-NEXT:   - BasicBlock:      entry
 ; REMARKS-NEXT:   - BundleCount:     '20'
-; REMARKS-NEXT:   - ByteCount:       '160'
+; REMARKS-NEXT:   - ByteCount:       '144'
 ; REMARKS-NEXT: ...
 ; REMARKS-NEXT: --- !Analysis
 ; REMARKS-NEXT: Pass:            aie-asm-printer
@@ -55,8 +55,8 @@ define weak_odr dso_local void @convert_bf16_to_bfp16(ptr noalias %in, ptr noali
 ;
 ; ASM-LABEL: convert_bf16_to_bfp16:
 ; ASM:       // %bb.0: // %entry
-; ASM-NEXT:    lda r0, [p2, #0]; nopb ; nops ; nopx ; mov m0, #4; nopv
-; ASM-NEXT:    padda [p2], m0; nopx
+; ASM-NEXT:    lda r0, [p2, #0]; mov m0, #4
+; ASM-NEXT:    padda [p2], m0
 ; ASM-NEXT:    lda dn0, [p2], #4
 ; ASM-NEXT:    lda m1, [p2, #0]
 ; ASM-NEXT:    nop
@@ -68,10 +68,10 @@ define weak_odr dso_local void @convert_bf16_to_bfp16(ptr noalias %in, ptr noali
 ; ASM-NEXT:    vldb.pop.512.2d x4, [p0, lf0, r24, d1]
 ; ASM-NEXT:    nop
 ; ASM-NEXT:    lda m0, [p2, #4]; vldb.fill.512 [p0, lf0, r24]
-; ASM-NEXT:    vlda.pop.512 x6, [p0, lf0, r24]; movxm ls, #.LBB0_1
-; ASM-NEXT:    vldb.pop.512.2d x4, [p0, lf0, r24, d1]; movxm le, #.L_LEnd0
-; ASM-NEXT:    add.nc lc, r0, #-3
-; ASM-NEXT:    nopa ; vldb.fill.512 [p0, lf0, r24]; nops ; nopxm ; nopv
+; ASM-NEXT:    vlda.pop.512 x6, [p0, lf0, r24]
+; ASM-NEXT:    vldb.pop.512.2d x4, [p0, lf0, r24, d1]; movxm ls, #.LBB0_1
+; ASM-NEXT:    movxm le, #.L_LEnd0
+; ASM-NEXT:    nopa ; vldb.fill.512 [p0, lf0, r24]; nops ; nopx ; add.nc lc, r0, #-3; nopv
 ; ASM-NEXT:    vlda.pop.512 x6, [p0, lf0, r24]; nopb ; nops ; nopx ; vconv.fp32.bf16 cml1, x6; nopv
 ; ASM-NEXT:    nopa ; vldb.pop.512.2d x4, [p0, lf0, r24, d1]; nops ; nopx ; vconv.fp32.bf16 cmh1, x4; nopv
 ; ASM-NEXT:    nopa ; nopb ; movs dc0, dj0; nopx ; mov p2, p1; nopv

--- a/llvm/test/CodeGen/AIE/aie2p/end-to-end/sigmoid_int8_1.ll
+++ b/llvm/test/CodeGen/AIE/aie2p/end-to-end/sigmoid_int8_1.ll
@@ -11,15 +11,15 @@
 define void @sigmoid_int8_1() {
 ; CHECK-LABEL: sigmoid_int8_1:
 ; CHECK:       // %bb.0: // %entry
-; CHECK-NEXT:    nopa ; nopb ; nopx ; mov crunpacksize, #1
+; CHECK-NEXT:    nopa ; nopb ; nops ; nopx ; mov crunpacksize, #1; nopv
 ; CHECK-NEXT:    movxm ls, #.LBB0_1
-; CHECK-NEXT:    mova p0, #0; movxm le, #.L_LEnd0
+; CHECK-NEXT:    mova p0, #0; nopb ; movxm le, #.L_LEnd0
 ; CHECK-NEXT:    mova r0, #0; vldb.unpack x3, unpacksign0, [p0, #0]; mov crsrsmode, #0
 ; CHECK-NEXT:    vbcst.32 x4, r0
-; CHECK-NEXT:    mova r1, #1; add.nc lc, r0, #-3
-; CHECK-NEXT:    nopa ; nopb ; nops ; nopx ; vbcst.16 x0, r1; nopv
-; CHECK-NEXT:    nopa ; nopb ; nops ; nopx ; vbcst.16 x2, r0; nopv
-; CHECK-NEXT:    nopa ; vldb.unpack x3, unpacksign0, [p0, #0]; nopx ; vmov x7, x2; nops
+; CHECK-NEXT:    mova r1, #1; nopb ; nops ; nopx ; add.nc lc, r0, #-3; nopv
+; CHECK-NEXT:    vbcst.16 x0, r1
+; CHECK-NEXT:    vbcst.16 x2, r0
+; CHECK-NEXT:    vldb.unpack x3, unpacksign0, [p0, #0]; vmov x7, x2
 ; CHECK-NEXT:    vmov x6, x2
 ; CHECK-NEXT:    vmin_ge.16 x9, r16, x3, x0, vaddsign0
 ; CHECK-NEXT:    vmax_lt.16 x8, r16, x9, x2, vaddsign0; vclr dm0

--- a/llvm/test/CodeGen/AIE/aie2p/schedule/events-and-post-swp.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/schedule/events-and-post-swp.mir
@@ -14,18 +14,18 @@
   ; CHECK-LABEL: keep_event_order:
   ; CHECK:         .p2align 4
   ; CHECK-NEXT:  // %bb.0: // %entry
-  ; CHECK-NEXT:    nopa ; nopb ; nops ; event #0; nopm ; nopv
-  ; CHECK-NEXT:    nopa ; event #1
+  ; CHECK-NEXT:    event #0
+  ; CHECK-NEXT:    event #1
   ; CHECK-NEXT:    event #0
   ; CHECK-NEXT:    event #1
   ; CHECK-NEXT:    event #0
   ; CHECK-NEXT:    vldb x2, [p0], #64
   ; CHECK-NEXT:    vldb x2, [p0], #64
+  ; CHECK-NEXT:    vldb x2, [p0], #64
   ; CHECK-NEXT:    vldb x2, [p0], #64; movxm ls, #.LBB0_1
   ; CHECK-NEXT:    mova r2, #-5; vldb x2, [p0], #64; movxm le, #.L_LEnd0
   ; CHECK-NEXT:    vldb x2, [p0], #64; lshl r1, r1, r2; vbcst.16 x0, r0
-  ; CHECK-NEXT:    vldb x2, [p0], #64; add.nc lc, r1, #-13
-  ; CHECK-NEXT:    mova r0, #824; vldb x2, [p0], #64; nops ; nopxm ; nopv
+  ; CHECK-NEXT:    mova r0, #824; vldb x2, [p0], #64; nops ; nopx ; add.nc lc, r1, #-13; nopv
   ; CHECK-NEXT:    nopa ; vldb x2, [p0], #64; nops ; nopxm ; vmul dm0, y1, y0,r0
   ; CHECK-NEXT:    nopa ; vldb x2, [p0], #64; nops ; nopxm ; vmul dm0, y1, y0,r0
   ; CHECK-NEXT:    nopa ; vldb x2, [p0], #64; nops ; nopxm ; vmul dm0, y1, y0,r0

--- a/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/Conv2D_bfp16_conv.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/Conv2D_bfp16_conv.mir
@@ -16,7 +16,7 @@
   ; CONSERVATIVE-LABEL: convert_bf16_to_bfp16:
   ; CONSERVATIVE:         .p2align 4
   ; CONSERVATIVE-NEXT:  // %bb.0: // %entry
-  ; CONSERVATIVE-NEXT:    lda r0, [p2, #0]; nopxm
+  ; CONSERVATIVE-NEXT:    lda r0, [p2, #0]
   ; CONSERVATIVE-NEXT:    nop
   ; CONSERVATIVE-NEXT:    nop
   ; CONSERVATIVE-NEXT:    nop
@@ -48,7 +48,7 @@
   ; CONSERVATIVE-NEXT:    mov p2, p1
   ; CONSERVATIVE-NEXT:    vldb.fill.512 [p0, lf0, r24]; add.nc lc, r0, #-2
   ; CONSERVATIVE-NEXT:    vldb.pop.512 x0, [p0, lf0, r24]; movxm ls, #.LBB0_2
-  ; CONSERVATIVE-NEXT:    vldb.pop.512.2d x2, [p0, lf0, r24, d1]; movxm le, #.L_LEnd0
+  ; CONSERVATIVE-NEXT:    nopa ; vldb.pop.512.2d x2, [p0, lf0, r24, d1]; nops ; movxm le, #.L_LEnd0; nopv
   ; CONSERVATIVE-NEXT:    nopa ; nopb ; nops ; nopx ; vconv.fp32.bf16 cml0, x0; nopv
   ; CONSERVATIVE-NEXT:    nopa ; nopb ; nops ; nopx ; vconv.fp32.bf16 cmh0, x2; nopv
   ; CONSERVATIVE-NEXT:    nopa ; nopb ; nops ; nopx ; mov dc0, dj0; nopv
@@ -56,8 +56,8 @@
   ; CONSERVATIVE-NEXT:  .LBB0_2: // =>This Inner Loop Header: Depth=1
   ; CONSERVATIVE-NEXT:    nopa ; vldb.fill.512 [p0, lf0, r24]; vst.push.576.conv.bfp16ebs8.fp32 dm0, [p2, sf, r26]; nopxm ; nopv
   ; CONSERVATIVE-NEXT:    nopa ; vldb.pop.512 x0, [p0, lf0, r24]; vst.flush.512.conv [p2, sf, r26]; nopxm ; nopv
-  ; CONSERVATIVE-NEXT:    nopa ; vldb.pop.512.2d x2, [p0, lf0, r24, d1]; vst.flush.512.conv.2d [p2, sf, r26, d0]; nopxm ; nopv
-  ; CONSERVATIVE-NEXT:    nopa ; nopb ; nopx ; vconv.fp32.bf16 cml0, x0
+  ; CONSERVATIVE-NEXT:    vst.flush.512.conv.2d [p2, sf, r26, d0]; vldb.pop.512.2d x2, [p0, lf0, r24, d1]; nopx
+  ; CONSERVATIVE-NEXT:    vconv.fp32.bf16 cml0, x0
   ; CONSERVATIVE-NEXT:    vconv.fp32.bf16 cmh0, x2
   ; CONSERVATIVE-NEXT:  .L_LEnd0:
   ; CONSERVATIVE-NEXT:    nopa ; nopb ; nops ; nopxm ; nopv
@@ -87,7 +87,7 @@
   ; OPTIMISTIC-LABEL: convert_bf16_to_bfp16:
   ; OPTIMISTIC:         .p2align 4
   ; OPTIMISTIC-NEXT:  // %bb.0: // %entry
-  ; OPTIMISTIC-NEXT:    lda r0, [p2, #0]; nopb ; nops ; nopxm ; nopv
+  ; OPTIMISTIC-NEXT:    lda r0, [p2, #0]
   ; OPTIMISTIC-NEXT:    nop
   ; OPTIMISTIC-NEXT:    nop
   ; OPTIMISTIC-NEXT:    nop
@@ -116,10 +116,10 @@
   ; OPTIMISTIC-NEXT:    vldb.pop.512.2d x2, [p0, lf0, r24, d1]
   ; OPTIMISTIC-NEXT:    nop
   ; OPTIMISTIC-NEXT:    vldb.fill.512 [p0, lf0, r24]
-  ; OPTIMISTIC-NEXT:    vldb.pop.512 x0, [p0, lf0, r24]; add.nc lc, r0, #-3
-  ; OPTIMISTIC-NEXT:    vldb.pop.512.2d x2, [p0, lf0, r24, d1]; movxm ls, #.LBB0_2
-  ; OPTIMISTIC-NEXT:    movxm le, #.L_LEnd0
-  ; OPTIMISTIC-NEXT:    nopa ; vldb.fill.512 [p0, lf0, r24]; nops ; nopx ; mov p2, p1; nopv
+  ; OPTIMISTIC-NEXT:    vldb.pop.512 x0, [p0, lf0, r24]; mov p2, p1
+  ; OPTIMISTIC-NEXT:    vldb.pop.512.2d x2, [p0, lf0, r24, d1]; add.nc lc, r0, #-3
+  ; OPTIMISTIC-NEXT:    movxm ls, #.LBB0_2
+  ; OPTIMISTIC-NEXT:    nopa ; vldb.fill.512 [p0, lf0, r24]; nops ; movxm le, #.L_LEnd0; nopv
   ; OPTIMISTIC-NEXT:    nopa ; vldb.pop.512 x0, [p0, lf0, r24]; nops ; nopx ; vconv.fp32.bf16 cml0, x0; nopv
   ; OPTIMISTIC-NEXT:    nopa ; vldb.pop.512.2d x2, [p0, lf0, r24, d1]; nops ; nopx ; vconv.fp32.bf16 cmh0, x2; nopv
   ; OPTIMISTIC-NEXT:    nopa ; nopb ; nops ; nopx ; mov dc0, dj0; nopv

--- a/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/Conv2D_bfp16_kernel_fixedslot.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/Conv2D_bfp16_kernel_fixedslot.mir
@@ -14,17 +14,17 @@
   ; CHECK-LABEL: conv2d_bfp16:
   ; CHECK:         .p2align 4
   ; CHECK-NEXT:  // %bb.0: // %entry
-  ; CHECK-NEXT:    mova r25, #0
+  ; CHECK-NEXT:    mova r25, #0; nopb ; nopx
   ; CHECK-NEXT:    vlda.fill.512 [p1, lf1, r25]
   ; CHECK-NEXT:    vlda.fill.512 [p1, lf1, r25]
   ; CHECK-NEXT:    vlda.pop.576 ex0, [p1, lf1, r25]
   ; CHECK-NEXT:    vlda.pop.576.3d ex4, [p1, lf1, r25, d0]; movx r24, #0
   ; CHECK-NEXT:    vlda.fill.512 [p1, lf1, r25]; vldb.fill.512 [p0, lf0, r24]
   ; CHECK-NEXT:    vlda.fill.512 [p1, lf1, r25]; vldb.pop.576 ex2, [p0, lf0, r24]
-  ; CHECK-NEXT:    vlda.pop.576 ex0, [p1, lf1, r25]; add.nc lc, r1, #-4
-  ; CHECK-NEXT:    vlda.pop.576.3d ex4, [p1, lf1, r25, d0]; vldb.pop.576 ex6, [p0, lf0, r24, m1]; movxm ls, #.LBB0_1
-  ; CHECK-NEXT:    vlda.fill.512 [p1, lf1, r25]; vldb.fill.512 [p0, lf0, r24]; movxm le, #.L_LEnd0
-  ; CHECK-NEXT:    vlda.fill.512 [p1, lf1, r25]; vldb.pop.576 ex2, [p0, lf0, r24]; nops ; nopxm ; nopv
+  ; CHECK-NEXT:    vlda.pop.576 ex0, [p1, lf1, r25]
+  ; CHECK-NEXT:    vlda.pop.576.3d ex4, [p1, lf1, r25, d0]; vldb.pop.576 ex6, [p0, lf0, r24, m1]; add.nc lc, r1, #-4
+  ; CHECK-NEXT:    vlda.fill.512 [p1, lf1, r25]; vldb.fill.512 [p0, lf0, r24]; movxm ls, #.LBB0_1
+  ; CHECK-NEXT:    vlda.fill.512 [p1, lf1, r25]; vldb.pop.576 ex2, [p0, lf0, r24]; nops ; movxm le, #.L_LEnd0; nopv
   ; CHECK-NEXT:    vlda.pop.576 ex0, [p1, lf1, r25]; nopb ; nops ; nopxm ; nopv
   ; CHECK-NEXT:    vlda.pop.576.3d ex4, [p1, lf1, r25, d0]; vldb.pop.576 ex6, [p0, lf0, r24, m1]; nops ; nopx ; vshuffle ex8, ex0, ex4, r4; nopv
   ; CHECK-NEXT:    vlda.fill.512 [p1, lf1, r25]; vldb.fill.512 [p0, lf0, r24]; nops ; movx r0, #780; vshuffle ex10, ex0, ex4, r5; nopv

--- a/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/Conv2D_bfp16_kernel_multislot.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/Conv2D_bfp16_kernel_multislot.mir
@@ -14,17 +14,17 @@
   ; CHECK-LABEL: conv2d_bfp16:
   ; CHECK:         .p2align 4
   ; CHECK-NEXT:  // %bb.0: // %entry
-  ; CHECK-NEXT:    mova r25, #0
+  ; CHECK-NEXT:    mova r25, #0; nopb ; nopx
   ; CHECK-NEXT:    vldb.fill.512 [p1, lf1, r25]
   ; CHECK-NEXT:    vldb.fill.512 [p1, lf1, r25]
   ; CHECK-NEXT:    vldb.pop.576 ex0, [p1, lf1, r25]
   ; CHECK-NEXT:    mova r24, #0; vldb.pop.576.3d ex4, [p1, lf1, r25, d0]
   ; CHECK-NEXT:    vlda.fill.512 [p0, lf0, r24]; vldb.fill.512 [p1, lf1, r25]
   ; CHECK-NEXT:    vlda.pop.576 ex2, [p0, lf0, r24]; vldb.fill.512 [p1, lf1, r25]
-  ; CHECK-NEXT:    vldb.pop.576 ex0, [p1, lf1, r25]; add.nc lc, r1, #-4
-  ; CHECK-NEXT:    vlda.pop.576 ex6, [p0, lf0, r24, m1]; vldb.pop.576.3d ex4, [p1, lf1, r25, d0]; movxm ls, #.LBB0_1
-  ; CHECK-NEXT:    vlda.fill.512 [p0, lf0, r24]; vldb.fill.512 [p1, lf1, r25]; movxm le, #.L_LEnd0
-  ; CHECK-NEXT:    vlda.pop.576 ex2, [p0, lf0, r24]; vldb.fill.512 [p1, lf1, r25]; nops ; nopxm ; nopv
+  ; CHECK-NEXT:    vldb.pop.576 ex0, [p1, lf1, r25]
+  ; CHECK-NEXT:    vlda.pop.576 ex6, [p0, lf0, r24, m1]; vldb.pop.576.3d ex4, [p1, lf1, r25, d0]; add.nc lc, r1, #-4
+  ; CHECK-NEXT:    vlda.fill.512 [p0, lf0, r24]; vldb.fill.512 [p1, lf1, r25]; movxm ls, #.LBB0_1
+  ; CHECK-NEXT:    vlda.pop.576 ex2, [p0, lf0, r24]; vldb.fill.512 [p1, lf1, r25]; nops ; movxm le, #.L_LEnd0; nopv
   ; CHECK-NEXT:    nopa ; vldb.pop.576 ex0, [p1, lf1, r25]; nops ; nopxm ; nopv
   ; CHECK-NEXT:    vlda.pop.576 ex6, [p0, lf0, r24, m1]; vldb.pop.576.3d ex4, [p1, lf1, r25, d0]; nops ; nopx ; vshuffle ex8, ex0, ex4, r4; nopv
   ; CHECK-NEXT:    vlda.fill.512 [p0, lf0, r24]; vldb.fill.512 [p1, lf1, r25]; nops ; movx r0, #780; vshuffle ex10, ex0, ex4, r5; nopv

--- a/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/end-to-end.ll
+++ b/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/end-to-end.ll
@@ -16,10 +16,9 @@
 define <32 x i16> @zol(i32 %n, ptr %p) {
 ; CHECK-LABEL: zol:
 ; CHECK:       // %bb.0: // %entry
-; CHECK-NEXT:    add.nc lc, r0, #-7
+; CHECK-NEXT:    nopa ; nopx ; add.nc lc, r0, #-7
 ; CHECK-NEXT:    movxm ls, #.LBB0_1
-; CHECK-NEXT:    movxm le, #.L_LEnd0
-; CHECK-NEXT:    nopa ; vldb x4, [p0], #64; nops ; nopxm ; nopv
+; CHECK-NEXT:    nopa ; vldb x4, [p0], #64; nops ; movxm le, #.L_LEnd0; nopv
 ; CHECK-NEXT:    nopa ; vldb x4, [p0], #64; nops ; nopxm ; nopv
 ; CHECK-NEXT:    nopa ; vldb x4, [p0], #64; nops ; nopxm ; nopv
 ; CHECK-NEXT:    nopa ; vldb x4, [p0], #64; nops ; nopxm ; nopv

--- a/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/epilogue-lock-after-store.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/epilogue-lock-after-store.mir
@@ -22,13 +22,12 @@ body:             |
   ; CHECK-NEXT:   successors: %bb.1(0x80000000)
   ; CHECK-NEXT:   liveins: $p0, $p1, $r0, $r18, $m0
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT:   $lc = ADD_NC_mv_add_ri $r0, -2
-  ; CHECK-NEXT:   BUNDLE implicit-def $x0, implicit-def $wl0, implicit-def $wh0, implicit-def $p0, implicit-def $ls, implicit killed $p0 {
+  ; CHECK-NEXT:   BUNDLE implicit-def $x0, implicit-def $wl0, implicit-def $wh0, implicit-def $p0, implicit-def $lc, implicit killed $p0, implicit $r0 {
   ; CHECK-NEXT:     $x0, $p0 = VLDB_dmx_ldb_x_pstm_nrm_imm killed $p0, 64
-  ; CHECK-NEXT:     $ls = MOVXM %bb.2
+  ; CHECK-NEXT:     $lc = ADD_NC_mv_add_ri $r0, -2
   ; CHECK-NEXT:   }
+  ; CHECK-NEXT:   $ls = MOVXM %bb.2
   ; CHECK-NEXT:   $le = MOVXM <mcsymbol .L_LEnd0>
-  ; CHECK-NEXT:   NOP
   ; CHECK-NEXT:   NOP
   ; CHECK-NEXT:   NOP
   ; CHECK-NEXT:   NOP

--- a/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/gemm-bfp16-v2.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/gemm-bfp16-v2.mir
@@ -17,8 +17,8 @@
   ; CHECK-LABEL: gemm:
   ; CHECK:         .p2align 4
   ; CHECK-NEXT:  // %bb.0: // %entry
-  ; CHECK-NEXT:    vlda.conv.fp32.bf16 cmh4, [p7, #64]; vldb x2, [p6, #64]; nopx ; mov p5, p6; nops
-  ; CHECK-NEXT:    padda [p5], m4; vldb.3d x0, [p6], d0; mov p3, p7
+  ; CHECK-NEXT:    vlda.conv.fp32.bf16 cmh4, [p7, #64]; vldb x2, [p6, #64]; nops ; nopx ; mov p5, p6; nopv
+  ; CHECK-NEXT:    padda [p5], m4; vldb.3d x0, [p6], d0; nopx ; mov p3, p7; nops
   ; CHECK-NEXT:    vlda.3d.conv.fp32.bf16 cml4, [p7], d1; vldb x6, [p5, #0]
   ; CHECK-NEXT:    vldb x4, [p5, #64]
   ; CHECK-NEXT:    paddb [p3], m5
@@ -33,7 +33,7 @@
   ; CHECK-NEXT:    vlda.conv.fp32.bf16 cml4, [p3, #0]; vmul.f dm4, y0, y5, r2
   ; CHECK-NEXT:    vlda.conv.fp32.bf16 cmh4, [p3, #64]; add.nc lc, r0, #-1
   ; CHECK-NEXT:    movxm ls, #.LBB0_1
-  ; CHECK-NEXT:    movxm le, #.L_LEnd0
+  ; CHECK-NEXT:    nopa ; nopb ; nops ; movxm le, #.L_LEnd0; nopv
   ; CHECK-NEXT:    .p2align 4
   ; CHECK-NEXT:  .LBB0_1: // %for.body
   ; CHECK-NEXT:    // =>This Inner Loop Header: Depth=1

--- a/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/gemm-bfp16-v6.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/gemm-bfp16-v6.mir
@@ -23,7 +23,7 @@
   ; CHECK-LABEL: gemm:
   ; CHECK:         .p2align 4
   ; CHECK-NEXT:  // %bb.0: // %entry
-  ; CHECK-NEXT:    nopa ; vldb x4, [p7, #64]; movs p4, p7; nopxm ; nopv
+  ; CHECK-NEXT:    vldb x4, [p7, #64]; movs p4, p7
   ; CHECK-NEXT:    vldb.3d x7, [p7], d0
   ; CHECK-NEXT:    paddb [p4], m4
   ; CHECK-NEXT:    vldb x9, [p4, #0]
@@ -39,10 +39,10 @@
   ; CHECK-NEXT:    padda [p5], m5; vldb x5, [p4, #64]
   ; CHECK-NEXT:    vlda.conv.fp32.bf16 cml4, [p5, #0]; add.nc lc, r0, #-3; vmul.f dm4, y4, y5, r2
   ; CHECK-NEXT:    vlda.conv.fp32.bf16 cmh4, [p5, #64]; movxm ls, #.LBB0_1
-  ; CHECK-NEXT:    movxm le, #.L_LEnd0
-  ; CHECK-NEXT:    nopa ; nopb ; vconv.bfp16ebs8.fp32 ex1, dm4; nopx ; vshuffle x6, x7, x4, r0; nopv
-  ; CHECK-NEXT:    nopa ; vldb x4, [p7, #64]; movs p4, p7; nopx ; vshuffle x7, x7, x4, r1; nopv
-  ; CHECK-NEXT:    nopa ; vldb.3d x7, [p7], d0; vconv.bfp16ebs8.fp32 ex0, dm4; nopx ; mov p5, p6; nopv
+  ; CHECK-NEXT:    nopa ; nopb ; nops ; movxm le, #.L_LEnd0; nopv
+  ; CHECK-NEXT:    nopa ; vconv.bfp16ebs8.fp32 ex1, dm4; nopx ; vshuffle x6, x7, x4, r0
+  ; CHECK-NEXT:    movs p4, p7; vldb x4, [p7, #64]; vshuffle x7, x7, x4, r1
+  ; CHECK-NEXT:    vconv.bfp16ebs8.fp32 ex0, dm4; vldb.3d x7, [p7], d0; mov p5, p6
   ; CHECK-NEXT:    .p2align 4
   ; CHECK-NEXT:  .LBB0_1: // %for.body
   ; CHECK-NEXT:    // =>This Inner Loop Header: Depth=1

--- a/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/gemm-bfp16-v9.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/gemm-bfp16-v9.mir
@@ -22,8 +22,8 @@
   ; CHECK-LABEL: gemm:
   ; CHECK:         .p2align 4
   ; CHECK-NEXT:  // %bb.0: // %entry
-  ; CHECK-NEXT:    vldb x4, [p7, #64]; nopx
-  ; CHECK-NEXT:    vldb.3d x11, [p7], d0; movs p4, p7
+  ; CHECK-NEXT:    nopa ; vldb x4, [p7, #64]; nops ; nopxm ; nopv
+  ; CHECK-NEXT:    movs p4, p7; vldb.3d x11, [p7], d0; nopx
   ; CHECK-NEXT:    nop
   ; CHECK-NEXT:    paddb [p4], m4
   ; CHECK-NEXT:    vldb x5, [p4, #64]
@@ -41,15 +41,15 @@
   ; CHECK-NEXT:    vlda.conv.fp32.bf16 cml4, [p5, #0]; vconv.bfp16ebs8.fp32 ex0, dm4; movxm ls, #.LBB0_1
   ; CHECK-NEXT:    vlda.conv.fp32.bf16 cmh4, [p6, #64]; vshuffle x6, x11, x4, r0
   ; CHECK-NEXT:    vlda.3d.conv.fp32.bf16 cml4, [p6], d1; vldb x4, [p7, #64]; movs p5, p6; vshuffle x7, x11, x4, r1
-  ; CHECK-NEXT:    movs p4, p7; vldb.3d x11, [p7], d0; movxm le, #.L_LEnd0
+  ; CHECK-NEXT:    nopa ; vldb.3d x11, [p7], d0; movs p4, p7; movxm le, #.L_LEnd0; nopv
   ; CHECK-NEXT:    .p2align 4
   ; CHECK-NEXT:  .LBB0_1: // %for.body
   ; CHECK-NEXT:    // =>This Inner Loop Header: Depth=1
   ; CHECK-NEXT:    nopa ; nopb ; vconv.bfp16ebs8.fp32 ex1, dm4; nopxm ; vmul.f dm4, y3, y5, r2
   ; CHECK-NEXT:    nopa ; paddb [p4], m4; vconv.bfp16ebs8.fp32 ex3, dm4; nopx ; vshuffle x8, x10, x5, r0; nopv
-  ; CHECK-NEXT:    nopa ; vldb x5, [p4, #64]; nops ; nopx ; vshuffle x9, x10, x5, r1; nopv
-  ; CHECK-NEXT:    padda [p5], m5; vldb x10, [p4, #0]; vconv.bfp16ebs8.fp32 ex2, dm4; nopxm ; nopv
-  ; CHECK-NEXT:    vlda.conv.fp32.bf16 cmh4, [p5, #64]; nopb ; nopx ; vmul.f dm4, y4, y5, r2
+  ; CHECK-NEXT:    nopa ; vldb x5, [p4, #64]; nopx ; vshuffle x9, x10, x5, r1
+  ; CHECK-NEXT:    padda [p5], m5; vldb x10, [p4, #0]; vconv.bfp16ebs8.fp32 ex2, dm4
+  ; CHECK-NEXT:    vlda.conv.fp32.bf16 cmh4, [p5, #64]; vmul.f dm4, y4, y5, r2
   ; CHECK-NEXT:    vlda.conv.fp32.bf16 cml4, [p5, #0]; vconv.bfp16ebs8.fp32 ex0, dm4; vmac.f dm3, dm3, ex0, ex1, r3
   ; CHECK-NEXT:    vlda.conv.fp32.bf16 cmh4, [p6, #64]; vshuffle x6, x11, x4, r0; vmac.f dm2, dm2, ex0, ex3, r3
   ; CHECK-NEXT:    vlda.3d.conv.fp32.bf16 cml4, [p6], d1; vldb x4, [p7, #64]; movs p5, p6; nopx ; vshuffle x7, x11, x4, r1; vmac.f dm1, dm1, ex2, ex1, r3

--- a/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/gemm-bfp16.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/gemm-bfp16.mir
@@ -17,7 +17,7 @@
   ; CHECK-LABEL: gemm:
   ; CHECK:         .p2align 4
   ; CHECK-NEXT:  // %bb.0: // %entry
-  ; CHECK-NEXT:    vldb.3d x2, [p6], d0; mov p5, p6
+  ; CHECK-NEXT:    nopa ; vldb.3d x2, [p6], d0; nops ; nopx ; mov p5, p6; nopv
   ; CHECK-NEXT:    padda [p5], m4; vldb x4, [p5, #64]; mov p3, p7
   ; CHECK-NEXT:    vlda.3d.conv.fp32.bf16 cml4, [p7], d1; vldb x6, [p5], #64
   ; CHECK-NEXT:    vlda.conv.fp32.bf16 cmh4, [p3, #64]; vldb x8, [p5, #0]
@@ -34,13 +34,13 @@
   ; CHECK-NEXT:    vlda.conv.fp32.bf16 cmh4, [p3, #0]
   ; CHECK-NEXT:    add.nc lc, r0, #-1
   ; CHECK-NEXT:    movxm ls, #.LBB0_1
-  ; CHECK-NEXT:    vconv.bfp16ebs8.fp32 ex6, dm4; movxm le, #.L_LEnd0
+  ; CHECK-NEXT:    nopa ; nopb ; vconv.bfp16ebs8.fp32 ex6, dm4; movxm le, #.L_LEnd0; nopv
   ; CHECK-NEXT:    .p2align 4
   ; CHECK-NEXT:  .LBB0_1: // %for.body
   ; CHECK-NEXT:    // =>This Inner Loop Header: Depth=1
-  ; CHECK-NEXT:    nopa ; vldb.3d x2, [p6], d0; nops ; nopx ; mov p5, p6; nopv
-  ; CHECK-NEXT:    padda [p5], m4; vldb x4, [p5, #64]; vconv.bfp16ebs8.fp32 ex4, dm4; nopx ; mov p3, p7; nopv
-  ; CHECK-NEXT:    vlda.3d.conv.fp32.bf16 cml4, [p7], d1; vldb x6, [p5], #64; nopx
+  ; CHECK-NEXT:    vldb.3d x2, [p6], d0; mov p5, p6
+  ; CHECK-NEXT:    padda [p5], m4; vldb x4, [p5, #64]; vconv.bfp16ebs8.fp32 ex4, dm4; mov p3, p7
+  ; CHECK-NEXT:    vlda.3d.conv.fp32.bf16 cml4, [p7], d1; vldb x6, [p5], #64
   ; CHECK-NEXT:    vlda.conv.fp32.bf16 cmh4, [p3, #64]; vldb x8, [p5, #0]; vconv.bfp16ebs8.fp32 ex8, dm4; vmac.f dm3, dm3, ex2, ex6, r3
   ; CHECK-NEXT:    paddb [p3], m5
   ; CHECK-NEXT:    vmac.f dm2, dm2, ex2, ex4, r3

--- a/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/multiSlotAssignment/future_conflict_assignment.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/multiSlotAssignment/future_conflict_assignment.mir
@@ -30,8 +30,8 @@
   ; CHECK-LABEL: future_conflict_assignment:
   ; CHECK:         .p2align 4
   ; CHECK-NEXT:  // %bb.0:
-  ; CHECK-NEXT:    mova r1, #0; nopb ; nopxm
-  ; CHECK-NEXT:    ge r1, r1, r0
+  ; CHECK-NEXT:    mova r1, #0; nopb ; nops ; nopxm ; nopv
+  ; CHECK-NEXT:    nopa ; ge r1, r1, r0
   ; CHECK-NEXT:    jnz r1, #.LBB0_4
   ; CHECK-NEXT:    nop // Delay Slot 5
   ; CHECK-NEXT:    nop // Delay Slot 4
@@ -41,8 +41,7 @@
   ; CHECK-NEXT:  // %bb.1:
   ; CHECK-NEXT:    add.nc lc, r0, #0
   ; CHECK-NEXT:    movxm ls, #.LBB0_2
-  ; CHECK-NEXT:    movxm le, #.L_LEnd0
-  ; CHECK-NEXT:    nopa ; nopb ; nops ; nopxm ; nopv
+  ; CHECK-NEXT:    nopa ; nopb ; nops ; movxm le, #.L_LEnd0; nopv
   ; CHECK-NEXT:    nopa ; nopb ; nops ; nopxm ; nopv
   ; CHECK-NEXT:    nopa ; nopb ; nops ; nopxm ; nopv
   ; CHECK-NEXT:    nopa ; nopb ; nops ; nopxm ; nopv

--- a/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/multiSlotAssignment/non_overlapping_addrspace.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/multiSlotAssignment/non_overlapping_addrspace.mir
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2025 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2025-2026 Advanced Micro Devices, Inc. or its affiliates
 
 
 # RUN: llc  --mtriple=aie2p -O2 --start-before=postmisched \
@@ -26,8 +26,8 @@
   ; CHECK-LABEL: non_overlapping_addrspace:
   ; CHECK:         .p2align 4
   ; CHECK-NEXT:  // %bb.0:
-  ; CHECK-NEXT:    mova r1, #0; nopb ; nopxm
-  ; CHECK-NEXT:    ge r1, r1, r0
+  ; CHECK-NEXT:    mova r1, #0; nopb ; nops ; nopxm ; nopv
+  ; CHECK-NEXT:    nopa ; ge r1, r1, r0
   ; CHECK-NEXT:    jnz r1, #.LBB0_4
   ; CHECK-NEXT:    nop // Delay Slot 5
   ; CHECK-NEXT:    nop // Delay Slot 4
@@ -37,8 +37,7 @@
   ; CHECK-NEXT:  // %bb.1:
   ; CHECK-NEXT:    add.nc lc, r0, #0
   ; CHECK-NEXT:    movxm ls, #.LBB0_2
-  ; CHECK-NEXT:    movxm le, #.L_LEnd0
-  ; CHECK-NEXT:    nopa ; nopb ; nops ; nopxm ; nopv
+  ; CHECK-NEXT:    nopa ; nopb ; nops ; movxm le, #.L_LEnd0; nopv
   ; CHECK-NEXT:    nopa ; nopb ; nops ; nopxm ; nopv
   ; CHECK-NEXT:    nopa ; nopb ; nops ; nopxm ; nopv
   ; CHECK-NEXT:    nopa ; nopb ; nops ; nopxm ; nopv

--- a/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/multiSlotAssignment/partially_materialized.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/multiSlotAssignment/partially_materialized.mir
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2025 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2025-2026 Advanced Micro Devices, Inc. or its affiliates
 
 
 # RUN: llc  --mtriple=aie2p -O2 --start-before=postmisched \
@@ -23,8 +23,8 @@
   ; CHECK-LABEL: partially_materialized:
   ; CHECK:         .p2align 4
   ; CHECK-NEXT:  // %bb.0:
-  ; CHECK-NEXT:    mova r1, #0; nopb ; nopxm
-  ; CHECK-NEXT:    ge r1, r1, r0
+  ; CHECK-NEXT:    mova r1, #0; nopb ; nops ; nopxm ; nopv
+  ; CHECK-NEXT:    nopa ; ge r1, r1, r0
   ; CHECK-NEXT:    jnz r1, #.LBB0_4
   ; CHECK-NEXT:    nop // Delay Slot 5
   ; CHECK-NEXT:    nop // Delay Slot 4
@@ -34,8 +34,7 @@
   ; CHECK-NEXT:  // %bb.1:
   ; CHECK-NEXT:    add.nc lc, r0, #0
   ; CHECK-NEXT:    movxm ls, #.LBB0_2
-  ; CHECK-NEXT:    movxm le, #.L_LEnd0
-  ; CHECK-NEXT:    nopa ; nopb ; nops ; nopxm ; nopv
+  ; CHECK-NEXT:    nopa ; nopb ; nops ; movxm le, #.L_LEnd0; nopv
   ; CHECK-NEXT:    nopa ; nopb ; nops ; nopxm ; nopv
   ; CHECK-NEXT:    nopa ; nopb ; nops ; nopxm ; nopv
   ; CHECK-NEXT:    nopa ; nopb ; nops ; nopxm ; nopv

--- a/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/multiSlotAssignment/reassign_slots.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/multiSlotAssignment/reassign_slots.mir
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2025 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2025-2026 Advanced Micro Devices, Inc. or its affiliates
 
 
 # RUN: llc  --mtriple=aie2p -O2 --start-before=postmisched \
@@ -21,8 +21,8 @@
   ; CHECK-LABEL: reassign_slots:
   ; CHECK:         .p2align 4
   ; CHECK-NEXT:  // %bb.0:
-  ; CHECK-NEXT:    mova r1, #0; nopb ; nopxm
-  ; CHECK-NEXT:    ge r1, r1, r0
+  ; CHECK-NEXT:    mova r1, #0; nopb ; nops ; nopxm ; nopv
+  ; CHECK-NEXT:    nopa ; ge r1, r1, r0
   ; CHECK-NEXT:    jnz r1, #.LBB0_4
   ; CHECK-NEXT:    nop // Delay Slot 5
   ; CHECK-NEXT:    nop // Delay Slot 4
@@ -32,8 +32,7 @@
   ; CHECK-NEXT:  // %bb.1:
   ; CHECK-NEXT:    add.nc lc, r0, #0
   ; CHECK-NEXT:    movxm ls, #.LBB0_2
-  ; CHECK-NEXT:    movxm le, #.L_LEnd0
-  ; CHECK-NEXT:    nopa ; nopb ; nops ; nopxm ; nopv
+  ; CHECK-NEXT:    nopa ; nopb ; nops ; movxm le, #.L_LEnd0; nopv
   ; CHECK-NEXT:    nopa ; nopb ; nops ; nopxm ; nopv
   ; CHECK-NEXT:    nopa ; nopb ; nops ; nopxm ; nopv
   ; CHECK-NEXT:    nopa ; nopb ; nops ; nopxm ; nopv

--- a/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/reduce-mean-templated.ll
+++ b/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/reduce-mean-templated.ll
@@ -18,16 +18,16 @@
 define void @reduceMeanTemplated(ptr noalias %ifm, ptr addrspace(6) noalias %ofm) {
 ; CHECK-LABEL: reduceMeanTemplated:
 ; CHECK:       // %bb.0: // %entry
-; CHECK-NEXT:    mova dj2, #128; mov m0, #0
-; CHECK-NEXT:    vlda bmlh3, [p1, #64]; movs p3, p1; nopx ; mov p2, p1
+; CHECK-NEXT:    mova dj2, #128; nopx ; mov m0, #0
+; CHECK-NEXT:    vlda bmlh3, [p1, #64]; movs p3, p1; mov p2, p1
 ; CHECK-NEXT:    movs m1, m0; mov dj1, dj2
 ; CHECK-NEXT:    movs dn1, m0; mov dc1, m0
 ; CHECK-NEXT:    vlda.2d bmll3, [p1], d1
 ; CHECK-NEXT:    vlda bmlh3, [p1, #64]; movxm ls, #.LBB0_1; vclr dm0
 ; CHECK-NEXT:    movxm le, #.L_LEnd0
-; CHECK-NEXT:    mova r0, #0; movx r1, #1; mov dj0, m0
-; CHECK-NEXT:    vlda.2d bmll3, [p1], d1; movs dj4, m0; add.nc lc, r1, #-3; vadd.f dm4, dm3, dm0, r0
-; CHECK-NEXT:    vlda bmlh3, [p1, #64]; nopb ; movs dc2, m0; nopx ; vbcst.32 x0, r0; nopv
+; CHECK-NEXT:    mova r0, #0; mov dj0, m0
+; CHECK-NEXT:    vlda.2d bmll3, [p1], d1; nopb ; movs dj4, m0; movx r1, #1; vbcst.32 x0, r0; vadd.f dm4, dm3, dm0, r0
+; CHECK-NEXT:    vlda bmlh3, [p1, #64]; nopb ; movs dc2, m0; nopx ; add.nc lc, r1, #-3; nopv
 ; CHECK-NEXT:    nopa ; nopb ; movs dc0, m0; nopx ; mov dn0, m0; nopv
 ; CHECK-NEXT:    nopa ; nopb ; movs dc4, m0; nopx ; mov dn4, m0; nopv
 ; CHECK-NEXT:    vlda.2d bmll3, [p1], d1; nopb ; movs m2, m0; nopx ; mov dn2, m0; vadd.f dm4, dm3, dm0, r0

--- a/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/scale.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/scale.mir
@@ -16,13 +16,13 @@
   ; CHECK-LABEL: scale:
   ; CHECK:         .p2align 4
   ; CHECK-NEXT:  // %bb.0: // %entry
-  ; CHECK-NEXT:    vldb x2, [p0], #64; nopx
+  ; CHECK-NEXT:    nopa ; vldb x2, [p0], #64; nopx
+  ; CHECK-NEXT:    vldb x2, [p0], #64
   ; CHECK-NEXT:    vldb x2, [p0], #64
   ; CHECK-NEXT:    vldb x2, [p0], #64; movxm ls, #.LBB0_1
   ; CHECK-NEXT:    mova r2, #-5; vldb x2, [p0], #64; movxm le, #.L_LEnd0
   ; CHECK-NEXT:    vldb x2, [p0], #64; lshl r1, r1, r2; vbcst.16 x0, r0
-  ; CHECK-NEXT:    vldb x2, [p0], #64; add.nc lc, r1, #-13
-  ; CHECK-NEXT:    mova r0, #824; vldb x2, [p0], #64; nops ; nopxm ; nopv
+  ; CHECK-NEXT:    mova r0, #824; vldb x2, [p0], #64; nops ; nopx ; add.nc lc, r1, #-13; nopv
   ; CHECK-NEXT:    nopa ; vldb x2, [p0], #64; nops ; nopxm ; vmul dm0, y1, y0,r0
   ; CHECK-NEXT:    nopa ; vldb x2, [p0], #64; nops ; nopxm ; vmul dm0, y1, y0,r0
   ; CHECK-NEXT:    nopa ; vldb x2, [p0], #64; nops ; nopxm ; vmul dm0, y1, y0,r0

--- a/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/softmax-aa.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/softmax-aa.mir
@@ -33,15 +33,15 @@
   ; CHECK-NEXT:  .LBB0_2: // %for.cond2.preheader
   ; CHECK-NEXT:    // =>This Loop Header: Depth=1
   ; CHECK-NEXT:    // Child Loop BB0_3 Depth 2
-  ; CHECK-NEXT:    nopa ; vldb wl2, [p1], #32; nops ; nopxm ; nopv
-  ; CHECK-NEXT:    nopx
+  ; CHECK-NEXT:    vldb wl2, [p1], #32; nopx
+  ; CHECK-NEXT:    nop
   ; CHECK-NEXT:    nop
   ; CHECK-NEXT:    nop
   ; CHECK-NEXT:    vldb wl2, [p1], #32
+  ; CHECK-NEXT:    nop
   ; CHECK-NEXT:    add.nc lc, r1, #-3
-  ; CHECK-NEXT:    movxm ls, #.LBB0_3
-  ; CHECK-NEXT:    movxm le, #.L_LEnd0; vmul.f dm0, x2, x0, r2
-  ; CHECK-NEXT:    nopa ; vldb wl2, [p1], #32; nops ; nopxm ; nopv
+  ; CHECK-NEXT:    movxm ls, #.LBB0_3; vmul.f dm0, x2, x0, r2
+  ; CHECK-NEXT:    nopa ; vldb wl2, [p1], #32; nops ; movxm le, #.L_LEnd0; nopv
   ; CHECK-NEXT:    nopa ; nopb ; nops ; nopxm ; nopv
   ; CHECK-NEXT:    nopa ; nopb ; nops ; nopxm ; nopv
   ; CHECK-NEXT:    nopa ; nopb ; nops ; nopxm ; vmul.f dm0, x2, x0, r2
@@ -141,16 +141,16 @@
   ; CHECK-NEXT:  .LBB1_2: // %for.cond2.preheader
   ; CHECK-NEXT:    // =>This Loop Header: Depth=1
   ; CHECK-NEXT:    // Child Loop BB1_3 Depth 2
-  ; CHECK-NEXT:    padda [p1], m0; nopb ; nopxm ; nops
-  ; CHECK-NEXT:    vldb wl2, [p1], #32
+  ; CHECK-NEXT:    padda [p1], m0; nopb ; nops ; nopxm ; nopv
+  ; CHECK-NEXT:    vldb wl2, [p1], #32; nopx
   ; CHECK-NEXT:    nop
   ; CHECK-NEXT:    nop
   ; CHECK-NEXT:    nop
   ; CHECK-NEXT:    vldb wl2, [p1], #32
+  ; CHECK-NEXT:    nop
   ; CHECK-NEXT:    add.nc lc, r1, #-3
-  ; CHECK-NEXT:    movxm ls, #.LBB1_3
-  ; CHECK-NEXT:    movxm le, #.L_LEnd1; vmul.f dm0, x2, x0, r2
-  ; CHECK-NEXT:    nopa ; vldb wl2, [p1], #32; nops ; nopxm ; nopv
+  ; CHECK-NEXT:    movxm ls, #.LBB1_3; vmul.f dm0, x2, x0, r2
+  ; CHECK-NEXT:    nopa ; vldb wl2, [p1], #32; nops ; movxm le, #.L_LEnd1; nopv
   ; CHECK-NEXT:    nopa ; nopb ; nops ; nopxm ; nopv
   ; CHECK-NEXT:    nopa ; nopb ; nops ; nopxm ; nopv
   ; CHECK-NEXT:    padda [p0], m0; nopb ; nops ; nopxm ; vmul.f dm0, x2, x0, r2
@@ -252,9 +252,9 @@
   ; CHECK-NEXT:  .LBB2_2: // %for.cond2.preheader
   ; CHECK-NEXT:    // =>This Loop Header: Depth=1
   ; CHECK-NEXT:    // Child Loop BB2_3 Depth 2
-  ; CHECK-NEXT:    add.nc lc, r1, #0
+  ; CHECK-NEXT:    nopa ; nopx ; add.nc lc, r1, #0
   ; CHECK-NEXT:    movxm ls, #.LBB2_3
-  ; CHECK-NEXT:    movxm le, #.L_LEnd2
+  ; CHECK-NEXT:    nopa ; nopb ; nops ; movxm le, #.L_LEnd2; nopv
   ; CHECK-NEXT:    .p2align 4
   ; CHECK-NEXT:  .LBB2_3: // %for.body5
   ; CHECK-NEXT:    // Parent Loop BB2_2 Depth=1
@@ -263,8 +263,8 @@
   ; CHECK-NEXT:    nopa ; nopb ; nops ; nopxm ; nopv
   ; CHECK-NEXT:    nopa ; nopb ; nops ; nopxm ; nopv
   ; CHECK-NEXT:    nopa ; nopb ; nops ; nopxm ; nopv
-  ; CHECK-NEXT:    nopa ; nopb ; nops ; nopxm ; nopv
-  ; CHECK-NEXT:    nopa ; nopb ; nops ; nopxm ; nopv
+  ; CHECK-NEXT:    nopa ; nopb ; nopxm ; nops
+  ; CHECK-NEXT:    nop
   ; CHECK-NEXT:    nop
   ; CHECK-NEXT:    vmul.f dm0, x2, x0, r2
   ; CHECK-NEXT:    nop
@@ -353,9 +353,9 @@
   ; CHECK-NEXT:  .LBB3_2: // %for.cond2.preheader
   ; CHECK-NEXT:    // =>This Loop Header: Depth=1
   ; CHECK-NEXT:    // Child Loop BB3_3 Depth 2
-  ; CHECK-NEXT:    nopa ; nopb ; nops ; nopx ; add.nc lc, r1, #0; nopv
+  ; CHECK-NEXT:    nopa ; nopx ; add.nc lc, r1, #0
   ; CHECK-NEXT:    movxm ls, #.LBB3_3
-  ; CHECK-NEXT:    padda [p1], m0; movxm le, #.L_LEnd3
+  ; CHECK-NEXT:    padda [p1], m0; nopb ; nops ; movxm le, #.L_LEnd3; nopv
   ; CHECK-NEXT:    .p2align 4
   ; CHECK-NEXT:  .LBB3_3: // %for.body5
   ; CHECK-NEXT:    // Parent Loop BB3_2 Depth=1
@@ -364,8 +364,8 @@
   ; CHECK-NEXT:    nopa ; nopb ; nops ; nopxm ; nopv
   ; CHECK-NEXT:    nopa ; nopb ; nops ; nopxm ; nopv
   ; CHECK-NEXT:    nopa ; nopb ; nops ; nopxm ; nopv
-  ; CHECK-NEXT:    nopa ; nopb ; nops ; nopxm ; nopv
-  ; CHECK-NEXT:    nopa ; nopb ; nops ; nopxm ; nopv
+  ; CHECK-NEXT:    nopa ; nopb ; nopxm ; nops
+  ; CHECK-NEXT:    nop
   ; CHECK-NEXT:    nop
   ; CHECK-NEXT:    vmul.f dm0, x2, x0, r2
   ; CHECK-NEXT:    nop

--- a/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/speculative-first-stage.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/speculative-first-stage.mir
@@ -20,11 +20,11 @@
   ; CHECK-LABEL: vmax_fourstage:
   ; CHECK:         .p2align 4
   ; CHECK-NEXT:  // %bb.0: // %entry
-  ; CHECK-NEXT:    vlda x1, [p0, #64]; nopxm
-  ; CHECK-NEXT:    vlda x2, [p0], #128; add.nc lc, r1, #-3
-  ; CHECK-NEXT:    movxm ls, #.LBB0_1
-  ; CHECK-NEXT:    vlda x1, [p0, #64]; movxm le, #.L_LEnd0
-  ; CHECK-NEXT:    vlda x2, [p0], #128; nopb ; nops ; nopxm ; nopv
+  ; CHECK-NEXT:    vlda x1, [p0, #64]; nopb ; nopxm ; nops
+  ; CHECK-NEXT:    vlda x2, [p0], #128
+  ; CHECK-NEXT:    add.nc lc, r1, #-3
+  ; CHECK-NEXT:    vlda x1, [p0, #64]; movxm ls, #.LBB0_1
+  ; CHECK-NEXT:    vlda x2, [p0], #128; nopb ; nops ; movxm le, #.L_LEnd0; nopv
   ; CHECK-NEXT:    nopa ; nopb ; nops ; nopxm ; nopv
   ; CHECK-NEXT:    vlda x1, [p0, #64]; nopb ; nops ; nopxm ; nopv
   ; CHECK-NEXT:    vlda x2, [p0], #128; nopb ; nops ; nopx ; vbcst.32 x0, r0; nopv
@@ -69,10 +69,9 @@
   ; CHECK-LABEL: vmax_threestage:
   ; CHECK:         .p2align 4
   ; CHECK-NEXT:  // %bb.0: // %entry
-  ; CHECK-NEXT:    nopa ; nopb ; nopx ; add.nc lc, r1, #-2
-  ; CHECK-NEXT:    vlda x1, [p0, #64]; movxm ls, #.LBB1_1
-  ; CHECK-NEXT:    vlda x2, [p0], #128; movxm le, #.L_LEnd1
-  ; CHECK-NEXT:    nopa ; nopb ; nops ; nopxm ; nopv
+  ; CHECK-NEXT:    vlda x1, [p0, #64]; add.nc lc, r1, #-2
+  ; CHECK-NEXT:    vlda x2, [p0], #128; movxm ls, #.LBB1_1
+  ; CHECK-NEXT:    nopa ; nopb ; nops ; movxm le, #.L_LEnd1; nopv
   ; CHECK-NEXT:    vlda x1, [p0, #64]; nopb ; nops ; nopxm ; nopv
   ; CHECK-NEXT:    vlda x2, [p0], #128; nopb ; nops ; nopxm ; nopv
   ; CHECK-NEXT:    nopa ; nopb ; nops ; nopxm ; nopv

--- a/llvm/test/CodeGen/AIE/aie2ps/elongate/zol_112bytes_elongate.mir
+++ b/llvm/test/CodeGen/AIE/aie2ps/elongate/zol_112bytes_elongate.mir
@@ -15,18 +15,18 @@ body:             |
     ; CHECK-LABEL: name: zol_112bytes_constraint
     ; CHECK: BUNDLE implicit-def $r1, implicit-def $r2, implicit-def $lc, implicit $p0, implicit $r0 {
     ; CHECK-NEXT:   renamable $r1 = LDA_dms_lda_scalar_ld_idx_imm renamable $p0, 0
-    ; CHECK-NEXT:   NOPB
-    ; CHECK-NEXT:   NOPS
     ; CHECK-NEXT:   renamable $r2 = MOVX_alu_cg_or 0
     ; CHECK-NEXT:   $lc = MOV_alu_mv_mv_mv_scl $r0
-    ; CHECK-NEXT:   NOPV
     ; CHECK-NEXT: }
     ; CHECK-NEXT: BUNDLE implicit-def $ls {
-    ; CHECK-NEXT:   NOPA
     ; CHECK-NEXT:   MOVXM_lng_cg_ls_abs 0, implicit-def $ls
     ; CHECK-NEXT: }
     ; CHECK-NEXT: BUNDLE implicit-def $le {
+    ; CHECK-NEXT:   NOPA
+    ; CHECK-NEXT:   NOPB
+    ; CHECK-NEXT:   NOPS
     ; CHECK-NEXT:   MOVXM_lng_cg_le_abs <mcsymbol .L_1120>, implicit-def $le
+    ; CHECK-NEXT:   NOPV
     ; CHECK-NEXT: }
     ; CHECK-NEXT: BUNDLE implicit-def $r3 {
     ; CHECK-NEXT:   NOPA
@@ -67,16 +67,11 @@ body:             |
     ; CHECK-NEXT: BUNDLE {
     ; CHECK-NEXT:   NOPA
     ; CHECK-NEXT:   NOPB
-    ; CHECK-NEXT:   NOPS
     ; CHECK-NEXT:   NOPXM
-    ; CHECK-NEXT:   NOPV
+    ; CHECK-NEXT:   NOPS
     ; CHECK-NEXT: }
     ; CHECK-NEXT: BUNDLE {
-    ; CHECK-NEXT:   NOPA
-    ; CHECK-NEXT:   NOPB
-    ; CHECK-NEXT:   NOPS
-    ; CHECK-NEXT:   NOPXM
-    ; CHECK-NEXT:   NOPV
+    ; CHECK-NEXT:   NOP
     ; CHECK-NEXT: }
     BUNDLE implicit-def $r1, implicit-def $r2, implicit-def $lc, implicit $p0, implicit $r0 {
       renamable $r1 = LDA_dms_lda_scalar_ld_idx_imm renamable $p0, 0

--- a/llvm/test/CodeGen/AIE/aie2ps/elongate/zol_112bytes_elongate1.mir
+++ b/llvm/test/CodeGen/AIE/aie2ps/elongate/zol_112bytes_elongate1.mir
@@ -18,9 +18,8 @@ body:             |
   ; CHECK-NEXT:   liveins: $p0, $r0
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   BUNDLE implicit-def $x6, implicit-def $wl6, implicit-def $wh6, implicit-def $p0, implicit killed $p0 {
-  ; CHECK-NEXT:     NOPA
   ; CHECK-NEXT:     renamable $x6, renamable $p0 = VLDB_dmx_ldb_x_pstm_nrm_imm killed renamable $p0, 0 :: (load (<32 x s16>))
-  ; CHECK-NEXT:     NOPXM
+  ; CHECK-NEXT:     NOPX
   ; CHECK-NEXT:   }
   ; CHECK-NEXT:   BUNDLE implicit-def $r0, implicit-def dead $srcarry, implicit killed $r0 {
   ; CHECK-NEXT:     renamable $r0 = ADD_add_r_ri killed renamable $r0, -1, implicit-def dead $srcarry
@@ -38,8 +37,11 @@ body:             |
   ; CHECK-NEXT:     MOVXM_lng_cg_ls_abs 0, implicit-def $ls
   ; CHECK-NEXT:   }
   ; CHECK-NEXT:   BUNDLE implicit-def $x1, implicit-def $wl1, implicit-def $wh1, implicit-def $p0, implicit-def $le, implicit killed $p0 {
+  ; CHECK-NEXT:     NOPA
   ; CHECK-NEXT:     renamable $x1, renamable $p0 = VLDB_dmx_ldb_x_pstm_nrm_imm killed renamable $p0, 128 :: (load (<32 x s16>))
+  ; CHECK-NEXT:     NOPS
   ; CHECK-NEXT:     MOVXM_lng_cg_le_abs <mcsymbol .L_1120>, implicit-def $le
+  ; CHECK-NEXT:     NOPV
   ; CHECK-NEXT:   }
   ; CHECK-NEXT:   BUNDLE implicit-def $x0, implicit-def $wl0, implicit-def $wh0, implicit-def $p0, implicit-def $r0, implicit-def dead $srcarry, implicit killed $p0, implicit killed $r0 {
   ; CHECK-NEXT:     NOPA
@@ -64,20 +66,13 @@ body:             |
   ; CHECK-NEXT:     NOPV
   ; CHECK-NEXT:   }
   ; CHECK-NEXT:   BUNDLE implicit-def $x0, implicit-def $wl0, implicit-def $wh0, implicit-def $p0, implicit-def $r0, implicit-def dead $srcarry, implicit killed $p0, implicit killed $r0 {
-  ; CHECK-NEXT:     NOPA
   ; CHECK-NEXT:     renamable $x0, renamable $p0 = VLDB_dmx_ldb_x_pstm_nrm_imm killed renamable $p0, 64 :: (load (<32 x s16>))
-  ; CHECK-NEXT:     NOPS
   ; CHECK-NEXT:     renamable $r0 = ADD_add_r_ri killed renamable $r0, -1, implicit-def dead $srcarry
   ; CHECK-NEXT:     NOPM
-  ; CHECK-NEXT:     NOPV
   ; CHECK-NEXT:   }
   ; CHECK-NEXT:   BUNDLE implicit-def $x2, implicit-def $wl2, implicit-def $wh2, implicit-def $p0, implicit-def $x4, implicit-def $wl4, implicit-def $wh4, implicit killed $p0, implicit $x6, implicit killed $x0, implicit $crbf8conf, implicit $crfp8conf {
-  ; CHECK-NEXT:     NOPA
   ; CHECK-NEXT:     renamable $x2, renamable $p0 = VLDB_dmx_ldb_x_pstm_nrm_imm killed renamable $p0, 64 :: (load (<32 x s16>))
-  ; CHECK-NEXT:     NOPS
-  ; CHECK-NEXT:     NOPX
   ; CHECK-NEXT:     renamable $x4 = VADD_16 renamable $x6, killed renamable $x0, implicit $crbf8conf, implicit $crfp8conf
-  ; CHECK-NEXT:     NOPV
   ; CHECK-NEXT:   }
   ; CHECK-NEXT:   BUNDLE implicit-def $x1, implicit-def $wl1, implicit-def $wh1, implicit-def $p0, implicit killed $p0 {
   ; CHECK-NEXT:     renamable $x1, renamable $p0 = VLDB_dmx_ldb_x_pstm_nrm_imm killed renamable $p0, 128 :: (load (<32 x s16>))
@@ -213,9 +208,8 @@ body:             |
   ; CHECK-NEXT:   liveins: $p0, $r0
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   BUNDLE implicit-def $x6, implicit-def $wl6, implicit-def $wh6, implicit-def $p0, implicit killed $p0 {
-  ; CHECK-NEXT:     NOPA
   ; CHECK-NEXT:     renamable $x6, renamable $p0 = VLDB_dmx_ldb_x_pstm_nrm_imm killed renamable $p0, 0 :: (load (<32 x s16>))
-  ; CHECK-NEXT:     NOPXM
+  ; CHECK-NEXT:     NOPX
   ; CHECK-NEXT:   }
   ; CHECK-NEXT:   BUNDLE implicit-def $r0, implicit-def dead $srcarry, implicit killed $r0 {
   ; CHECK-NEXT:     renamable $r0 = ADD_add_r_ri killed renamable $r0, -1, implicit-def dead $srcarry
@@ -233,8 +227,11 @@ body:             |
   ; CHECK-NEXT:     MOVXM_lng_cg_ls_abs 0, implicit-def $ls
   ; CHECK-NEXT:   }
   ; CHECK-NEXT:   BUNDLE implicit-def $x1, implicit-def $wl1, implicit-def $wh1, implicit-def $p0, implicit-def $le, implicit killed $p0 {
+  ; CHECK-NEXT:     NOPA
   ; CHECK-NEXT:     renamable $x1, renamable $p0 = VLDB_dmx_ldb_x_pstm_nrm_imm killed renamable $p0, 128 :: (load (<32 x s16>))
+  ; CHECK-NEXT:     NOPS
   ; CHECK-NEXT:     MOVXM_lng_cg_le_abs <mcsymbol .L_1120>, implicit-def $le
+  ; CHECK-NEXT:     NOPV
   ; CHECK-NEXT:   }
   ; CHECK-NEXT:   BUNDLE implicit-def $x0, implicit-def $wl0, implicit-def $wh0, implicit-def $p0, implicit-def $r0, implicit-def dead $srcarry, implicit killed $p0, implicit killed $r0 {
   ; CHECK-NEXT:     NOPA
@@ -259,20 +256,13 @@ body:             |
   ; CHECK-NEXT:     NOPV
   ; CHECK-NEXT:   }
   ; CHECK-NEXT:   BUNDLE implicit-def $x0, implicit-def $wl0, implicit-def $wh0, implicit-def $p0, implicit-def $r0, implicit-def dead $srcarry, implicit killed $p0, implicit killed $r0 {
-  ; CHECK-NEXT:     NOPA
   ; CHECK-NEXT:     renamable $x0, renamable $p0 = VLDB_dmx_ldb_x_pstm_nrm_imm killed renamable $p0, 64 :: (load (<32 x s16>))
-  ; CHECK-NEXT:     NOPS
   ; CHECK-NEXT:     renamable $r0 = ADD_add_r_ri killed renamable $r0, -1, implicit-def dead $srcarry
   ; CHECK-NEXT:     NOPM
-  ; CHECK-NEXT:     NOPV
   ; CHECK-NEXT:   }
   ; CHECK-NEXT:   BUNDLE implicit-def $x2, implicit-def $wl2, implicit-def $wh2, implicit-def $p0, implicit-def $x4, implicit-def $wl4, implicit-def $wh4, implicit killed $p0, implicit $x6, implicit killed $x0, implicit $crbf8conf, implicit $crfp8conf {
-  ; CHECK-NEXT:     NOPA
   ; CHECK-NEXT:     renamable $x2, renamable $p0 = VLDB_dmx_ldb_x_pstm_nrm_imm killed renamable $p0, 64 :: (load (<32 x s16>))
-  ; CHECK-NEXT:     NOPS
-  ; CHECK-NEXT:     NOPX
   ; CHECK-NEXT:     renamable $x4 = VADD_16 renamable $x6, killed renamable $x0, implicit $crbf8conf, implicit $crfp8conf
-  ; CHECK-NEXT:     NOPV
   ; CHECK-NEXT:   }
   ; CHECK-NEXT:   BUNDLE implicit-def $x1, implicit-def $wl1, implicit-def $wh1, implicit-def $p0, implicit killed $p0 {
   ; CHECK-NEXT:     renamable $x1, renamable $p0 = VLDB_dmx_ldb_x_pstm_nrm_imm killed renamable $p0, 128 :: (load (<32 x s16>))

--- a/llvm/test/CodeGen/AIE/aie2ps/schedule/postpipeliner/conv2d_bf16.mir
+++ b/llvm/test/CodeGen/AIE/aie2ps/schedule/postpipeliner/conv2d_bf16.mir
@@ -67,20 +67,22 @@ body:             |
   ; CHECK-NEXT:     renamable $x10, renamable $p1 = VLDA_dmx_lda_x_ld_pstm_nrm_imm killed renamable $p1, 64, debug-location !6 :: (load (<16 x s32>), addrspace 6)
   ; CHECK-NEXT:     $x1, $p0, $lf0, $r24 = VLDB_POP_dmx_ldb_fifo_x_normal_pop killed $p0, killed $lf0, killed $r24, debug-location !6 :: (load unknown-size, align 1)
   ; CHECK-NEXT:   }
-  ; CHECK-NEXT:   BUNDLE implicit-def $x11, implicit-def $wl11, implicit-def $wh11, implicit-def $p1, implicit-def $p0, implicit-def $dc1, implicit-def $dc5, implicit-def $lc, implicit killed $p1, implicit killed $p0, implicit $d1_3d, implicit killed $r5, debug-location !6 {
+  ; CHECK-NEXT:   BUNDLE implicit-def $x11, implicit-def $wl11, implicit-def $wh11, implicit-def $p1, implicit-def $p0, implicit-def $dc1, implicit-def $dc5, implicit killed $p1, implicit killed $p0, implicit $d1_3d, debug-location !6 {
   ; CHECK-NEXT:     renamable $x11, renamable $p1 = VLDA_dmx_lda_x_ld_pstm_nrm_imm killed renamable $p1, 64, debug-location !6 :: (load (<16 x s32>), addrspace 6)
   ; CHECK-NEXT:     $p0, $dc1, $dc5 = PADDS_3D killed $p0, $d1_3d, debug-location !6
+  ; CHECK-NEXT:   }
+  ; CHECK-NEXT:   BUNDLE implicit-def $x5, implicit-def $wl5, implicit-def $wh5, implicit-def $p0, implicit-def $lf0, implicit-def $lfl0, implicit-def $lfh0, implicit-def $r24, implicit-def $lfe, implicit-def $srfifo_uf, implicit-def $lc, implicit $r30, implicit killed $p0, implicit killed $lf0, implicit killed $r24, implicit killed $lfe, implicit killed $r5, debug-location !6 {
+  ; CHECK-NEXT:     $x5, $p0, $lf0, $r24 = VLDB_POPX $r30, $r30, killed $p0, killed $lf0, killed $r24, implicit-def $lfe, implicit-def $srfifo_uf, implicit killed $lfe, debug-location !6 :: (load unknown-size, align 1)
   ; CHECK-NEXT:     $lc = ADD_NC_add_lc_ri killed $r5, -2, debug-location !6
   ; CHECK-NEXT:   }
-  ; CHECK-NEXT:   BUNDLE implicit-def $x5, implicit-def $wl5, implicit-def $wh5, implicit-def $p0, implicit-def $lf0, implicit-def $lfl0, implicit-def $lfh0, implicit-def $r24, implicit-def $lfe, implicit-def $srfifo_uf, implicit-def $ls, implicit $r30, implicit killed $p0, implicit killed $lf0, implicit killed $r24, implicit killed $lfe, debug-location !6 {
-  ; CHECK-NEXT:     $x5, $p0, $lf0, $r24 = VLDB_POPX $r30, $r30, killed $p0, killed $lf0, killed $r24, implicit-def $lfe, implicit-def $srfifo_uf, implicit killed $lfe, debug-location !6 :: (load unknown-size, align 1)
+  ; CHECK-NEXT:   BUNDLE implicit-def $x3, implicit-def $wl3, implicit-def $wh3, implicit-def $p0, implicit-def $lf0, implicit-def $lfl0, implicit-def $lfh0, implicit-def $r24, implicit-def $ls, implicit killed $p0, implicit killed $lf0, implicit killed $r24, debug-location !6 {
+  ; CHECK-NEXT:     $x3, $p0, $lf0, $r24 = VLDA_POP_dmx_lda_fifo_x_normal_pop killed $p0, killed $lf0, killed $r24, debug-location !6 :: (load unknown-size, align 1)
   ; CHECK-NEXT:     MOVXM_lng_cg_ls_abs %bb.2, implicit-def $ls, debug-location !6
   ; CHECK-NEXT:   }
-  ; CHECK-NEXT:   BUNDLE implicit-def $x3, implicit-def $wl3, implicit-def $wh3, implicit-def $p0, implicit-def $lf0, implicit-def $lfl0, implicit-def $lfh0, implicit-def $r24, implicit-def $le, implicit killed $p0, implicit killed $lf0, implicit killed $r24, debug-location !6 {
-  ; CHECK-NEXT:     $x3, $p0, $lf0, $r24 = VLDA_POP_dmx_lda_fifo_x_normal_pop killed $p0, killed $lf0, killed $r24, debug-location !6 :: (load unknown-size, align 1)
+  ; CHECK-NEXT:   BUNDLE implicit-def $x6, implicit-def $wl6, implicit-def $wh6, implicit-def $p0, implicit-def $lf0, implicit-def $lfl0, implicit-def $lfh0, implicit-def $r24, implicit-def $le, implicit killed $p0, implicit killed $lf0, implicit killed $r24, debug-location !6 {
+  ; CHECK-NEXT:     $x6, $p0, $lf0, $r24 = VLDB_POP_dmx_ldb_fifo_x_normal_pop killed $p0, killed $lf0, killed $r24, debug-location !6 :: (load unknown-size, align 1)
   ; CHECK-NEXT:     MOVXM_lng_cg_le_abs <mcsymbol .L_LEnd0>, implicit-def $le, debug-location !6
   ; CHECK-NEXT:   }
-  ; CHECK-NEXT:   $x6, $p0, $lf0, $r24 = VLDB_POP_dmx_ldb_fifo_x_normal_pop killed $p0, killed $lf0, killed $r24, debug-location !6 :: (load unknown-size, align 1)
   ; CHECK-NEXT:   BUNDLE implicit-def $x10, implicit-def $wl10, implicit-def $wh10, implicit-def $p1, implicit-def $x1, implicit-def $wl1, implicit-def $wh1, implicit-def $p0, implicit-def $lf0, implicit-def $lfl0, implicit-def $lfh0, implicit-def $r24, implicit killed $p1, implicit killed $p0, implicit killed $lf0, implicit killed $r24, debug-location !6 {
   ; CHECK-NEXT:     renamable $x10, renamable $p1 = VLDA_dmx_lda_x_ld_pstm_nrm_imm killed renamable $p1, 64, debug-location !6 :: (load (<16 x s32>), addrspace 6)
   ; CHECK-NEXT:     $x1, $p0, $lf0, $r24 = VLDB_POP_dmx_ldb_fifo_x_normal_pop killed $p0, killed $lf0, killed $r24, debug-location !6 :: (load unknown-size, align 1)

--- a/llvm/test/CodeGen/AIE/hardware-loops/zol-loop.ll
+++ b/llvm/test/CodeGen/AIE/hardware-loops/zol-loop.ll
@@ -16,7 +16,7 @@
 define void @simple_loop(i32 noundef %n, ptr nocapture readonly %in, ptr nocapture writeonly %out) {
 ; AIE2-LABEL: simple_loop:
 ; AIE2:       // %bb.0: // %entry
-; AIE2-NEXT:    mova r1, #0
+; AIE2-NEXT:    mova r1, #0; nopb ; nopxm ; nops
 ; AIE2-NEXT:    ge r2, r1, r0
 ; AIE2-NEXT:    jnz r2, #.LBB0_3
 ; AIE2-NEXT:    nop // Delay Slot 5
@@ -27,7 +27,7 @@ define void @simple_loop(i32 noundef %n, ptr nocapture readonly %in, ptr nocaptu
 ; AIE2-NEXT:  // %bb.1: // %for.body.preheader
 ; AIE2-NEXT:    add.nc lc, r0, #0
 ; AIE2-NEXT:    mova r2, #1; movxm ls, #.LBB0_2
-; AIE2-NEXT:    mova r0, #2; movxm le, #.L_LEnd0
+; AIE2-NEXT:    nopb ; mova r0, #2; nops ; movxm le, #.L_LEnd0; nopv
 ; AIE2-NEXT:  .LBB0_2: // %for.body
 ; AIE2-NEXT:    // =>This Inner Loop Header: Depth=1
 ; AIE2-NEXT:    nopb ; lda r3, [p0, #0]; nops ; nopxm ; nopv
@@ -35,8 +35,8 @@ define void @simple_loop(i32 noundef %n, ptr nocapture readonly %in, ptr nocaptu
 ; AIE2-NEXT:    nopb ; nopa ; nops ; nopxm ; nopv
 ; AIE2-NEXT:    nopb ; nopa ; nops ; nopxm ; nopv
 ; AIE2-NEXT:    nopb ; nopa ; nops ; nopxm ; nopv
-; AIE2-NEXT:    nopb ; nopa ; nops ; lshl r4, r1, r0; nopm ; nopv
-; AIE2-NEXT:    nopa ; nopb ; add r1, r1, #1
+; AIE2-NEXT:    lshl r4, r1, r0
+; AIE2-NEXT:    add r1, r1, #1
 ; AIE2-NEXT:    add r3, r2, r3; mov dj0, r4
 ; AIE2-NEXT:  .L_LEnd0:
 ; AIE2-NEXT:    nopb ; nopa ; st r3, [p1, dj0]; add r2, r2, #-1; nopm ; nopv
@@ -50,7 +50,7 @@ define void @simple_loop(i32 noundef %n, ptr nocapture readonly %in, ptr nocaptu
 ;
 ; AIE2P-LABEL: simple_loop:
 ; AIE2P:       // %bb.0: // %entry
-; AIE2P-NEXT:    mova r1, #0
+; AIE2P-NEXT:    mova r1, #0; nopb ; nopxm ; nops
 ; AIE2P-NEXT:    ge r2, r1, r0
 ; AIE2P-NEXT:    jnz r2, #.LBB0_3
 ; AIE2P-NEXT:    nop // Delay Slot 5
@@ -61,7 +61,7 @@ define void @simple_loop(i32 noundef %n, ptr nocapture readonly %in, ptr nocaptu
 ; AIE2P-NEXT:  // %bb.1: // %for.body.preheader
 ; AIE2P-NEXT:    add.nc lc, r0, #0
 ; AIE2P-NEXT:    mova r2, #1; movxm ls, #.LBB0_2
-; AIE2P-NEXT:    mova r0, #2; movxm le, #.L_LEnd0
+; AIE2P-NEXT:    mova r0, #2; nopb ; nops ; movxm le, #.L_LEnd0; nopv
 ; AIE2P-NEXT:  .LBB0_2: // %for.body
 ; AIE2P-NEXT:    // =>This Inner Loop Header: Depth=1
 ; AIE2P-NEXT:    lda r3, [p0, #0]; nopb ; nops ; nopxm ; nopv
@@ -69,8 +69,8 @@ define void @simple_loop(i32 noundef %n, ptr nocapture readonly %in, ptr nocaptu
 ; AIE2P-NEXT:    nopa ; nopb ; nops ; nopxm ; nopv
 ; AIE2P-NEXT:    nopa ; nopb ; nops ; nopxm ; nopv
 ; AIE2P-NEXT:    nopa ; nopb ; nops ; nopxm ; nopv
-; AIE2P-NEXT:    nopa ; nopb ; nops ; lshl r4, r1, r0; nopm ; nopv
-; AIE2P-NEXT:    nopa ; add r1, r1, #1; nopm
+; AIE2P-NEXT:    nopa ; lshl r4, r1, r0
+; AIE2P-NEXT:    add r1, r1, #1
 ; AIE2P-NEXT:    add r3, r2, r3; mov dj0, r4
 ; AIE2P-NEXT:  .L_LEnd0:
 ; AIE2P-NEXT:    nopa ; nopb ; st r3, [p1, dj0]; add r2, r2, #-1; nopm ; nopv
@@ -84,7 +84,7 @@ define void @simple_loop(i32 noundef %n, ptr nocapture readonly %in, ptr nocaptu
 ;
 ; AIE2PS-LABEL: simple_loop:
 ; AIE2PS:       // %bb.0: // %entry
-; AIE2PS-NEXT:    mova r2, #0
+; AIE2PS-NEXT:    mova r2, #0; nopb ; nopxm ; nops
 ; AIE2PS-NEXT:    ge r4, r2, r0
 ; AIE2PS-NEXT:    jnz r4, #.LBB0_3
 ; AIE2PS-NEXT:    nop // Delay Slot 5
@@ -95,7 +95,7 @@ define void @simple_loop(i32 noundef %n, ptr nocapture readonly %in, ptr nocaptu
 ; AIE2PS-NEXT:  // %bb.1: // %for.body.preheader
 ; AIE2PS-NEXT:    add.nc lc, r0, #0
 ; AIE2PS-NEXT:    mova r4, #1; movxm ls, #.LBB0_2
-; AIE2PS-NEXT:    mova r0, #2; movxm le, #.L_LEnd0
+; AIE2PS-NEXT:    mova r0, #2; nopb ; nops ; movxm le, #.L_LEnd0; nopv
 ; AIE2PS-NEXT:  .LBB0_2: // %for.body
 ; AIE2PS-NEXT:    // =>This Inner Loop Header: Depth=1
 ; AIE2PS-NEXT:    lda r6, [p0, #0]; nopb ; nops ; nopxm ; nopv
@@ -103,8 +103,8 @@ define void @simple_loop(i32 noundef %n, ptr nocapture readonly %in, ptr nocaptu
 ; AIE2PS-NEXT:    nopa ; nopb ; nops ; nopxm ; nopv
 ; AIE2PS-NEXT:    nopa ; nopb ; nops ; nopxm ; nopv
 ; AIE2PS-NEXT:    nopa ; nopb ; nops ; nopxm ; nopv
-; AIE2PS-NEXT:    nopa ; nopb ; nops ; lshl r16, r2, r0; nopm ; nopv
-; AIE2PS-NEXT:    nopa ; add r2, r2, #1; nopm
+; AIE2PS-NEXT:    nopa ; lshl r16, r2, r0
+; AIE2PS-NEXT:    add r2, r2, #1
 ; AIE2PS-NEXT:    add r6, r4, r6; mov dj0, r16
 ; AIE2PS-NEXT:  .L_LEnd0:
 ; AIE2PS-NEXT:    nopa ; nopb ; st r6, [p1, dj0]; add r4, r4, #-1; nopm ; nopv
@@ -138,10 +138,9 @@ for.body:                                         ; preds = %entry, %for.body
 define i32 @static_bounded_loop(i32 %num) {
 ; AIE2-LABEL: static_bounded_loop:
 ; AIE2:       // %bb.0: // %entry
-; AIE2-NEXT:    nopb ; nopa ; nops ; movxm ls, #.LBB1_1; nopv
-; AIE2-NEXT:    mova r2, #64; nopb ; movxm le, #.L_LEnd1
-; AIE2-NEXT:    add.nc lc, r2, #0
-; AIE2-NEXT:    nopb ; nopa ; nops ; nopxm ; nopv
+; AIE2-NEXT:    movxm ls, #.LBB1_1
+; AIE2-NEXT:    mova r2, #64; movxm le, #.L_LEnd1
+; AIE2-NEXT:    nopb ; nopa ; nops ; nopx ; add.nc lc, r2, #0; nopv
 ; AIE2-NEXT:    nopb ; nopa ; nops ; nopxm ; nopv
 ; AIE2-NEXT:    nopb ; nopa ; nops ; nopxm ; nopv
 ; AIE2-NEXT:    nopb ; nopa ; nops ; nopxm ; nopv
@@ -162,10 +161,9 @@ define i32 @static_bounded_loop(i32 %num) {
 ;
 ; AIE2P-LABEL: static_bounded_loop:
 ; AIE2P:       // %bb.0: // %entry
-; AIE2P-NEXT:    nopa ; nopb ; nops ; movxm ls, #.LBB1_1; nopv
-; AIE2P-NEXT:    mova r2, #64; nopb ; movxm le, #.L_LEnd1
-; AIE2P-NEXT:    add.nc lc, r2, #0
-; AIE2P-NEXT:    nopa ; nopb ; nops ; nopxm ; nopv
+; AIE2P-NEXT:    movxm ls, #.LBB1_1
+; AIE2P-NEXT:    mova r2, #64; movxm le, #.L_LEnd1
+; AIE2P-NEXT:    nopa ; nopb ; nops ; nopx ; add.nc lc, r2, #0; nopv
 ; AIE2P-NEXT:    nopa ; nopb ; nops ; nopxm ; nopv
 ; AIE2P-NEXT:    nopa ; nopb ; nops ; nopxm ; nopv
 ; AIE2P-NEXT:    nopa ; nopb ; nops ; nopxm ; nopv
@@ -186,10 +184,9 @@ define i32 @static_bounded_loop(i32 %num) {
 ;
 ; AIE2PS-LABEL: static_bounded_loop:
 ; AIE2PS:       // %bb.0: // %entry
-; AIE2PS-NEXT:    nopa ; nopb ; nops ; movxm ls, #.LBB1_1; nopv
-; AIE2PS-NEXT:    mova r3, #64; nopb ; movxm le, #.L_LEnd1
-; AIE2PS-NEXT:    add.nc lc, r3, #0
-; AIE2PS-NEXT:    nopa ; nopb ; nops ; nopxm ; nopv
+; AIE2PS-NEXT:    movxm ls, #.LBB1_1
+; AIE2PS-NEXT:    mova r3, #64; movxm le, #.L_LEnd1
+; AIE2PS-NEXT:    nopa ; nopb ; nops ; add.nc lc, r3, #0; nopm ; nopv
 ; AIE2PS-NEXT:    nopa ; nopb ; nops ; nopxm ; nopv
 ; AIE2PS-NEXT:    nopa ; nopb ; nops ; nopxm ; nopv
 ; AIE2PS-NEXT:    nopa ; nopb ; nops ; nopxm ; nopv

--- a/llvm/test/CodeGen/AIE/schedule/commit-block-schedule.ll
+++ b/llvm/test/CodeGen/AIE/schedule/commit-block-schedule.ll
@@ -18,10 +18,9 @@ define void @test_commit_block_schedule(i1 %0) {
 ; CHECK-NEXT:  .LBB0_1: // %for.body41
 ; CHECK-NEXT:    // =>This Loop Header: Depth=1
 ; CHECK-NEXT:    // Child Loop BB0_2 Depth 2
-; CHECK-NEXT:    add.nc lc, r2, #0
+; CHECK-NEXT:    nopa ; nopx ; add.nc lc, r2, #0
 ; CHECK-NEXT:    movxm ls, #.LBB0_2
-; CHECK-NEXT:    movxm le, #.L_LEnd0
-; CHECK-NEXT:    nopa ; nopb ; nops ; nopxm ; nopv
+; CHECK-NEXT:    nopa ; nopb ; nops ; movxm le, #.L_LEnd0; nopv
 ; CHECK-NEXT:    nopa ; nopb ; nops ; nopxm ; nopv
 ; CHECK-NEXT:    nopa ; nopb ; nops ; nopxm ; nopv
 ; CHECK-NEXT:    nopa ; nopb ; nops ; nopx ; vmov cml2, cml0; nopv

--- a/llvm/test/CodeGen/AIE/schedule/pointer-hazard.mir
+++ b/llvm/test/CodeGen/AIE/schedule/pointer-hazard.mir
@@ -17,16 +17,16 @@
   ; CHECK-LABEL: _Z16scale_vectorizedPsS_ii:
   ; CHECK:         .p2align 4
   ; CHECK-NEXT:  // %bb.0: // %entry
-  ; CHECK-NEXT:    nopa ; event #0
+  ; CHECK-NEXT:    nopa ; event #0; nopm
   ; CHECK-NEXT:    vldb wh2, [p0, #32]
   ; CHECK-NEXT:    vlda wl2, [p0], #64
   ; CHECK-NEXT:    vldb wh2, [p0, #32]
   ; CHECK-NEXT:    vlda wl2, [p0], #64
-  ; CHECK-NEXT:    mova r2, #-5; vldb wh2, [p0, #32]; movxm ls, #.LBB0_1
-  ; CHECK-NEXT:    vlda wl2, [p0], #64; movxm le, #.L_LEnd0
-  ; CHECK-NEXT:    vldb wh2, [p0, #32]; lshl r1, r1, r2; vbcst.16 x0, r0
-  ; CHECK-NEXT:    vlda wl2, [p0], #64; movx r0, #824; add.nc lc, r1, #-7
-  ; CHECK-NEXT:    vldb wh2, [p0, #32]; nopa ; nops ; nopxm ; vmul cm0, x2, x0, r0
+  ; CHECK-NEXT:    mova r2, #-5; vldb wh2, [p0, #32]; vbcst.16 x0, r0
+  ; CHECK-NEXT:    vlda wl2, [p0], #64; movxm ls, #.LBB0_1
+  ; CHECK-NEXT:    mova r0, #824; vldb wh2, [p0, #32]; movxm le, #.L_LEnd0
+  ; CHECK-NEXT:    vlda wl2, [p0], #64; lshl r1, r1, r2
+  ; CHECK-NEXT:    vldb wh2, [p0, #32]; nopa ; nops ; nopx ; add.nc lc, r1, #-7; vmul cm0, x2, x0, r0
   ; CHECK-NEXT:    nopb ; vlda wl2, [p0], #64; nops ; nopxm ; nopv
   ; CHECK-NEXT:    vldb wh2, [p0, #32]; nopa ; nops ; nopxm ; vmul cm0, x2, x0, r0
   ; CHECK-NEXT:    nopb ; vlda wl2, [p0], #64; nops ; movx r3, #0; nopm ; nopv

--- a/llvm/test/CodeGen/AIE/schedule/sched-initialize-topscb-once.ll
+++ b/llvm/test/CodeGen/AIE/schedule/sched-initialize-topscb-once.ll
@@ -10,10 +10,10 @@
 define void @load_store_with_call() {
 ; CHECK-LABEL: load_store_with_call:
 ; CHECK:       // %bb.0: // %entry
-; CHECK-NEXT:    nopa ; nopb ; nops ; movxm ls, #.LBB0_1; nopv
+; CHECK-NEXT:    nopa ; nopb ; movxm ls, #.LBB0_1
 ; CHECK-NEXT:    mova r0, #0; movxm le, #.L_LEnd0
-; CHECK-NEXT:    mova p5, #0; add.nc lc, r0, #-7
-; CHECK-NEXT:    nopa ; vldb x2, [p5, #0]; nops ; paddxm [sp], #64; nopv
+; CHECK-NEXT:    mova p5, #0; paddxm [sp], #64
+; CHECK-NEXT:    nopa ; vldb x2, [p5, #0]; nops ; nopx ; add.nc lc, r0, #-7; nopv
 ; CHECK-NEXT:    nopa ; vldb x2, [p5, #0]; st lr, [sp, #-64]; nopxm ; nopv // 4-byte Folded Spill
 ; CHECK-NEXT:    nopa ; vldb x2, [p5, #0]; nops ; nopxm ; nopv
 ; CHECK-NEXT:    nopa ; vldb x2, [p5, #0]; nops ; nopxm ; nopv


### PR DESCRIPTION
I ran full mllib suite on aie2p, PM size improvements across the board up to 80 bytes per kernel and some Compute Cycle Count impovements up to 1.9% on PADD2D and PADD3D.
<img width="4400" height="1800" alt="image" src="https://github.com/user-attachments/assets/98218dbe-ba44-422e-877d-58d8b1200908" />

<img width="4400" height="1800" alt="image" src="https://github.com/user-attachments/assets/1fe73330-f323-424b-85a4-1ddc8b8c3789" />
