### PR TITLE
[NFC][AIEX] Remove unnecessary byte_incr overloads

### DIFF
--- a/clang/lib/Headers/aie2p/aie2p_aie_api_compat.h
+++ b/clang/lib/Headers/aie2p/aie2p_aie_api_compat.h
@@ -2045,7 +2045,6 @@ inline __attribute__((always_inline)) void * add_2d_int(void * , int , int , add
 inline __attribute__((always_inline)) void * add_2d_byte_int(void * , int , int , addr_t , addr_t , addr_t & );
 inline __attribute__((always_inline)) void * add_3d_int(void * , int , int , int , addr_t , addr_t , addr_t & , addr_t , addr_t , addr_t & );
 inline __attribute__((always_inline)) void * add_3d_byte_int(void * , int , int , int , addr_t , addr_t , addr_t & , addr_t , addr_t , addr_t & );
-inline __attribute__((always_inline)) void * byte_incr(void * , int );
 inline __attribute__((always_inline)) int delay1(int );
 inline __attribute__((always_inline)) int delay2(int );
 inline __attribute__((always_inline)) int delay3(int );

--- a/clang/lib/Headers/aie2ps/aie2ps_aie_api_compat.h
+++ b/clang/lib/Headers/aie2ps/aie2ps_aie_api_compat.h
@@ -2139,7 +2139,6 @@ inline __attribute__((always_inline)) void * add_2d_int(void * , int , int , add
 inline __attribute__((always_inline)) void * add_2d_byte_int(void * , int , int , addr_t , addr_t , addr_t & );
 inline __attribute__((always_inline)) void * add_3d_int(void * , int , int , int , addr_t , addr_t , addr_t & , addr_t , addr_t , addr_t & );
 inline __attribute__((always_inline)) void * add_3d_byte_int(void * , int , int , int , addr_t , addr_t , addr_t & , addr_t , addr_t , addr_t & );
-inline __attribute__((always_inline)) void * byte_incr(void * , int );
 inline __attribute__((always_inline)) int delay1(int );
 inline __attribute__((always_inline)) int delay2(int );
 inline __attribute__((always_inline)) int delay3(int );

--- a/clang/lib/Headers/aiev2/aiev2_aie_api_compat.h
+++ b/clang/lib/Headers/aiev2/aiev2_aie_api_compat.h
@@ -1447,7 +1447,6 @@ inline __attribute__((always_inline)) void * add_2d_int(void * , int , int , add
 inline __attribute__((always_inline)) void * add_2d_byte_int(void * , int , int , addr_t , addr_t , addr_t & );
 inline __attribute__((always_inline)) void * add_3d_int(void * , int , int , int , addr_t , addr_t , addr_t & , addr_t , addr_t , addr_t & );
 inline __attribute__((always_inline)) void * add_3d_byte_int(void * , int , int , int , addr_t , addr_t , addr_t & , addr_t , addr_t , addr_t & );
-inline __attribute__((always_inline)) void * byte_incr(void * , int );
 inline __attribute__((always_inline)) int delay1(int );
 inline __attribute__((always_inline)) int delay2(int );
 inline __attribute__((always_inline)) int delay3(int );


### PR DESCRIPTION
These shadow the generic template
template <typename T> INTRINSIC(T *) byte_incr(T *a, int i);

, without providing a definition anywhere. Remove these so the template will be instantiated instead.