### PR TITLE
[AIEX] Move printf declaration under extern "C"

### DIFF
--- a/clang/lib/Headers/aie2pintrin.h
+++ b/clang/lib/Headers/aie2pintrin.h
@@ -49,6 +49,7 @@
 #include "aie2p/aie2p_nlf.h"
 #include "aie2p/aie2p_nlf_vector.h"
 #include "aie2p/aie2p_aie_api_compat.h"
+// clang-format on
 #endif /* __cplusplus */
 
 // Locks
@@ -70,8 +71,15 @@ INTRINSIC(void)
 write_tm(uint32 regVal, uint32 regAddr, uint32 TMAddrSpaceStart = 0x80000) {
   return __builtin_aie2p_write_tm(regVal, (int *)(TMAddrSpaceStart + regAddr));
 }
-// FIXME: this belongs to libc's stdio.h
-void printf(const char *__restrict, ...);
-
 #endif /* __cplusplus && !(__AIECC__DISABLE_READ_WRITE_TM) */
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+// FIXME: this belongs to libc's stdio.h
+int printf(const char *__restrict, ...);
+#if defined(__cplusplus)
+}
+#endif
+
 #endif /* __AIE2PINTRIN_H */

--- a/clang/lib/Headers/aie2psintrin.h
+++ b/clang/lib/Headers/aie2psintrin.h
@@ -98,8 +98,14 @@ write_tm(uint32 regVal, uint32 regAddr, uint32 TMAddrSpaceStart = 0x80000) {
 }
 #endif /* __cplusplus && !(__AIECC__DISABLE_READ_WRITE_TM) */
 
+#if defined(__cplusplus)
+extern "C" {
+#endif
 // FIXME: this belongs to libc's stdio.h
-void printf(const char *__restrict, ...);
+int printf(const char *__restrict, ...);
+#if defined(__cplusplus)
+}
+#endif
 
 // _Float16 math function overloads: resolve ambiguity by promoting to float.
 // Without these, calls like std::sqrt(_Float16) are ambiguous between the

--- a/clang/lib/Headers/aiev2intrin.h
+++ b/clang/lib/Headers/aiev2intrin.h
@@ -82,7 +82,13 @@ INTRINSIC(bfloat16) as_bfloat16(short x) {
   return __builtin_bit_cast(bfloat16, x);
 }
 
+#if defined(__cplusplus)
+extern "C" {
+#endif
 // FIXME: this belongs to libc's stdio.h
-void printf(const char *__restrict, ...);
+int printf(const char *__restrict, ...);
+#if defined(__cplusplus)
+}
+#endif
 
 #endif /* __AIEV2INTRIN_H */


### PR DESCRIPTION
This was wrongly mangling the symbol name in C++ mode. Also, correct the prototype to use int return.