### PR TITLE
[AIE2PS] Skip zero-bank instructions in bank-based slot materialization

### DIFF
--- a/llvm/lib/Target/AIE/AIEMultiSlotInstrMaterializer.cpp
+++ b/llvm/lib/Target/AIE/AIEMultiSlotInstrMaterializer.cpp
@@ -78,12 +78,15 @@ public:
 
   /// \return whether a Slot can be assigned to \b MI and assign it in the
   /// mapping.
-  bool isSlotAssignable(const MachineInstr &MI, const AIEHazardRecognizer &HR) {
+  bool tryAssignSlot(const MachineInstr &MI, const AIEHazardRecognizer &HR) {
     auto MemBankBits = HR.getMemoryBanks(&MI);
     LLVM_DEBUG(dbgs() << "Memory Bank: " << MemBankBits << " " << MI);
+    // Instructions without memory bank info are skipped -- they don't
+    // participate in bank-based assignment and will be handled by slot-pressure
+    // materialization instead.
     if (!MemBankBits) {
-      LLVM_DEBUG(dbgs() << "Warning: No MemoryBanks assigned to " << MI);
-      return false;
+      LLVM_DEBUG(dbgs() << "Skipping (no MemoryBanks): " << MI);
+      return true;
     }
 
     std::optional<MCSlotKind> SelectedSlot = getAssignedSlot(MemBankBits);
@@ -176,7 +179,7 @@ bool assignSlots(SlotMapping &SlotToBanks, const MachineBasicBlock &MBB,
     if (!MI.mayLoad() || !TII->isMultiSlotPseudo(MI))
       continue;
 
-    if (!SlotToBanks.isSlotAssignable(MI, HR)) {
+    if (!SlotToBanks.tryAssignSlot(MI, HR)) {
       return false;
     }
   }
@@ -434,6 +437,13 @@ void materializeSlots(const SlotMapping &SlotToBanks, MachineBasicBlock &MBB,
 
   for (auto &MI : MBB) {
     if (!MI.mayLoad() || !TII->isMultiSlotPseudo(MI))
+      continue;
+
+    // Skip instructions without memory bank info -- they were not assigned
+    // a slot by the bank-based strategy and remain as pseudos for
+    // slot-pressure materialization.
+    const auto MemBankBits = HR.getMemoryBanks(&MI);
+    if (!MemBankBits)
       continue;
 
     materializeInstr(MI, SlotToBanks, TII, HR);

--- a/llvm/test/CodeGen/AIE/aie2ps/schedule/postpipeliner/conv2d_bf16.mir
+++ b/llvm/test/CodeGen/AIE/aie2ps/schedule/postpipeliner/conv2d_bf16.mir
@@ -61,63 +61,80 @@ body:             |
   ; CHECK-NEXT:   liveins: $cml0, $cml1, $cml2, $cml3, $m4, $m5, $p1, $r5, $r8, $r10, $r12, $r18, $r30, $x0, $x2, $d1_3d, $p0, $lf0, $r24, $lfe
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   $x5, $p0, $lf0, $r24 = VLDB_POPX $r30, $r30, killed $p0, killed $lf0, killed $r24, implicit-def $lfe, implicit-def $srfifo_uf, implicit killed $lfe, debug-location !6 :: (load unknown-size, align 1)
-  ; CHECK-NEXT:   $x3, $p0, $lf0, $r24 = VLDA_POP_dmx_lda_fifo_x_normal_pop killed $p0, killed $lf0, killed $r24, debug-location !6 :: (load unknown-size, align 1)
+  ; CHECK-NEXT:   $x3, $p0, $lf0, $r24 = VLDB_POP_dmx_ldb_fifo_x_normal_pop killed $p0, killed $lf0, killed $r24, debug-location !6 :: (load unknown-size, align 1)
   ; CHECK-NEXT:   $x6, $p0, $lf0, $r24 = VLDB_POP_dmx_ldb_fifo_x_normal_pop killed $p0, killed $lf0, killed $r24, debug-location !6 :: (load unknown-size, align 1)
-  ; CHECK-NEXT:   BUNDLE implicit-def $x10, implicit-def $wl10, implicit-def $wh10, implicit-def $p1, implicit-def $x1, implicit-def $wl1, implicit-def $wh1, implicit-def $p0, implicit-def $lf0, implicit-def $lfl0, implicit-def $lfh0, implicit-def $r24, implicit killed $p1, implicit killed $p0, implicit killed $lf0, implicit killed $r24, debug-location !6 {
+  ; CHECK-NEXT:   $x1, $p0, $lf0, $r24 = VLDA_POP_dmx_lda_fifo_x_normal_pop killed $p0, killed $lf0, killed $r24, debug-location !6 :: (load unknown-size, align 1)
+  ; CHECK-NEXT:   $p0, $dc1, $dc5 = PADDS_3D killed $p0, $d1_3d, debug-location !6
+  ; CHECK-NEXT:   BUNDLE implicit-def $x10, implicit-def $wl10, implicit-def $wh10, implicit-def $p1, implicit-def $x5, implicit-def $wl5, implicit-def $wh5, implicit-def $p0, implicit-def $lf0, implicit-def $lfl0, implicit-def $lfh0, implicit-def $r24, implicit-def $lfe, implicit-def $srfifo_uf, implicit killed $p1, implicit $r30, implicit killed $p0, implicit killed $lf0, implicit killed $r24, implicit killed $lfe, debug-location !6 {
   ; CHECK-NEXT:     renamable $x10, renamable $p1 = VLDA_dmx_lda_x_ld_pstm_nrm_imm killed renamable $p1, 64, debug-location !6 :: (load (<16 x s32>), addrspace 6)
-  ; CHECK-NEXT:     $x1, $p0, $lf0, $r24 = VLDB_POP_dmx_ldb_fifo_x_normal_pop killed $p0, killed $lf0, killed $r24, debug-location !6 :: (load unknown-size, align 1)
-  ; CHECK-NEXT:   }
-  ; CHECK-NEXT:   BUNDLE implicit-def $x11, implicit-def $wl11, implicit-def $wh11, implicit-def $p1, implicit-def $p0, implicit-def $dc1, implicit-def $dc5, implicit killed $p1, implicit killed $p0, implicit $d1_3d, debug-location !6 {
-  ; CHECK-NEXT:     renamable $x11, renamable $p1 = VLDA_dmx_lda_x_ld_pstm_nrm_imm killed renamable $p1, 64, debug-location !6 :: (load (<16 x s32>), addrspace 6)
-  ; CHECK-NEXT:     $p0, $dc1, $dc5 = PADDS_3D killed $p0, $d1_3d, debug-location !6
-  ; CHECK-NEXT:   }
-  ; CHECK-NEXT:   BUNDLE implicit-def $x5, implicit-def $wl5, implicit-def $wh5, implicit-def $p0, implicit-def $lf0, implicit-def $lfl0, implicit-def $lfh0, implicit-def $r24, implicit-def $lfe, implicit-def $srfifo_uf, implicit-def $lc, implicit $r30, implicit killed $p0, implicit killed $lf0, implicit killed $r24, implicit killed $lfe, implicit killed $r5, debug-location !6 {
   ; CHECK-NEXT:     $x5, $p0, $lf0, $r24 = VLDB_POPX $r30, $r30, killed $p0, killed $lf0, killed $r24, implicit-def $lfe, implicit-def $srfifo_uf, implicit killed $lfe, debug-location !6 :: (load unknown-size, align 1)
-  ; CHECK-NEXT:     $lc = ADD_NC_add_lc_ri killed $r5, -2, debug-location !6
   ; CHECK-NEXT:   }
-  ; CHECK-NEXT:   BUNDLE implicit-def $x3, implicit-def $wl3, implicit-def $wh3, implicit-def $p0, implicit-def $lf0, implicit-def $lfl0, implicit-def $lfh0, implicit-def $r24, implicit-def $ls, implicit killed $p0, implicit killed $lf0, implicit killed $r24, debug-location !6 {
-  ; CHECK-NEXT:     $x3, $p0, $lf0, $r24 = VLDA_POP_dmx_lda_fifo_x_normal_pop killed $p0, killed $lf0, killed $r24, debug-location !6 :: (load unknown-size, align 1)
+  ; CHECK-NEXT:   BUNDLE implicit-def $x11, implicit-def $wl11, implicit-def $wh11, implicit-def $p1, implicit-def $x3, implicit-def $wl3, implicit-def $wh3, implicit-def $p0, implicit-def $lf0, implicit-def $lfl0, implicit-def $lfh0, implicit-def $r24, implicit killed $p1, implicit killed $p0, implicit killed $lf0, implicit killed $r24, debug-location !6 {
+  ; CHECK-NEXT:     renamable $x11, renamable $p1 = VLDA_dmx_lda_x_ld_pstm_nrm_imm killed renamable $p1, 64, debug-location !6 :: (load (<16 x s32>), addrspace 6)
+  ; CHECK-NEXT:     $x3, $p0, $lf0, $r24 = VLDB_POP_dmx_ldb_fifo_x_normal_pop killed $p0, killed $lf0, killed $r24, debug-location !6 :: (load unknown-size, align 1)
+  ; CHECK-NEXT:   }
+  ; CHECK-NEXT:   BUNDLE implicit-def $x6, implicit-def $wl6, implicit-def $wh6, implicit-def $p0, implicit-def $lf0, implicit-def $lfl0, implicit-def $lfh0, implicit-def $r24, implicit-def $ls, implicit killed $p0, implicit killed $lf0, implicit killed $r24, debug-location !6 {
+  ; CHECK-NEXT:     $x6, $p0, $lf0, $r24 = VLDB_POP_dmx_ldb_fifo_x_normal_pop killed $p0, killed $lf0, killed $r24, debug-location !6 :: (load unknown-size, align 1)
   ; CHECK-NEXT:     MOVXM_lng_cg_ls_abs %bb.2, implicit-def $ls, debug-location !6
   ; CHECK-NEXT:   }
-  ; CHECK-NEXT:   BUNDLE implicit-def $x6, implicit-def $wl6, implicit-def $wh6, implicit-def $p0, implicit-def $lf0, implicit-def $lfl0, implicit-def $lfh0, implicit-def $r24, implicit-def $le, implicit killed $p0, implicit killed $lf0, implicit killed $r24, debug-location !6 {
-  ; CHECK-NEXT:     $x6, $p0, $lf0, $r24 = VLDB_POP_dmx_ldb_fifo_x_normal_pop killed $p0, killed $lf0, killed $r24, debug-location !6 :: (load unknown-size, align 1)
+  ; CHECK-NEXT:   BUNDLE implicit-def $x1, implicit-def $wl1, implicit-def $wh1, implicit-def $p0, implicit-def $lf0, implicit-def $lfl0, implicit-def $lfh0, implicit-def $r24, implicit-def $le, implicit killed $p0, implicit killed $lf0, implicit killed $r24, debug-location !6 {
+  ; CHECK-NEXT:     $x1, $p0, $lf0, $r24 = VLDA_POP_dmx_lda_fifo_x_normal_pop killed $p0, killed $lf0, killed $r24, debug-location !6 :: (load unknown-size, align 1)
   ; CHECK-NEXT:     MOVXM_lng_cg_le_abs <mcsymbol .L_LEnd0>, implicit-def $le, debug-location !6
   ; CHECK-NEXT:   }
-  ; CHECK-NEXT:   BUNDLE implicit-def $x10, implicit-def $wl10, implicit-def $wh10, implicit-def $p1, implicit-def $x1, implicit-def $wl1, implicit-def $wh1, implicit-def $p0, implicit-def $lf0, implicit-def $lfl0, implicit-def $lfh0, implicit-def $r24, implicit killed $p1, implicit killed $p0, implicit killed $lf0, implicit killed $r24, debug-location !6 {
-  ; CHECK-NEXT:     renamable $x10, renamable $p1 = VLDA_dmx_lda_x_ld_pstm_nrm_imm killed renamable $p1, 64, debug-location !6 :: (load (<16 x s32>), addrspace 6)
-  ; CHECK-NEXT:     $x1, $p0, $lf0, $r24 = VLDB_POP_dmx_ldb_fifo_x_normal_pop killed $p0, killed $lf0, killed $r24, debug-location !6 :: (load unknown-size, align 1)
+  ; CHECK-NEXT:   BUNDLE implicit-def $p0, implicit-def $dc1, implicit-def $dc5, implicit-def $x7, implicit-def $wl7, implicit-def $wh7, implicit killed $p0, implicit $d1_3d, implicit killed $x5, implicit $x3, implicit $r18, debug-location !6 {
+  ; CHECK-NEXT:     $p0, $dc1, $dc5 = PADDS_3D killed $p0, $d1_3d, debug-location !6
+  ; CHECK-NEXT:     renamable $x7 = VSHUFFLE_vec_shuffle_x killed renamable $x5, renamable $x3, renamable $r18, debug-location !6
   ; CHECK-NEXT:   }
-  ; CHECK-NEXT:   BUNDLE implicit-def $x11, implicit-def $wl11, implicit-def $wh11, implicit-def $p1, implicit-def $p0, implicit-def $dc1, implicit-def $dc5, implicit-def $x7, implicit-def $wl7, implicit-def $wh7, implicit killed $p1, implicit killed $p0, implicit $d1_3d, implicit killed $x5, implicit killed $x3, implicit $r18, debug-location !6 {
+  ; CHECK-NEXT:   BUNDLE implicit-def $x10, implicit-def $wl10, implicit-def $wh10, implicit-def $p1, implicit-def $x5, implicit-def $wl5, implicit-def $wh5, implicit-def $p0, implicit-def $lf0, implicit-def $lfl0, implicit-def $lfh0, implicit-def $r24, implicit-def $lfe, implicit-def $srfifo_uf, implicit-def $x4, implicit-def $wl4, implicit-def $wh4, implicit killed $p1, implicit $r30, implicit killed $p0, implicit killed $lf0, implicit killed $r24, implicit killed $lfe, implicit killed $x3, implicit $r12, debug-location !6 {
+  ; CHECK-NEXT:     renamable $x10, renamable $p1 = VLDA_dmx_lda_x_ld_pstm_nrm_imm killed renamable $p1, 64, debug-location !6 :: (load (<16 x s32>), addrspace 6)
+  ; CHECK-NEXT:     $x5, $p0, $lf0, $r24 = VLDB_POPX $r30, $r30, killed $p0, killed $lf0, killed $r24, implicit-def $lfe, implicit-def $srfifo_uf, implicit killed $lfe, debug-location !6 :: (load unknown-size, align 1)
+  ; CHECK-NEXT:     renamable $x4 = VSHUFFLE_vec_shuffle_x internal renamable $x5, killed renamable $x3, renamable $r12, debug-location !6
+  ; CHECK-NEXT:   }
+  ; CHECK-NEXT:   BUNDLE implicit-def $x11, implicit-def $wl11, implicit-def $wh11, implicit-def $p1, implicit-def $x3, implicit-def $wl3, implicit-def $wh3, implicit-def $p0, implicit-def $lf0, implicit-def $lfl0, implicit-def $lfh0, implicit-def $r24, implicit-def $x8, implicit-def $wl8, implicit-def $wh8, implicit killed $p1, implicit killed $p0, implicit killed $lf0, implicit killed $r24, implicit killed $x6, implicit $x1, implicit $r18, debug-location !6 {
   ; CHECK-NEXT:     renamable $x11, renamable $p1 = VLDA_dmx_lda_x_ld_pstm_nrm_imm killed renamable $p1, 64, debug-location !6 :: (load (<16 x s32>), addrspace 6)
+  ; CHECK-NEXT:     $x3, $p0, $lf0, $r24 = VLDB_POP_dmx_ldb_fifo_x_normal_pop killed $p0, killed $lf0, killed $r24, debug-location !6 :: (load unknown-size, align 1)
+  ; CHECK-NEXT:     renamable $x8 = VSHUFFLE_vec_shuffle_x killed renamable $x6, renamable $x1, renamable $r18, debug-location !6
+  ; CHECK-NEXT:   }
+  ; CHECK-NEXT:   BUNDLE implicit-def $x6, implicit-def $wl6, implicit-def $wh6, implicit-def $p0, implicit-def $lf0, implicit-def $lfl0, implicit-def $lfh0, implicit-def $r24, implicit-def $lc, implicit killed $p0, implicit killed $lf0, implicit killed $r24, implicit killed $r5, implicit killed $x1, implicit $r12, debug-location !6 {
+  ; CHECK-NEXT:     $x6, $p0, $lf0, $r24 = VLDB_POP_dmx_ldb_fifo_x_normal_pop killed $p0, killed $lf0, killed $r24, debug-location !6 :: (load unknown-size, align 1)
+  ; CHECK-NEXT:     $lc = ADD_NC_add_lc_ri killed $r5, -3, debug-location !6
+  ; CHECK-NEXT:     renamable $x6 = VSHUFFLE_vec_shuffle_x internal renamable $x6, killed renamable $x1, renamable $r12, debug-location !6
+  ; CHECK-NEXT:   }
+  ; CHECK-NEXT:   BUNDLE implicit-def $x1, implicit-def $wl1, implicit-def $wh1, implicit-def $p0, implicit-def $lf0, implicit-def $lfl0, implicit-def $lfh0, implicit-def $r24, implicit-def $cml3, implicit-def $bmll3, implicit-def $bmlh3, implicit-def dead $srfpflags, implicit killed $p0, implicit killed $lf0, implicit killed $r24, implicit killed $cml3, implicit killed $x7, implicit $y5, implicit $r8, implicit $crbf8conf, implicit $crfp8conf, implicit $crfpmask, debug-location !6 {
+  ; CHECK-NEXT:     $x1, $p0, $lf0, $r24 = VLDA_POP_dmx_lda_fifo_x_normal_pop killed $p0, killed $lf0, killed $r24, debug-location !6 :: (load unknown-size, align 1)
+  ; CHECK-NEXT:     $cml3 = VMAC_f_vmac_bf_half_vmul_bf_core_X_Y killed $cml3, killed $x7, $y5, $r8, implicit-def dead $srfpflags, implicit $crbf8conf, implicit $crfp8conf, implicit $crfpmask, debug-location !6
+  ; CHECK-NEXT:   }
+  ; CHECK-NEXT:   BUNDLE implicit-def $p0, implicit-def $dc1, implicit-def $dc5, implicit-def $x7, implicit-def $wl7, implicit-def $wh7, implicit-def $cml0, implicit-def $bmll0, implicit-def $bmlh0, implicit-def dead $srfpflags, implicit killed $p0, implicit $d1_3d, implicit killed $x5, implicit killed $x3, implicit $r18, implicit killed $cml0, implicit killed $x6, implicit killed $y5, implicit $r8, implicit $crbf8conf, implicit $crfp8conf, implicit $crfpmask, debug-location !6 {
   ; CHECK-NEXT:     $p0, $dc1, $dc5 = PADDS_3D killed $p0, $d1_3d, debug-location !6
   ; CHECK-NEXT:     renamable $x7 = VSHUFFLE_vec_shuffle_x killed renamable $x5, killed renamable $x3, renamable $r18, debug-location !6
+  ; CHECK-NEXT:     $cml0 = VMAC_f_vmac_bf_half_vmul_bf_core_X_Y killed $cml0, killed $x6, killed $y5, $r8, implicit-def dead $srfpflags, implicit $crbf8conf, implicit $crfp8conf, implicit $crfpmask, debug-location !6
   ; CHECK-NEXT:   }
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT: bb.2.for.body266.i:
   ; CHECK-NEXT:   successors: %bb.2(0x7c000000), %bb.3(0x04000000)
   ; CHECK-NEXT:   liveins: $lfe, $cml0, $cml1, $cml2, $cml3, $dc1, $dc5, $p1, $r8, $r12, $r18, $r30, $d1_3d, $p0, $lf0, $r24
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT:   BUNDLE implicit-def $x5, implicit-def $wl5, implicit-def $wh5, implicit-def $p0, implicit-def $lf0, implicit-def $lfl0, implicit-def $lfh0, implicit-def $r24, implicit-def $lfe, implicit-def $srfifo_uf, implicit-def $x4, implicit-def $wl4, implicit-def $wh4, implicit $r30, implicit killed $p0, implicit killed $lf0, implicit killed $r24, implicit killed $lfe, implicit killed $x3, implicit $r12, debug-location !6 {
+  ; CHECK-NEXT:   BUNDLE implicit-def $x10, implicit-def $wl10, implicit-def $wh10, implicit-def $p1, implicit-def $x5, implicit-def $wl5, implicit-def $wh5, implicit-def $p0, implicit-def $lf0, implicit-def $lfl0, implicit-def $lfh0, implicit-def $r24, implicit-def $lfe, implicit-def $srfifo_uf, implicit-def $x4, implicit-def $wl4, implicit-def $wh4, implicit-def $cml2, implicit-def $bmll2, implicit-def $bmlh2, implicit-def dead $srfpflags, implicit killed $p1, implicit $r30, implicit killed $p0, implicit killed $lf0, implicit killed $r24, implicit killed $lfe, implicit killed $x3, implicit $r12, implicit killed $cml2, implicit $y5, implicit $r8, implicit $crbf8conf, implicit $crfp8conf, implicit $crfpmask, debug-location !6 {
+  ; CHECK-NEXT:     renamable $x10, renamable $p1 = VLDA_dmx_lda_x_ld_pstm_nrm_imm killed renamable $p1, 64, debug-location !6 :: (load (<16 x s32>), addrspace 6)
   ; CHECK-NEXT:     $x5, $p0, $lf0, $r24 = VLDB_POPX $r30, $r30, killed $p0, killed $lf0, killed $r24, implicit-def $lfe, implicit-def $srfifo_uf, implicit killed $lfe, debug-location !6 :: (load unknown-size, align 1)
   ; CHECK-NEXT:     renamable $x4 = VSHUFFLE_vec_shuffle_x internal renamable $x5, killed renamable $x3, renamable $r12, debug-location !6
+  ; CHECK-NEXT:     $cml2 = VMAC_f_vmac_bf_half_vmul_bf_core_X_Y killed $cml2, internal $x4, $y5, $r8, implicit-def dead $srfpflags, implicit $crbf8conf, implicit $crfp8conf, implicit $crfpmask, debug-location !6
   ; CHECK-NEXT:   }
-  ; CHECK-NEXT:   BUNDLE implicit-def $x3, implicit-def $wl3, implicit-def $wh3, implicit-def $p0, implicit-def $lf0, implicit-def $lfl0, implicit-def $lfh0, implicit-def $r24, implicit-def $x8, implicit-def $wl8, implicit-def $wh8, implicit-def $cml3, implicit-def $bmll3, implicit-def $bmlh3, implicit-def dead $srfpflags, implicit killed $p0, implicit killed $lf0, implicit killed $r24, implicit killed $x6, implicit $x1, implicit $r18, implicit killed $cml3, implicit killed $x7, implicit $y5, implicit $r8, implicit $crbf8conf, implicit $crfp8conf, implicit $crfpmask, debug-location !6 {
-  ; CHECK-NEXT:     $x3, $p0, $lf0, $r24 = VLDA_POP_dmx_lda_fifo_x_normal_pop killed $p0, killed $lf0, killed $r24, debug-location !6 :: (load unknown-size, align 1)
+  ; CHECK-NEXT:   BUNDLE implicit-def $x11, implicit-def $wl11, implicit-def $wh11, implicit-def $p1, implicit-def $x3, implicit-def $wl3, implicit-def $wh3, implicit-def $p0, implicit-def $lf0, implicit-def $lfl0, implicit-def $lfh0, implicit-def $r24, implicit-def $x8, implicit-def $wl8, implicit-def $wh8, implicit-def $cml1, implicit-def $bmll1, implicit-def $bmlh1, implicit-def dead $srfpflags, implicit killed $p1, implicit killed $p0, implicit killed $lf0, implicit killed $r24, implicit killed $x6, implicit $x1, implicit $r18, implicit killed $cml1, implicit $y5, implicit $r8, implicit $crbf8conf, implicit $crfp8conf, implicit $crfpmask, debug-location !6 {
+  ; CHECK-NEXT:     renamable $x11, renamable $p1 = VLDA_dmx_lda_x_ld_pstm_nrm_imm killed renamable $p1, 64, debug-location !6 :: (load (<16 x s32>), addrspace 6)
+  ; CHECK-NEXT:     $x3, $p0, $lf0, $r24 = VLDB_POP_dmx_ldb_fifo_x_normal_pop killed $p0, killed $lf0, killed $r24, debug-location !6 :: (load unknown-size, align 1)
   ; CHECK-NEXT:     renamable $x8 = VSHUFFLE_vec_shuffle_x killed renamable $x6, renamable $x1, renamable $r18, debug-location !6
-  ; CHECK-NEXT:     $cml3 = VMAC_f_vmac_bf_half_vmul_bf_core_X_Y killed $cml3, killed $x7, $y5, $r8, implicit-def dead $srfpflags, implicit $crbf8conf, implicit $crfp8conf, implicit $crfpmask, debug-location !6
+  ; CHECK-NEXT:     $cml1 = VMAC_f_vmac_bf_half_vmul_bf_core_X_Y killed $cml1, internal $x8, $y5, $r8, implicit-def dead $srfpflags, implicit $crbf8conf, implicit $crfp8conf, implicit $crfpmask, debug-location !6
   ; CHECK-NEXT:   }
-  ; CHECK-NEXT:   BUNDLE implicit-def $x6, implicit-def $wl6, implicit-def $wh6, implicit-def $p0, implicit-def $lf0, implicit-def $lfl0, implicit-def $lfh0, implicit-def $r24, implicit-def $cml2, implicit-def $bmll2, implicit-def $bmlh2, implicit-def dead $srfpflags, implicit killed $p0, implicit killed $lf0, implicit killed $r24, implicit killed $x1, implicit $r12, implicit killed $cml2, implicit killed $x4, implicit $y5, implicit $r8, implicit $crbf8conf, implicit $crfp8conf, implicit $crfpmask, debug-location !6 {
+  ; CHECK-NEXT:   BUNDLE implicit-def $x6, implicit-def $wl6, implicit-def $wh6, implicit-def $p0, implicit-def $lf0, implicit-def $lfl0, implicit-def $lfh0, implicit-def $r24, implicit killed $p0, implicit killed $lf0, implicit killed $r24, implicit killed $x1, implicit $r12, debug-location !6 {
   ; CHECK-NEXT:     $x6, $p0, $lf0, $r24 = VLDB_POP_dmx_ldb_fifo_x_normal_pop killed $p0, killed $lf0, killed $r24, debug-location !6 :: (load unknown-size, align 1)
   ; CHECK-NEXT:     renamable $x6 = VSHUFFLE_vec_shuffle_x internal renamable $x6, killed renamable $x1, renamable $r12, debug-location !6
-  ; CHECK-NEXT:     $cml2 = VMAC_f_vmac_bf_half_vmul_bf_core_X_Y killed $cml2, killed $x4, $y5, $r8, implicit-def dead $srfpflags, implicit $crbf8conf, implicit $crfp8conf, implicit $crfpmask, debug-location !6
   ; CHECK-NEXT:   }
-  ; CHECK-NEXT:   BUNDLE implicit-def $x10, implicit-def $wl10, implicit-def $wh10, implicit-def $p1, implicit-def $x1, implicit-def $wl1, implicit-def $wh1, implicit-def $p0, implicit-def $lf0, implicit-def $lfl0, implicit-def $lfh0, implicit-def $r24, implicit-def $cml1, implicit-def $bmll1, implicit-def $bmlh1, implicit-def dead $srfpflags, implicit killed $p1, implicit killed $p0, implicit killed $lf0, implicit killed $r24, implicit killed $cml1, implicit killed $x8, implicit $y5, implicit $r8, implicit $crbf8conf, implicit $crfp8conf, implicit $crfpmask, debug-location !6 {
-  ; CHECK-NEXT:     renamable $x10, renamable $p1 = VLDA_dmx_lda_x_ld_pstm_nrm_imm killed renamable $p1, 64, debug-location !6 :: (load (<16 x s32>), addrspace 6)
-  ; CHECK-NEXT:     $x1, $p0, $lf0, $r24 = VLDB_POP_dmx_ldb_fifo_x_normal_pop killed $p0, killed $lf0, killed $r24, debug-location !6 :: (load unknown-size, align 1)
-  ; CHECK-NEXT:     $cml1 = VMAC_f_vmac_bf_half_vmul_bf_core_X_Y killed $cml1, killed $x8, $y5, $r8, implicit-def dead $srfpflags, implicit $crbf8conf, implicit $crfp8conf, implicit $crfpmask, debug-location !6
+  ; CHECK-NEXT:   BUNDLE implicit-def $x1, implicit-def $wl1, implicit-def $wh1, implicit-def $p0, implicit-def $lf0, implicit-def $lfl0, implicit-def $lfh0, implicit-def $r24, implicit-def $cml3, implicit-def $bmll3, implicit-def $bmlh3, implicit-def dead $srfpflags, implicit killed $p0, implicit killed $lf0, implicit killed $r24, implicit killed $cml3, implicit killed $x7, implicit $y5, implicit $r8, implicit $crbf8conf, implicit $crfp8conf, implicit $crfpmask, debug-location !6 {
+  ; CHECK-NEXT:     $x1, $p0, $lf0, $r24 = VLDA_POP_dmx_lda_fifo_x_normal_pop killed $p0, killed $lf0, killed $r24, debug-location !6 :: (load unknown-size, align 1)
+  ; CHECK-NEXT:     $cml3 = VMAC_f_vmac_bf_half_vmul_bf_core_X_Y killed $cml3, killed $x7, $y5, $r8, implicit-def dead $srfpflags, implicit $crbf8conf, implicit $crfp8conf, implicit $crfpmask, debug-location !6
   ; CHECK-NEXT:   }
-  ; CHECK-NEXT:   BUNDLE implicit-def $x11, implicit-def $wl11, implicit-def $wh11, implicit-def $p1, implicit-def $p0, implicit-def $dc1, implicit-def $dc5, implicit-def $x7, implicit-def $wl7, implicit-def $wh7, implicit-def $cml0, implicit-def $bmll0, implicit-def $bmlh0, implicit-def dead $srfpflags, implicit killed $p1, implicit killed $p0, implicit $d1_3d, implicit killed $x5, implicit killed $x3, implicit $r18, implicit killed $cml0, implicit killed $x6, implicit killed $y5, implicit $r8, implicit $crbf8conf, implicit $crfp8conf, implicit $crfpmask, debug-location !6 {
-  ; CHECK-NEXT:     renamable $x11, renamable $p1 = VLDA_dmx_lda_x_ld_pstm_nrm_imm killed renamable $p1, 64, debug-location !6 :: (load (<16 x s32>), addrspace 6)
+  ; CHECK-NEXT:   BUNDLE implicit-def $p0, implicit-def $dc1, implicit-def $dc5, implicit-def $x7, implicit-def $wl7, implicit-def $wh7, implicit-def $cml0, implicit-def $bmll0, implicit-def $bmlh0, implicit-def dead $srfpflags, implicit killed $p0, implicit $d1_3d, implicit killed $x5, implicit killed $x3, implicit $r18, implicit killed $cml0, implicit killed $x6, implicit killed $y5, implicit $r8, implicit $crbf8conf, implicit $crfp8conf, implicit $crfpmask, debug-location !6 {
   ; CHECK-NEXT:     $p0, $dc1, $dc5 = PADDS_3D killed $p0, $d1_3d, debug-location !6
   ; CHECK-NEXT:     renamable $x7 = VSHUFFLE_vec_shuffle_x killed renamable $x5, killed renamable $x3, renamable $r18, debug-location !6
   ; CHECK-NEXT:     $cml0 = VMAC_f_vmac_bf_half_vmul_bf_core_X_Y killed $cml0, killed $x6, killed $y5, $r8, implicit-def dead $srfpflags, implicit $crbf8conf, implicit $crfp8conf, implicit $crfpmask, debug-location !6
@@ -127,31 +144,35 @@ body:             |
   ; CHECK-NEXT: bb.3.for.cond.cleanup265.i:
   ; CHECK-NEXT:   liveins: $cml0, $cml1, $cml2, $cml3
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT:   renamable $x4 = VSHUFFLE_vec_shuffle_x renamable $x5, renamable $x3, renamable $r12, debug-location !6
-  ; CHECK-NEXT:   BUNDLE implicit-def $x8, implicit-def $wl8, implicit-def $wh8, implicit-def $cml3, implicit-def $bmll3, implicit-def $bmlh3, implicit-def dead $srfpflags, implicit $x6, implicit $x1, implicit $r18, implicit killed $cml3, implicit killed $x7, implicit $y5, implicit $r8, implicit $crbf8conf, implicit $crfp8conf, implicit $crfpmask, debug-location !6 {
+  ; CHECK-NEXT:   BUNDLE implicit-def $x10, implicit-def $wl10, implicit-def $wh10, implicit-def $p1, implicit-def $x4, implicit-def $wl4, implicit-def $wh4, implicit-def $cml2, implicit-def $bmll2, implicit-def $bmlh2, implicit-def dead $srfpflags, implicit killed $p1, implicit $x5, implicit $x3, implicit $r12, implicit killed $cml2, implicit $y5, implicit $r8, implicit $crbf8conf, implicit $crfp8conf, implicit $crfpmask, debug-location !6 {
+  ; CHECK-NEXT:     renamable $x10, renamable $p1 = VLDA_dmx_lda_x_ld_pstm_nrm_imm killed renamable $p1, 64, debug-location !6 :: (load (<16 x s32>), addrspace 6)
+  ; CHECK-NEXT:     renamable $x4 = VSHUFFLE_vec_shuffle_x renamable $x5, renamable $x3, renamable $r12, debug-location !6
+  ; CHECK-NEXT:     $cml2 = VMAC_f_vmac_bf_half_vmul_bf_core_X_Y killed $cml2, internal $x4, $y5, $r8, implicit-def dead $srfpflags, implicit $crbf8conf, implicit $crfp8conf, implicit $crfpmask, debug-location !6
+  ; CHECK-NEXT:   }
+  ; CHECK-NEXT:   BUNDLE implicit-def $x11, implicit-def $wl11, implicit-def $wh11, implicit-def $p1, implicit-def $x8, implicit-def $wl8, implicit-def $wh8, implicit-def $cml1, implicit-def $bmll1, implicit-def $bmlh1, implicit-def dead $srfpflags, implicit killed $p1, implicit $x6, implicit $x1, implicit $r18, implicit killed $cml1, implicit $y5, implicit $r8, implicit $crbf8conf, implicit $crfp8conf, implicit $crfpmask, debug-location !6 {
+  ; CHECK-NEXT:     renamable $x11, renamable $p1 = VLDA_dmx_lda_x_ld_pstm_nrm_imm killed renamable $p1, 64, debug-location !6 :: (load (<16 x s32>), addrspace 6)
   ; CHECK-NEXT:     renamable $x8 = VSHUFFLE_vec_shuffle_x renamable $x6, renamable $x1, renamable $r18, debug-location !6
-  ; CHECK-NEXT:     $cml3 = VMAC_f_vmac_bf_half_vmul_bf_core_X_Y killed $cml3, killed $x7, $y5, $r8, implicit-def dead $srfpflags, implicit $crbf8conf, implicit $crfp8conf, implicit $crfpmask, debug-location !6
+  ; CHECK-NEXT:     $cml1 = VMAC_f_vmac_bf_half_vmul_bf_core_X_Y killed $cml1, internal $x8, $y5, $r8, implicit-def dead $srfpflags, implicit $crbf8conf, implicit $crfp8conf, implicit $crfpmask, debug-location !6
   ; CHECK-NEXT:   }
-  ; CHECK-NEXT:   BUNDLE implicit-def $x6, implicit-def $wl6, implicit-def $wh6, implicit-def $cml2, implicit-def $bmll2, implicit-def $bmlh2, implicit-def dead $srfpflags, implicit killed $x6, implicit $x1, implicit $r12, implicit killed $cml2, implicit killed $x4, implicit $y5, implicit $r8, implicit $crbf8conf, implicit $crfp8conf, implicit $crfpmask, debug-location !6 {
-  ; CHECK-NEXT:     renamable $x6 = VSHUFFLE_vec_shuffle_x killed renamable $x6, renamable $x1, renamable $r12, debug-location !6
-  ; CHECK-NEXT:     $cml2 = VMAC_f_vmac_bf_half_vmul_bf_core_X_Y killed $cml2, killed $x4, $y5, $r8, implicit-def dead $srfpflags, implicit $crbf8conf, implicit $crfp8conf, implicit $crfpmask, debug-location !6
-  ; CHECK-NEXT:   }
-  ; CHECK-NEXT:   $cml1 = VMAC_f_vmac_bf_half_vmul_bf_core_X_Y killed $cml1, killed $x8, $y5, $r8, implicit-def dead $srfpflags, implicit $crbf8conf, implicit $crfp8conf, implicit $crfpmask, debug-location !6
+  ; CHECK-NEXT:   renamable $x6 = VSHUFFLE_vec_shuffle_x killed renamable $x6, renamable $x1, renamable $r12, debug-location !6
+  ; CHECK-NEXT:   $cml3 = VMAC_f_vmac_bf_half_vmul_bf_core_X_Y killed $cml3, killed $x7, $y5, $r8, implicit-def dead $srfpflags, implicit $crbf8conf, implicit $crfp8conf, implicit $crfpmask, debug-location !6
   ; CHECK-NEXT:   BUNDLE implicit-def $x7, implicit-def $wl7, implicit-def $wh7, implicit-def $cml0, implicit-def $bmll0, implicit-def $bmlh0, implicit-def dead $srfpflags, implicit $x5, implicit $x3, implicit $r18, implicit killed $cml0, implicit $x6, implicit $y5, implicit $r8, implicit $crbf8conf, implicit $crfp8conf, implicit $crfpmask, debug-location !6 {
   ; CHECK-NEXT:     renamable $x7 = VSHUFFLE_vec_shuffle_x renamable $x5, renamable $x3, renamable $r18, debug-location !6
   ; CHECK-NEXT:     $cml0 = VMAC_f_vmac_bf_half_vmul_bf_core_X_Y killed $cml0, $x6, $y5, $r8, implicit-def dead $srfpflags, implicit $crbf8conf, implicit $crfp8conf, implicit $crfpmask, debug-location !6
   ; CHECK-NEXT:   }
-  ; CHECK-NEXT:   renamable $x4 = VSHUFFLE_vec_shuffle_x killed renamable $x5, killed renamable $x3, renamable $r12, debug-location !6
-  ; CHECK-NEXT:   BUNDLE implicit-def $x8, implicit-def $wl8, implicit-def $wh8, implicit-def $cml3, implicit-def $bmll3, implicit-def $bmlh3, implicit-def dead $srfpflags, implicit $x6, implicit $x1, implicit killed $r18, implicit killed $cml3, implicit killed $x7, implicit $y5, implicit $r8, implicit $crbf8conf, implicit $crfp8conf, implicit $crfpmask, debug-location !6 {
+  ; CHECK-NEXT:   BUNDLE implicit-def $x4, implicit-def $wl4, implicit-def $wh4, implicit-def $cml2, implicit-def $bmll2, implicit-def $bmlh2, implicit-def dead $srfpflags, implicit killed $x5, implicit killed $x3, implicit $r12, implicit killed $cml2, implicit $y5, implicit $r8, implicit $crbf8conf, implicit $crfp8conf, implicit $crfpmask, debug-location !6 {
+  ; CHECK-NEXT:     renamable $x4 = VSHUFFLE_vec_shuffle_x killed renamable $x5, killed renamable $x3, renamable $r12, debug-location !6
+  ; CHECK-NEXT:     $cml2 = VMAC_f_vmac_bf_half_vmul_bf_core_X_Y killed $cml2, internal $x4, $y5, $r8, implicit-def dead $srfpflags, implicit $crbf8conf, implicit $crfp8conf, implicit $crfpmask, debug-location !6
+  ; CHECK-NEXT:   }
+  ; CHECK-NEXT:   BUNDLE implicit-def $x8, implicit-def $wl8, implicit-def $wh8, implicit-def $cml1, implicit-def $bmll1, implicit-def $bmlh1, implicit-def dead $srfpflags, implicit $x6, implicit $x1, implicit killed $r18, implicit killed $cml1, implicit $y5, implicit $r8, implicit $crbf8conf, implicit $crfp8conf, implicit $crfpmask, debug-location !6 {
   ; CHECK-NEXT:     renamable $x8 = VSHUFFLE_vec_shuffle_x renamable $x6, renamable $x1, killed renamable $r18, debug-location !6
-  ; CHECK-NEXT:     $cml3 = VMAC_f_vmac_bf_half_vmul_bf_core_X_Y killed $cml3, killed $x7, $y5, $r8, implicit-def dead $srfpflags, implicit $crbf8conf, implicit $crfp8conf, implicit $crfpmask, debug-location !6
+  ; CHECK-NEXT:     $cml1 = VMAC_f_vmac_bf_half_vmul_bf_core_X_Y killed $cml1, internal $x8, $y5, $r8, implicit-def dead $srfpflags, implicit $crbf8conf, implicit $crfp8conf, implicit $crfpmask, debug-location !6
   ; CHECK-NEXT:   }
-  ; CHECK-NEXT:   BUNDLE implicit-def $x6, implicit-def $wl6, implicit-def $wh6, implicit-def $cml2, implicit-def $bmll2, implicit-def $bmlh2, implicit-def dead $srfpflags, implicit killed $x6, implicit killed $x1, implicit killed $r12, implicit killed $cml2, implicit killed $x4, implicit $y5, implicit $r8, implicit $crbf8conf, implicit $crfp8conf, implicit $crfpmask, debug-location !6 {
-  ; CHECK-NEXT:     renamable $x6 = VSHUFFLE_vec_shuffle_x killed renamable $x6, killed renamable $x1, killed renamable $r12, debug-location !6
-  ; CHECK-NEXT:     $cml2 = VMAC_f_vmac_bf_half_vmul_bf_core_X_Y killed $cml2, killed $x4, $y5, $r8, implicit-def dead $srfpflags, implicit $crbf8conf, implicit $crfp8conf, implicit $crfpmask, debug-location !6
-  ; CHECK-NEXT:   }
-  ; CHECK-NEXT:   $cml1 = VMAC_f_vmac_bf_half_vmul_bf_core_X_Y killed $cml1, killed $x8, $y5, $r8, implicit-def dead $srfpflags, implicit $crbf8conf, implicit $crfp8conf, implicit $crfpmask, debug-location !6
-  ; CHECK-NEXT:   $cml0 = VMAC_f_vmac_bf_half_vmul_bf_core_X_Y killed $cml0, killed $x6, killed $y5, killed $r8, implicit-def dead $srfpflags, implicit $crbf8conf, implicit $crfp8conf, implicit $crfpmask, debug-location !6
+  ; CHECK-NEXT:   renamable $x6 = VSHUFFLE_vec_shuffle_x killed renamable $x6, killed renamable $x1, killed renamable $r12, debug-location !6
+  ; CHECK-NEXT:   $cml3 = VMAC_f_vmac_bf_half_vmul_bf_core_X_Y killed $cml3, killed $x7, $y5, $r8, implicit-def dead $srfpflags, implicit $crbf8conf, implicit $crfp8conf, implicit $crfpmask, debug-location !6
+  ; CHECK-NEXT:   $cml0 = VMAC_f_vmac_bf_half_vmul_bf_core_X_Y killed $cml0, killed $x6, $y5, $r8, implicit-def dead $srfpflags, implicit $crbf8conf, implicit $crfp8conf, implicit $crfpmask, debug-location !6
+  ; CHECK-NEXT:   $cml2 = VMAC_f_vmac_bf_half_vmul_bf_core_X_Y killed $cml2, killed $x4, $y5, $r8, implicit-def dead $srfpflags, implicit $crbf8conf, implicit $crfp8conf, implicit $crfpmask, debug-location !6
+  ; CHECK-NEXT:   $cml1 = VMAC_f_vmac_bf_half_vmul_bf_core_X_Y killed $cml1, killed $x8, killed $y5, killed $r8, implicit-def dead $srfpflags, implicit $crbf8conf, implicit $crfp8conf, implicit $crfpmask, debug-location !6
   ; CHECK-NEXT:   NOP
   ; CHECK-NEXT:   RET implicit $lr
   ; CHECK-NEXT:   NOP


### PR DESCRIPTION
When a multi-slot pseudo has no memory bank info (e.g. FIFO pops with unknown-size and no addrspace), skip it in the bank-based strategy instead of aborting the entire strategy. This allows instructions with valid addrspace annotations to be assigned slots based on their memory bank, while zero-bank instructions fall through to slot-pressure materialization.

This PR only improves performance with a pipeliner heuristic update (https://github.com/Xilinx/llvm-aie/pull/956).

I will be providing the combined QoR numbers.