### PR TITLE
[AIE1] Fix libc: Pass -mno-vitis-headers to try_compile (#1801)

### DIFF
--- a/libc/startup/baremetal/aie/crt1.cc
+++ b/libc/startup/baremetal/aie/crt1.cc
@@ -3,7 +3,12 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// (c) Copyright 2024 Advanced Micro Devices, Inc. or its affiliates
+// (c) Copyright 2024-2026 Advanced Micro Devices, Inc. or its affiliates
+#if __AIEARCH__ == 10
+#include "aiev1intrin.h"
+#else
+#error "Unsupported __AIEARCH__ version"
+#endif
 
 extern "C" {
 extern int main(int, char **);


### PR DESCRIPTION
somehow we missed aie1 in the runtime patch 