### PR TITLE
[AIE] Fold brcond(xor(setcc, 1)) into PseudoJZ

### DIFF
--- a/llvm/lib/Target/AIE/AIE2InstrPatterns.td
+++ b/llvm/lib/Target/AIE/AIE2InstrPatterns.td
@@ -278,6 +278,26 @@ def : Pat <(brcond (i32 (setne eR:$mRx, (i32 0))), bb:$addr), (PseudoJNZ eR:$mRx
 // Absorb logical negation by reversing branch condition
 def : Pat <(brcond (i32 (seteq eR:$mRx, (i32 0))), bb:$addr), (PseudoJZ eR:$mRx, bb:$addr)>;
 
+// Absorb negation through xor(setcc,1) by inverting conditional branch
+multiclass BrcondXorCmpPat<PatFrag CondOp, Instruction CmpInst> {
+  def : Pat<(brcond (i32 (xor (i32 (CondOp (i32 eR:$a), (i32 eR:$b))), (i32 1))), bb:$addr),
+            (PseudoJZ (CmpInst eR:$a, eR:$b), bb:$addr)>;
+}
+multiclass BrcondXorCmpSwapPat<PatFrag CondOp, Instruction CmpInst> {
+  def : Pat<(brcond (i32 (xor (i32 (CondOp (i32 eR:$a), (i32 eR:$b))), (i32 1))), bb:$addr),
+            (PseudoJZ (CmpInst eR:$b, eR:$a), bb:$addr)>;
+}
+defm : BrcondXorCmpPat<seteq, EQ>;
+defm : BrcondXorCmpPat<setne, NE>;
+defm : BrcondXorCmpPat<setlt, LT>;
+defm : BrcondXorCmpPat<setge, GE>;
+defm : BrcondXorCmpPat<setult, LTU>;
+defm : BrcondXorCmpPat<setuge, GEU>;
+defm : BrcondXorCmpSwapPat<setgt, LT>;
+defm : BrcondXorCmpSwapPat<setle, GE>;
+defm : BrcondXorCmpSwapPat<setugt, LTU>;
+defm : BrcondXorCmpSwapPat<setule, GEU>;
+
 
 // MUL Intrinsic
 def : Pat<(int_aie2_I512_I512_acc64_mul_conf VEC512:$s1, VEC512:$s2, eR:$c),

--- a/llvm/lib/Target/AIE/aie2p/AIE2PInstrPatterns.td
+++ b/llvm/lib/Target/AIE/aie2p/AIE2PInstrPatterns.td
@@ -222,6 +222,26 @@ def : Pat <(brcond (i32 (setne eR:$mRx, (i32 0))), bb:$addr), (PseudoJNZ eR:$mRx
 // Absorb logical negation by reversing branch condition
 def : Pat <(brcond (i32 (seteq eR:$mRx, (i32 0))), bb:$addr), (PseudoJZ eR:$mRx, bb:$addr)>;
 
+// Absorb negation through xor(setcc,1) by inverting conditional branch
+multiclass BrcondXorCmpPat<PatFrag CondOp, Instruction CmpInst> {
+  def : Pat<(brcond (i32 (xor (i32 (CondOp (i32 eR:$a), (i32 eR:$b))), (i32 1))), bb:$addr),
+            (PseudoJZ (CmpInst eR:$a, eR:$b), bb:$addr)>;
+}
+multiclass BrcondXorCmpSwapPat<PatFrag CondOp, Instruction CmpInst> {
+  def : Pat<(brcond (i32 (xor (i32 (CondOp (i32 eR:$a), (i32 eR:$b))), (i32 1))), bb:$addr),
+            (PseudoJZ (CmpInst eR:$b, eR:$a), bb:$addr)>;
+}
+defm : BrcondXorCmpPat<seteq, EQ>;
+defm : BrcondXorCmpPat<setne, NE>;
+defm : BrcondXorCmpPat<setlt, LT>;
+defm : BrcondXorCmpPat<setge, GE>;
+defm : BrcondXorCmpPat<setult, LTU>;
+defm : BrcondXorCmpPat<setuge, GEU>;
+defm : BrcondXorCmpSwapPat<setgt, LT>;
+defm : BrcondXorCmpSwapPat<setle, GE>;
+defm : BrcondXorCmpSwapPat<setugt, LTU>;
+defm : BrcondXorCmpSwapPat<setule, GEU>;
+
 
 // ACC ADD
 def : Pat<(int_aie2p_ACC2048_add_conf ACC2048:$acc1, ACC2048:$acc2, eR:$acc),

--- a/llvm/lib/Target/AIE/aie2ps/AIE2PSInstrPatterns.td
+++ b/llvm/lib/Target/AIE/aie2ps/AIE2PSInstrPatterns.td
@@ -262,6 +262,26 @@ def : Pat <(brcond (i32 (setne eR:$mRx, (i32 0))), bb:$addr), (PseudoJNZ eR:$mRx
 // Absorb logical negation by reversing branch condition
 def : Pat <(brcond (i32 (seteq eR:$mRx, (i32 0))), bb:$addr), (PseudoJZ eR:$mRx, bb:$addr)>;
 
+// Absorb negation through xor(setcc,1) by inverting conditional branch
+multiclass BrcondXorCmpPat<PatFrag CondOp, Instruction CmpInst> {
+  def : Pat<(brcond (i32 (xor (i32 (CondOp (i32 eR:$a), (i32 eR:$b))), (i32 1))), bb:$addr),
+            (PseudoJZ (CmpInst eR:$a, eR:$b), bb:$addr)>;
+}
+multiclass BrcondXorCmpSwapPat<PatFrag CondOp, Instruction CmpInst> {
+  def : Pat<(brcond (i32 (xor (i32 (CondOp (i32 eR:$a), (i32 eR:$b))), (i32 1))), bb:$addr),
+            (PseudoJZ (CmpInst eR:$b, eR:$a), bb:$addr)>;
+}
+defm : BrcondXorCmpPat<seteq, EQ>;
+defm : BrcondXorCmpPat<setne, NE>;
+defm : BrcondXorCmpPat<setlt, LT>;
+defm : BrcondXorCmpPat<setge, GE>;
+defm : BrcondXorCmpPat<setult, LTU>;
+defm : BrcondXorCmpPat<setuge, GEU>;
+defm : BrcondXorCmpSwapPat<setgt, LT>;
+defm : BrcondXorCmpSwapPat<setle, GE>;
+defm : BrcondXorCmpSwapPat<setugt, LTU>;
+defm : BrcondXorCmpSwapPat<setule, GEU>;
+
 // ACC ADD
 def : Pat<(int_aie2ps_ACC2048_add_conf ACC2048:$acc1, ACC2048:$acc2, eR:$conf),
            (VADD_vacc ACC2048:$acc1, ACC2048:$acc2, eR:$conf)>;

--- a/llvm/test/CodeGen/AIE/GlobalISel/inst-select-brcond.mir
+++ b/llvm/test/CodeGen/AIE/GlobalISel/inst-select-brcond.mir
@@ -87,9 +87,7 @@ body: |
   ; AIE2-NEXT:   [[COPY:%[0-9]+]]:er = COPY $r6
   ; AIE2-NEXT:   [[COPY1:%[0-9]+]]:er = COPY $r7
   ; AIE2-NEXT:   [[EQ:%[0-9]+]]:er = EQ [[COPY]], [[COPY1]]
-  ; AIE2-NEXT:   [[MOV_RLC_imm10_pseudo:%[0-9]+]]:er = MOV_RLC_imm10_pseudo 1
-  ; AIE2-NEXT:   [[XOR:%[0-9]+]]:er = XOR [[EQ]], [[MOV_RLC_imm10_pseudo]]
-  ; AIE2-NEXT:   PseudoJNZ [[XOR]], %bb.2
+  ; AIE2-NEXT:   PseudoJZ [[EQ]], %bb.2
   ; AIE2-NEXT: {{  $}}
   ; AIE2-NEXT: bb.1:
   ; AIE2-NEXT:   successors: %bb.2(0x80000000)
@@ -103,9 +101,7 @@ body: |
   ; AIE2P-NEXT:   [[COPY:%[0-9]+]]:er = COPY $r6
   ; AIE2P-NEXT:   [[COPY1:%[0-9]+]]:er = COPY $r7
   ; AIE2P-NEXT:   [[EQ:%[0-9]+]]:er = EQ [[COPY]], [[COPY1]]
-  ; AIE2P-NEXT:   [[MOV_RLC_imm11_pseudo:%[0-9]+]]:er = MOV_RLC_imm11_pseudo 1
-  ; AIE2P-NEXT:   [[XOR:%[0-9]+]]:er = XOR [[EQ]], [[MOV_RLC_imm11_pseudo]]
-  ; AIE2P-NEXT:   PseudoJNZ [[XOR]], %bb.2
+  ; AIE2P-NEXT:   PseudoJZ [[EQ]], %bb.2
   ; AIE2P-NEXT: {{  $}}
   ; AIE2P-NEXT: bb.1:
   ; AIE2P-NEXT:   successors: %bb.2(0x80000000)
@@ -119,9 +115,7 @@ body: |
   ; AIE2PS-NEXT:   [[COPY:%[0-9]+]]:mlockid_reg = COPY $r6
   ; AIE2PS-NEXT:   [[COPY1:%[0-9]+]]:mlockid_reg = COPY $r7
   ; AIE2PS-NEXT:   [[EQ:%[0-9]+]]:mlockid_reg = EQ [[COPY]], [[COPY1]]
-  ; AIE2PS-NEXT:   [[MOV_RLC_imm11_pseudo:%[0-9]+]]:mlockid_reg = MOV_RLC_imm11_pseudo 1
-  ; AIE2PS-NEXT:   [[XOR:%[0-9]+]]:mlockid_reg = XOR [[EQ]], [[MOV_RLC_imm11_pseudo]]
-  ; AIE2PS-NEXT:   PseudoJNZ [[XOR]], %bb.2
+  ; AIE2PS-NEXT:   PseudoJZ [[EQ]], %bb.2
   ; AIE2PS-NEXT: {{  $}}
   ; AIE2PS-NEXT: bb.1:
   ; AIE2PS-NEXT:   successors: %bb.2(0x80000000)
@@ -170,9 +164,7 @@ body: |
   ; AIE2-NEXT:   [[COPY:%[0-9]+]]:er = COPY $r6
   ; AIE2-NEXT:   [[COPY1:%[0-9]+]]:er = COPY $r7
   ; AIE2-NEXT:   [[NE:%[0-9]+]]:er = NE [[COPY]], [[COPY1]]
-  ; AIE2-NEXT:   [[MOV_RLC_imm10_pseudo:%[0-9]+]]:er = MOV_RLC_imm10_pseudo 1
-  ; AIE2-NEXT:   [[XOR:%[0-9]+]]:er = XOR [[NE]], [[MOV_RLC_imm10_pseudo]]
-  ; AIE2-NEXT:   PseudoJNZ [[XOR]], %bb.2
+  ; AIE2-NEXT:   PseudoJZ [[NE]], %bb.2
   ; AIE2-NEXT: {{  $}}
   ; AIE2-NEXT: bb.1:
   ; AIE2-NEXT:   successors: %bb.2(0x80000000)
@@ -186,9 +178,7 @@ body: |
   ; AIE2P-NEXT:   [[COPY:%[0-9]+]]:er = COPY $r6
   ; AIE2P-NEXT:   [[COPY1:%[0-9]+]]:er = COPY $r7
   ; AIE2P-NEXT:   [[NE:%[0-9]+]]:er = NE [[COPY]], [[COPY1]]
-  ; AIE2P-NEXT:   [[MOV_RLC_imm11_pseudo:%[0-9]+]]:er = MOV_RLC_imm11_pseudo 1
-  ; AIE2P-NEXT:   [[XOR:%[0-9]+]]:er = XOR [[NE]], [[MOV_RLC_imm11_pseudo]]
-  ; AIE2P-NEXT:   PseudoJNZ [[XOR]], %bb.2
+  ; AIE2P-NEXT:   PseudoJZ [[NE]], %bb.2
   ; AIE2P-NEXT: {{  $}}
   ; AIE2P-NEXT: bb.1:
   ; AIE2P-NEXT:   successors: %bb.2(0x80000000)
@@ -202,9 +192,7 @@ body: |
   ; AIE2PS-NEXT:   [[COPY:%[0-9]+]]:mlockid_reg = COPY $r6
   ; AIE2PS-NEXT:   [[COPY1:%[0-9]+]]:mlockid_reg = COPY $r7
   ; AIE2PS-NEXT:   [[NE:%[0-9]+]]:mlockid_reg = NE [[COPY]], [[COPY1]]
-  ; AIE2PS-NEXT:   [[MOV_RLC_imm11_pseudo:%[0-9]+]]:mlockid_reg = MOV_RLC_imm11_pseudo 1
-  ; AIE2PS-NEXT:   [[XOR:%[0-9]+]]:mlockid_reg = XOR [[NE]], [[MOV_RLC_imm11_pseudo]]
-  ; AIE2PS-NEXT:   PseudoJNZ [[XOR]], %bb.2
+  ; AIE2PS-NEXT:   PseudoJZ [[NE]], %bb.2
   ; AIE2PS-NEXT: {{  $}}
   ; AIE2PS-NEXT: bb.1:
   ; AIE2PS-NEXT:   successors: %bb.2(0x80000000)
@@ -253,9 +241,7 @@ body: |
   ; AIE2-NEXT:   [[COPY:%[0-9]+]]:er = COPY $r6
   ; AIE2-NEXT:   [[COPY1:%[0-9]+]]:er = COPY $r7
   ; AIE2-NEXT:   [[LT:%[0-9]+]]:er = LT [[COPY]], [[COPY1]]
-  ; AIE2-NEXT:   [[MOV_RLC_imm10_pseudo:%[0-9]+]]:er = MOV_RLC_imm10_pseudo 1
-  ; AIE2-NEXT:   [[XOR:%[0-9]+]]:er = XOR [[LT]], [[MOV_RLC_imm10_pseudo]]
-  ; AIE2-NEXT:   PseudoJNZ [[XOR]], %bb.2
+  ; AIE2-NEXT:   PseudoJZ [[LT]], %bb.2
   ; AIE2-NEXT: {{  $}}
   ; AIE2-NEXT: bb.1:
   ; AIE2-NEXT:   successors: %bb.2(0x80000000)
@@ -269,9 +255,7 @@ body: |
   ; AIE2P-NEXT:   [[COPY:%[0-9]+]]:er = COPY $r6
   ; AIE2P-NEXT:   [[COPY1:%[0-9]+]]:er = COPY $r7
   ; AIE2P-NEXT:   [[LT:%[0-9]+]]:er = LT [[COPY]], [[COPY1]]
-  ; AIE2P-NEXT:   [[MOV_RLC_imm11_pseudo:%[0-9]+]]:er = MOV_RLC_imm11_pseudo 1
-  ; AIE2P-NEXT:   [[XOR:%[0-9]+]]:er = XOR [[LT]], [[MOV_RLC_imm11_pseudo]]
-  ; AIE2P-NEXT:   PseudoJNZ [[XOR]], %bb.2
+  ; AIE2P-NEXT:   PseudoJZ [[LT]], %bb.2
   ; AIE2P-NEXT: {{  $}}
   ; AIE2P-NEXT: bb.1:
   ; AIE2P-NEXT:   successors: %bb.2(0x80000000)
@@ -285,9 +269,7 @@ body: |
   ; AIE2PS-NEXT:   [[COPY:%[0-9]+]]:mlockid_reg = COPY $r6
   ; AIE2PS-NEXT:   [[COPY1:%[0-9]+]]:mlockid_reg = COPY $r7
   ; AIE2PS-NEXT:   [[LT:%[0-9]+]]:mlockid_reg = LT [[COPY]], [[COPY1]]
-  ; AIE2PS-NEXT:   [[MOV_RLC_imm11_pseudo:%[0-9]+]]:mlockid_reg = MOV_RLC_imm11_pseudo 1
-  ; AIE2PS-NEXT:   [[XOR:%[0-9]+]]:mlockid_reg = XOR [[LT]], [[MOV_RLC_imm11_pseudo]]
-  ; AIE2PS-NEXT:   PseudoJNZ [[XOR]], %bb.2
+  ; AIE2PS-NEXT:   PseudoJZ [[LT]], %bb.2
   ; AIE2PS-NEXT: {{  $}}
   ; AIE2PS-NEXT: bb.1:
   ; AIE2PS-NEXT:   successors: %bb.2(0x80000000)
@@ -336,9 +318,7 @@ body: |
   ; AIE2-NEXT:   [[COPY:%[0-9]+]]:er = COPY $r6
   ; AIE2-NEXT:   [[COPY1:%[0-9]+]]:er = COPY $r7
   ; AIE2-NEXT:   [[GE:%[0-9]+]]:er = GE [[COPY]], [[COPY1]]
-  ; AIE2-NEXT:   [[MOV_RLC_imm10_pseudo:%[0-9]+]]:er = MOV_RLC_imm10_pseudo 1
-  ; AIE2-NEXT:   [[XOR:%[0-9]+]]:er = XOR [[GE]], [[MOV_RLC_imm10_pseudo]]
-  ; AIE2-NEXT:   PseudoJNZ [[XOR]], %bb.2
+  ; AIE2-NEXT:   PseudoJZ [[GE]], %bb.2
   ; AIE2-NEXT: {{  $}}
   ; AIE2-NEXT: bb.1:
   ; AIE2-NEXT:   successors: %bb.2(0x80000000)
@@ -352,9 +332,7 @@ body: |
   ; AIE2P-NEXT:   [[COPY:%[0-9]+]]:er = COPY $r6
   ; AIE2P-NEXT:   [[COPY1:%[0-9]+]]:er = COPY $r7
   ; AIE2P-NEXT:   [[GE:%[0-9]+]]:er = GE [[COPY]], [[COPY1]]
-  ; AIE2P-NEXT:   [[MOV_RLC_imm11_pseudo:%[0-9]+]]:er = MOV_RLC_imm11_pseudo 1
-  ; AIE2P-NEXT:   [[XOR:%[0-9]+]]:er = XOR [[GE]], [[MOV_RLC_imm11_pseudo]]
-  ; AIE2P-NEXT:   PseudoJNZ [[XOR]], %bb.2
+  ; AIE2P-NEXT:   PseudoJZ [[GE]], %bb.2
   ; AIE2P-NEXT: {{  $}}
   ; AIE2P-NEXT: bb.1:
   ; AIE2P-NEXT:   successors: %bb.2(0x80000000)
@@ -368,9 +346,7 @@ body: |
   ; AIE2PS-NEXT:   [[COPY:%[0-9]+]]:mlockid_reg = COPY $r6
   ; AIE2PS-NEXT:   [[COPY1:%[0-9]+]]:mlockid_reg = COPY $r7
   ; AIE2PS-NEXT:   [[GE:%[0-9]+]]:mlockid_reg = GE [[COPY]], [[COPY1]]
-  ; AIE2PS-NEXT:   [[MOV_RLC_imm11_pseudo:%[0-9]+]]:mlockid_reg = MOV_RLC_imm11_pseudo 1
-  ; AIE2PS-NEXT:   [[XOR:%[0-9]+]]:mlockid_reg = XOR [[GE]], [[MOV_RLC_imm11_pseudo]]
-  ; AIE2PS-NEXT:   PseudoJNZ [[XOR]], %bb.2
+  ; AIE2PS-NEXT:   PseudoJZ [[GE]], %bb.2
   ; AIE2PS-NEXT: {{  $}}
   ; AIE2PS-NEXT: bb.1:
   ; AIE2PS-NEXT:   successors: %bb.2(0x80000000)
@@ -419,9 +395,7 @@ body: |
   ; AIE2-NEXT:   [[COPY:%[0-9]+]]:er = COPY $r6
   ; AIE2-NEXT:   [[COPY1:%[0-9]+]]:er = COPY $r7
   ; AIE2-NEXT:   [[LT:%[0-9]+]]:er = LT [[COPY1]], [[COPY]]
-  ; AIE2-NEXT:   [[MOV_RLC_imm10_pseudo:%[0-9]+]]:er = MOV_RLC_imm10_pseudo 1
-  ; AIE2-NEXT:   [[XOR:%[0-9]+]]:er = XOR [[LT]], [[MOV_RLC_imm10_pseudo]]
-  ; AIE2-NEXT:   PseudoJNZ [[XOR]], %bb.2
+  ; AIE2-NEXT:   PseudoJZ [[LT]], %bb.2
   ; AIE2-NEXT: {{  $}}
   ; AIE2-NEXT: bb.1:
   ; AIE2-NEXT:   successors: %bb.2(0x80000000)
@@ -435,9 +409,7 @@ body: |
   ; AIE2P-NEXT:   [[COPY:%[0-9]+]]:er = COPY $r6
   ; AIE2P-NEXT:   [[COPY1:%[0-9]+]]:er = COPY $r7
   ; AIE2P-NEXT:   [[LT:%[0-9]+]]:er = LT [[COPY1]], [[COPY]]
-  ; AIE2P-NEXT:   [[MOV_RLC_imm11_pseudo:%[0-9]+]]:er = MOV_RLC_imm11_pseudo 1
-  ; AIE2P-NEXT:   [[XOR:%[0-9]+]]:er = XOR [[LT]], [[MOV_RLC_imm11_pseudo]]
-  ; AIE2P-NEXT:   PseudoJNZ [[XOR]], %bb.2
+  ; AIE2P-NEXT:   PseudoJZ [[LT]], %bb.2
   ; AIE2P-NEXT: {{  $}}
   ; AIE2P-NEXT: bb.1:
   ; AIE2P-NEXT:   successors: %bb.2(0x80000000)
@@ -451,9 +423,7 @@ body: |
   ; AIE2PS-NEXT:   [[COPY:%[0-9]+]]:mlockid_reg = COPY $r6
   ; AIE2PS-NEXT:   [[COPY1:%[0-9]+]]:mlockid_reg = COPY $r7
   ; AIE2PS-NEXT:   [[LT:%[0-9]+]]:mlockid_reg = LT [[COPY1]], [[COPY]]
-  ; AIE2PS-NEXT:   [[MOV_RLC_imm11_pseudo:%[0-9]+]]:mlockid_reg = MOV_RLC_imm11_pseudo 1
-  ; AIE2PS-NEXT:   [[XOR:%[0-9]+]]:mlockid_reg = XOR [[LT]], [[MOV_RLC_imm11_pseudo]]
-  ; AIE2PS-NEXT:   PseudoJNZ [[XOR]], %bb.2
+  ; AIE2PS-NEXT:   PseudoJZ [[LT]], %bb.2
   ; AIE2PS-NEXT: {{  $}}
   ; AIE2PS-NEXT: bb.1:
   ; AIE2PS-NEXT:   successors: %bb.2(0x80000000)
@@ -502,9 +472,7 @@ body: |
   ; AIE2-NEXT:   [[COPY:%[0-9]+]]:er = COPY $r6
   ; AIE2-NEXT:   [[COPY1:%[0-9]+]]:er = COPY $r7
   ; AIE2-NEXT:   [[GE:%[0-9]+]]:er = GE [[COPY1]], [[COPY]]
-  ; AIE2-NEXT:   [[MOV_RLC_imm10_pseudo:%[0-9]+]]:er = MOV_RLC_imm10_pseudo 1
-  ; AIE2-NEXT:   [[XOR:%[0-9]+]]:er = XOR [[GE]], [[MOV_RLC_imm10_pseudo]]
-  ; AIE2-NEXT:   PseudoJNZ [[XOR]], %bb.2
+  ; AIE2-NEXT:   PseudoJZ [[GE]], %bb.2
   ; AIE2-NEXT: {{  $}}
   ; AIE2-NEXT: bb.1:
   ; AIE2-NEXT:   successors: %bb.2(0x80000000)
@@ -518,9 +486,7 @@ body: |
   ; AIE2P-NEXT:   [[COPY:%[0-9]+]]:er = COPY $r6
   ; AIE2P-NEXT:   [[COPY1:%[0-9]+]]:er = COPY $r7
   ; AIE2P-NEXT:   [[GE:%[0-9]+]]:er = GE [[COPY1]], [[COPY]]
-  ; AIE2P-NEXT:   [[MOV_RLC_imm11_pseudo:%[0-9]+]]:er = MOV_RLC_imm11_pseudo 1
-  ; AIE2P-NEXT:   [[XOR:%[0-9]+]]:er = XOR [[GE]], [[MOV_RLC_imm11_pseudo]]
-  ; AIE2P-NEXT:   PseudoJNZ [[XOR]], %bb.2
+  ; AIE2P-NEXT:   PseudoJZ [[GE]], %bb.2
   ; AIE2P-NEXT: {{  $}}
   ; AIE2P-NEXT: bb.1:
   ; AIE2P-NEXT:   successors: %bb.2(0x80000000)
@@ -534,9 +500,7 @@ body: |
   ; AIE2PS-NEXT:   [[COPY:%[0-9]+]]:mlockid_reg = COPY $r6
   ; AIE2PS-NEXT:   [[COPY1:%[0-9]+]]:mlockid_reg = COPY $r7
   ; AIE2PS-NEXT:   [[GE:%[0-9]+]]:mlockid_reg = GE [[COPY1]], [[COPY]]
-  ; AIE2PS-NEXT:   [[MOV_RLC_imm11_pseudo:%[0-9]+]]:mlockid_reg = MOV_RLC_imm11_pseudo 1
-  ; AIE2PS-NEXT:   [[XOR:%[0-9]+]]:mlockid_reg = XOR [[GE]], [[MOV_RLC_imm11_pseudo]]
-  ; AIE2PS-NEXT:   PseudoJNZ [[XOR]], %bb.2
+  ; AIE2PS-NEXT:   PseudoJZ [[GE]], %bb.2
   ; AIE2PS-NEXT: {{  $}}
   ; AIE2PS-NEXT: bb.1:
   ; AIE2PS-NEXT:   successors: %bb.2(0x80000000)
@@ -585,9 +549,7 @@ body: |
   ; AIE2-NEXT:   [[COPY:%[0-9]+]]:er = COPY $r6
   ; AIE2-NEXT:   [[COPY1:%[0-9]+]]:er = COPY $r7
   ; AIE2-NEXT:   [[LTU:%[0-9]+]]:er = LTU [[COPY]], [[COPY1]]
-  ; AIE2-NEXT:   [[MOV_RLC_imm10_pseudo:%[0-9]+]]:er = MOV_RLC_imm10_pseudo 1
-  ; AIE2-NEXT:   [[XOR:%[0-9]+]]:er = XOR [[LTU]], [[MOV_RLC_imm10_pseudo]]
-  ; AIE2-NEXT:   PseudoJNZ [[XOR]], %bb.2
+  ; AIE2-NEXT:   PseudoJZ [[LTU]], %bb.2
   ; AIE2-NEXT: {{  $}}
   ; AIE2-NEXT: bb.1:
   ; AIE2-NEXT:   successors: %bb.2(0x80000000)
@@ -601,9 +563,7 @@ body: |
   ; AIE2P-NEXT:   [[COPY:%[0-9]+]]:er = COPY $r6
   ; AIE2P-NEXT:   [[COPY1:%[0-9]+]]:er = COPY $r7
   ; AIE2P-NEXT:   [[LTU:%[0-9]+]]:er = LTU [[COPY]], [[COPY1]]
-  ; AIE2P-NEXT:   [[MOV_RLC_imm11_pseudo:%[0-9]+]]:er = MOV_RLC_imm11_pseudo 1
-  ; AIE2P-NEXT:   [[XOR:%[0-9]+]]:er = XOR [[LTU]], [[MOV_RLC_imm11_pseudo]]
-  ; AIE2P-NEXT:   PseudoJNZ [[XOR]], %bb.2
+  ; AIE2P-NEXT:   PseudoJZ [[LTU]], %bb.2
   ; AIE2P-NEXT: {{  $}}
   ; AIE2P-NEXT: bb.1:
   ; AIE2P-NEXT:   successors: %bb.2(0x80000000)
@@ -617,9 +577,7 @@ body: |
   ; AIE2PS-NEXT:   [[COPY:%[0-9]+]]:mlockid_reg = COPY $r6
   ; AIE2PS-NEXT:   [[COPY1:%[0-9]+]]:mlockid_reg = COPY $r7
   ; AIE2PS-NEXT:   [[LTU:%[0-9]+]]:mlockid_reg = LTU [[COPY]], [[COPY1]]
-  ; AIE2PS-NEXT:   [[MOV_RLC_imm11_pseudo:%[0-9]+]]:mlockid_reg = MOV_RLC_imm11_pseudo 1
-  ; AIE2PS-NEXT:   [[XOR:%[0-9]+]]:mlockid_reg = XOR [[LTU]], [[MOV_RLC_imm11_pseudo]]
-  ; AIE2PS-NEXT:   PseudoJNZ [[XOR]], %bb.2
+  ; AIE2PS-NEXT:   PseudoJZ [[LTU]], %bb.2
   ; AIE2PS-NEXT: {{  $}}
   ; AIE2PS-NEXT: bb.1:
   ; AIE2PS-NEXT:   successors: %bb.2(0x80000000)
@@ -668,9 +626,7 @@ body: |
   ; AIE2-NEXT:   [[COPY:%[0-9]+]]:er = COPY $r6
   ; AIE2-NEXT:   [[COPY1:%[0-9]+]]:er = COPY $r7
   ; AIE2-NEXT:   [[GEU:%[0-9]+]]:er = GEU [[COPY]], [[COPY1]]
-  ; AIE2-NEXT:   [[MOV_RLC_imm10_pseudo:%[0-9]+]]:er = MOV_RLC_imm10_pseudo 1
-  ; AIE2-NEXT:   [[XOR:%[0-9]+]]:er = XOR [[GEU]], [[MOV_RLC_imm10_pseudo]]
-  ; AIE2-NEXT:   PseudoJNZ [[XOR]], %bb.2
+  ; AIE2-NEXT:   PseudoJZ [[GEU]], %bb.2
   ; AIE2-NEXT: {{  $}}
   ; AIE2-NEXT: bb.1:
   ; AIE2-NEXT:   successors: %bb.2(0x80000000)
@@ -684,9 +640,7 @@ body: |
   ; AIE2P-NEXT:   [[COPY:%[0-9]+]]:er = COPY $r6
   ; AIE2P-NEXT:   [[COPY1:%[0-9]+]]:er = COPY $r7
   ; AIE2P-NEXT:   [[GEU:%[0-9]+]]:er = GEU [[COPY]], [[COPY1]]
-  ; AIE2P-NEXT:   [[MOV_RLC_imm11_pseudo:%[0-9]+]]:er = MOV_RLC_imm11_pseudo 1
-  ; AIE2P-NEXT:   [[XOR:%[0-9]+]]:er = XOR [[GEU]], [[MOV_RLC_imm11_pseudo]]
-  ; AIE2P-NEXT:   PseudoJNZ [[XOR]], %bb.2
+  ; AIE2P-NEXT:   PseudoJZ [[GEU]], %bb.2
   ; AIE2P-NEXT: {{  $}}
   ; AIE2P-NEXT: bb.1:
   ; AIE2P-NEXT:   successors: %bb.2(0x80000000)
@@ -700,9 +654,7 @@ body: |
   ; AIE2PS-NEXT:   [[COPY:%[0-9]+]]:mlockid_reg = COPY $r6
   ; AIE2PS-NEXT:   [[COPY1:%[0-9]+]]:mlockid_reg = COPY $r7
   ; AIE2PS-NEXT:   [[GEU:%[0-9]+]]:mlockid_reg = GEU [[COPY]], [[COPY1]]
-  ; AIE2PS-NEXT:   [[MOV_RLC_imm11_pseudo:%[0-9]+]]:mlockid_reg = MOV_RLC_imm11_pseudo 1
-  ; AIE2PS-NEXT:   [[XOR:%[0-9]+]]:mlockid_reg = XOR [[GEU]], [[MOV_RLC_imm11_pseudo]]
-  ; AIE2PS-NEXT:   PseudoJNZ [[XOR]], %bb.2
+  ; AIE2PS-NEXT:   PseudoJZ [[GEU]], %bb.2
   ; AIE2PS-NEXT: {{  $}}
   ; AIE2PS-NEXT: bb.1:
   ; AIE2PS-NEXT:   successors: %bb.2(0x80000000)
@@ -751,9 +703,7 @@ body: |
   ; AIE2-NEXT:   [[COPY:%[0-9]+]]:er = COPY $r6
   ; AIE2-NEXT:   [[COPY1:%[0-9]+]]:er = COPY $r7
   ; AIE2-NEXT:   [[LTU:%[0-9]+]]:er = LTU [[COPY1]], [[COPY]]
-  ; AIE2-NEXT:   [[MOV_RLC_imm10_pseudo:%[0-9]+]]:er = MOV_RLC_imm10_pseudo 1
-  ; AIE2-NEXT:   [[XOR:%[0-9]+]]:er = XOR [[LTU]], [[MOV_RLC_imm10_pseudo]]
-  ; AIE2-NEXT:   PseudoJNZ [[XOR]], %bb.2
+  ; AIE2-NEXT:   PseudoJZ [[LTU]], %bb.2
   ; AIE2-NEXT: {{  $}}
   ; AIE2-NEXT: bb.1:
   ; AIE2-NEXT:   successors: %bb.2(0x80000000)
@@ -767,9 +717,7 @@ body: |
   ; AIE2P-NEXT:   [[COPY:%[0-9]+]]:er = COPY $r6
   ; AIE2P-NEXT:   [[COPY1:%[0-9]+]]:er = COPY $r7
   ; AIE2P-NEXT:   [[LTU:%[0-9]+]]:er = LTU [[COPY1]], [[COPY]]
-  ; AIE2P-NEXT:   [[MOV_RLC_imm11_pseudo:%[0-9]+]]:er = MOV_RLC_imm11_pseudo 1
-  ; AIE2P-NEXT:   [[XOR:%[0-9]+]]:er = XOR [[LTU]], [[MOV_RLC_imm11_pseudo]]
-  ; AIE2P-NEXT:   PseudoJNZ [[XOR]], %bb.2
+  ; AIE2P-NEXT:   PseudoJZ [[LTU]], %bb.2
   ; AIE2P-NEXT: {{  $}}
   ; AIE2P-NEXT: bb.1:
   ; AIE2P-NEXT:   successors: %bb.2(0x80000000)
@@ -783,9 +731,7 @@ body: |
   ; AIE2PS-NEXT:   [[COPY:%[0-9]+]]:mlockid_reg = COPY $r6
   ; AIE2PS-NEXT:   [[COPY1:%[0-9]+]]:mlockid_reg = COPY $r7
   ; AIE2PS-NEXT:   [[LTU:%[0-9]+]]:mlockid_reg = LTU [[COPY1]], [[COPY]]
-  ; AIE2PS-NEXT:   [[MOV_RLC_imm11_pseudo:%[0-9]+]]:mlockid_reg = MOV_RLC_imm11_pseudo 1
-  ; AIE2PS-NEXT:   [[XOR:%[0-9]+]]:mlockid_reg = XOR [[LTU]], [[MOV_RLC_imm11_pseudo]]
-  ; AIE2PS-NEXT:   PseudoJNZ [[XOR]], %bb.2
+  ; AIE2PS-NEXT:   PseudoJZ [[LTU]], %bb.2
   ; AIE2PS-NEXT: {{  $}}
   ; AIE2PS-NEXT: bb.1:
   ; AIE2PS-NEXT:   successors: %bb.2(0x80000000)
@@ -834,9 +780,7 @@ body: |
   ; AIE2-NEXT:   [[COPY:%[0-9]+]]:er = COPY $r6
   ; AIE2-NEXT:   [[COPY1:%[0-9]+]]:er = COPY $r7
   ; AIE2-NEXT:   [[GEU:%[0-9]+]]:er = GEU [[COPY1]], [[COPY]]
-  ; AIE2-NEXT:   [[MOV_RLC_imm10_pseudo:%[0-9]+]]:er = MOV_RLC_imm10_pseudo 1
-  ; AIE2-NEXT:   [[XOR:%[0-9]+]]:er = XOR [[GEU]], [[MOV_RLC_imm10_pseudo]]
-  ; AIE2-NEXT:   PseudoJNZ [[XOR]], %bb.2
+  ; AIE2-NEXT:   PseudoJZ [[GEU]], %bb.2
   ; AIE2-NEXT: {{  $}}
   ; AIE2-NEXT: bb.1:
   ; AIE2-NEXT:   successors: %bb.2(0x80000000)
@@ -850,9 +794,7 @@ body: |
   ; AIE2P-NEXT:   [[COPY:%[0-9]+]]:er = COPY $r6
   ; AIE2P-NEXT:   [[COPY1:%[0-9]+]]:er = COPY $r7
   ; AIE2P-NEXT:   [[GEU:%[0-9]+]]:er = GEU [[COPY1]], [[COPY]]
-  ; AIE2P-NEXT:   [[MOV_RLC_imm11_pseudo:%[0-9]+]]:er = MOV_RLC_imm11_pseudo 1
-  ; AIE2P-NEXT:   [[XOR:%[0-9]+]]:er = XOR [[GEU]], [[MOV_RLC_imm11_pseudo]]
-  ; AIE2P-NEXT:   PseudoJNZ [[XOR]], %bb.2
+  ; AIE2P-NEXT:   PseudoJZ [[GEU]], %bb.2
   ; AIE2P-NEXT: {{  $}}
   ; AIE2P-NEXT: bb.1:
   ; AIE2P-NEXT:   successors: %bb.2(0x80000000)
@@ -866,9 +808,7 @@ body: |
   ; AIE2PS-NEXT:   [[COPY:%[0-9]+]]:mlockid_reg = COPY $r6
   ; AIE2PS-NEXT:   [[COPY1:%[0-9]+]]:mlockid_reg = COPY $r7
   ; AIE2PS-NEXT:   [[GEU:%[0-9]+]]:mlockid_reg = GEU [[COPY1]], [[COPY]]
-  ; AIE2PS-NEXT:   [[MOV_RLC_imm11_pseudo:%[0-9]+]]:mlockid_reg = MOV_RLC_imm11_pseudo 1
-  ; AIE2PS-NEXT:   [[XOR:%[0-9]+]]:mlockid_reg = XOR [[GEU]], [[MOV_RLC_imm11_pseudo]]
-  ; AIE2PS-NEXT:   PseudoJNZ [[XOR]], %bb.2
+  ; AIE2PS-NEXT:   PseudoJZ [[GEU]], %bb.2
   ; AIE2PS-NEXT: {{  $}}
   ; AIE2PS-NEXT: bb.1:
   ; AIE2PS-NEXT:   successors: %bb.2(0x80000000)

--- a/llvm/test/CodeGen/AIE/GlobalISel/inst-select-brcond.mir
+++ b/llvm/test/CodeGen/AIE/GlobalISel/inst-select-brcond.mir
@@ -7,8 +7,8 @@
 # (c) Copyright 2023-2026 Advanced Micro Devices, Inc. or its affiliates
 # RUN: llc -mtriple aie -run-pass=instruction-select %s -verify-machineinstrs -o - | FileCheck --check-prefix=AIE %s
 # RUN: llc -mtriple aie2 -run-pass=instruction-select %s -verify-machineinstrs -o - | FileCheck --check-prefix=AIE2 %s
-# RUN: llc -mtriple aie2p -run-pass=instruction-select %s -verify-machineinstrs -o - | FileCheck --check-prefix=AIE2 %s
-# RUN: llc -mtriple aie2ps -run-pass=instruction-select %s -verify-machineinstrs -o - | FileCheck --check-prefix=AIE2 %s
+# RUN: llc -mtriple aie2p -run-pass=instruction-select %s -verify-machineinstrs -o - | FileCheck --check-prefix=AIE2P %s
+# RUN: llc -mtriple aie2ps -run-pass=instruction-select %s -verify-machineinstrs -o - | FileCheck --check-prefix=AIE2PS %s
 
 ---
 name:            brcond
@@ -33,9 +33,930 @@ body: |
   ; AIE2-NEXT:   PseudoJNZ [[COPY]], %bb.1
   ; AIE2-NEXT: {{  $}}
   ; AIE2-NEXT: bb.1:
+  ;
+  ; AIE2P-LABEL: name: brcond
+  ; AIE2P: bb.0:
+  ; AIE2P-NEXT:   successors: %bb.1(0x80000000)
+  ; AIE2P-NEXT: {{  $}}
+  ; AIE2P-NEXT:   [[COPY:%[0-9]+]]:er = COPY $r6
+  ; AIE2P-NEXT:   PseudoJNZ [[COPY]], %bb.1
+  ; AIE2P-NEXT: {{  $}}
+  ; AIE2P-NEXT: bb.1:
+  ;
+  ; AIE2PS-LABEL: name: brcond
+  ; AIE2PS: bb.0:
+  ; AIE2PS-NEXT:   successors: %bb.1(0x80000000)
+  ; AIE2PS-NEXT: {{  $}}
+  ; AIE2PS-NEXT:   [[COPY:%[0-9]+]]:er = COPY $r6
+  ; AIE2PS-NEXT:   PseudoJNZ [[COPY]], %bb.1
+  ; AIE2PS-NEXT: {{  $}}
+  ; AIE2PS-NEXT: bb.1:
   bb.0:
     %0:gprregbank(s32) = COPY $r6
     G_BRCOND %0, %bb.1
 
   bb.1:
+...
+
+---
+name:            brcond_xor_icmp
+legalized:       true
+regBankSelected: true
+
+body: |
+  ; AIE-LABEL: name: brcond_xor_icmp
+  ; AIE: bb.0:
+  ; AIE-NEXT:   successors: %bb.1(0x40000000), %bb.2(0x40000000)
+  ; AIE-NEXT: {{  $}}
+  ; AIE-NEXT:   [[COPY:%[0-9]+]]:gpr = COPY $r6
+  ; AIE-NEXT:   [[COPY1:%[0-9]+]]:gpr = COPY $r7
+  ; AIE-NEXT:   [[EQ:%[0-9]+]]:gpr = EQ [[COPY]], [[COPY1]]
+  ; AIE-NEXT:   [[MOV_U20_:%[0-9]+]]:gpr = MOV_U20 1
+  ; AIE-NEXT:   [[XOR:%[0-9]+]]:gpr = XOR [[EQ]], [[MOV_U20_]]
+  ; AIE-NEXT:   BNEZ [[XOR]], %bb.2
+  ; AIE-NEXT: {{  $}}
+  ; AIE-NEXT: bb.1:
+  ; AIE-NEXT:   successors: %bb.2(0x80000000)
+  ; AIE-NEXT: {{  $}}
+  ; AIE-NEXT: bb.2:
+  ;
+  ; AIE2-LABEL: name: brcond_xor_icmp
+  ; AIE2: bb.0:
+  ; AIE2-NEXT:   successors: %bb.1(0x40000000), %bb.2(0x40000000)
+  ; AIE2-NEXT: {{  $}}
+  ; AIE2-NEXT:   [[COPY:%[0-9]+]]:er = COPY $r6
+  ; AIE2-NEXT:   [[COPY1:%[0-9]+]]:er = COPY $r7
+  ; AIE2-NEXT:   [[EQ:%[0-9]+]]:er = EQ [[COPY]], [[COPY1]]
+  ; AIE2-NEXT:   [[MOV_RLC_imm10_pseudo:%[0-9]+]]:er = MOV_RLC_imm10_pseudo 1
+  ; AIE2-NEXT:   [[XOR:%[0-9]+]]:er = XOR [[EQ]], [[MOV_RLC_imm10_pseudo]]
+  ; AIE2-NEXT:   PseudoJNZ [[XOR]], %bb.2
+  ; AIE2-NEXT: {{  $}}
+  ; AIE2-NEXT: bb.1:
+  ; AIE2-NEXT:   successors: %bb.2(0x80000000)
+  ; AIE2-NEXT: {{  $}}
+  ; AIE2-NEXT: bb.2:
+  ;
+  ; AIE2P-LABEL: name: brcond_xor_icmp
+  ; AIE2P: bb.0:
+  ; AIE2P-NEXT:   successors: %bb.1(0x40000000), %bb.2(0x40000000)
+  ; AIE2P-NEXT: {{  $}}
+  ; AIE2P-NEXT:   [[COPY:%[0-9]+]]:er = COPY $r6
+  ; AIE2P-NEXT:   [[COPY1:%[0-9]+]]:er = COPY $r7
+  ; AIE2P-NEXT:   [[EQ:%[0-9]+]]:er = EQ [[COPY]], [[COPY1]]
+  ; AIE2P-NEXT:   [[MOV_RLC_imm11_pseudo:%[0-9]+]]:er = MOV_RLC_imm11_pseudo 1
+  ; AIE2P-NEXT:   [[XOR:%[0-9]+]]:er = XOR [[EQ]], [[MOV_RLC_imm11_pseudo]]
+  ; AIE2P-NEXT:   PseudoJNZ [[XOR]], %bb.2
+  ; AIE2P-NEXT: {{  $}}
+  ; AIE2P-NEXT: bb.1:
+  ; AIE2P-NEXT:   successors: %bb.2(0x80000000)
+  ; AIE2P-NEXT: {{  $}}
+  ; AIE2P-NEXT: bb.2:
+  ;
+  ; AIE2PS-LABEL: name: brcond_xor_icmp
+  ; AIE2PS: bb.0:
+  ; AIE2PS-NEXT:   successors: %bb.1(0x40000000), %bb.2(0x40000000)
+  ; AIE2PS-NEXT: {{  $}}
+  ; AIE2PS-NEXT:   [[COPY:%[0-9]+]]:mlockid_reg = COPY $r6
+  ; AIE2PS-NEXT:   [[COPY1:%[0-9]+]]:mlockid_reg = COPY $r7
+  ; AIE2PS-NEXT:   [[EQ:%[0-9]+]]:mlockid_reg = EQ [[COPY]], [[COPY1]]
+  ; AIE2PS-NEXT:   [[MOV_RLC_imm11_pseudo:%[0-9]+]]:mlockid_reg = MOV_RLC_imm11_pseudo 1
+  ; AIE2PS-NEXT:   [[XOR:%[0-9]+]]:mlockid_reg = XOR [[EQ]], [[MOV_RLC_imm11_pseudo]]
+  ; AIE2PS-NEXT:   PseudoJNZ [[XOR]], %bb.2
+  ; AIE2PS-NEXT: {{  $}}
+  ; AIE2PS-NEXT: bb.1:
+  ; AIE2PS-NEXT:   successors: %bb.2(0x80000000)
+  ; AIE2PS-NEXT: {{  $}}
+  ; AIE2PS-NEXT: bb.2:
+  bb.0:
+    successors: %bb.1, %bb.2
+    %0:gprregbank(s32) = COPY $r6
+    %1:gprregbank(s32) = COPY $r7
+    %2:gprregbank(s32) = G_ICMP intpred(eq), %0, %1
+    %3:gprregbank(s32) = G_CONSTANT i32 1
+    %4:gprregbank(s32) = G_XOR %2, %3
+    G_BRCOND %4, %bb.2
+
+  bb.1:
+
+  bb.2:
+...
+
+---
+name:            brcond_xor_icmp_ne
+legalized:       true
+regBankSelected: true
+
+body: |
+  ; AIE-LABEL: name: brcond_xor_icmp_ne
+  ; AIE: bb.0:
+  ; AIE-NEXT:   successors: %bb.1(0x40000000), %bb.2(0x40000000)
+  ; AIE-NEXT: {{  $}}
+  ; AIE-NEXT:   [[COPY:%[0-9]+]]:gpr = COPY $r6
+  ; AIE-NEXT:   [[COPY1:%[0-9]+]]:gpr = COPY $r7
+  ; AIE-NEXT:   [[NE:%[0-9]+]]:gpr = NE [[COPY]], [[COPY1]]
+  ; AIE-NEXT:   [[MOV_U20_:%[0-9]+]]:gpr = MOV_U20 1
+  ; AIE-NEXT:   [[XOR:%[0-9]+]]:gpr = XOR [[NE]], [[MOV_U20_]]
+  ; AIE-NEXT:   BNEZ [[XOR]], %bb.2
+  ; AIE-NEXT: {{  $}}
+  ; AIE-NEXT: bb.1:
+  ; AIE-NEXT:   successors: %bb.2(0x80000000)
+  ; AIE-NEXT: {{  $}}
+  ; AIE-NEXT: bb.2:
+  ;
+  ; AIE2-LABEL: name: brcond_xor_icmp_ne
+  ; AIE2: bb.0:
+  ; AIE2-NEXT:   successors: %bb.1(0x40000000), %bb.2(0x40000000)
+  ; AIE2-NEXT: {{  $}}
+  ; AIE2-NEXT:   [[COPY:%[0-9]+]]:er = COPY $r6
+  ; AIE2-NEXT:   [[COPY1:%[0-9]+]]:er = COPY $r7
+  ; AIE2-NEXT:   [[NE:%[0-9]+]]:er = NE [[COPY]], [[COPY1]]
+  ; AIE2-NEXT:   [[MOV_RLC_imm10_pseudo:%[0-9]+]]:er = MOV_RLC_imm10_pseudo 1
+  ; AIE2-NEXT:   [[XOR:%[0-9]+]]:er = XOR [[NE]], [[MOV_RLC_imm10_pseudo]]
+  ; AIE2-NEXT:   PseudoJNZ [[XOR]], %bb.2
+  ; AIE2-NEXT: {{  $}}
+  ; AIE2-NEXT: bb.1:
+  ; AIE2-NEXT:   successors: %bb.2(0x80000000)
+  ; AIE2-NEXT: {{  $}}
+  ; AIE2-NEXT: bb.2:
+  ;
+  ; AIE2P-LABEL: name: brcond_xor_icmp_ne
+  ; AIE2P: bb.0:
+  ; AIE2P-NEXT:   successors: %bb.1(0x40000000), %bb.2(0x40000000)
+  ; AIE2P-NEXT: {{  $}}
+  ; AIE2P-NEXT:   [[COPY:%[0-9]+]]:er = COPY $r6
+  ; AIE2P-NEXT:   [[COPY1:%[0-9]+]]:er = COPY $r7
+  ; AIE2P-NEXT:   [[NE:%[0-9]+]]:er = NE [[COPY]], [[COPY1]]
+  ; AIE2P-NEXT:   [[MOV_RLC_imm11_pseudo:%[0-9]+]]:er = MOV_RLC_imm11_pseudo 1
+  ; AIE2P-NEXT:   [[XOR:%[0-9]+]]:er = XOR [[NE]], [[MOV_RLC_imm11_pseudo]]
+  ; AIE2P-NEXT:   PseudoJNZ [[XOR]], %bb.2
+  ; AIE2P-NEXT: {{  $}}
+  ; AIE2P-NEXT: bb.1:
+  ; AIE2P-NEXT:   successors: %bb.2(0x80000000)
+  ; AIE2P-NEXT: {{  $}}
+  ; AIE2P-NEXT: bb.2:
+  ;
+  ; AIE2PS-LABEL: name: brcond_xor_icmp_ne
+  ; AIE2PS: bb.0:
+  ; AIE2PS-NEXT:   successors: %bb.1(0x40000000), %bb.2(0x40000000)
+  ; AIE2PS-NEXT: {{  $}}
+  ; AIE2PS-NEXT:   [[COPY:%[0-9]+]]:mlockid_reg = COPY $r6
+  ; AIE2PS-NEXT:   [[COPY1:%[0-9]+]]:mlockid_reg = COPY $r7
+  ; AIE2PS-NEXT:   [[NE:%[0-9]+]]:mlockid_reg = NE [[COPY]], [[COPY1]]
+  ; AIE2PS-NEXT:   [[MOV_RLC_imm11_pseudo:%[0-9]+]]:mlockid_reg = MOV_RLC_imm11_pseudo 1
+  ; AIE2PS-NEXT:   [[XOR:%[0-9]+]]:mlockid_reg = XOR [[NE]], [[MOV_RLC_imm11_pseudo]]
+  ; AIE2PS-NEXT:   PseudoJNZ [[XOR]], %bb.2
+  ; AIE2PS-NEXT: {{  $}}
+  ; AIE2PS-NEXT: bb.1:
+  ; AIE2PS-NEXT:   successors: %bb.2(0x80000000)
+  ; AIE2PS-NEXT: {{  $}}
+  ; AIE2PS-NEXT: bb.2:
+  bb.0:
+    successors: %bb.1, %bb.2
+    %0:gprregbank(s32) = COPY $r6
+    %1:gprregbank(s32) = COPY $r7
+    %2:gprregbank(s32) = G_ICMP intpred(ne), %0, %1
+    %3:gprregbank(s32) = G_CONSTANT i32 1
+    %4:gprregbank(s32) = G_XOR %2, %3
+    G_BRCOND %4, %bb.2
+
+  bb.1:
+
+  bb.2:
+...
+
+---
+name:            brcond_xor_icmp_slt
+legalized:       true
+regBankSelected: true
+
+body: |
+  ; AIE-LABEL: name: brcond_xor_icmp_slt
+  ; AIE: bb.0:
+  ; AIE-NEXT:   successors: %bb.1(0x40000000), %bb.2(0x40000000)
+  ; AIE-NEXT: {{  $}}
+  ; AIE-NEXT:   [[COPY:%[0-9]+]]:gpr = COPY $r6
+  ; AIE-NEXT:   [[COPY1:%[0-9]+]]:gpr = COPY $r7
+  ; AIE-NEXT:   [[LT:%[0-9]+]]:gpr = LT [[COPY]], [[COPY1]]
+  ; AIE-NEXT:   [[MOV_U20_:%[0-9]+]]:gpr = MOV_U20 1
+  ; AIE-NEXT:   [[XOR:%[0-9]+]]:gpr = XOR [[LT]], [[MOV_U20_]]
+  ; AIE-NEXT:   BNEZ [[XOR]], %bb.2
+  ; AIE-NEXT: {{  $}}
+  ; AIE-NEXT: bb.1:
+  ; AIE-NEXT:   successors: %bb.2(0x80000000)
+  ; AIE-NEXT: {{  $}}
+  ; AIE-NEXT: bb.2:
+  ;
+  ; AIE2-LABEL: name: brcond_xor_icmp_slt
+  ; AIE2: bb.0:
+  ; AIE2-NEXT:   successors: %bb.1(0x40000000), %bb.2(0x40000000)
+  ; AIE2-NEXT: {{  $}}
+  ; AIE2-NEXT:   [[COPY:%[0-9]+]]:er = COPY $r6
+  ; AIE2-NEXT:   [[COPY1:%[0-9]+]]:er = COPY $r7
+  ; AIE2-NEXT:   [[LT:%[0-9]+]]:er = LT [[COPY]], [[COPY1]]
+  ; AIE2-NEXT:   [[MOV_RLC_imm10_pseudo:%[0-9]+]]:er = MOV_RLC_imm10_pseudo 1
+  ; AIE2-NEXT:   [[XOR:%[0-9]+]]:er = XOR [[LT]], [[MOV_RLC_imm10_pseudo]]
+  ; AIE2-NEXT:   PseudoJNZ [[XOR]], %bb.2
+  ; AIE2-NEXT: {{  $}}
+  ; AIE2-NEXT: bb.1:
+  ; AIE2-NEXT:   successors: %bb.2(0x80000000)
+  ; AIE2-NEXT: {{  $}}
+  ; AIE2-NEXT: bb.2:
+  ;
+  ; AIE2P-LABEL: name: brcond_xor_icmp_slt
+  ; AIE2P: bb.0:
+  ; AIE2P-NEXT:   successors: %bb.1(0x40000000), %bb.2(0x40000000)
+  ; AIE2P-NEXT: {{  $}}
+  ; AIE2P-NEXT:   [[COPY:%[0-9]+]]:er = COPY $r6
+  ; AIE2P-NEXT:   [[COPY1:%[0-9]+]]:er = COPY $r7
+  ; AIE2P-NEXT:   [[LT:%[0-9]+]]:er = LT [[COPY]], [[COPY1]]
+  ; AIE2P-NEXT:   [[MOV_RLC_imm11_pseudo:%[0-9]+]]:er = MOV_RLC_imm11_pseudo 1
+  ; AIE2P-NEXT:   [[XOR:%[0-9]+]]:er = XOR [[LT]], [[MOV_RLC_imm11_pseudo]]
+  ; AIE2P-NEXT:   PseudoJNZ [[XOR]], %bb.2
+  ; AIE2P-NEXT: {{  $}}
+  ; AIE2P-NEXT: bb.1:
+  ; AIE2P-NEXT:   successors: %bb.2(0x80000000)
+  ; AIE2P-NEXT: {{  $}}
+  ; AIE2P-NEXT: bb.2:
+  ;
+  ; AIE2PS-LABEL: name: brcond_xor_icmp_slt
+  ; AIE2PS: bb.0:
+  ; AIE2PS-NEXT:   successors: %bb.1(0x40000000), %bb.2(0x40000000)
+  ; AIE2PS-NEXT: {{  $}}
+  ; AIE2PS-NEXT:   [[COPY:%[0-9]+]]:mlockid_reg = COPY $r6
+  ; AIE2PS-NEXT:   [[COPY1:%[0-9]+]]:mlockid_reg = COPY $r7
+  ; AIE2PS-NEXT:   [[LT:%[0-9]+]]:mlockid_reg = LT [[COPY]], [[COPY1]]
+  ; AIE2PS-NEXT:   [[MOV_RLC_imm11_pseudo:%[0-9]+]]:mlockid_reg = MOV_RLC_imm11_pseudo 1
+  ; AIE2PS-NEXT:   [[XOR:%[0-9]+]]:mlockid_reg = XOR [[LT]], [[MOV_RLC_imm11_pseudo]]
+  ; AIE2PS-NEXT:   PseudoJNZ [[XOR]], %bb.2
+  ; AIE2PS-NEXT: {{  $}}
+  ; AIE2PS-NEXT: bb.1:
+  ; AIE2PS-NEXT:   successors: %bb.2(0x80000000)
+  ; AIE2PS-NEXT: {{  $}}
+  ; AIE2PS-NEXT: bb.2:
+  bb.0:
+    successors: %bb.1, %bb.2
+    %0:gprregbank(s32) = COPY $r6
+    %1:gprregbank(s32) = COPY $r7
+    %2:gprregbank(s32) = G_ICMP intpred(slt), %0, %1
+    %3:gprregbank(s32) = G_CONSTANT i32 1
+    %4:gprregbank(s32) = G_XOR %2, %3
+    G_BRCOND %4, %bb.2
+
+  bb.1:
+
+  bb.2:
+...
+
+---
+name:            brcond_xor_icmp_sge
+legalized:       true
+regBankSelected: true
+
+body: |
+  ; AIE-LABEL: name: brcond_xor_icmp_sge
+  ; AIE: bb.0:
+  ; AIE-NEXT:   successors: %bb.1(0x40000000), %bb.2(0x40000000)
+  ; AIE-NEXT: {{  $}}
+  ; AIE-NEXT:   [[COPY:%[0-9]+]]:gpr = COPY $r6
+  ; AIE-NEXT:   [[COPY1:%[0-9]+]]:gpr = COPY $r7
+  ; AIE-NEXT:   [[GE:%[0-9]+]]:gpr = GE [[COPY]], [[COPY1]]
+  ; AIE-NEXT:   [[MOV_U20_:%[0-9]+]]:gpr = MOV_U20 1
+  ; AIE-NEXT:   [[XOR:%[0-9]+]]:gpr = XOR [[GE]], [[MOV_U20_]]
+  ; AIE-NEXT:   BNEZ [[XOR]], %bb.2
+  ; AIE-NEXT: {{  $}}
+  ; AIE-NEXT: bb.1:
+  ; AIE-NEXT:   successors: %bb.2(0x80000000)
+  ; AIE-NEXT: {{  $}}
+  ; AIE-NEXT: bb.2:
+  ;
+  ; AIE2-LABEL: name: brcond_xor_icmp_sge
+  ; AIE2: bb.0:
+  ; AIE2-NEXT:   successors: %bb.1(0x40000000), %bb.2(0x40000000)
+  ; AIE2-NEXT: {{  $}}
+  ; AIE2-NEXT:   [[COPY:%[0-9]+]]:er = COPY $r6
+  ; AIE2-NEXT:   [[COPY1:%[0-9]+]]:er = COPY $r7
+  ; AIE2-NEXT:   [[GE:%[0-9]+]]:er = GE [[COPY]], [[COPY1]]
+  ; AIE2-NEXT:   [[MOV_RLC_imm10_pseudo:%[0-9]+]]:er = MOV_RLC_imm10_pseudo 1
+  ; AIE2-NEXT:   [[XOR:%[0-9]+]]:er = XOR [[GE]], [[MOV_RLC_imm10_pseudo]]
+  ; AIE2-NEXT:   PseudoJNZ [[XOR]], %bb.2
+  ; AIE2-NEXT: {{  $}}
+  ; AIE2-NEXT: bb.1:
+  ; AIE2-NEXT:   successors: %bb.2(0x80000000)
+  ; AIE2-NEXT: {{  $}}
+  ; AIE2-NEXT: bb.2:
+  ;
+  ; AIE2P-LABEL: name: brcond_xor_icmp_sge
+  ; AIE2P: bb.0:
+  ; AIE2P-NEXT:   successors: %bb.1(0x40000000), %bb.2(0x40000000)
+  ; AIE2P-NEXT: {{  $}}
+  ; AIE2P-NEXT:   [[COPY:%[0-9]+]]:er = COPY $r6
+  ; AIE2P-NEXT:   [[COPY1:%[0-9]+]]:er = COPY $r7
+  ; AIE2P-NEXT:   [[GE:%[0-9]+]]:er = GE [[COPY]], [[COPY1]]
+  ; AIE2P-NEXT:   [[MOV_RLC_imm11_pseudo:%[0-9]+]]:er = MOV_RLC_imm11_pseudo 1
+  ; AIE2P-NEXT:   [[XOR:%[0-9]+]]:er = XOR [[GE]], [[MOV_RLC_imm11_pseudo]]
+  ; AIE2P-NEXT:   PseudoJNZ [[XOR]], %bb.2
+  ; AIE2P-NEXT: {{  $}}
+  ; AIE2P-NEXT: bb.1:
+  ; AIE2P-NEXT:   successors: %bb.2(0x80000000)
+  ; AIE2P-NEXT: {{  $}}
+  ; AIE2P-NEXT: bb.2:
+  ;
+  ; AIE2PS-LABEL: name: brcond_xor_icmp_sge
+  ; AIE2PS: bb.0:
+  ; AIE2PS-NEXT:   successors: %bb.1(0x40000000), %bb.2(0x40000000)
+  ; AIE2PS-NEXT: {{  $}}
+  ; AIE2PS-NEXT:   [[COPY:%[0-9]+]]:mlockid_reg = COPY $r6
+  ; AIE2PS-NEXT:   [[COPY1:%[0-9]+]]:mlockid_reg = COPY $r7
+  ; AIE2PS-NEXT:   [[GE:%[0-9]+]]:mlockid_reg = GE [[COPY]], [[COPY1]]
+  ; AIE2PS-NEXT:   [[MOV_RLC_imm11_pseudo:%[0-9]+]]:mlockid_reg = MOV_RLC_imm11_pseudo 1
+  ; AIE2PS-NEXT:   [[XOR:%[0-9]+]]:mlockid_reg = XOR [[GE]], [[MOV_RLC_imm11_pseudo]]
+  ; AIE2PS-NEXT:   PseudoJNZ [[XOR]], %bb.2
+  ; AIE2PS-NEXT: {{  $}}
+  ; AIE2PS-NEXT: bb.1:
+  ; AIE2PS-NEXT:   successors: %bb.2(0x80000000)
+  ; AIE2PS-NEXT: {{  $}}
+  ; AIE2PS-NEXT: bb.2:
+  bb.0:
+    successors: %bb.1, %bb.2
+    %0:gprregbank(s32) = COPY $r6
+    %1:gprregbank(s32) = COPY $r7
+    %2:gprregbank(s32) = G_ICMP intpred(sge), %0, %1
+    %3:gprregbank(s32) = G_CONSTANT i32 1
+    %4:gprregbank(s32) = G_XOR %2, %3
+    G_BRCOND %4, %bb.2
+
+  bb.1:
+
+  bb.2:
+...
+
+---
+name:            brcond_xor_icmp_sgt
+legalized:       true
+regBankSelected: true
+
+body: |
+  ; AIE-LABEL: name: brcond_xor_icmp_sgt
+  ; AIE: bb.0:
+  ; AIE-NEXT:   successors: %bb.1(0x40000000), %bb.2(0x40000000)
+  ; AIE-NEXT: {{  $}}
+  ; AIE-NEXT:   [[COPY:%[0-9]+]]:gpr = COPY $r6
+  ; AIE-NEXT:   [[COPY1:%[0-9]+]]:gpr = COPY $r7
+  ; AIE-NEXT:   [[LT:%[0-9]+]]:gpr = LT [[COPY1]], [[COPY]]
+  ; AIE-NEXT:   [[MOV_U20_:%[0-9]+]]:gpr = MOV_U20 1
+  ; AIE-NEXT:   [[XOR:%[0-9]+]]:gpr = XOR [[LT]], [[MOV_U20_]]
+  ; AIE-NEXT:   BNEZ [[XOR]], %bb.2
+  ; AIE-NEXT: {{  $}}
+  ; AIE-NEXT: bb.1:
+  ; AIE-NEXT:   successors: %bb.2(0x80000000)
+  ; AIE-NEXT: {{  $}}
+  ; AIE-NEXT: bb.2:
+  ;
+  ; AIE2-LABEL: name: brcond_xor_icmp_sgt
+  ; AIE2: bb.0:
+  ; AIE2-NEXT:   successors: %bb.1(0x40000000), %bb.2(0x40000000)
+  ; AIE2-NEXT: {{  $}}
+  ; AIE2-NEXT:   [[COPY:%[0-9]+]]:er = COPY $r6
+  ; AIE2-NEXT:   [[COPY1:%[0-9]+]]:er = COPY $r7
+  ; AIE2-NEXT:   [[LT:%[0-9]+]]:er = LT [[COPY1]], [[COPY]]
+  ; AIE2-NEXT:   [[MOV_RLC_imm10_pseudo:%[0-9]+]]:er = MOV_RLC_imm10_pseudo 1
+  ; AIE2-NEXT:   [[XOR:%[0-9]+]]:er = XOR [[LT]], [[MOV_RLC_imm10_pseudo]]
+  ; AIE2-NEXT:   PseudoJNZ [[XOR]], %bb.2
+  ; AIE2-NEXT: {{  $}}
+  ; AIE2-NEXT: bb.1:
+  ; AIE2-NEXT:   successors: %bb.2(0x80000000)
+  ; AIE2-NEXT: {{  $}}
+  ; AIE2-NEXT: bb.2:
+  ;
+  ; AIE2P-LABEL: name: brcond_xor_icmp_sgt
+  ; AIE2P: bb.0:
+  ; AIE2P-NEXT:   successors: %bb.1(0x40000000), %bb.2(0x40000000)
+  ; AIE2P-NEXT: {{  $}}
+  ; AIE2P-NEXT:   [[COPY:%[0-9]+]]:er = COPY $r6
+  ; AIE2P-NEXT:   [[COPY1:%[0-9]+]]:er = COPY $r7
+  ; AIE2P-NEXT:   [[LT:%[0-9]+]]:er = LT [[COPY1]], [[COPY]]
+  ; AIE2P-NEXT:   [[MOV_RLC_imm11_pseudo:%[0-9]+]]:er = MOV_RLC_imm11_pseudo 1
+  ; AIE2P-NEXT:   [[XOR:%[0-9]+]]:er = XOR [[LT]], [[MOV_RLC_imm11_pseudo]]
+  ; AIE2P-NEXT:   PseudoJNZ [[XOR]], %bb.2
+  ; AIE2P-NEXT: {{  $}}
+  ; AIE2P-NEXT: bb.1:
+  ; AIE2P-NEXT:   successors: %bb.2(0x80000000)
+  ; AIE2P-NEXT: {{  $}}
+  ; AIE2P-NEXT: bb.2:
+  ;
+  ; AIE2PS-LABEL: name: brcond_xor_icmp_sgt
+  ; AIE2PS: bb.0:
+  ; AIE2PS-NEXT:   successors: %bb.1(0x40000000), %bb.2(0x40000000)
+  ; AIE2PS-NEXT: {{  $}}
+  ; AIE2PS-NEXT:   [[COPY:%[0-9]+]]:mlockid_reg = COPY $r6
+  ; AIE2PS-NEXT:   [[COPY1:%[0-9]+]]:mlockid_reg = COPY $r7
+  ; AIE2PS-NEXT:   [[LT:%[0-9]+]]:mlockid_reg = LT [[COPY1]], [[COPY]]
+  ; AIE2PS-NEXT:   [[MOV_RLC_imm11_pseudo:%[0-9]+]]:mlockid_reg = MOV_RLC_imm11_pseudo 1
+  ; AIE2PS-NEXT:   [[XOR:%[0-9]+]]:mlockid_reg = XOR [[LT]], [[MOV_RLC_imm11_pseudo]]
+  ; AIE2PS-NEXT:   PseudoJNZ [[XOR]], %bb.2
+  ; AIE2PS-NEXT: {{  $}}
+  ; AIE2PS-NEXT: bb.1:
+  ; AIE2PS-NEXT:   successors: %bb.2(0x80000000)
+  ; AIE2PS-NEXT: {{  $}}
+  ; AIE2PS-NEXT: bb.2:
+  bb.0:
+    successors: %bb.1, %bb.2
+    %0:gprregbank(s32) = COPY $r6
+    %1:gprregbank(s32) = COPY $r7
+    %2:gprregbank(s32) = G_ICMP intpred(sgt), %0, %1
+    %3:gprregbank(s32) = G_CONSTANT i32 1
+    %4:gprregbank(s32) = G_XOR %2, %3
+    G_BRCOND %4, %bb.2
+
+  bb.1:
+
+  bb.2:
+...
+
+---
+name:            brcond_xor_icmp_sle
+legalized:       true
+regBankSelected: true
+
+body: |
+  ; AIE-LABEL: name: brcond_xor_icmp_sle
+  ; AIE: bb.0:
+  ; AIE-NEXT:   successors: %bb.1(0x40000000), %bb.2(0x40000000)
+  ; AIE-NEXT: {{  $}}
+  ; AIE-NEXT:   [[COPY:%[0-9]+]]:gpr = COPY $r6
+  ; AIE-NEXT:   [[COPY1:%[0-9]+]]:gpr = COPY $r7
+  ; AIE-NEXT:   [[GE:%[0-9]+]]:gpr = GE [[COPY1]], [[COPY]]
+  ; AIE-NEXT:   [[MOV_U20_:%[0-9]+]]:gpr = MOV_U20 1
+  ; AIE-NEXT:   [[XOR:%[0-9]+]]:gpr = XOR [[GE]], [[MOV_U20_]]
+  ; AIE-NEXT:   BNEZ [[XOR]], %bb.2
+  ; AIE-NEXT: {{  $}}
+  ; AIE-NEXT: bb.1:
+  ; AIE-NEXT:   successors: %bb.2(0x80000000)
+  ; AIE-NEXT: {{  $}}
+  ; AIE-NEXT: bb.2:
+  ;
+  ; AIE2-LABEL: name: brcond_xor_icmp_sle
+  ; AIE2: bb.0:
+  ; AIE2-NEXT:   successors: %bb.1(0x40000000), %bb.2(0x40000000)
+  ; AIE2-NEXT: {{  $}}
+  ; AIE2-NEXT:   [[COPY:%[0-9]+]]:er = COPY $r6
+  ; AIE2-NEXT:   [[COPY1:%[0-9]+]]:er = COPY $r7
+  ; AIE2-NEXT:   [[GE:%[0-9]+]]:er = GE [[COPY1]], [[COPY]]
+  ; AIE2-NEXT:   [[MOV_RLC_imm10_pseudo:%[0-9]+]]:er = MOV_RLC_imm10_pseudo 1
+  ; AIE2-NEXT:   [[XOR:%[0-9]+]]:er = XOR [[GE]], [[MOV_RLC_imm10_pseudo]]
+  ; AIE2-NEXT:   PseudoJNZ [[XOR]], %bb.2
+  ; AIE2-NEXT: {{  $}}
+  ; AIE2-NEXT: bb.1:
+  ; AIE2-NEXT:   successors: %bb.2(0x80000000)
+  ; AIE2-NEXT: {{  $}}
+  ; AIE2-NEXT: bb.2:
+  ;
+  ; AIE2P-LABEL: name: brcond_xor_icmp_sle
+  ; AIE2P: bb.0:
+  ; AIE2P-NEXT:   successors: %bb.1(0x40000000), %bb.2(0x40000000)
+  ; AIE2P-NEXT: {{  $}}
+  ; AIE2P-NEXT:   [[COPY:%[0-9]+]]:er = COPY $r6
+  ; AIE2P-NEXT:   [[COPY1:%[0-9]+]]:er = COPY $r7
+  ; AIE2P-NEXT:   [[GE:%[0-9]+]]:er = GE [[COPY1]], [[COPY]]
+  ; AIE2P-NEXT:   [[MOV_RLC_imm11_pseudo:%[0-9]+]]:er = MOV_RLC_imm11_pseudo 1
+  ; AIE2P-NEXT:   [[XOR:%[0-9]+]]:er = XOR [[GE]], [[MOV_RLC_imm11_pseudo]]
+  ; AIE2P-NEXT:   PseudoJNZ [[XOR]], %bb.2
+  ; AIE2P-NEXT: {{  $}}
+  ; AIE2P-NEXT: bb.1:
+  ; AIE2P-NEXT:   successors: %bb.2(0x80000000)
+  ; AIE2P-NEXT: {{  $}}
+  ; AIE2P-NEXT: bb.2:
+  ;
+  ; AIE2PS-LABEL: name: brcond_xor_icmp_sle
+  ; AIE2PS: bb.0:
+  ; AIE2PS-NEXT:   successors: %bb.1(0x40000000), %bb.2(0x40000000)
+  ; AIE2PS-NEXT: {{  $}}
+  ; AIE2PS-NEXT:   [[COPY:%[0-9]+]]:mlockid_reg = COPY $r6
+  ; AIE2PS-NEXT:   [[COPY1:%[0-9]+]]:mlockid_reg = COPY $r7
+  ; AIE2PS-NEXT:   [[GE:%[0-9]+]]:mlockid_reg = GE [[COPY1]], [[COPY]]
+  ; AIE2PS-NEXT:   [[MOV_RLC_imm11_pseudo:%[0-9]+]]:mlockid_reg = MOV_RLC_imm11_pseudo 1
+  ; AIE2PS-NEXT:   [[XOR:%[0-9]+]]:mlockid_reg = XOR [[GE]], [[MOV_RLC_imm11_pseudo]]
+  ; AIE2PS-NEXT:   PseudoJNZ [[XOR]], %bb.2
+  ; AIE2PS-NEXT: {{  $}}
+  ; AIE2PS-NEXT: bb.1:
+  ; AIE2PS-NEXT:   successors: %bb.2(0x80000000)
+  ; AIE2PS-NEXT: {{  $}}
+  ; AIE2PS-NEXT: bb.2:
+  bb.0:
+    successors: %bb.1, %bb.2
+    %0:gprregbank(s32) = COPY $r6
+    %1:gprregbank(s32) = COPY $r7
+    %2:gprregbank(s32) = G_ICMP intpred(sle), %0, %1
+    %3:gprregbank(s32) = G_CONSTANT i32 1
+    %4:gprregbank(s32) = G_XOR %2, %3
+    G_BRCOND %4, %bb.2
+
+  bb.1:
+
+  bb.2:
+...
+
+---
+name:            brcond_xor_icmp_ult
+legalized:       true
+regBankSelected: true
+
+body: |
+  ; AIE-LABEL: name: brcond_xor_icmp_ult
+  ; AIE: bb.0:
+  ; AIE-NEXT:   successors: %bb.1(0x40000000), %bb.2(0x40000000)
+  ; AIE-NEXT: {{  $}}
+  ; AIE-NEXT:   [[COPY:%[0-9]+]]:gpr = COPY $r6
+  ; AIE-NEXT:   [[COPY1:%[0-9]+]]:gpr = COPY $r7
+  ; AIE-NEXT:   [[LTU:%[0-9]+]]:gpr = LTU [[COPY]], [[COPY1]]
+  ; AIE-NEXT:   [[MOV_U20_:%[0-9]+]]:gpr = MOV_U20 1
+  ; AIE-NEXT:   [[XOR:%[0-9]+]]:gpr = XOR [[LTU]], [[MOV_U20_]]
+  ; AIE-NEXT:   BNEZ [[XOR]], %bb.2
+  ; AIE-NEXT: {{  $}}
+  ; AIE-NEXT: bb.1:
+  ; AIE-NEXT:   successors: %bb.2(0x80000000)
+  ; AIE-NEXT: {{  $}}
+  ; AIE-NEXT: bb.2:
+  ;
+  ; AIE2-LABEL: name: brcond_xor_icmp_ult
+  ; AIE2: bb.0:
+  ; AIE2-NEXT:   successors: %bb.1(0x40000000), %bb.2(0x40000000)
+  ; AIE2-NEXT: {{  $}}
+  ; AIE2-NEXT:   [[COPY:%[0-9]+]]:er = COPY $r6
+  ; AIE2-NEXT:   [[COPY1:%[0-9]+]]:er = COPY $r7
+  ; AIE2-NEXT:   [[LTU:%[0-9]+]]:er = LTU [[COPY]], [[COPY1]]
+  ; AIE2-NEXT:   [[MOV_RLC_imm10_pseudo:%[0-9]+]]:er = MOV_RLC_imm10_pseudo 1
+  ; AIE2-NEXT:   [[XOR:%[0-9]+]]:er = XOR [[LTU]], [[MOV_RLC_imm10_pseudo]]
+  ; AIE2-NEXT:   PseudoJNZ [[XOR]], %bb.2
+  ; AIE2-NEXT: {{  $}}
+  ; AIE2-NEXT: bb.1:
+  ; AIE2-NEXT:   successors: %bb.2(0x80000000)
+  ; AIE2-NEXT: {{  $}}
+  ; AIE2-NEXT: bb.2:
+  ;
+  ; AIE2P-LABEL: name: brcond_xor_icmp_ult
+  ; AIE2P: bb.0:
+  ; AIE2P-NEXT:   successors: %bb.1(0x40000000), %bb.2(0x40000000)
+  ; AIE2P-NEXT: {{  $}}
+  ; AIE2P-NEXT:   [[COPY:%[0-9]+]]:er = COPY $r6
+  ; AIE2P-NEXT:   [[COPY1:%[0-9]+]]:er = COPY $r7
+  ; AIE2P-NEXT:   [[LTU:%[0-9]+]]:er = LTU [[COPY]], [[COPY1]]
+  ; AIE2P-NEXT:   [[MOV_RLC_imm11_pseudo:%[0-9]+]]:er = MOV_RLC_imm11_pseudo 1
+  ; AIE2P-NEXT:   [[XOR:%[0-9]+]]:er = XOR [[LTU]], [[MOV_RLC_imm11_pseudo]]
+  ; AIE2P-NEXT:   PseudoJNZ [[XOR]], %bb.2
+  ; AIE2P-NEXT: {{  $}}
+  ; AIE2P-NEXT: bb.1:
+  ; AIE2P-NEXT:   successors: %bb.2(0x80000000)
+  ; AIE2P-NEXT: {{  $}}
+  ; AIE2P-NEXT: bb.2:
+  ;
+  ; AIE2PS-LABEL: name: brcond_xor_icmp_ult
+  ; AIE2PS: bb.0:
+  ; AIE2PS-NEXT:   successors: %bb.1(0x40000000), %bb.2(0x40000000)
+  ; AIE2PS-NEXT: {{  $}}
+  ; AIE2PS-NEXT:   [[COPY:%[0-9]+]]:mlockid_reg = COPY $r6
+  ; AIE2PS-NEXT:   [[COPY1:%[0-9]+]]:mlockid_reg = COPY $r7
+  ; AIE2PS-NEXT:   [[LTU:%[0-9]+]]:mlockid_reg = LTU [[COPY]], [[COPY1]]
+  ; AIE2PS-NEXT:   [[MOV_RLC_imm11_pseudo:%[0-9]+]]:mlockid_reg = MOV_RLC_imm11_pseudo 1
+  ; AIE2PS-NEXT:   [[XOR:%[0-9]+]]:mlockid_reg = XOR [[LTU]], [[MOV_RLC_imm11_pseudo]]
+  ; AIE2PS-NEXT:   PseudoJNZ [[XOR]], %bb.2
+  ; AIE2PS-NEXT: {{  $}}
+  ; AIE2PS-NEXT: bb.1:
+  ; AIE2PS-NEXT:   successors: %bb.2(0x80000000)
+  ; AIE2PS-NEXT: {{  $}}
+  ; AIE2PS-NEXT: bb.2:
+  bb.0:
+    successors: %bb.1, %bb.2
+    %0:gprregbank(s32) = COPY $r6
+    %1:gprregbank(s32) = COPY $r7
+    %2:gprregbank(s32) = G_ICMP intpred(ult), %0, %1
+    %3:gprregbank(s32) = G_CONSTANT i32 1
+    %4:gprregbank(s32) = G_XOR %2, %3
+    G_BRCOND %4, %bb.2
+
+  bb.1:
+
+  bb.2:
+...
+
+---
+name:            brcond_xor_icmp_uge
+legalized:       true
+regBankSelected: true
+
+body: |
+  ; AIE-LABEL: name: brcond_xor_icmp_uge
+  ; AIE: bb.0:
+  ; AIE-NEXT:   successors: %bb.1(0x40000000), %bb.2(0x40000000)
+  ; AIE-NEXT: {{  $}}
+  ; AIE-NEXT:   [[COPY:%[0-9]+]]:gpr = COPY $r6
+  ; AIE-NEXT:   [[COPY1:%[0-9]+]]:gpr = COPY $r7
+  ; AIE-NEXT:   [[GEU:%[0-9]+]]:gpr = GEU [[COPY]], [[COPY1]]
+  ; AIE-NEXT:   [[MOV_U20_:%[0-9]+]]:gpr = MOV_U20 1
+  ; AIE-NEXT:   [[XOR:%[0-9]+]]:gpr = XOR [[GEU]], [[MOV_U20_]]
+  ; AIE-NEXT:   BNEZ [[XOR]], %bb.2
+  ; AIE-NEXT: {{  $}}
+  ; AIE-NEXT: bb.1:
+  ; AIE-NEXT:   successors: %bb.2(0x80000000)
+  ; AIE-NEXT: {{  $}}
+  ; AIE-NEXT: bb.2:
+  ;
+  ; AIE2-LABEL: name: brcond_xor_icmp_uge
+  ; AIE2: bb.0:
+  ; AIE2-NEXT:   successors: %bb.1(0x40000000), %bb.2(0x40000000)
+  ; AIE2-NEXT: {{  $}}
+  ; AIE2-NEXT:   [[COPY:%[0-9]+]]:er = COPY $r6
+  ; AIE2-NEXT:   [[COPY1:%[0-9]+]]:er = COPY $r7
+  ; AIE2-NEXT:   [[GEU:%[0-9]+]]:er = GEU [[COPY]], [[COPY1]]
+  ; AIE2-NEXT:   [[MOV_RLC_imm10_pseudo:%[0-9]+]]:er = MOV_RLC_imm10_pseudo 1
+  ; AIE2-NEXT:   [[XOR:%[0-9]+]]:er = XOR [[GEU]], [[MOV_RLC_imm10_pseudo]]
+  ; AIE2-NEXT:   PseudoJNZ [[XOR]], %bb.2
+  ; AIE2-NEXT: {{  $}}
+  ; AIE2-NEXT: bb.1:
+  ; AIE2-NEXT:   successors: %bb.2(0x80000000)
+  ; AIE2-NEXT: {{  $}}
+  ; AIE2-NEXT: bb.2:
+  ;
+  ; AIE2P-LABEL: name: brcond_xor_icmp_uge
+  ; AIE2P: bb.0:
+  ; AIE2P-NEXT:   successors: %bb.1(0x40000000), %bb.2(0x40000000)
+  ; AIE2P-NEXT: {{  $}}
+  ; AIE2P-NEXT:   [[COPY:%[0-9]+]]:er = COPY $r6
+  ; AIE2P-NEXT:   [[COPY1:%[0-9]+]]:er = COPY $r7
+  ; AIE2P-NEXT:   [[GEU:%[0-9]+]]:er = GEU [[COPY]], [[COPY1]]
+  ; AIE2P-NEXT:   [[MOV_RLC_imm11_pseudo:%[0-9]+]]:er = MOV_RLC_imm11_pseudo 1
+  ; AIE2P-NEXT:   [[XOR:%[0-9]+]]:er = XOR [[GEU]], [[MOV_RLC_imm11_pseudo]]
+  ; AIE2P-NEXT:   PseudoJNZ [[XOR]], %bb.2
+  ; AIE2P-NEXT: {{  $}}
+  ; AIE2P-NEXT: bb.1:
+  ; AIE2P-NEXT:   successors: %bb.2(0x80000000)
+  ; AIE2P-NEXT: {{  $}}
+  ; AIE2P-NEXT: bb.2:
+  ;
+  ; AIE2PS-LABEL: name: brcond_xor_icmp_uge
+  ; AIE2PS: bb.0:
+  ; AIE2PS-NEXT:   successors: %bb.1(0x40000000), %bb.2(0x40000000)
+  ; AIE2PS-NEXT: {{  $}}
+  ; AIE2PS-NEXT:   [[COPY:%[0-9]+]]:mlockid_reg = COPY $r6
+  ; AIE2PS-NEXT:   [[COPY1:%[0-9]+]]:mlockid_reg = COPY $r7
+  ; AIE2PS-NEXT:   [[GEU:%[0-9]+]]:mlockid_reg = GEU [[COPY]], [[COPY1]]
+  ; AIE2PS-NEXT:   [[MOV_RLC_imm11_pseudo:%[0-9]+]]:mlockid_reg = MOV_RLC_imm11_pseudo 1
+  ; AIE2PS-NEXT:   [[XOR:%[0-9]+]]:mlockid_reg = XOR [[GEU]], [[MOV_RLC_imm11_pseudo]]
+  ; AIE2PS-NEXT:   PseudoJNZ [[XOR]], %bb.2
+  ; AIE2PS-NEXT: {{  $}}
+  ; AIE2PS-NEXT: bb.1:
+  ; AIE2PS-NEXT:   successors: %bb.2(0x80000000)
+  ; AIE2PS-NEXT: {{  $}}
+  ; AIE2PS-NEXT: bb.2:
+  bb.0:
+    successors: %bb.1, %bb.2
+    %0:gprregbank(s32) = COPY $r6
+    %1:gprregbank(s32) = COPY $r7
+    %2:gprregbank(s32) = G_ICMP intpred(uge), %0, %1
+    %3:gprregbank(s32) = G_CONSTANT i32 1
+    %4:gprregbank(s32) = G_XOR %2, %3
+    G_BRCOND %4, %bb.2
+
+  bb.1:
+
+  bb.2:
+...
+
+---
+name:            brcond_xor_icmp_ugt
+legalized:       true
+regBankSelected: true
+
+body: |
+  ; AIE-LABEL: name: brcond_xor_icmp_ugt
+  ; AIE: bb.0:
+  ; AIE-NEXT:   successors: %bb.1(0x40000000), %bb.2(0x40000000)
+  ; AIE-NEXT: {{  $}}
+  ; AIE-NEXT:   [[COPY:%[0-9]+]]:gpr = COPY $r6
+  ; AIE-NEXT:   [[COPY1:%[0-9]+]]:gpr = COPY $r7
+  ; AIE-NEXT:   [[LTU:%[0-9]+]]:gpr = LTU [[COPY1]], [[COPY]]
+  ; AIE-NEXT:   [[MOV_U20_:%[0-9]+]]:gpr = MOV_U20 1
+  ; AIE-NEXT:   [[XOR:%[0-9]+]]:gpr = XOR [[LTU]], [[MOV_U20_]]
+  ; AIE-NEXT:   BNEZ [[XOR]], %bb.2
+  ; AIE-NEXT: {{  $}}
+  ; AIE-NEXT: bb.1:
+  ; AIE-NEXT:   successors: %bb.2(0x80000000)
+  ; AIE-NEXT: {{  $}}
+  ; AIE-NEXT: bb.2:
+  ;
+  ; AIE2-LABEL: name: brcond_xor_icmp_ugt
+  ; AIE2: bb.0:
+  ; AIE2-NEXT:   successors: %bb.1(0x40000000), %bb.2(0x40000000)
+  ; AIE2-NEXT: {{  $}}
+  ; AIE2-NEXT:   [[COPY:%[0-9]+]]:er = COPY $r6
+  ; AIE2-NEXT:   [[COPY1:%[0-9]+]]:er = COPY $r7
+  ; AIE2-NEXT:   [[LTU:%[0-9]+]]:er = LTU [[COPY1]], [[COPY]]
+  ; AIE2-NEXT:   [[MOV_RLC_imm10_pseudo:%[0-9]+]]:er = MOV_RLC_imm10_pseudo 1
+  ; AIE2-NEXT:   [[XOR:%[0-9]+]]:er = XOR [[LTU]], [[MOV_RLC_imm10_pseudo]]
+  ; AIE2-NEXT:   PseudoJNZ [[XOR]], %bb.2
+  ; AIE2-NEXT: {{  $}}
+  ; AIE2-NEXT: bb.1:
+  ; AIE2-NEXT:   successors: %bb.2(0x80000000)
+  ; AIE2-NEXT: {{  $}}
+  ; AIE2-NEXT: bb.2:
+  ;
+  ; AIE2P-LABEL: name: brcond_xor_icmp_ugt
+  ; AIE2P: bb.0:
+  ; AIE2P-NEXT:   successors: %bb.1(0x40000000), %bb.2(0x40000000)
+  ; AIE2P-NEXT: {{  $}}
+  ; AIE2P-NEXT:   [[COPY:%[0-9]+]]:er = COPY $r6
+  ; AIE2P-NEXT:   [[COPY1:%[0-9]+]]:er = COPY $r7
+  ; AIE2P-NEXT:   [[LTU:%[0-9]+]]:er = LTU [[COPY1]], [[COPY]]
+  ; AIE2P-NEXT:   [[MOV_RLC_imm11_pseudo:%[0-9]+]]:er = MOV_RLC_imm11_pseudo 1
+  ; AIE2P-NEXT:   [[XOR:%[0-9]+]]:er = XOR [[LTU]], [[MOV_RLC_imm11_pseudo]]
+  ; AIE2P-NEXT:   PseudoJNZ [[XOR]], %bb.2
+  ; AIE2P-NEXT: {{  $}}
+  ; AIE2P-NEXT: bb.1:
+  ; AIE2P-NEXT:   successors: %bb.2(0x80000000)
+  ; AIE2P-NEXT: {{  $}}
+  ; AIE2P-NEXT: bb.2:
+  ;
+  ; AIE2PS-LABEL: name: brcond_xor_icmp_ugt
+  ; AIE2PS: bb.0:
+  ; AIE2PS-NEXT:   successors: %bb.1(0x40000000), %bb.2(0x40000000)
+  ; AIE2PS-NEXT: {{  $}}
+  ; AIE2PS-NEXT:   [[COPY:%[0-9]+]]:mlockid_reg = COPY $r6
+  ; AIE2PS-NEXT:   [[COPY1:%[0-9]+]]:mlockid_reg = COPY $r7
+  ; AIE2PS-NEXT:   [[LTU:%[0-9]+]]:mlockid_reg = LTU [[COPY1]], [[COPY]]
+  ; AIE2PS-NEXT:   [[MOV_RLC_imm11_pseudo:%[0-9]+]]:mlockid_reg = MOV_RLC_imm11_pseudo 1
+  ; AIE2PS-NEXT:   [[XOR:%[0-9]+]]:mlockid_reg = XOR [[LTU]], [[MOV_RLC_imm11_pseudo]]
+  ; AIE2PS-NEXT:   PseudoJNZ [[XOR]], %bb.2
+  ; AIE2PS-NEXT: {{  $}}
+  ; AIE2PS-NEXT: bb.1:
+  ; AIE2PS-NEXT:   successors: %bb.2(0x80000000)
+  ; AIE2PS-NEXT: {{  $}}
+  ; AIE2PS-NEXT: bb.2:
+  bb.0:
+    successors: %bb.1, %bb.2
+    %0:gprregbank(s32) = COPY $r6
+    %1:gprregbank(s32) = COPY $r7
+    %2:gprregbank(s32) = G_ICMP intpred(ugt), %0, %1
+    %3:gprregbank(s32) = G_CONSTANT i32 1
+    %4:gprregbank(s32) = G_XOR %2, %3
+    G_BRCOND %4, %bb.2
+
+  bb.1:
+
+  bb.2:
+...
+
+---
+name:            brcond_xor_icmp_ule
+legalized:       true
+regBankSelected: true
+
+body: |
+  ; AIE-LABEL: name: brcond_xor_icmp_ule
+  ; AIE: bb.0:
+  ; AIE-NEXT:   successors: %bb.1(0x40000000), %bb.2(0x40000000)
+  ; AIE-NEXT: {{  $}}
+  ; AIE-NEXT:   [[COPY:%[0-9]+]]:gpr = COPY $r6
+  ; AIE-NEXT:   [[COPY1:%[0-9]+]]:gpr = COPY $r7
+  ; AIE-NEXT:   [[GEU:%[0-9]+]]:gpr = GEU [[COPY1]], [[COPY]]
+  ; AIE-NEXT:   [[MOV_U20_:%[0-9]+]]:gpr = MOV_U20 1
+  ; AIE-NEXT:   [[XOR:%[0-9]+]]:gpr = XOR [[GEU]], [[MOV_U20_]]
+  ; AIE-NEXT:   BNEZ [[XOR]], %bb.2
+  ; AIE-NEXT: {{  $}}
+  ; AIE-NEXT: bb.1:
+  ; AIE-NEXT:   successors: %bb.2(0x80000000)
+  ; AIE-NEXT: {{  $}}
+  ; AIE-NEXT: bb.2:
+  ;
+  ; AIE2-LABEL: name: brcond_xor_icmp_ule
+  ; AIE2: bb.0:
+  ; AIE2-NEXT:   successors: %bb.1(0x40000000), %bb.2(0x40000000)
+  ; AIE2-NEXT: {{  $}}
+  ; AIE2-NEXT:   [[COPY:%[0-9]+]]:er = COPY $r6
+  ; AIE2-NEXT:   [[COPY1:%[0-9]+]]:er = COPY $r7
+  ; AIE2-NEXT:   [[GEU:%[0-9]+]]:er = GEU [[COPY1]], [[COPY]]
+  ; AIE2-NEXT:   [[MOV_RLC_imm10_pseudo:%[0-9]+]]:er = MOV_RLC_imm10_pseudo 1
+  ; AIE2-NEXT:   [[XOR:%[0-9]+]]:er = XOR [[GEU]], [[MOV_RLC_imm10_pseudo]]
+  ; AIE2-NEXT:   PseudoJNZ [[XOR]], %bb.2
+  ; AIE2-NEXT: {{  $}}
+  ; AIE2-NEXT: bb.1:
+  ; AIE2-NEXT:   successors: %bb.2(0x80000000)
+  ; AIE2-NEXT: {{  $}}
+  ; AIE2-NEXT: bb.2:
+  ;
+  ; AIE2P-LABEL: name: brcond_xor_icmp_ule
+  ; AIE2P: bb.0:
+  ; AIE2P-NEXT:   successors: %bb.1(0x40000000), %bb.2(0x40000000)
+  ; AIE2P-NEXT: {{  $}}
+  ; AIE2P-NEXT:   [[COPY:%[0-9]+]]:er = COPY $r6
+  ; AIE2P-NEXT:   [[COPY1:%[0-9]+]]:er = COPY $r7
+  ; AIE2P-NEXT:   [[GEU:%[0-9]+]]:er = GEU [[COPY1]], [[COPY]]
+  ; AIE2P-NEXT:   [[MOV_RLC_imm11_pseudo:%[0-9]+]]:er = MOV_RLC_imm11_pseudo 1
+  ; AIE2P-NEXT:   [[XOR:%[0-9]+]]:er = XOR [[GEU]], [[MOV_RLC_imm11_pseudo]]
+  ; AIE2P-NEXT:   PseudoJNZ [[XOR]], %bb.2
+  ; AIE2P-NEXT: {{  $}}
+  ; AIE2P-NEXT: bb.1:
+  ; AIE2P-NEXT:   successors: %bb.2(0x80000000)
+  ; AIE2P-NEXT: {{  $}}
+  ; AIE2P-NEXT: bb.2:
+  ;
+  ; AIE2PS-LABEL: name: brcond_xor_icmp_ule
+  ; AIE2PS: bb.0:
+  ; AIE2PS-NEXT:   successors: %bb.1(0x40000000), %bb.2(0x40000000)
+  ; AIE2PS-NEXT: {{  $}}
+  ; AIE2PS-NEXT:   [[COPY:%[0-9]+]]:mlockid_reg = COPY $r6
+  ; AIE2PS-NEXT:   [[COPY1:%[0-9]+]]:mlockid_reg = COPY $r7
+  ; AIE2PS-NEXT:   [[GEU:%[0-9]+]]:mlockid_reg = GEU [[COPY1]], [[COPY]]
+  ; AIE2PS-NEXT:   [[MOV_RLC_imm11_pseudo:%[0-9]+]]:mlockid_reg = MOV_RLC_imm11_pseudo 1
+  ; AIE2PS-NEXT:   [[XOR:%[0-9]+]]:mlockid_reg = XOR [[GEU]], [[MOV_RLC_imm11_pseudo]]
+  ; AIE2PS-NEXT:   PseudoJNZ [[XOR]], %bb.2
+  ; AIE2PS-NEXT: {{  $}}
+  ; AIE2PS-NEXT: bb.1:
+  ; AIE2PS-NEXT:   successors: %bb.2(0x80000000)
+  ; AIE2PS-NEXT: {{  $}}
+  ; AIE2PS-NEXT: bb.2:
+  bb.0:
+    successors: %bb.1, %bb.2
+    %0:gprregbank(s32) = COPY $r6
+    %1:gprregbank(s32) = COPY $r7
+    %2:gprregbank(s32) = G_ICMP intpred(ule), %0, %1
+    %3:gprregbank(s32) = G_CONSTANT i32 1
+    %4:gprregbank(s32) = G_XOR %2, %3
+    G_BRCOND %4, %bb.2
+
+  bb.1:
+
+  bb.2:
+...
+
+---
+name:            brcond_xor_non_boolean
+legalized:       true
+regBankSelected: true
+
+body: |
+  ; AIE-LABEL: name: brcond_xor_non_boolean
+  ; AIE: bb.0:
+  ; AIE-NEXT:   successors: %bb.1(0x40000000), %bb.2(0x40000000)
+  ; AIE-NEXT: {{  $}}
+  ; AIE-NEXT:   [[COPY:%[0-9]+]]:gpr = COPY $r6
+  ; AIE-NEXT:   [[MOV_U20_:%[0-9]+]]:gpr = MOV_U20 1
+  ; AIE-NEXT:   [[XOR:%[0-9]+]]:gpr = XOR [[COPY]], [[MOV_U20_]]
+  ; AIE-NEXT:   BNEZ [[XOR]], %bb.2
+  ; AIE-NEXT: {{  $}}
+  ; AIE-NEXT: bb.1:
+  ; AIE-NEXT:   successors: %bb.2(0x80000000)
+  ; AIE-NEXT: {{  $}}
+  ; AIE-NEXT: bb.2:
+  ;
+  ; AIE2-LABEL: name: brcond_xor_non_boolean
+  ; AIE2: bb.0:
+  ; AIE2-NEXT:   successors: %bb.1(0x40000000), %bb.2(0x40000000)
+  ; AIE2-NEXT: {{  $}}
+  ; AIE2-NEXT:   [[COPY:%[0-9]+]]:er = COPY $r6
+  ; AIE2-NEXT:   [[MOV_RLC_imm10_pseudo:%[0-9]+]]:er = MOV_RLC_imm10_pseudo 1
+  ; AIE2-NEXT:   [[XOR:%[0-9]+]]:er = XOR [[COPY]], [[MOV_RLC_imm10_pseudo]]
+  ; AIE2-NEXT:   PseudoJNZ [[XOR]], %bb.2
+  ; AIE2-NEXT: {{  $}}
+  ; AIE2-NEXT: bb.1:
+  ; AIE2-NEXT:   successors: %bb.2(0x80000000)
+  ; AIE2-NEXT: {{  $}}
+  ; AIE2-NEXT: bb.2:
+  ;
+  ; AIE2P-LABEL: name: brcond_xor_non_boolean
+  ; AIE2P: bb.0:
+  ; AIE2P-NEXT:   successors: %bb.1(0x40000000), %bb.2(0x40000000)
+  ; AIE2P-NEXT: {{  $}}
+  ; AIE2P-NEXT:   [[COPY:%[0-9]+]]:er = COPY $r6
+  ; AIE2P-NEXT:   [[MOV_RLC_imm11_pseudo:%[0-9]+]]:er = MOV_RLC_imm11_pseudo 1
+  ; AIE2P-NEXT:   [[XOR:%[0-9]+]]:er = XOR [[COPY]], [[MOV_RLC_imm11_pseudo]]
+  ; AIE2P-NEXT:   PseudoJNZ [[XOR]], %bb.2
+  ; AIE2P-NEXT: {{  $}}
+  ; AIE2P-NEXT: bb.1:
+  ; AIE2P-NEXT:   successors: %bb.2(0x80000000)
+  ; AIE2P-NEXT: {{  $}}
+  ; AIE2P-NEXT: bb.2:
+  ;
+  ; AIE2PS-LABEL: name: brcond_xor_non_boolean
+  ; AIE2PS: bb.0:
+  ; AIE2PS-NEXT:   successors: %bb.1(0x40000000), %bb.2(0x40000000)
+  ; AIE2PS-NEXT: {{  $}}
+  ; AIE2PS-NEXT:   [[COPY:%[0-9]+]]:mlockid_reg = COPY $r6
+  ; AIE2PS-NEXT:   [[MOV_RLC_imm11_pseudo:%[0-9]+]]:mlockid_reg = MOV_RLC_imm11_pseudo 1
+  ; AIE2PS-NEXT:   [[XOR:%[0-9]+]]:mlockid_reg = XOR [[COPY]], [[MOV_RLC_imm11_pseudo]]
+  ; AIE2PS-NEXT:   PseudoJNZ [[XOR]], %bb.2
+  ; AIE2PS-NEXT: {{  $}}
+  ; AIE2PS-NEXT: bb.1:
+  ; AIE2PS-NEXT:   successors: %bb.2(0x80000000)
+  ; AIE2PS-NEXT: {{  $}}
+  ; AIE2PS-NEXT: bb.2:
+  bb.0:
+    successors: %bb.1, %bb.2
+    %0:gprregbank(s32) = COPY $r6
+    %1:gprregbank(s32) = G_CONSTANT i32 1
+    %2:gprregbank(s32) = G_XOR %0, %1
+    G_BRCOND %2, %bb.2
+
+  bb.1:
+
+  bb.2:
 ...


### PR DESCRIPTION
The existing GlobalISel `matchNotCmp` combine tries to pull the negation into the icmp itself. However, if the icmp has other users, it bails out.
Here, we look for such remaining negation patterns, and pull them into the conditional branch itself