### PR TITLE
[PDLL] Add support for Tuple to Range conversion in constraint section

### DIFF
--- a/mlir/lib/Tools/PDLL/Parser/Parser.cpp
+++ b/mlir/lib/Tools/PDLL/Parser/Parser.cpp
@@ -899,10 +899,11 @@ LogicalResult Parser::convertTupleExpressionTo(
   // Handle conversion to a range.
   auto convertToRange = [&](ArrayRef<ast::Type> allowedElementTypes,
                             ast::RangeType resultTy) -> LogicalResult {
-    // TODO: We currently only allow range conversion within a rewrite context.
-    if (parserContext != ParserContext::Rewrite) {
-      return emitErrorFn()->attachNote("Tuple to Range conversion is currently "
-                                       "only allowed within a rewrite context");
+    if (parserContext != ParserContext::Rewrite &&
+        parserContext != ParserContext::Constraint) {
+      return emitErrorFn()->attachNote(
+          "Tuple to Range conversion is currently only allowed within a "
+          "rewrite or constraint context");
     }
 
     // All of the tuple elements must be allowed types.

--- a/mlir/test/mlir-pdll/Parser/constraint.pdll
+++ b/mlir/test/mlir-pdll/Parser/constraint.pdll
@@ -80,3 +80,69 @@ Constraint Outer() {
   Constraint() {};
   Constraint() => attr<"10">;
 }
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// ValueRange creation inside a Constraint body
+//===----------------------------------------------------------------------===//
+
+// Test building a ValueRange from individual Values via a let statement inside
+// a Constraint body.
+
+// CHECK: Module
+// CHECK: `-UserConstraintDecl {{.*}} Name<Foo> ResultType<ValueRange>
+// CHECK:   `Inputs`
+// CHECK:     |-VariableDecl {{.*}} Name<v1> Type<Value>
+// CHECK:     `-VariableDecl {{.*}} Name<v2> Type<Value>
+// CHECK:   `Results`
+// CHECK:     `-VariableDecl {{.*}} Name<> Type<ValueRange>
+// CHECK:   `-CompoundStmt {{.*}}
+// CHECK:     |-LetStmt
+// CHECK:     | `-VariableDecl {{.*}} Name<r> Type<ValueRange>
+// CHECK:     |   `-RangeExpr {{.*}} Type<ValueRange>
+// CHECK:     |     |-MemberAccessExpr {{.*}} Member<0> Type<Value>
+// CHECK:     |     `-MemberAccessExpr {{.*}} Member<1> Type<Value>
+// CHECK:     `-ReturnStmt
+// CHECK:       `-DeclRefExpr {{.*}} Type<ValueRange>
+// CHECK:         `-VariableDecl {{.*}} Name<r> Type<ValueRange>
+Constraint Foo(v1: Value, v2: Value) -> ValueRange {
+  let r: ValueRange = (v1, v2);
+  return r;
+}
+
+// -----
+
+// Test building a ValueRange from a mix of Value and ValueRange arguments.
+
+// CHECK: Module
+// CHECK: `-UserConstraintDecl {{.*}} Name<Foo> ResultType<ValueRange>
+// CHECK:   `Inputs`
+// CHECK:     |-VariableDecl {{.*}} Name<v> Type<Value>
+// CHECK:     `-VariableDecl {{.*}} Name<vr> Type<ValueRange>
+// CHECK:   `Results`
+// CHECK:     `-VariableDecl {{.*}} Name<> Type<ValueRange>
+// CHECK:   `-CompoundStmt {{.*}}
+// CHECK:     `-ReturnStmt
+// CHECK:       `-RangeExpr {{.*}} Type<ValueRange>
+// CHECK:         |-MemberAccessExpr {{.*}} Member<0> Type<Value>
+// CHECK:         `-MemberAccessExpr {{.*}} Member<1> Type<ValueRange>
+Constraint Foo(v: Value, vr: ValueRange) -> ValueRange => (v, vr);
+
+// -----
+
+// Test building a TypeRange from individual Types inside a Constraint body.
+
+// CHECK: Module
+// CHECK: `-UserConstraintDecl {{.*}} Name<Foo> ResultType<TypeRange>
+// CHECK:   `Inputs`
+// CHECK:     |-VariableDecl {{.*}} Name<t1> Type<Type>
+// CHECK:     `-VariableDecl {{.*}} Name<t2> Type<Type>
+// CHECK:   `Results`
+// CHECK:     `-VariableDecl {{.*}} Name<> Type<TypeRange>
+// CHECK:   `-CompoundStmt {{.*}}
+// CHECK:     `-ReturnStmt
+// CHECK:       `-RangeExpr {{.*}} Type<TypeRange>
+// CHECK:         |-MemberAccessExpr {{.*}} Member<0> Type<Type>
+// CHECK:         `-MemberAccessExpr {{.*}} Member<1> Type<Type>
+Constraint Foo(t1: Type, t2: Type) -> TypeRange => (t1, t2);

--- a/mlir/test/mlir-pdll/Parser/expr-failure.pdll
+++ b/mlir/test/mlir-pdll/Parser/expr-failure.pdll
@@ -156,7 +156,7 @@ Pattern ConstraintArrayAttrWithAttrAndValue {
 
 Pattern {
   // CHECK: unable to convert expression of type `Tuple<>` to the expected type of `ValueRange`
-  // CHECK: Tuple to Range conversion is currently only allowed within a rewrite context
+  // CHECK: Tuple to Range conversion is currently only allowed within a rewrite or constraint context
   erase op<>(());
 }
 


### PR DESCRIPTION
The PR lift the restrict to convert tuple to range in the constraint section of PDLL patterns.
This will allows making more generic constraints.

**todo:**

- [ ] update licenses