### PR TITLE
Make `mlir-tests` also run on push to `aie-public`

### DIFF
--- a/.github/workflows/mlir-tests.yml
+++ b/.github/workflows/mlir-tests.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
   # Only builds on push populate the ccache that can be used by PRs
   push:
-    branches: [ main, feature/fused-ops ]
+    branches: [ main, feature/fused-ops, aie-public ]
 
 concurrency:
   # Skip intermediate builds: always.


### PR DESCRIPTION
Required to have a cache archive available to pull in PR builds.