### PR TITLE
[AIE2PS] Add copyPhysReg support for PLFR register

### DIFF
--- a/llvm/lib/Target/AIE/aie2ps/AIE2PSInstrInfo.cpp
+++ b/llvm/lib/Target/AIE/aie2ps/AIE2PSInstrInfo.cpp
@@ -367,6 +367,9 @@ void AIE2PSInstrInfo::copyPhysReg(MachineBasicBlock &MBB,
                 getLoSubReg(TRI, SrcReg), KillSrc);
     copyPhysReg(MBB, MBBI, DL, getHiSubReg(TRI, DstReg),
                 getHiSubReg(TRI, SrcReg), KillSrc);
+  } else if ((AIE2PS::ePSRFLdFRegClass.contains(SrcReg)) &&
+             (AIE2PS::ePSRFLdFRegClass.contains(DstReg))) {
+    copyThroughSubRegs(MBB, MBBI, DL, DstReg, SrcReg, KillSrc);
   } else {
     llvm_unreachable("unhandled case in copyPhysReg");
   }

--- a/llvm/test/CodeGen/AIE/aie2ps/run-physreg-copy.mir
+++ b/llvm/test/CodeGen/AIE/aie2ps/run-physreg-copy.mir
@@ -632,3 +632,15 @@ body: |
     ; CHECK-NEXT: $bmlh0 = VMOV_alu_mv_mv_mv_x $lfh0
   $cml0 = COPY $lf0
 ...
+
+---
+name:            test_copy_plfr
+body: |
+  bb.0:
+    ; CHECK-LABEL: name: test_copy_plfr
+    ; CHECK: $lfl1 = VMOV_alu_mv_mv_mv_x $lfl0
+    ; CHECK-NEXT: $lfh1 = VMOV_alu_mv_mv_mv_x $lfh0
+    ; CHECK-NEXT: $r25 = MOV_OR_pseudo $r24
+    ; CHECK-NEXT: $p1 = MOV_scalar_pseudo $p0
+  $plfr1 = COPY $plfr0
+...


### PR DESCRIPTION
PLFR has no dedicated copy instruction, so decompose it into its three subregisters (lf, r, p) via copyThroughSubRegs.