### PR TITLE
[AIE] Enable pragma II as upper bound

### DIFF
--- a/clang/lib/Driver/ToolChains/AIE.cpp
+++ b/clang/lib/Driver/ToolChains/AIE.cpp
@@ -193,6 +193,9 @@ void AIEToolChain::addClangTargetOptions(
   // Enable Loop Iteration Count Assumptions
   CC1Args.append({"-mllvm", "-enable-loop-iter-count-assumptions=true"});
 
+  // Treat pragma II as maximum bound instead of exact value
+  CC1Args.append({"-mllvm", "-pipeliner-pragma-as-max-ii=true"});
+
   bool UseBuiltins = DriverArgs.hasFlag(options::OPT_fbuiltin,
                                         options::OPT_fno_builtin, false);
 

--- a/clang/test/Driver/aie/aie-toolchain.c
+++ b/clang/test/Driver/aie/aie-toolchain.c
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// (c) Copyright 2023-2025 Advanced Micro Devices, Inc. or its affiliates
+// (c) Copyright 2023-2026 Advanced Micro Devices, Inc. or its affiliates
 //
 //===----------------------------------------------------------------------===//
 
@@ -20,6 +20,11 @@
 // CC1: "-mllvm" "-vectorize-loops=false"
 // CC1: "-mllvm" "-vectorize-slp=false"
 // CC1: "-mllvm" "--two-entry-phi-node-folding-threshold=10"
+// CC1: "-mllvm" "-mandatory-inlining-before-opt=false"
+// CC1: "-mllvm" "-basic-aa-full-phi-analysis=true"
+// CC1: "-mllvm" "-basic-aa-max-lookup-search-depth=10"
+// CC1: "-mllvm" "-enable-loop-iter-count-assumptions=true"
+// CC1: "-mllvm" "-pipeliner-pragma-as-max-ii=true"
 // CC1: "-fno-builtin-memset"
 // CC1: "-fno-builtin-memcpy"
 // CC1: "-fno-builtin-memmove"

--- a/llvm/lib/CodeGen/MachinePipeliner.cpp
+++ b/llvm/lib/CodeGen/MachinePipeliner.cpp
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// Modifications (c) Copyright 2023-2024 Advanced Micro Devices, Inc. or its
+// Modifications (c) Copyright 2023-2026 Advanced Micro Devices, Inc. or its
 // affiliates
 //
 //===----------------------------------------------------------------------===//
@@ -196,6 +196,10 @@ static cl::opt<int>
 static cl::opt<bool>
     MVECodeGen("pipeliner-mve-cg", cl::Hidden, cl::init(false),
                cl::desc("Use the MVE code generator for software pipelining"));
+
+static cl::opt<bool> SwpPragmaAsMaxII(
+    "pipeliner-pragma-as-max-ii", cl::Hidden, cl::init(false),
+    cl::desc("Treat pragma II as maximum bound instead of exact value"));
 
 namespace llvm {
 
@@ -545,7 +549,7 @@ bool MachinePipeliner::useWindowScheduler(bool Changed) {
 void SwingSchedulerDAG::setMII(unsigned ResMII, unsigned RecMII) {
   if (SwpForceII > 0)
     MII = SwpForceII;
-  else if (II_setByPragma > 0)
+  else if (II_setByPragma > 0 && !SwpPragmaAsMaxII)
     MII = II_setByPragma;
   else
     MII = std::max(ResMII, RecMII);


### PR DESCRIPTION
Add support for using pragma initiation interval as a maximum constraint
rather than forcing an exact II value, and enable it automatically for
AIE targets.

Backend Changes (llvm/lib/CodeGen/MachinePipeliner.cpp):
- Add -pipeliner-pragma-as-max-ii flag (default: false)
- Modify setMII() to use computed MII when flag is enabled
- When flag is disabled, preserve existing behavior (exact II)

Driver Changes (clang/lib/Driver/ToolChains/AIE.cpp):
- Automatically pass -mllvm -pipeliner-pragma-as-max-ii=true for AIE
- Enables flexible scheduling without requiring user flags

Test Updates (clang/test/Driver/aie/aie-toolchain.c):
- Verify flag is correctly passed to backend for all AIE targets

Behavior:
- AIE targets: pragma II=24, MII=9 → tries II=9..24 (finds optimal)
- Other targets: pragma II=24 → tries II=24 only (unchanged)

This resolves cases where the optimal II exceeds MII+SwpIISearchRange
but is still within the pragma constraint, improving code generation
for AIE targets while maintaining backward compatibility.