### PR TITLE
[AIE] Post-RA scheduler: fix scoreboard init order, exploit negative latencies, and improve top/bottom-up handoff

### DIFF
--- a/llvm/lib/Target/AIE/AIEMachineScheduler.cpp
+++ b/llvm/lib/Target/AIE/AIEMachineScheduler.cpp
@@ -565,7 +565,8 @@ SUnit *AIEPostRASchedStrategy::pickNodeAndCycle(
 }
 
 int AIEPostRASchedStrategy::getMaxDeltaCycles(const SchedBoundary &Zone) const {
-  // Top-down scheduling does not support DeltaCycles
+  // DeltaCycles for top-down are handled directly in isAvailableNode via the
+  // TopReadyCycle loop; this function only governs the bottom-up delta window.
   if (Zone.isTop() || Zone.getCurrCycle() >= RegionBottomUpCycles - 1)
     return 0;
   return std::min({int(RegionBottomUpCycles - 1 - Zone.getCurrCycle()),
@@ -1429,6 +1430,32 @@ void AIEScheduleDAGMI::releasePred(SUnit *SU, SDep *PredEdge) {
   --PredSU->NumSuccsLeft;
   if (PredSU->NumSuccsLeft == 0 && PredSU != &EntrySU)
     SchedImpl->releaseBottomNode(PredSU);
+}
+
+void AIEScheduleDAGMI::releaseSucc(SUnit *SU, SDep *SuccEdge) {
+
+  if (SuccEdge->isWeak())
+    return ScheduleDAGMI::releaseSucc(SU, SuccEdge);
+
+  // Update the ready cycle of SU's successor. When AllowNegativeLatencies is
+  // enabled, use the signed latency so that a successor with a negative-latency
+  // edge can be scheduled in a cycle earlier than SU->TopReadyCycle + latency.
+  // This is the top-down counterpart of the negative-latency handling in
+  // releasePred: just as a predecessor can be pulled closer to its consumer
+  // (bottom-up), a successor can be pulled closer to its producer (top-down).
+  SUnit *SuccSU = SuccEdge->getSUnit();
+  const int Latency = AllowNegativeLatencies ? SuccEdge->getSignedLatency()
+                                             : (int)SuccEdge->getLatency();
+  // Use signed arithmetic to correctly handle negative latencies. The result
+  // is clamped to zero since TopReadyCycle is unsigned and a negative ready
+  // cycle has no meaning (the instruction is ready from the very first cycle).
+  const int NewReadyCycle = int(SU->TopReadyCycle) + Latency;
+  if (NewReadyCycle > int(SuccSU->TopReadyCycle))
+    SuccSU->TopReadyCycle = NewReadyCycle;
+
+  --SuccSU->NumPredsLeft;
+  if (SuccSU->NumPredsLeft == 0 && SuccSU != &ExitSU)
+    SchedImpl->releaseTopNode(SuccSU);
 }
 
 AIEPreRASchedStrategy *AIEScheduleDAGMILive::getSchedImpl() const {

--- a/llvm/lib/Target/AIE/AIEMachineScheduler.cpp
+++ b/llvm/lib/Target/AIE/AIEMachineScheduler.cpp
@@ -494,9 +494,26 @@ bool AIEPostRASchedStrategy::mustSwitchToBottomUp() {
 
   // We must switch when we have an empty AQ and instructions that cannot
   // progress in the PQ.
-  return AQ.size() == 0 && all_of(PQ, [&](const SUnit *SU) {
-           return doesNotProgressInZone(Zone, *SU);
-         });
+  if (AQ.size() == 0 && all_of(PQ, [&](const SUnit *SU) {
+        return doesNotProgressInZone(Zone, *SU);
+      }))
+    return true;
+
+  // Also switch when the AQ is empty and all progressable pending instructions
+  // would only become ready at a cycle >= RegionTopDownCycles (i.e., beyond
+  // the top-fixed bundle region). Scheduling them top-down would waste cycles
+  // and push anti-dependent instructions into the bottom zone as standalone
+  // instructions, degrading bundle packing.
+  if (RegionTopDownCycles && AQ.size() == 0) {
+    for (const SUnit *SU : PQ) {
+      if (!doesNotProgressInZone(Zone, *SU) &&
+          SU->TopReadyCycle < RegionTopDownCycles)
+        return false;
+    }
+    return true;
+  }
+
+  return false;
 }
 
 SUnit *AIEPostRASchedStrategy::pickNodeAndCycle(

--- a/llvm/lib/Target/AIE/AIEMachineScheduler.cpp
+++ b/llvm/lib/Target/AIE/AIEMachineScheduler.cpp
@@ -375,23 +375,14 @@ void AIEPostRASchedStrategy::initializeTopScoreBoard() {
 
   const unsigned ConflictHorizon = TopHazardRec->getConflictHorizon();
   ArrayRef<MachineBundle> LoopBundles = EpilogueContextOpt->Loop;
-  const unsigned LoopCount = EpilogueContextOpt->LoopCount;
   const unsigned LoopSize = LoopBundles.size();
 
-  int BlockedCycles = 0;
-  int LoopReplayTimes = 0;
+  // ceil(LoopSize / ConflictHorizon)
+  const int LoopReplayTimes =
+      (LoopSize + ConflictHorizon - 1) / ConflictHorizon;
 
-  // If we can get a full horizon of pipeline conflicts, go for it,
-  // otherwise, stick to the min iteration count and block some cycles.
-  const unsigned LastGuaranteedLoopCycles = LoopCount * LoopSize;
-  if (LastGuaranteedLoopCycles < ConflictHorizon) {
-    BlockedCycles = ConflictHorizon - LastGuaranteedLoopCycles;
-    LoopReplayTimes = LoopCount;
-  } else {
-    LoopReplayTimes = (ConflictHorizon + (LoopSize - 1)) / LoopSize;
-  }
-
-  // Replay SWP loop enough times.
+  // Replay SWP loop enough times (right before the epilogue) until the
+  // scoreboard reaches a steady state.
   for (int I = 0; I < LoopReplayTimes; I++) {
     for (auto &Bundle : LoopBundles) {
       for (MachineInstr *MI : Bundle.getInstrs()) {
@@ -399,17 +390,6 @@ void AIEPostRASchedStrategy::initializeTopScoreBoard() {
       }
       TopHazardRec->AdvanceCycle();
     }
-  }
-
-  // Block cycles, if needed.
-  for (int I = 0; I < BlockedCycles; ++I) {
-    TopHazardRec->blockCycleInScoreboard(0);
-    TopHazardRec->AdvanceCycle();
-  }
-
-  // Receed to the starting point.
-  for (int I = 0; I < BlockedCycles; ++I) {
-    TopHazardRec->RecedeCycle();
   }
 
   DEBUG_BLOCKS(TopHazardRec->dumpScoreboard());

--- a/llvm/lib/Target/AIE/AIEMachineScheduler.h
+++ b/llvm/lib/Target/AIE/AIEMachineScheduler.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// (c) Copyright 2023-2025 Advanced Micro Devices, Inc. or its affiliates
+// (c) Copyright 2023-2026 Advanced Micro Devices, Inc. or its affiliates
 //
 //===----------------------------------------------------------------------===//
 //
@@ -268,6 +268,7 @@ public:
 
 protected:
   void releasePred(SUnit *SU, SDep *PredEdge) override;
+  void releaseSucc(SUnit *SU, SDep *SuccEdge) override;
 };
 
 /// Similar to AIEScheduleDAGMI but for ScheduleDAGMILive.

--- a/llvm/test/CodeGen/AIE/aie2/lit.local.cfg
+++ b/llvm/test/CodeGen/AIE/aie2/lit.local.cfg
@@ -4,12 +4,15 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2023-2024 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2023-2026 Advanced Micro Devices, Inc. or its affiliates
 import os
 
 config.substitutions.insert(0, ('%last-mi-pass', 'machinemoduleinfo'))
-config.substitutions.insert(0, ('%topdown-single', '--issue-limit=1 --aie-bottomup-cycles=0'))
-config.substitutions.insert(0, ('%topdown-multi', '--issue-limit=6 --aie-bottomup-cycles=0'))
+config.substitutions.insert(0, ('%topdown-single', '--issue-limit=1 --aie-bottomup-cycles=0 --aie-negative-latencies=false'))
+config.substitutions.insert(0, ('%topdown-single-negative-lat', '--issue-limit=1 --aie-bottomup-cycles=0'))
+config.substitutions.insert(0, ('%topdown-multi', '--issue-limit=6 --aie-bottomup-cycles=0 --aie-negative-latencies=false'))
+config.substitutions.insert(0, ('%topdown-multi-negative-lat', '--issue-limit=6 --aie-bottomup-cycles=0'))
+
 
 imisched_path = os.path.join(config.llvm_src_root, 'utils', 'imisched.py')
 config.substitutions.insert(0, ('%imisched', f"{config.python_executable} {imisched_path}"))

--- a/llvm/test/CodeGen/AIE/aie2/schedule/divs.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/divs.mir
@@ -4,8 +4,9 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2023-2024 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2023-2026 Advanced Micro Devices, Inc. or its affiliates
 # RUN: llc -mtriple=aie2 -run-pass=postmisched %topdown-multi %s -o - | FileCheck %s
+# RUN: llc -mtriple=aie2 -run-pass=postmisched %topdown-multi-negative-lat %s -o - | FileCheck %s --check-prefix=CHECK-NEG-LAT
 
 ---
 name:            test_inputs
@@ -45,6 +46,19 @@ body:             |
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: $r12, $r31 = DIVS killed $r31, killed $r0, killed $r2
+    ; CHECK-NEG-LAT-LABEL: name: test_inputs
+    ; CHECK-NEG-LAT: liveins: $r0, $r2, $r12, $r31, $p1
+    ; CHECK-NEG-LAT-NEXT: {{  $}}
+    ; CHECK-NEG-LAT: $r31 = LDA_dms_lda_idx_imm $p1, 0
+    ; CHECK-NEG-LAT-NEXT: $r0 = LDA_dms_lda_idx_imm $p1, 4
+    ; CHECK-NEG-LAT-NEXT: $r2 = LDA_dms_lda_idx_imm killed $p1, 8
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: $r12, $r31 = DIVS killed $r31, $r0, $r2
+    ; CHECK-NEG-LAT-NEXT: $r12, $r31 = DIVS killed $r31, $r0, $r2
+    ; CHECK-NEG-LAT-NEXT: $r12, $r31 = DIVS killed $r31, killed $r0, killed $r2
     $r31 = LDA_dms_lda_idx_imm $p1, 0
     $r12, $r31 = DIVS  $r31, $r0, $r2
     $r0 = LDA_dms_lda_idx_imm $p1, 4
@@ -71,6 +85,16 @@ body:             |
     ; CHECK-NEXT: }
     ; CHECK-NEXT: ST_dms_sts_idx_imm killed $r31, killed $p1, 0
     ; CHECK-NEXT: NOP
+    ; CHECK-NEG-LAT-LABEL: name: test_outputs
+    ; CHECK-NEG-LAT: liveins: $r0, $r2, $r12, $r31, $p1
+    ; CHECK-NEG-LAT-NEXT: {{  $}}
+    ; CHECK-NEG-LAT: $r12, $r31 = DIVS killed $r31, $r0, $r2
+    ; CHECK-NEG-LAT-NEXT: BUNDLE implicit-def $r12, implicit-def $r31, implicit killed $r12, implicit $p1, implicit killed $r31, implicit killed $r0, implicit killed $r2 {
+    ; CHECK-NEG-LAT-NEXT: ST_dms_sts_idx_imm killed $r12, $p1, 0
+    ; CHECK-NEG-LAT-NEXT: $r12, $r31 = DIVS killed $r31, killed $r0, killed $r2
+    ; CHECK-NEG-LAT-NEXT: }
+    ; CHECK-NEG-LAT-NEXT: ST_dms_sts_idx_imm killed $r31, killed $p1, 0
+    ; CHECK-NEG-LAT-NEXT: NOP
     $r12, $r31 = DIVS  $r31, $r0, $r2
     ST_dms_sts_idx_imm $r12, $p1, 0
     $r12, $r31 = DIVS  $r31, $r0, $r2

--- a/llvm/test/CodeGen/AIE/aie2/schedule/memory_dependencies_st.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/memory_dependencies_st.mir
@@ -4,8 +4,9 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2023-2024 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2023-2026 Advanced Micro Devices, Inc. or its affiliates
 # RUN: llc -march=aie2 -run-pass=postmisched %topdown-multi %s -o - | FileCheck %s
+# RUN: llc -march=aie2 -run-pass=postmisched %topdown-multi-negative-lat %s -o - | FileCheck %s --check-prefix=CHECK-NEG-LAT
 
 # This test shows how ordered load/stores are handled.
 # In most cases, we just need to keep them one cycle appart, but for example
@@ -64,6 +65,37 @@ body:             |
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
+    ; CHECK-NEG-LAT-LABEL: name: STORE_E5_LOAD_E5
+    ; CHECK-NEG-LAT: BUNDLE implicit-def $r2, implicit-def $wl2, implicit $p0 {
+    ; CHECK-NEG-LAT-NEXT: $r2 = LDA_dms_lda_idx_imm $p0, 0 :: (load (s32), addrspace 6)
+    ; CHECK-NEG-LAT-NEXT: $wl2 = VLDB_dmw_ldb_ag_idx_imm $p0, 0 :: (load (<8 x s32>), addrspace 5)
+    ; CHECK-NEG-LAT-NEXT: }
+    ; CHECK-NEG-LAT-NEXT: ST_dms_sts_idx_imm $r0, $p0, 0
+    ; CHECK-NEG-LAT-NEXT: BUNDLE implicit-def $r2, implicit-def $wl2, implicit $p0 {
+    ; CHECK-NEG-LAT-NEXT: $r2 = LDA_dms_lda_idx_imm $p0, 0 :: (load (s32), addrspace 6)
+    ; CHECK-NEG-LAT-NEXT: $wl2 = VLDB_dmw_ldb_ag_idx_imm $p0, 0 :: (load (<8 x s32>), addrspace 5)
+    ; CHECK-NEG-LAT-NEXT: }
+    ; CHECK-NEG-LAT-NEXT: $p1 = ST_dms_sts_pstm_nrm_imm $r0, killed $p1, 0
+    ; CHECK-NEG-LAT-NEXT: BUNDLE implicit-def $r2, implicit-def $wl2, implicit $p0 {
+    ; CHECK-NEG-LAT-NEXT: $r2 = LDA_dms_lda_idx_imm $p0, 0 :: (load (s32), addrspace 6)
+    ; CHECK-NEG-LAT-NEXT: $wl2 = VLDB_dmw_ldb_ag_idx_imm $p0, 0 :: (load (<8 x s32>), addrspace 5)
+    ; CHECK-NEG-LAT-NEXT: }
+    ; CHECK-NEG-LAT-NEXT: $p2, $dc0 = ST_2D_dms_sts $r0, killed $p2, killed $d0
+    ; CHECK-NEG-LAT-NEXT: BUNDLE implicit-def $r2, implicit-def $wl2, implicit $p0 {
+    ; CHECK-NEG-LAT-NEXT: $r2 = LDA_dms_lda_idx_imm $p0, 0 :: (load (s32), addrspace 6)
+    ; CHECK-NEG-LAT-NEXT: $wl2 = VLDB_dmw_ldb_ag_idx_imm $p0, 0 :: (load (<8 x s32>), addrspace 5)
+    ; CHECK-NEG-LAT-NEXT: }
+    ; CHECK-NEG-LAT-NEXT: $p3, $dc1, $dc5 = ST_3D_dms_sts killed $r0, killed $p3, killed $d1_3d
+    ; CHECK-NEG-LAT-NEXT: BUNDLE implicit-def $r2, implicit-def $wl2, implicit killed $p0 {
+    ; CHECK-NEG-LAT-NEXT: $r2 = LDA_dms_lda_idx_imm $p0, 0 :: (load (s32), addrspace 6)
+    ; CHECK-NEG-LAT-NEXT: $wl2 = VLDB_dmw_ldb_ag_idx_imm killed $p0, 0 :: (load (<8 x s32>), addrspace 5)
+    ; CHECK-NEG-LAT-NEXT: }
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
     $r2 = LDA_dms_lda_idx_imm $p0, 0 :: (load (s32), addrspace 6)
     $wl2 = VLDB_dmw_ldb_ag_idx_imm $p0, 0 :: (load (<8 x s32>), addrspace 5)
     ST_dms_sts_idx_imm $r0, $p0, 0                 ; II_ST
@@ -98,6 +130,17 @@ body:             |
     ; CHECK-NEXT: $p3, $dc1, $dc5 = ST_3D_dms_sts killed $r0, killed $p3, killed $d1_3d
     ; CHECK-NEXT: ST_dms_sts_idx_imm killed $r2, killed $p0, 0
     ; CHECK-NEXT: NOP
+    ; CHECK-NEG-LAT-LABEL: name: STORE_E5_STORE_E5
+    ; CHECK-NEG-LAT: ST_dms_sts_idx_imm $r2, $p0, 0
+    ; CHECK-NEG-LAT-NEXT: ST_dms_sts_idx_imm $r0, $p0, 0
+    ; CHECK-NEG-LAT-NEXT: ST_dms_sts_idx_imm $r2, $p0, 0
+    ; CHECK-NEG-LAT-NEXT: $p1 = ST_dms_sts_pstm_nrm_imm $r0, killed $p1, 0
+    ; CHECK-NEG-LAT-NEXT: ST_dms_sts_idx_imm $r2, $p0, 0
+    ; CHECK-NEG-LAT-NEXT: $p2, $dc0 = ST_2D_dms_sts $r0, killed $p2, killed $d0
+    ; CHECK-NEG-LAT-NEXT: ST_dms_sts_idx_imm $r2, $p0, 0
+    ; CHECK-NEG-LAT-NEXT: $p3, $dc1, $dc5 = ST_3D_dms_sts killed $r0, killed $p3, killed $d1_3d
+    ; CHECK-NEG-LAT-NEXT: ST_dms_sts_idx_imm killed $r2, killed $p0, 0
+    ; CHECK-NEG-LAT-NEXT: NOP
     ST_dms_sts_idx_imm $r2, $p0, 0
     ST_dms_sts_idx_imm $r0, $p0, 0                 ; II_ST
     ST_dms_sts_idx_imm $r2, $p0, 0
@@ -137,6 +180,19 @@ body:             |
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
+    ; CHECK-NEG-LAT-LABEL: name: STORE_E5_STORE_E7
+    ; CHECK-NEG-LAT: VST_SRS_D8_S32_ag_idx_imm $p0, 0, $cm0, $s0, implicit-def $srsrs_of, implicit $crsat, implicit $crrnd, implicit $crsrssign
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: VST_SRS_D8_S32_ag_idx_imm $p0, 0, $cm0, $s0, implicit-def $srsrs_of, implicit $crsat, implicit $crrnd, implicit $crsrssign
+    ; CHECK-NEG-LAT-NEXT: ST_dms_sts_idx_imm $r0, $p0, 0
+    ; CHECK-NEG-LAT-NEXT: VST_SRS_D8_S32_ag_idx_imm $p0, 0, $cm0, $s0, implicit-def $srsrs_of, implicit $crsat, implicit $crrnd, implicit $crsrssign
+    ; CHECK-NEG-LAT-NEXT: $p1 = ST_dms_sts_pstm_nrm_imm $r0, killed $p1, 0
+    ; CHECK-NEG-LAT-NEXT: VST_SRS_D8_S32_ag_idx_imm $p0, 0, $cm0, $s0, implicit-def $srsrs_of, implicit $crsat, implicit $crrnd, implicit $crsrssign
+    ; CHECK-NEG-LAT-NEXT: $p2, $dc0 = ST_2D_dms_sts $r0, killed $p2, killed $d0
+    ; CHECK-NEG-LAT-NEXT: VST_SRS_D8_S32_ag_idx_imm killed $p0, 0, killed $cm0, killed $s0, implicit-def $srsrs_of, implicit $crsat, implicit $crrnd, implicit $crsrssign
+    ; CHECK-NEG-LAT-NEXT: $p3, $dc1, $dc5 = ST_3D_dms_sts killed $r0, killed $p3, killed $d1_3d
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
     VST_SRS_D8_S32_ag_idx_imm $p0, 0, $cm0, $s0, implicit-def $srsrs_of, implicit $crsat, implicit $crrnd, implicit $crsrssign
     ST_dms_sts_idx_imm $r0, $p0, 0                 ; II_ST
     VST_SRS_D8_S32_ag_idx_imm $p0, 0, $cm0, $s0, implicit-def $srsrs_of, implicit $crsat, implicit $crrnd, implicit $crsrssign
@@ -196,6 +252,47 @@ body:             |
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
+    ; CHECK-NEG-LAT-LABEL: name: STORE_E5_STORE_E11
+    ; CHECK-NEG-LAT: ST_S8_ag_idx_imm $r2, $p0, 0
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: ST_dms_sts_idx_imm $r0, $p0, 0
+    ; CHECK-NEG-LAT-NEXT: ST_S8_ag_idx_imm $r2, $p0, 0
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: $p1 = ST_dms_sts_pstm_nrm_imm $r0, killed $p1, 0
+    ; CHECK-NEG-LAT-NEXT: ST_S8_ag_idx_imm $r2, $p0, 0
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: $p2, $dc0 = ST_2D_dms_sts $r0, killed $p2, killed $d0
+    ; CHECK-NEG-LAT-NEXT: ST_S8_ag_idx_imm $r2, $p0, 0
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: $p3, $dc1, $dc5 = ST_3D_dms_sts killed $r0, killed $p3, killed $d1_3d
+    ; CHECK-NEG-LAT-NEXT: ST_S8_ag_idx_imm killed $r2, killed $p0, 0
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
     ST_S8_ag_idx_imm $r2, $p0, 0
     ST_dms_sts_idx_imm $r0, $p0, 0                 ; II_ST
     ST_S8_ag_idx_imm $r2, $p0, 0

--- a/llvm/test/CodeGen/AIE/aie2/schedule/memory_dependencies_st_q.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/memory_dependencies_st_q.mir
@@ -4,8 +4,9 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2023-2024 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2023-2026 Advanced Micro Devices, Inc. or its affiliates
 # RUN: llc -march=aie2 -run-pass=postmisched %topdown-multi %s -o - | FileCheck %s
+# RUN: llc -march=aie2 -run-pass=postmisched %topdown-multi-negative-lat %s -o - | FileCheck %s --check-prefix=CHECK-NEG-LAT
 
 # This test shows how ordered load/stores are handled.
 # In most cases, we just need to keep them one cycle appart, but for example
@@ -61,6 +62,37 @@ body:             |
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
+    ; CHECK-NEG-LAT-LABEL: name: STORE_E5_LOAD_E5
+    ; CHECK-NEG-LAT: BUNDLE implicit-def $r2, implicit-def $wl2, implicit $p0 {
+    ; CHECK-NEG-LAT-NEXT: $r2 = LDA_dms_lda_idx_imm $p0, 0 :: (load (s32), addrspace 6)
+    ; CHECK-NEG-LAT-NEXT: $wl2 = VLDB_dmw_ldb_ag_idx_imm $p0, 0 :: (load (<8 x s32>), addrspace 5)
+    ; CHECK-NEG-LAT-NEXT: }
+    ; CHECK-NEG-LAT-NEXT: ST_dmv_sts_q_ag_idx_imm $q0, $p0, 0
+    ; CHECK-NEG-LAT-NEXT: BUNDLE implicit-def $r2, implicit-def $wl2, implicit $p0 {
+    ; CHECK-NEG-LAT-NEXT: $r2 = LDA_dms_lda_idx_imm $p0, 0 :: (load (s32), addrspace 6)
+    ; CHECK-NEG-LAT-NEXT: $wl2 = VLDB_dmw_ldb_ag_idx_imm $p0, 0 :: (load (<8 x s32>), addrspace 5)
+    ; CHECK-NEG-LAT-NEXT: }
+    ; CHECK-NEG-LAT-NEXT: $p1 = ST_dmv_sts_q_ag_pstm_nrm_imm $q0, killed $p1, 0
+    ; CHECK-NEG-LAT-NEXT: BUNDLE implicit-def $r2, implicit-def $wl2, implicit $p0 {
+    ; CHECK-NEG-LAT-NEXT: $r2 = LDA_dms_lda_idx_imm $p0, 0 :: (load (s32), addrspace 6)
+    ; CHECK-NEG-LAT-NEXT: $wl2 = VLDB_dmw_ldb_ag_idx_imm $p0, 0 :: (load (<8 x s32>), addrspace 5)
+    ; CHECK-NEG-LAT-NEXT: }
+    ; CHECK-NEG-LAT-NEXT: $p2, $dc0 = ST_2D_dmv_sts_q $q0, killed $p2, killed $d0
+    ; CHECK-NEG-LAT-NEXT: BUNDLE implicit-def $r2, implicit-def $wl2, implicit $p0 {
+    ; CHECK-NEG-LAT-NEXT: $r2 = LDA_dms_lda_idx_imm $p0, 0 :: (load (s32), addrspace 6)
+    ; CHECK-NEG-LAT-NEXT: $wl2 = VLDB_dmw_ldb_ag_idx_imm $p0, 0 :: (load (<8 x s32>), addrspace 5)
+    ; CHECK-NEG-LAT-NEXT: }
+    ; CHECK-NEG-LAT-NEXT: $p3, $dc1, $dc5 = ST_3D_dmv_sts_q killed $q0, killed $p3, killed $d1_3d
+    ; CHECK-NEG-LAT-NEXT: BUNDLE implicit-def $r2, implicit-def $wl2, implicit killed $p0 {
+    ; CHECK-NEG-LAT-NEXT: $r2 = LDA_dms_lda_idx_imm $p0, 0 :: (load (s32), addrspace 6)
+    ; CHECK-NEG-LAT-NEXT: $wl2 = VLDB_dmw_ldb_ag_idx_imm killed $p0, 0 :: (load (<8 x s32>), addrspace 5)
+    ; CHECK-NEG-LAT-NEXT: }
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
     $r2 = LDA_dms_lda_idx_imm $p0, 0 :: (load (s32), addrspace 6)
     $wl2 = VLDB_dmw_ldb_ag_idx_imm $p0, 0 :: (load (<8 x s32>), addrspace 5)
     ST_dmv_sts_q_ag_idx_imm $q0, $p0, 0                 ; II_ST_Q
@@ -95,6 +127,17 @@ body:             |
     ; CHECK-NEXT: $p3, $dc1, $dc5 = ST_3D_dmv_sts_q killed $q0, killed $p3, killed $d1_3d
     ; CHECK-NEXT: ST_dms_sts_idx_imm killed $r2, killed $p0, 0
     ; CHECK-NEXT: NOP
+    ; CHECK-NEG-LAT-LABEL: name: STORE_E5_STORE_E5
+    ; CHECK-NEG-LAT: ST_dms_sts_idx_imm $r2, $p0, 0
+    ; CHECK-NEG-LAT-NEXT: ST_dmv_sts_q_ag_idx_imm $q0, $p0, 0
+    ; CHECK-NEG-LAT-NEXT: ST_dms_sts_idx_imm $r2, $p0, 0
+    ; CHECK-NEG-LAT-NEXT: $p1 = ST_dmv_sts_q_ag_pstm_nrm_imm $q0, killed $p1, 0
+    ; CHECK-NEG-LAT-NEXT: ST_dms_sts_idx_imm $r2, $p0, 0
+    ; CHECK-NEG-LAT-NEXT: $p2, $dc0 = ST_2D_dmv_sts_q $q0, killed $p2, killed $d0
+    ; CHECK-NEG-LAT-NEXT: ST_dms_sts_idx_imm $r2, $p0, 0
+    ; CHECK-NEG-LAT-NEXT: $p3, $dc1, $dc5 = ST_3D_dmv_sts_q killed $q0, killed $p3, killed $d1_3d
+    ; CHECK-NEG-LAT-NEXT: ST_dms_sts_idx_imm killed $r2, killed $p0, 0
+    ; CHECK-NEG-LAT-NEXT: NOP
     ST_dms_sts_idx_imm $r2, $p0, 0
     ST_dmv_sts_q_ag_idx_imm $q0, $p0, 0                 ; II_ST_Q
     ST_dms_sts_idx_imm $r2, $p0, 0
@@ -134,6 +177,19 @@ body:             |
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
+    ; CHECK-NEG-LAT-LABEL: name: STORE_E5_STORE_E7
+    ; CHECK-NEG-LAT: VST_SRS_D8_S32_ag_idx_imm $p0, 0, $cm0, $s0, implicit-def $srsrs_of, implicit $crsat, implicit $crrnd, implicit $crsrssign
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: VST_SRS_D8_S32_ag_idx_imm $p0, 0, $cm0, $s0, implicit-def $srsrs_of, implicit $crsat, implicit $crrnd, implicit $crsrssign
+    ; CHECK-NEG-LAT-NEXT: ST_dmv_sts_q_ag_idx_imm $q0, $p0, 0
+    ; CHECK-NEG-LAT-NEXT: VST_SRS_D8_S32_ag_idx_imm $p0, 0, $cm0, $s0, implicit-def $srsrs_of, implicit $crsat, implicit $crrnd, implicit $crsrssign
+    ; CHECK-NEG-LAT-NEXT: $p1 = ST_dmv_sts_q_ag_pstm_nrm_imm $q0, killed $p1, 0
+    ; CHECK-NEG-LAT-NEXT: VST_SRS_D8_S32_ag_idx_imm $p0, 0, $cm0, $s0, implicit-def $srsrs_of, implicit $crsat, implicit $crrnd, implicit $crsrssign
+    ; CHECK-NEG-LAT-NEXT: $p2, $dc0 = ST_2D_dmv_sts_q $q0, killed $p2, killed $d0
+    ; CHECK-NEG-LAT-NEXT: VST_SRS_D8_S32_ag_idx_imm killed $p0, 0, killed $cm0, killed $s0, implicit-def $srsrs_of, implicit $crsat, implicit $crrnd, implicit $crsrssign
+    ; CHECK-NEG-LAT-NEXT: $p3, $dc1, $dc5 = ST_3D_dmv_sts_q killed $q0, killed $p3, killed $d1_3d
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
     VST_SRS_D8_S32_ag_idx_imm $p0, 0, $cm0, $s0, implicit-def $srsrs_of, implicit $crsat, implicit $crrnd, implicit $crsrssign
     ST_dmv_sts_q_ag_idx_imm $q0, $p0, 0                 ; II_ST_Q
     VST_SRS_D8_S32_ag_idx_imm $p0, 0, $cm0, $s0, implicit-def $srsrs_of, implicit $crsat, implicit $crrnd, implicit $crsrssign
@@ -193,6 +249,47 @@ body:             |
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
+    ; CHECK-NEG-LAT-LABEL: name: STORE_E5_STORE_E11
+    ; CHECK-NEG-LAT: ST_S8_ag_idx_imm $r2, $p0, 0
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: ST_dmv_sts_q_ag_idx_imm $q0, $p0, 0
+    ; CHECK-NEG-LAT-NEXT: ST_S8_ag_idx_imm $r2, $p0, 0
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: $p1 = ST_dmv_sts_q_ag_pstm_nrm_imm $q0, killed $p1, 0
+    ; CHECK-NEG-LAT-NEXT: ST_S8_ag_idx_imm $r2, $p0, 0
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: $p2, $dc0 = ST_2D_dmv_sts_q $q0, killed $p2, killed $d0
+    ; CHECK-NEG-LAT-NEXT: ST_S8_ag_idx_imm $r2, $p0, 0
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: $p3, $dc1, $dc5 = ST_3D_dmv_sts_q killed $q0, killed $p3, killed $d1_3d
+    ; CHECK-NEG-LAT-NEXT: ST_S8_ag_idx_imm killed $r2, killed $p0, 0
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
     ST_S8_ag_idx_imm $r2, $p0, 0
     ST_dmv_sts_q_ag_idx_imm $q0, $p0, 0                 ; II_ST_Q
     ST_S8_ag_idx_imm $r2, $p0, 0

--- a/llvm/test/CodeGen/AIE/aie2/schedule/memory_dependencies_vst_am.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/memory_dependencies_vst_am.mir
@@ -4,8 +4,9 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2023-2024 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2023-2026 Advanced Micro Devices, Inc. or its affiliates
 # RUN: llc -march=aie2 -run-pass=postmisched %topdown-multi %s -o - | FileCheck %s
+# RUN: llc -march=aie2 -run-pass=postmisched %topdown-multi-negative-lat %s -o - | FileCheck %s --check-prefix=CHECK-NEG-LAT
 
 # This test shows how ordered load/stores are handled.
 # In most cases, we just need to keep them one cycle appart, but for example
@@ -61,6 +62,37 @@ body:             |
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
+    ; CHECK-NEG-LAT-LABEL: name: AM_STORE_E5_LOAD_E5
+    ; CHECK-NEG-LAT: BUNDLE implicit-def $r2, implicit-def $wl2, implicit $p0 {
+    ; CHECK-NEG-LAT-NEXT: $r2 = LDA_dms_lda_idx_imm $p0, 0 :: (load (s32), addrspace 6)
+    ; CHECK-NEG-LAT-NEXT: $wl2 = VLDB_dmw_ldb_ag_idx_imm $p0, 0 :: (load (<8 x s32>), addrspace 5)
+    ; CHECK-NEG-LAT-NEXT: }
+    ; CHECK-NEG-LAT-NEXT: VST_dmw_sts_am_ag_idx_imm $amll0, $p0, 0
+    ; CHECK-NEG-LAT-NEXT: BUNDLE implicit-def $r2, implicit-def $wl2, implicit $p0 {
+    ; CHECK-NEG-LAT-NEXT: $r2 = LDA_dms_lda_idx_imm $p0, 0 :: (load (s32), addrspace 6)
+    ; CHECK-NEG-LAT-NEXT: $wl2 = VLDB_dmw_ldb_ag_idx_imm $p0, 0 :: (load (<8 x s32>), addrspace 5)
+    ; CHECK-NEG-LAT-NEXT: }
+    ; CHECK-NEG-LAT-NEXT: $p1 = VST_dmw_sts_am_ag_pstm_nrm_imm $amll0, killed $p1, 0
+    ; CHECK-NEG-LAT-NEXT: BUNDLE implicit-def $r2, implicit-def $wl2, implicit $p0 {
+    ; CHECK-NEG-LAT-NEXT: $r2 = LDA_dms_lda_idx_imm $p0, 0 :: (load (s32), addrspace 6)
+    ; CHECK-NEG-LAT-NEXT: $wl2 = VLDB_dmw_ldb_ag_idx_imm $p0, 0 :: (load (<8 x s32>), addrspace 5)
+    ; CHECK-NEG-LAT-NEXT: }
+    ; CHECK-NEG-LAT-NEXT: $p2, $dc0 = VST_2D_dmw_sts_am $amll0, killed $p2, killed $d0
+    ; CHECK-NEG-LAT-NEXT: BUNDLE implicit-def $r2, implicit-def $wl2, implicit $p0 {
+    ; CHECK-NEG-LAT-NEXT: $r2 = LDA_dms_lda_idx_imm $p0, 0 :: (load (s32), addrspace 6)
+    ; CHECK-NEG-LAT-NEXT: $wl2 = VLDB_dmw_ldb_ag_idx_imm $p0, 0 :: (load (<8 x s32>), addrspace 5)
+    ; CHECK-NEG-LAT-NEXT: }
+    ; CHECK-NEG-LAT-NEXT: $p3, $dc1, $dc5 = VST_3D_dmw_sts_am killed $amll0, killed $p3, killed $d1_3d
+    ; CHECK-NEG-LAT-NEXT: BUNDLE implicit-def $r2, implicit-def $wl2, implicit killed $p0 {
+    ; CHECK-NEG-LAT-NEXT: $r2 = LDA_dms_lda_idx_imm $p0, 0 :: (load (s32), addrspace 6)
+    ; CHECK-NEG-LAT-NEXT: $wl2 = VLDB_dmw_ldb_ag_idx_imm killed $p0, 0 :: (load (<8 x s32>), addrspace 5)
+    ; CHECK-NEG-LAT-NEXT: }
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
     $r2 = LDA_dms_lda_idx_imm $p0, 0 :: (load (s32), addrspace 6)
     $wl2 = VLDB_dmw_ldb_ag_idx_imm $p0, 0 :: (load (<8 x s32>), addrspace 5)
     VST_dmw_sts_am_ag_idx_imm $amll0, $p0, 0                ; II_VST_AM
@@ -95,6 +127,17 @@ body:             |
     ; CHECK-NEXT: $p3, $dc1, $dc5 = VST_3D_dmw_sts_am killed $amll0, killed $p3, killed $d1_3d
     ; CHECK-NEXT: ST_dms_sts_idx_imm killed $r2, killed $p0, 0
     ; CHECK-NEXT: NOP
+    ; CHECK-NEG-LAT-LABEL: name: AM_STORE_E5_STORE_E5
+    ; CHECK-NEG-LAT: ST_dms_sts_idx_imm $r2, $p0, 0
+    ; CHECK-NEG-LAT-NEXT: VST_dmw_sts_am_ag_idx_imm $amll0, $p0, 0
+    ; CHECK-NEG-LAT-NEXT: ST_dms_sts_idx_imm $r2, $p0, 0
+    ; CHECK-NEG-LAT-NEXT: $p1 = VST_dmw_sts_am_ag_pstm_nrm_imm $amll0, killed $p1, 0
+    ; CHECK-NEG-LAT-NEXT: ST_dms_sts_idx_imm $r2, $p0, 0
+    ; CHECK-NEG-LAT-NEXT: $p2, $dc0 = VST_2D_dmw_sts_am $amll0, killed $p2, killed $d0
+    ; CHECK-NEG-LAT-NEXT: ST_dms_sts_idx_imm $r2, $p0, 0
+    ; CHECK-NEG-LAT-NEXT: $p3, $dc1, $dc5 = VST_3D_dmw_sts_am killed $amll0, killed $p3, killed $d1_3d
+    ; CHECK-NEG-LAT-NEXT: ST_dms_sts_idx_imm killed $r2, killed $p0, 0
+    ; CHECK-NEG-LAT-NEXT: NOP
     ST_dms_sts_idx_imm $r2, $p0, 0
     VST_dmw_sts_am_ag_idx_imm $amll0, $p0, 0                ; II_VST_AM
     ST_dms_sts_idx_imm $r2, $p0, 0
@@ -134,6 +177,19 @@ body:             |
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
+    ; CHECK-NEG-LAT-LABEL: name: AM_STORE_E5_STORE_E7
+    ; CHECK-NEG-LAT: VST_SRS_D8_S32_ag_idx_imm $p0, 0, $cm0, $s0, implicit-def $srsrs_of, implicit $crsat, implicit $crrnd, implicit $crsrssign
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: VST_SRS_D8_S32_ag_idx_imm $p0, 0, $cm0, $s0, implicit-def $srsrs_of, implicit $crsat, implicit $crrnd, implicit $crsrssign
+    ; CHECK-NEG-LAT-NEXT: VST_dmw_sts_am_ag_idx_imm $amll0, $p0, 0
+    ; CHECK-NEG-LAT-NEXT: VST_SRS_D8_S32_ag_idx_imm $p0, 0, $cm0, $s0, implicit-def $srsrs_of, implicit $crsat, implicit $crrnd, implicit $crsrssign
+    ; CHECK-NEG-LAT-NEXT: $p1 = VST_dmw_sts_am_ag_pstm_nrm_imm $amll0, killed $p1, 0
+    ; CHECK-NEG-LAT-NEXT: VST_SRS_D8_S32_ag_idx_imm $p0, 0, $cm0, $s0, implicit-def $srsrs_of, implicit $crsat, implicit $crrnd, implicit $crsrssign
+    ; CHECK-NEG-LAT-NEXT: $p2, $dc0 = VST_2D_dmw_sts_am $amll0, killed $p2, killed $d0
+    ; CHECK-NEG-LAT-NEXT: VST_SRS_D8_S32_ag_idx_imm killed $p0, 0, $cm0, killed $s0, implicit-def $srsrs_of, implicit $crsat, implicit $crrnd, implicit $crsrssign
+    ; CHECK-NEG-LAT-NEXT: $p3, $dc1, $dc5 = VST_3D_dmw_sts_am killed $amll0, killed $p3, killed $d1_3d
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
     VST_SRS_D8_S32_ag_idx_imm $p0, 0, $cm0, $s0, implicit-def $srsrs_of, implicit $crsat, implicit $crrnd, implicit $crsrssign
     VST_dmw_sts_am_ag_idx_imm $amll0, $p0, 0                ; II_VST_AM
     VST_SRS_D8_S32_ag_idx_imm $p0, 0, $cm0, $s0, implicit-def $srsrs_of, implicit $crsat, implicit $crrnd, implicit $crsrssign
@@ -193,6 +249,47 @@ body:             |
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
+    ; CHECK-NEG-LAT-LABEL: name: AM_STORE_E5_STORE_E11
+    ; CHECK-NEG-LAT: ST_S8_ag_idx_imm $r2, $p0, 0
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: VST_dmw_sts_am_ag_idx_imm $amll0, $p0, 0
+    ; CHECK-NEG-LAT-NEXT: ST_S8_ag_idx_imm $r2, $p0, 0
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: $p1 = VST_dmw_sts_am_ag_pstm_nrm_imm $amll0, killed $p1, 0
+    ; CHECK-NEG-LAT-NEXT: ST_S8_ag_idx_imm $r2, $p0, 0
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: $p2, $dc0 = VST_2D_dmw_sts_am $amll0, killed $p2, killed $d0
+    ; CHECK-NEG-LAT-NEXT: ST_S8_ag_idx_imm $r2, $p0, 0
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: $p3, $dc1, $dc5 = VST_3D_dmw_sts_am killed $amll0, killed $p3, killed $d1_3d
+    ; CHECK-NEG-LAT-NEXT: ST_S8_ag_idx_imm killed $r2, killed $p0, 0
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
     ST_S8_ag_idx_imm $r2, $p0, 0
     VST_dmw_sts_am_ag_idx_imm $amll0, $p0, 0                ; II_VST_AM
     ST_S8_ag_idx_imm $r2, $p0, 0

--- a/llvm/test/CodeGen/AIE/aie2/schedule/memory_dependencies_vst_conv.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/memory_dependencies_vst_conv.mir
@@ -4,8 +4,9 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2023-2024 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2023-2026 Advanced Micro Devices, Inc. or its affiliates
 # RUN: llc -march=aie2 -run-pass=postmisched %topdown-multi %s -o - | FileCheck %s
+# RUN: llc -march=aie2 -run-pass=postmisched %topdown-multi-negative-lat %s -o - | FileCheck %s --check-prefix=CHECK-NEG-LAT
 
 # This test shows how ordered load/stores are handled.
 # In most cases, we just need to keep them one cycle appart, but for example
@@ -69,6 +70,39 @@ body:             |
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
+    ; CHECK-NEG-LAT-LABEL: name: CONV_STORE_E7_LOAD_E5
+    ; CHECK-NEG-LAT: BUNDLE implicit-def $r2, implicit-def $wl2, implicit-def $srf2fflags, implicit $p0, implicit $bml0, implicit $crrnd, implicit $crf2fmask {
+    ; CHECK-NEG-LAT-NEXT: $r2 = LDA_dms_lda_idx_imm $p0, 0 :: (load (s32), addrspace 6)
+    ; CHECK-NEG-LAT-NEXT: $wl2 = VLDB_dmw_ldb_ag_idx_imm $p0, 0 :: (load (<8 x s32>), addrspace 5)
+    ; CHECK-NEG-LAT-NEXT: VST_CONV_BF16_FP32_ag_idx_imm $p0, 0, $bml0, implicit-def $srf2fflags, implicit $crrnd, implicit $crf2fmask
+    ; CHECK-NEG-LAT-NEXT: }
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: $p1 = VST_CONV_BF16_FP32_ag_pstm_nrm_imm killed $p1, 0, $bml0, implicit-def $srf2fflags, implicit $crrnd, implicit $crf2fmask
+    ; CHECK-NEG-LAT-NEXT: BUNDLE implicit-def $r2, implicit-def $wl2, implicit $p0 {
+    ; CHECK-NEG-LAT-NEXT: $r2 = LDA_dms_lda_idx_imm $p0, 0 :: (load (s32), addrspace 6)
+    ; CHECK-NEG-LAT-NEXT: $wl2 = VLDB_dmw_ldb_ag_idx_imm $p0, 0 :: (load (<8 x s32>), addrspace 5)
+    ; CHECK-NEG-LAT-NEXT: }
+    ; CHECK-NEG-LAT-NEXT: $p2, $dc0 = VST_CONV_2D_BF16_FP32 killed $p2, killed $d0, $bml0, implicit-def $srf2fflags, implicit $crrnd, implicit $crf2fmask
+    ; CHECK-NEG-LAT-NEXT: BUNDLE implicit-def $r2, implicit-def $wl2, implicit $p0 {
+    ; CHECK-NEG-LAT-NEXT: $r2 = LDA_dms_lda_idx_imm $p0, 0 :: (load (s32), addrspace 6)
+    ; CHECK-NEG-LAT-NEXT: $wl2 = VLDB_dmw_ldb_ag_idx_imm $p0, 0 :: (load (<8 x s32>), addrspace 5)
+    ; CHECK-NEG-LAT-NEXT: }
+    ; CHECK-NEG-LAT-NEXT: $p3, $dc1, $dc5 = VST_CONV_3D_BF16_FP32 killed $p3, killed $d1_3d, killed $bml0, implicit-def $srf2fflags, implicit $crrnd, implicit $crf2fmask
+    ; CHECK-NEG-LAT-NEXT: BUNDLE implicit-def $r2, implicit-def $wl2, implicit $p0 {
+    ; CHECK-NEG-LAT-NEXT: $r2 = LDA_dms_lda_idx_imm $p0, 0 :: (load (s32), addrspace 6)
+    ; CHECK-NEG-LAT-NEXT: $wl2 = VLDB_dmw_ldb_ag_idx_imm $p0, 0 :: (load (<8 x s32>), addrspace 5)
+    ; CHECK-NEG-LAT-NEXT: }
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: BUNDLE implicit-def $r2, implicit-def $wl2, implicit killed $p0 {
+    ; CHECK-NEG-LAT-NEXT: $r2 = LDA_dms_lda_idx_imm $p0, 0 :: (load (s32), addrspace 6)
+    ; CHECK-NEG-LAT-NEXT: $wl2 = VLDB_dmw_ldb_ag_idx_imm killed $p0, 0 :: (load (<8 x s32>), addrspace 5)
+    ; CHECK-NEG-LAT-NEXT: }
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
     $r2 = LDA_dms_lda_idx_imm $p0, 0 :: (load (s32), addrspace 6)
     $wl2 = VLDB_dmw_ldb_ag_idx_imm $p0, 0 :: (load (<8 x s32>), addrspace 5)
     VST_CONV_BF16_FP32_ag_idx_imm $p0, 0, $bml0, implicit-def $srf2fflags, implicit $crrnd, implicit $crf2fmask
@@ -111,6 +145,19 @@ body:             |
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: ST_dms_sts_idx_imm killed $r2, killed $p0, 0
     ; CHECK-NEXT: NOP
+    ; CHECK-NEG-LAT-LABEL: name: CONV_STORE_E7_STORE_E5
+    ; CHECK-NEG-LAT: ST_dms_sts_idx_imm $r2, $p0, 0
+    ; CHECK-NEG-LAT-NEXT: VST_CONV_BF16_FP32_ag_idx_imm $p0, 0, $bml0, implicit-def $srf2fflags, implicit $crrnd, implicit $crf2fmask
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: $p1 = VST_CONV_BF16_FP32_ag_pstm_nrm_imm killed $p1, 0, $bml0, implicit-def $srf2fflags, implicit $crrnd, implicit $crf2fmask
+    ; CHECK-NEG-LAT-NEXT: ST_dms_sts_idx_imm $r2, $p0, 0
+    ; CHECK-NEG-LAT-NEXT: $p2, $dc0 = VST_CONV_2D_BF16_FP32 killed $p2, killed $d0, $bml0, implicit-def $srf2fflags, implicit $crrnd, implicit $crf2fmask
+    ; CHECK-NEG-LAT-NEXT: ST_dms_sts_idx_imm $r2, $p0, 0
+    ; CHECK-NEG-LAT-NEXT: $p3, $dc1, $dc5 = VST_CONV_3D_BF16_FP32 killed $p3, killed $d1_3d, killed $bml0, implicit-def $srf2fflags, implicit $crrnd, implicit $crf2fmask
+    ; CHECK-NEG-LAT-NEXT: ST_dms_sts_idx_imm $r2, $p0, 0
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: ST_dms_sts_idx_imm killed $r2, killed $p0, 0
+    ; CHECK-NEG-LAT-NEXT: NOP
     ST_dms_sts_idx_imm $r2, $p0, 0
     VST_CONV_BF16_FP32_ag_idx_imm $p0, 0, $bml0, implicit-def $srf2fflags, implicit $crrnd, implicit $crf2fmask
     ST_dms_sts_idx_imm $r2, $p0, 0
@@ -147,6 +194,21 @@ body:             |
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
+    ; CHECK-NEG-LAT-LABEL: name: CONV_STORE_E7_STORE_E7
+    ; CHECK-NEG-LAT: VST_SRS_D8_S32_ag_idx_imm $p0, 0, $cm0, $s0, implicit-def $srsrs_of, implicit $crsat, implicit $crrnd, implicit $crsrssign
+    ; CHECK-NEG-LAT-NEXT: VST_CONV_BF16_FP32_ag_idx_imm $p0, 0, $bml0, implicit-def $srf2fflags, implicit $crrnd, implicit $crf2fmask
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: VST_CONV_BF16_FP32_ag_idx_imm $p0, 0, $bml0, implicit-def $srf2fflags, implicit $crrnd, implicit $crf2fmask
+    ; CHECK-NEG-LAT-NEXT: $p1 = VST_CONV_BF16_FP32_ag_pstm_nrm_imm killed $p1, 0, $bml0, implicit-def $srf2fflags, implicit $crrnd, implicit $crf2fmask
+    ; CHECK-NEG-LAT-NEXT: VST_SRS_D8_S32_ag_idx_imm $p0, 0, $cm0, $s0, implicit-def $srsrs_of, implicit $crsat, implicit $crrnd, implicit $crsrssign
+    ; CHECK-NEG-LAT-NEXT: $p2, $dc0 = VST_CONV_2D_BF16_FP32 killed $p2, killed $d0, $bml0, implicit-def $srf2fflags, implicit $crrnd, implicit $crf2fmask
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: VST_CONV_BF16_FP32_ag_idx_imm $p0, 0, $bml0, implicit-def $srf2fflags, implicit $crrnd, implicit $crf2fmask
+    ; CHECK-NEG-LAT-NEXT: $p3, $dc1, $dc5 = VST_CONV_3D_BF16_FP32 killed $p3, killed $d1_3d, $bml0, implicit-def $srf2fflags, implicit $crrnd, implicit $crf2fmask
+    ; CHECK-NEG-LAT-NEXT: VST_SRS_D8_S32_ag_idx_imm killed $p0, 0, killed $cm0, killed $s0, implicit-def $srsrs_of, implicit $crsat, implicit $crrnd, implicit $crsrssign
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
     VST_SRS_D8_S32_ag_idx_imm $p0, 0, $cm0, $s0, implicit-def $srsrs_of, implicit $crsat, implicit $crrnd, implicit $crsrssign
     VST_CONV_BF16_FP32_ag_idx_imm $p0, 0, $bml0, implicit-def $srf2fflags, implicit $crrnd, implicit $crf2fmask
     VST_CONV_BF16_FP32_ag_idx_imm $p0, 0, $bml0, implicit-def $srf2fflags, implicit $crrnd, implicit $crf2fmask
@@ -206,6 +268,47 @@ body:             |
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
+    ; CHECK-NEG-LAT-LABEL: name: AM_STORE_E5_STORE_E11
+    ; CHECK-NEG-LAT: ST_S8_ag_idx_imm $r2, $p0, 0
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: VST_CONV_BF16_FP32_ag_idx_imm $p0, 0, $bml0, implicit-def $srf2fflags, implicit $crrnd, implicit $crf2fmask
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: ST_S8_ag_idx_imm $r2, $p0, 0
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: $p1 = VST_CONV_BF16_FP32_ag_pstm_nrm_imm killed $p1, 0, $bml0, implicit-def $srf2fflags, implicit $crrnd, implicit $crf2fmask
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: ST_S8_ag_idx_imm $r2, $p0, 0
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: $p2, $dc0 = VST_CONV_2D_BF16_FP32 killed $p2, killed $d0, $bml0, implicit-def $srf2fflags, implicit $crrnd, implicit $crf2fmask
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: ST_S8_ag_idx_imm $r2, $p0, 0
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: $p3, $dc1, $dc5 = VST_CONV_3D_BF16_FP32 killed $p3, killed $d1_3d, killed $bml0, implicit-def $srf2fflags, implicit $crrnd, implicit $crf2fmask
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: ST_S8_ag_idx_imm killed $r2, killed $p0, 0
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
     ST_S8_ag_idx_imm $r2, $p0, 0
     VST_CONV_BF16_FP32_ag_idx_imm $p0, 0, $bml0, implicit-def $srf2fflags, implicit $crrnd, implicit $crf2fmask
     ST_S8_ag_idx_imm $r2, $p0, 0

--- a/llvm/test/CodeGen/AIE/aie2/schedule/memory_dependencies_vst_pack.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/memory_dependencies_vst_pack.mir
@@ -4,8 +4,9 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2023-2024 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2023-2026 Advanced Micro Devices, Inc. or its affiliates
 # RUN: llc -march=aie2 -run-pass=postmisched %topdown-multi %s -o - | FileCheck %s
+# RUN: llc -march=aie2 -run-pass=postmisched %topdown-multi-negative-lat %s -o - | FileCheck %s --check-prefix=CHECK-NEG-LAT
 
 # This test shows how ordered load/stores are handled.
 # In most cases, we just need to keep them one cycle appart, but for example
@@ -64,6 +65,37 @@ body:             |
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
+    ; CHECK-NEG-LAT-LABEL: name: PACK_STORE_E5_LOAD_E5
+    ; CHECK-NEG-LAT: BUNDLE implicit-def $r2, implicit-def $wl2, implicit $p0 {
+    ; CHECK-NEG-LAT-NEXT: $r2 = LDA_dms_lda_idx_imm $p0, 0 :: (load (s32), addrspace 6)
+    ; CHECK-NEG-LAT-NEXT: $wl2 = VLDB_dmw_ldb_ag_idx_imm $p0, 0 :: (load (<8 x s32>), addrspace 5)
+    ; CHECK-NEG-LAT-NEXT: }
+    ; CHECK-NEG-LAT-NEXT: VST_PACK_D4_D8_ag_idx_imm $p0, 0, $x0, implicit $crsat, implicit $crpacksign
+    ; CHECK-NEG-LAT-NEXT: BUNDLE implicit-def $r2, implicit-def $wl2, implicit $p0 {
+    ; CHECK-NEG-LAT-NEXT: $r2 = LDA_dms_lda_idx_imm $p0, 0 :: (load (s32), addrspace 6)
+    ; CHECK-NEG-LAT-NEXT: $wl2 = VLDB_dmw_ldb_ag_idx_imm $p0, 0 :: (load (<8 x s32>), addrspace 5)
+    ; CHECK-NEG-LAT-NEXT: }
+    ; CHECK-NEG-LAT-NEXT: $p1 = VST_PACK_D4_D8_ag_pstm_nrm_imm killed $p1, 0, $x0, implicit $crsat, implicit $crpacksign
+    ; CHECK-NEG-LAT-NEXT: BUNDLE implicit-def $r2, implicit-def $wl2, implicit $p0 {
+    ; CHECK-NEG-LAT-NEXT: $r2 = LDA_dms_lda_idx_imm $p0, 0 :: (load (s32), addrspace 6)
+    ; CHECK-NEG-LAT-NEXT: $wl2 = VLDB_dmw_ldb_ag_idx_imm $p0, 0 :: (load (<8 x s32>), addrspace 5)
+    ; CHECK-NEG-LAT-NEXT: }
+    ; CHECK-NEG-LAT-NEXT: $p2, $dc0 = VST_2D_PACK_D4_D8 killed $p2, killed $d0, $x0, implicit $crsat, implicit $crpacksign
+    ; CHECK-NEG-LAT-NEXT: BUNDLE implicit-def $r2, implicit-def $wl2, implicit $p0 {
+    ; CHECK-NEG-LAT-NEXT: $r2 = LDA_dms_lda_idx_imm $p0, 0 :: (load (s32), addrspace 6)
+    ; CHECK-NEG-LAT-NEXT: $wl2 = VLDB_dmw_ldb_ag_idx_imm $p0, 0 :: (load (<8 x s32>), addrspace 5)
+    ; CHECK-NEG-LAT-NEXT: }
+    ; CHECK-NEG-LAT-NEXT: $p3, $dc1, $dc5 = VST_3D_PACK_D4_D8 killed $p3, killed $d1_3d, killed $x0, implicit $crsat, implicit $crpacksign
+    ; CHECK-NEG-LAT-NEXT: BUNDLE implicit-def $r2, implicit-def $wl2, implicit killed $p0 {
+    ; CHECK-NEG-LAT-NEXT: $r2 = LDA_dms_lda_idx_imm $p0, 0 :: (load (s32), addrspace 6)
+    ; CHECK-NEG-LAT-NEXT: $wl2 = VLDB_dmw_ldb_ag_idx_imm killed $p0, 0 :: (load (<8 x s32>), addrspace 5)
+    ; CHECK-NEG-LAT-NEXT: }
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
     $r2 = LDA_dms_lda_idx_imm $p0, 0 :: (load (s32), addrspace 6)
     $wl2 = VLDB_dmw_ldb_ag_idx_imm $p0, 0 :: (load (<8 x s32>), addrspace 5)
     VST_PACK_D4_D8_ag_idx_imm $p0, 0, $x0, implicit $crsat, implicit $crpacksign
@@ -98,6 +130,17 @@ body:             |
     ; CHECK-NEXT: $p3, $dc1, $dc5 = VST_3D_PACK_D4_D8 killed $p3, killed $d1_3d, killed $x0, implicit $crsat, implicit $crpacksign
     ; CHECK-NEXT: ST_dms_sts_idx_imm killed $r2, killed $p0, 0
     ; CHECK-NEXT: NOP
+    ; CHECK-NEG-LAT-LABEL: name: PACK_STORE_E5_STORE_E5
+    ; CHECK-NEG-LAT: ST_dms_sts_idx_imm $r2, $p0, 0
+    ; CHECK-NEG-LAT-NEXT: VST_PACK_D4_D8_ag_idx_imm $p0, 0, $x0, implicit $crsat, implicit $crpacksign
+    ; CHECK-NEG-LAT-NEXT: ST_dms_sts_idx_imm $r2, $p0, 0
+    ; CHECK-NEG-LAT-NEXT: $p1 = VST_PACK_D4_D8_ag_pstm_nrm_imm killed $p1, 0, $x0, implicit $crsat, implicit $crpacksign
+    ; CHECK-NEG-LAT-NEXT: ST_dms_sts_idx_imm $r2, $p0, 0
+    ; CHECK-NEG-LAT-NEXT: $p2, $dc0 = VST_2D_PACK_D4_D8 killed $p2, killed $d0, $x0, implicit $crsat, implicit $crpacksign
+    ; CHECK-NEG-LAT-NEXT: ST_dms_sts_idx_imm $r2, $p0, 0
+    ; CHECK-NEG-LAT-NEXT: $p3, $dc1, $dc5 = VST_3D_PACK_D4_D8 killed $p3, killed $d1_3d, killed $x0, implicit $crsat, implicit $crpacksign
+    ; CHECK-NEG-LAT-NEXT: ST_dms_sts_idx_imm killed $r2, killed $p0, 0
+    ; CHECK-NEG-LAT-NEXT: NOP
     ST_dms_sts_idx_imm $r2, $p0, 0
     VST_PACK_D4_D8_ag_idx_imm $p0, 0, $x0, implicit $crsat, implicit $crpacksign
     ST_dms_sts_idx_imm $r2, $p0, 0
@@ -137,6 +180,19 @@ body:             |
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
+    ; CHECK-NEG-LAT-LABEL: name: PACK_STORE_E5_STORE_E7
+    ; CHECK-NEG-LAT: VST_SRS_D8_S32_ag_idx_imm $p0, 0, $cm0, $s0, implicit-def $srsrs_of, implicit $crsat, implicit $crrnd, implicit $crsrssign
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: VST_SRS_D8_S32_ag_idx_imm $p0, 0, $cm0, $s0, implicit-def $srsrs_of, implicit $crsat, implicit $crrnd, implicit $crsrssign
+    ; CHECK-NEG-LAT-NEXT: VST_PACK_D4_D8_ag_idx_imm $p0, 0, $x0, implicit $crsat, implicit $crpacksign
+    ; CHECK-NEG-LAT-NEXT: VST_SRS_D8_S32_ag_idx_imm $p0, 0, $cm0, $s0, implicit-def $srsrs_of, implicit $crsat, implicit $crrnd, implicit $crsrssign
+    ; CHECK-NEG-LAT-NEXT: $p1 = VST_PACK_D4_D8_ag_pstm_nrm_imm killed $p1, 0, $x0, implicit $crsat, implicit $crpacksign
+    ; CHECK-NEG-LAT-NEXT: VST_SRS_D8_S32_ag_idx_imm $p0, 0, $cm0, $s0, implicit-def $srsrs_of, implicit $crsat, implicit $crrnd, implicit $crsrssign
+    ; CHECK-NEG-LAT-NEXT: $p2, $dc0 = VST_2D_PACK_D4_D8 killed $p2, killed $d0, $x0, implicit $crsat, implicit $crpacksign
+    ; CHECK-NEG-LAT-NEXT: VST_SRS_D8_S32_ag_idx_imm killed $p0, 0, killed $cm0, killed $s0, implicit-def $srsrs_of, implicit $crsat, implicit $crrnd, implicit $crsrssign
+    ; CHECK-NEG-LAT-NEXT: $p3, $dc1, $dc5 = VST_3D_PACK_D4_D8 killed $p3, killed $d1_3d, killed $x0, implicit $crsat, implicit $crpacksign
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
     VST_SRS_D8_S32_ag_idx_imm $p0, 0, $cm0, $s0, implicit-def $srsrs_of, implicit $crsat, implicit $crrnd, implicit $crsrssign
     VST_PACK_D4_D8_ag_idx_imm $p0, 0, $x0, implicit $crsat, implicit $crpacksign
     VST_SRS_D8_S32_ag_idx_imm $p0, 0, $cm0, $s0, implicit-def $srsrs_of, implicit $crsat, implicit $crrnd, implicit $crsrssign
@@ -197,6 +253,47 @@ body:             |
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
+    ; CHECK-NEG-LAT-LABEL: name: PACK_STORE_E5_STORE_E11
+    ; CHECK-NEG-LAT: ST_S8_ag_idx_imm $r2, $p0, 0
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: VST_PACK_D4_D8_ag_idx_imm $p0, 0, $x0, implicit $crsat, implicit $crpacksign
+    ; CHECK-NEG-LAT-NEXT: ST_S8_ag_idx_imm $r2, $p0, 0
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: $p1 = VST_PACK_D4_D8_ag_pstm_nrm_imm killed $p1, 0, $x0, implicit $crsat, implicit $crpacksign
+    ; CHECK-NEG-LAT-NEXT: ST_S8_ag_idx_imm $r2, $p0, 0
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: $p2, $dc0 = VST_2D_PACK_D4_D8 killed $p2, killed $d0, $x0, implicit $crsat, implicit $crpacksign
+    ; CHECK-NEG-LAT-NEXT: ST_S8_ag_idx_imm $r2, $p0, 0
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: $p3, $dc1, $dc5 = VST_3D_PACK_D4_D8 killed $p3, killed $d1_3d, killed $x0, implicit $crsat, implicit $crpacksign
+    ; CHECK-NEG-LAT-NEXT: ST_S8_ag_idx_imm killed $r2, killed $p0, 0
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
     ST_S8_ag_idx_imm $r2, $p0, 0
     VST_PACK_D4_D8_ag_idx_imm $p0, 0, $x0, implicit $crsat, implicit $crpacksign
     ST_S8_ag_idx_imm $r2, $p0, 0

--- a/llvm/test/CodeGen/AIE/aie2/schedule/memory_dependencies_vst_srs.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/memory_dependencies_vst_srs.mir
@@ -4,8 +4,9 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2023-2024 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2023-2026 Advanced Micro Devices, Inc. or its affiliates
 # RUN: llc -march=aie2 -run-pass=postmisched %topdown-multi %s -o - | FileCheck %s
+# RUN: llc -march=aie2 -run-pass=postmisched %topdown-multi-negative-lat %s -o - | FileCheck %s --check-prefix=CHECK-NEG-LAT
 
 # This test shows how ordered load/stores are handled.
 # In most cases, we just need to keep them one cycle appart, but for example
@@ -69,6 +70,39 @@ body:             |
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
+    ; CHECK-NEG-LAT-LABEL: name: SRS_STORE_E7_LOAD_E5
+    ; CHECK-NEG-LAT: BUNDLE implicit-def $r2, implicit-def $wl2, implicit-def $srsrs_of, implicit $p0, implicit $cm0, implicit $s0, implicit $crsat, implicit $crrnd, implicit $crsrssign {
+    ; CHECK-NEG-LAT-NEXT: $r2 = LDA_dms_lda_idx_imm $p0, 0 :: (load (s32), addrspace 6)
+    ; CHECK-NEG-LAT-NEXT: $wl2 = VLDB_dmw_ldb_ag_idx_imm $p0, 0 :: (load (<8 x s32>), addrspace 5)
+    ; CHECK-NEG-LAT-NEXT: VST_SRS_D8_S32_ag_idx_imm $p0, 0, $cm0, $s0, implicit-def $srsrs_of, implicit $crsat, implicit $crrnd, implicit $crsrssign
+    ; CHECK-NEG-LAT-NEXT: }
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: $p1 = VST_SRS_D8_S32_ag_pstm_nrm_imm killed $p1, 0, $cm0, $s0, implicit-def $srsrs_of, implicit $crsat, implicit $crrnd, implicit $crsrssign
+    ; CHECK-NEG-LAT-NEXT: BUNDLE implicit-def $r2, implicit-def $wl2, implicit $p0 {
+    ; CHECK-NEG-LAT-NEXT: $r2 = LDA_dms_lda_idx_imm $p0, 0 :: (load (s32), addrspace 6)
+    ; CHECK-NEG-LAT-NEXT: $wl2 = VLDB_dmw_ldb_ag_idx_imm $p0, 0 :: (load (<8 x s32>), addrspace 5)
+    ; CHECK-NEG-LAT-NEXT: }
+    ; CHECK-NEG-LAT-NEXT: $p2, $dc0 = VST_2D_SRS_D8_S32 killed $p2, killed $d0, $cm0, $s0, implicit-def $srsrs_of, implicit $crsat, implicit $crrnd, implicit $crsrssign
+    ; CHECK-NEG-LAT-NEXT: BUNDLE implicit-def $r2, implicit-def $wl2, implicit $p0 {
+    ; CHECK-NEG-LAT-NEXT: $r2 = LDA_dms_lda_idx_imm $p0, 0 :: (load (s32), addrspace 6)
+    ; CHECK-NEG-LAT-NEXT: $wl2 = VLDB_dmw_ldb_ag_idx_imm $p0, 0 :: (load (<8 x s32>), addrspace 5)
+    ; CHECK-NEG-LAT-NEXT: }
+    ; CHECK-NEG-LAT-NEXT: $p3, $dc1, $dc5 = VST_3D_SRS_D8_S32 killed $p3, killed $d1_3d, killed $cm0, killed $s0, implicit-def $srsrs_of, implicit $crsat, implicit $crrnd, implicit $crsrssign
+    ; CHECK-NEG-LAT-NEXT: BUNDLE implicit-def $r2, implicit-def $wl2, implicit $p0 {
+    ; CHECK-NEG-LAT-NEXT: $r2 = LDA_dms_lda_idx_imm $p0, 0 :: (load (s32), addrspace 6)
+    ; CHECK-NEG-LAT-NEXT: $wl2 = VLDB_dmw_ldb_ag_idx_imm $p0, 0 :: (load (<8 x s32>), addrspace 5)
+    ; CHECK-NEG-LAT-NEXT: }
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: BUNDLE implicit-def $r2, implicit-def $wl2, implicit killed $p0 {
+    ; CHECK-NEG-LAT-NEXT: $r2 = LDA_dms_lda_idx_imm $p0, 0 :: (load (s32), addrspace 6)
+    ; CHECK-NEG-LAT-NEXT: $wl2 = VLDB_dmw_ldb_ag_idx_imm killed $p0, 0 :: (load (<8 x s32>), addrspace 5)
+    ; CHECK-NEG-LAT-NEXT: }
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
     $r2 = LDA_dms_lda_idx_imm $p0, 0 :: (load (s32), addrspace 6)
     $wl2 = VLDB_dmw_ldb_ag_idx_imm $p0, 0 :: (load (<8 x s32>), addrspace 5)
     VST_SRS_D8_S32_ag_idx_imm $p0, 0, $cm0, $s0, implicit-def $srsrs_of, implicit $crsat, implicit $crrnd, implicit $crsrssign
@@ -111,6 +145,19 @@ body:             |
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: ST_dms_sts_idx_imm killed $r2, killed $p0, 0
     ; CHECK-NEXT: NOP
+    ; CHECK-NEG-LAT-LABEL: name: SRS_STORE_E7_STORE_E5
+    ; CHECK-NEG-LAT: ST_dms_sts_idx_imm $r2, $p0, 0
+    ; CHECK-NEG-LAT-NEXT: VST_SRS_D8_S32_ag_idx_imm $p0, 0, $cm0, $s0, implicit-def $srsrs_of, implicit $crsat, implicit $crrnd, implicit $crsrssign
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: $p1 = VST_SRS_D8_S32_ag_pstm_nrm_imm killed $p1, 0, $cm0, $s0, implicit-def $srsrs_of, implicit $crsat, implicit $crrnd, implicit $crsrssign
+    ; CHECK-NEG-LAT-NEXT: ST_dms_sts_idx_imm $r2, $p0, 0
+    ; CHECK-NEG-LAT-NEXT: $p2, $dc0 = VST_2D_SRS_D8_S32 killed $p2, killed $d0, $cm0, $s0, implicit-def $srsrs_of, implicit $crsat, implicit $crrnd, implicit $crsrssign
+    ; CHECK-NEG-LAT-NEXT: ST_dms_sts_idx_imm $r2, $p0, 0
+    ; CHECK-NEG-LAT-NEXT: $p3, $dc1, $dc5 = VST_3D_SRS_D8_S32 killed $p3, killed $d1_3d, killed $cm0, killed $s0, implicit-def $srsrs_of, implicit $crsat, implicit $crrnd, implicit $crsrssign
+    ; CHECK-NEG-LAT-NEXT: ST_dms_sts_idx_imm $r2, $p0, 0
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: ST_dms_sts_idx_imm killed $r2, killed $p0, 0
+    ; CHECK-NEG-LAT-NEXT: NOP
     ST_dms_sts_idx_imm $r2, $p0, 0
     VST_SRS_D8_S32_ag_idx_imm $p0, 0, $cm0, $s0, implicit-def $srsrs_of, implicit $crsat, implicit $crrnd, implicit $crsrssign
     ST_dms_sts_idx_imm $r2, $p0, 0
@@ -149,6 +196,23 @@ body:             |
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
+    ; CHECK-NEG-LAT-LABEL: name: SRS_STORE_E7_STORE_E7
+    ; CHECK-NEG-LAT: VST_SRS_D8_S32_ag_idx_imm $p0, 0, $cm0, $s0, implicit-def $srsrs_of, implicit $crsat, implicit $crrnd, implicit $crsrssign
+    ; CHECK-NEG-LAT-NEXT: VST_SRS_D8_S32_ag_idx_imm $p0, 0, $cm0, $s0, implicit-def $srsrs_of, implicit $crsat, implicit $crrnd, implicit $crsrssign
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: VST_CONV_BF16_FP32_ag_idx_imm $p0, 0, $bml0, implicit-def $srf2fflags, implicit $crrnd, implicit $crf2fmask
+    ; CHECK-NEG-LAT-NEXT: $p1 = VST_SRS_D8_S32_ag_pstm_nrm_imm killed $p1, 0, $cm0, $s0, implicit-def $srsrs_of, implicit $crsat, implicit $crrnd, implicit $crsrssign
+    ; CHECK-NEG-LAT-NEXT: VST_SRS_D8_S32_ag_idx_imm $p0, 0, $cm0, $s0, implicit-def $srsrs_of, implicit $crsat, implicit $crrnd, implicit $crsrssign
+    ; CHECK-NEG-LAT-NEXT: $p2, $dc0 = VST_2D_SRS_D8_S32 killed $p2, killed $d0, $cm0, $s0, implicit-def $srsrs_of, implicit $crsat, implicit $crrnd, implicit $crsrssign
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: VST_CONV_BF16_FP32_ag_idx_imm $p0, 0, $bml0, implicit-def $srf2fflags, implicit $crrnd, implicit $crf2fmask
+    ; CHECK-NEG-LAT-NEXT: $p3, $dc1, $dc5 = VST_3D_SRS_D8_S32 killed $p3, killed $d1_3d, $cm0, $s0, implicit-def $srsrs_of, implicit $crsat, implicit $crrnd, implicit $crsrssign
+    ; CHECK-NEG-LAT-NEXT: VST_SRS_D8_S32_ag_idx_imm killed $p0, 0, killed $cm0, killed $s0, implicit-def $srsrs_of, implicit $crsat, implicit $crrnd, implicit $crsrssign
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
     VST_SRS_D8_S32_ag_idx_imm $p0, 0, $cm0, $s0, implicit-def $srsrs_of, implicit $crsat, implicit $crrnd, implicit $crsrssign
     VST_SRS_D8_S32_ag_idx_imm $p0, 0, $cm0, $s0, implicit-def $srsrs_of, implicit $crsat, implicit $crrnd, implicit $crsrssign
     VST_CONV_BF16_FP32_ag_idx_imm $p0, 0, $bml0, implicit-def $srf2fflags, implicit $crrnd, implicit $crf2fmask
@@ -208,6 +272,47 @@ body:             |
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
+    ; CHECK-NEG-LAT-LABEL: name: SRS_STORE_E7_STORE_E11
+    ; CHECK-NEG-LAT: ST_S8_ag_idx_imm $r2, $p0, 0
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: VST_SRS_D8_S32_ag_idx_imm $p0, 0, $cm0, $s0, implicit-def $srsrs_of, implicit $crsat, implicit $crrnd, implicit $crsrssign
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: ST_S8_ag_idx_imm $r2, $p0, 0
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: $p1 = VST_SRS_D8_S32_ag_pstm_nrm_imm killed $p1, 0, $cm0, $s0, implicit-def $srsrs_of, implicit $crsat, implicit $crrnd, implicit $crsrssign
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: ST_S8_ag_idx_imm $r2, $p0, 0
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: $p2, $dc0 = VST_2D_SRS_D8_S32 killed $p2, killed $d0, $cm0, $s0, implicit-def $srsrs_of, implicit $crsat, implicit $crrnd, implicit $crsrssign
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: ST_S8_ag_idx_imm $r2, $p0, 0
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: $p3, $dc1, $dc5 = VST_3D_SRS_D8_S32 killed $p3, killed $d1_3d, killed $cm0, killed $s0, implicit-def $srsrs_of, implicit $crsat, implicit $crrnd, implicit $crsrssign
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: ST_S8_ag_idx_imm killed $r2, killed $p0, 0
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
     ST_S8_ag_idx_imm $r2, $p0, 0
     VST_SRS_D8_S32_ag_idx_imm $p0, 0, $cm0, $s0, implicit-def $srsrs_of, implicit $crsat, implicit $crrnd, implicit $crsrssign
     ST_S8_ag_idx_imm $r2, $p0, 0

--- a/llvm/test/CodeGen/AIE/aie2/schedule/memory_dependencies_vst_w.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/memory_dependencies_vst_w.mir
@@ -4,8 +4,9 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2023-2024 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2023-2026 Advanced Micro Devices, Inc. or its affiliates
 # RUN: llc -march=aie2 -run-pass=postmisched %topdown-multi %s -o - | FileCheck %s
+# RUN: llc -march=aie2 -run-pass=postmisched %topdown-multi-negative-lat %s -o - | FileCheck %s --check-prefix=CHECK-NEG-LAT
 
 # This test shows how ordered load/stores are handled.
 # In most cases, we just need to keep them one cycle appart, but for example
@@ -61,6 +62,37 @@ body:             |
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
+    ; CHECK-NEG-LAT-LABEL: name: W_STORE_E5_LOAD_E5
+    ; CHECK-NEG-LAT: BUNDLE implicit-def $r2, implicit-def $wl2, implicit $p0 {
+    ; CHECK-NEG-LAT-NEXT: $r2 = LDA_dms_lda_idx_imm $p0, 0 :: (load (s32), addrspace 6)
+    ; CHECK-NEG-LAT-NEXT: $wl2 = VLDB_dmw_ldb_ag_idx_imm $p0, 0 :: (load (<8 x s32>), addrspace 5)
+    ; CHECK-NEG-LAT-NEXT: }
+    ; CHECK-NEG-LAT-NEXT: VST_dmw_sts_w_ag_idx_imm $wl0, $p0, 0
+    ; CHECK-NEG-LAT-NEXT: BUNDLE implicit-def $r2, implicit-def $wl2, implicit $p0 {
+    ; CHECK-NEG-LAT-NEXT: $r2 = LDA_dms_lda_idx_imm $p0, 0 :: (load (s32), addrspace 6)
+    ; CHECK-NEG-LAT-NEXT: $wl2 = VLDB_dmw_ldb_ag_idx_imm $p0, 0 :: (load (<8 x s32>), addrspace 5)
+    ; CHECK-NEG-LAT-NEXT: }
+    ; CHECK-NEG-LAT-NEXT: $p1 = VST_dmw_sts_w_ag_pstm_nrm_imm $wl0, killed $p1, 0
+    ; CHECK-NEG-LAT-NEXT: BUNDLE implicit-def $r2, implicit-def $wl2, implicit $p0 {
+    ; CHECK-NEG-LAT-NEXT: $r2 = LDA_dms_lda_idx_imm $p0, 0 :: (load (s32), addrspace 6)
+    ; CHECK-NEG-LAT-NEXT: $wl2 = VLDB_dmw_ldb_ag_idx_imm $p0, 0 :: (load (<8 x s32>), addrspace 5)
+    ; CHECK-NEG-LAT-NEXT: }
+    ; CHECK-NEG-LAT-NEXT: $p2, $dc0 = VST_2D_dmw_sts_w $wl0, killed $p2, killed $d0
+    ; CHECK-NEG-LAT-NEXT: BUNDLE implicit-def $r2, implicit-def $wl2, implicit $p0 {
+    ; CHECK-NEG-LAT-NEXT: $r2 = LDA_dms_lda_idx_imm $p0, 0 :: (load (s32), addrspace 6)
+    ; CHECK-NEG-LAT-NEXT: $wl2 = VLDB_dmw_ldb_ag_idx_imm $p0, 0 :: (load (<8 x s32>), addrspace 5)
+    ; CHECK-NEG-LAT-NEXT: }
+    ; CHECK-NEG-LAT-NEXT: $p3, $dc1, $dc5 = VST_3D_dmw_sts_w killed $wl0, killed $p3, killed $d1_3d
+    ; CHECK-NEG-LAT-NEXT: BUNDLE implicit-def $r2, implicit-def $wl2, implicit killed $p0 {
+    ; CHECK-NEG-LAT-NEXT: $r2 = LDA_dms_lda_idx_imm $p0, 0 :: (load (s32), addrspace 6)
+    ; CHECK-NEG-LAT-NEXT: $wl2 = VLDB_dmw_ldb_ag_idx_imm killed $p0, 0 :: (load (<8 x s32>), addrspace 5)
+    ; CHECK-NEG-LAT-NEXT: }
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
     $r2 = LDA_dms_lda_idx_imm $p0, 0 :: (load (s32), addrspace 6)
     $wl2 = VLDB_dmw_ldb_ag_idx_imm $p0, 0 :: (load (<8 x s32>), addrspace 5)
     VST_dmw_sts_w_ag_idx_imm $wl0, $p0, 0                 ; II_VST_W
@@ -95,6 +127,17 @@ body:             |
     ; CHECK-NEXT: $p3, $dc1, $dc5 = VST_3D_dmw_sts_w killed $wl0, killed $p3, killed $d1_3d
     ; CHECK-NEXT: ST_dms_sts_idx_imm killed $r2, killed $p0, 0
     ; CHECK-NEXT: NOP
+    ; CHECK-NEG-LAT-LABEL: name: W_STORE_E5_STORE_E5
+    ; CHECK-NEG-LAT: ST_dms_sts_idx_imm $r2, $p0, 0
+    ; CHECK-NEG-LAT-NEXT: VST_dmw_sts_w_ag_idx_imm $wl0, $p0, 0
+    ; CHECK-NEG-LAT-NEXT: ST_dms_sts_idx_imm $r2, $p0, 0
+    ; CHECK-NEG-LAT-NEXT: $p1 = VST_dmw_sts_w_ag_pstm_nrm_imm $wl0, killed $p1, 0
+    ; CHECK-NEG-LAT-NEXT: ST_dms_sts_idx_imm $r2, $p0, 0
+    ; CHECK-NEG-LAT-NEXT: $p2, $dc0 = VST_2D_dmw_sts_w $wl0, killed $p2, killed $d0
+    ; CHECK-NEG-LAT-NEXT: ST_dms_sts_idx_imm $r2, $p0, 0
+    ; CHECK-NEG-LAT-NEXT: $p3, $dc1, $dc5 = VST_3D_dmw_sts_w killed $wl0, killed $p3, killed $d1_3d
+    ; CHECK-NEG-LAT-NEXT: ST_dms_sts_idx_imm killed $r2, killed $p0, 0
+    ; CHECK-NEG-LAT-NEXT: NOP
     ST_dms_sts_idx_imm $r2, $p0, 0
     VST_dmw_sts_w_ag_idx_imm $wl0, $p0, 0                 ; II_VST_W
     ST_dms_sts_idx_imm $r2, $p0, 0
@@ -134,6 +177,19 @@ body:             |
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
+    ; CHECK-NEG-LAT-LABEL: name: W_STORE_E5_STORE_E7
+    ; CHECK-NEG-LAT: VST_SRS_D8_S32_ag_idx_imm $p0, 0, $cm0, $s0, implicit-def $srsrs_of, implicit $crsat, implicit $crrnd, implicit $crsrssign
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: VST_SRS_D8_S32_ag_idx_imm $p0, 0, $cm0, $s0, implicit-def $srsrs_of, implicit $crsat, implicit $crrnd, implicit $crsrssign
+    ; CHECK-NEG-LAT-NEXT: VST_dmw_sts_w_ag_idx_imm $wl0, $p0, 0
+    ; CHECK-NEG-LAT-NEXT: VST_SRS_D8_S32_ag_idx_imm $p0, 0, $cm0, $s0, implicit-def $srsrs_of, implicit $crsat, implicit $crrnd, implicit $crsrssign
+    ; CHECK-NEG-LAT-NEXT: $p1 = VST_dmw_sts_w_ag_pstm_nrm_imm $wl0, killed $p1, 0
+    ; CHECK-NEG-LAT-NEXT: VST_SRS_D8_S32_ag_idx_imm $p0, 0, $cm0, $s0, implicit-def $srsrs_of, implicit $crsat, implicit $crrnd, implicit $crsrssign
+    ; CHECK-NEG-LAT-NEXT: $p2, $dc0 = VST_2D_dmw_sts_w $wl0, killed $p2, killed $d0
+    ; CHECK-NEG-LAT-NEXT: VST_SRS_D8_S32_ag_idx_imm killed $p0, 0, killed $cm0, killed $s0, implicit-def $srsrs_of, implicit $crsat, implicit $crrnd, implicit $crsrssign
+    ; CHECK-NEG-LAT-NEXT: $p3, $dc1, $dc5 = VST_3D_dmw_sts_w killed $wl0, killed $p3, killed $d1_3d
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
     VST_SRS_D8_S32_ag_idx_imm $p0, 0, $cm0, $s0, implicit-def $srsrs_of, implicit $crsat, implicit $crrnd, implicit $crsrssign
     VST_dmw_sts_w_ag_idx_imm $wl0, $p0, 0                 ; II_VST_W
     VST_SRS_D8_S32_ag_idx_imm $p0, 0, $cm0, $s0, implicit-def $srsrs_of, implicit $crsat, implicit $crrnd, implicit $crsrssign
@@ -193,6 +249,47 @@ body:             |
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
+    ; CHECK-NEG-LAT-LABEL: name: W_STORE_E5_STORE_E11
+    ; CHECK-NEG-LAT: ST_S8_ag_idx_imm $r2, $p0, 0
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: VST_dmw_sts_w_ag_idx_imm $wl0, $p0, 0
+    ; CHECK-NEG-LAT-NEXT: ST_S8_ag_idx_imm $r2, $p0, 0
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: $p1 = VST_dmw_sts_w_ag_pstm_nrm_imm $wl0, killed $p1, 0
+    ; CHECK-NEG-LAT-NEXT: ST_S8_ag_idx_imm $r2, $p0, 0
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: $p2, $dc0 = VST_2D_dmw_sts_w $wl0, killed $p2, killed $d0
+    ; CHECK-NEG-LAT-NEXT: ST_S8_ag_idx_imm $r2, $p0, 0
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: $p3, $dc1, $dc5 = VST_3D_dmw_sts_w killed $wl0, killed $p3, killed $d1_3d
+    ; CHECK-NEG-LAT-NEXT: ST_S8_ag_idx_imm killed $r2, killed $p0, 0
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
     ST_S8_ag_idx_imm $r2, $p0, 0
     VST_dmw_sts_w_ag_idx_imm $wl0, $p0, 0                 ; II_VST_W
     ST_S8_ag_idx_imm $r2, $p0, 0

--- a/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/add-store.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/add-store.mir
@@ -41,14 +41,6 @@
   ; CHECK-NEXT:  // %bb.3: // %for.cond.cleanup
   ; CHECK-NEXT:    nopa ; nopb ; nopxm ; st r1, [p0], #4
   ; CHECK-NEXT:    nop
-  ; CHECK-NEXT:    nop
-  ; CHECK-NEXT:    nop
-  ; CHECK-NEXT:    nop
-  ; CHECK-NEXT:    nop
-  ; CHECK-NEXT:    nop
-  ; CHECK-NEXT:    nop
-  ; CHECK-NEXT:    nop
-  ; CHECK-NEXT:    nop
   ; CHECK-NEXT:    .p2align 4
   ; CHECK-NEXT:  .LBB0_4: // %for.cond.cleanup
   ; CHECK-NEXT:    nopa ; ret lr

--- a/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/interleave-prologue.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/interleave-prologue.mir
@@ -58,13 +58,11 @@ body:             |
   ; CHECK-NEXT:   $x0 = VADD_16 killed $x0, $x6
   ; CHECK-NEXT:   $x0 = VADD_16 killed $x0, $x6
   ; CHECK-NEXT:   $x0 = VADD_16 killed $x0, killed $x6
-  ; CHECK-NEXT:   NOP
-  ; CHECK-NEXT:   VST_PACK_S8_S16_ag_idx_imm killed $p1, 0, killed $x0, implicit $crsat
   ; CHECK-NEXT:   RET implicit $lr
   ; CHECK-NEXT:   NOP
   ; CHECK-NEXT:   NOP
   ; CHECK-NEXT:   NOP
-  ; CHECK-NEXT:   NOP
+  ; CHECK-NEXT:   VST_PACK_S8_S16_ag_idx_imm killed $p1, 0, killed $x0, implicit $crsat
   ; CHECK-NEXT:   NOP
   ; CHECK-NEXT:   DelayedSchedBarrier
   bb.0:
@@ -167,13 +165,11 @@ body:             |
   ; CHECK-NEXT:   $x0 = VADD_16 killed $x0, $x6
   ; CHECK-NEXT:   $x0 = VADD_16 killed $x0, $x6
   ; CHECK-NEXT:   $x0 = VADD_16 killed $x0, killed $x6
-  ; CHECK-NEXT:   NOP
-  ; CHECK-NEXT:   VST_PACK_S8_S16_ag_idx_imm killed $p1, 0, killed $x0, implicit $crsat
   ; CHECK-NEXT:   RET implicit $lr
   ; CHECK-NEXT:   NOP
   ; CHECK-NEXT:   NOP
   ; CHECK-NEXT:   NOP
-  ; CHECK-NEXT:   NOP
+  ; CHECK-NEXT:   VST_PACK_S8_S16_ag_idx_imm killed $p1, 0, killed $x0, implicit $crsat
   ; CHECK-NEXT:   NOP
   ; CHECK-NEXT:   DelayedSchedBarrier
   bb.0:
@@ -270,13 +266,11 @@ body:             |
   ; CHECK-NEXT:   $x0 = VADD_16 killed $x0, $x6
   ; CHECK-NEXT:   $x0 = VADD_16 killed $x0, $x6
   ; CHECK-NEXT:   $x0 = VADD_16 killed $x0, killed $x6
-  ; CHECK-NEXT:   NOP
-  ; CHECK-NEXT:   VST_PACK_S8_S16_ag_idx_imm killed $p1, 0, killed $x0, implicit $crsat
   ; CHECK-NEXT:   RET implicit $lr
   ; CHECK-NEXT:   NOP
   ; CHECK-NEXT:   NOP
   ; CHECK-NEXT:   NOP
-  ; CHECK-NEXT:   NOP
+  ; CHECK-NEXT:   VST_PACK_S8_S16_ag_idx_imm killed $p1, 0, killed $x0, implicit $crsat
   ; CHECK-NEXT:   NOP
   ; CHECK-NEXT:   DelayedSchedBarrier
   bb.0:
@@ -397,12 +391,9 @@ body:             |
   ; CHECK-NEXT:   $cm2 = VMAC_vmac_cm_core_dense killed $cm2, killed $x5, killed $x0, killed $r4
   ; CHECK-NEXT:   NOP
   ; CHECK-NEXT:   NOP
-  ; CHECK-NEXT:   NOP
-  ; CHECK-NEXT:   NOP
-  ; CHECK-NEXT:   VST_SRS_S8_S32_ag_idx_imm killed $p1, 0, killed $cm2, killed $s0, implicit-def $srsrs_of, implicit $crsat, implicit $crrnd
   ; CHECK-NEXT:   RET implicit $lr
   ; CHECK-NEXT:   NOP
-  ; CHECK-NEXT:   NOP
+  ; CHECK-NEXT:   VST_SRS_S8_S32_ag_idx_imm killed $p1, 0, killed $cm2, killed $s0, implicit-def $srsrs_of, implicit $crsat, implicit $crrnd
   ; CHECK-NEXT:   NOP
   ; CHECK-NEXT:   NOP
   ; CHECK-NEXT:   NOP
@@ -492,13 +483,11 @@ body:             |
   ; CHECK-NEXT:   $x0 = VADD_16 killed $x0, $x6
   ; CHECK-NEXT:   $x0 = VADD_16 killed $x0, $x6
   ; CHECK-NEXT:   $x0 = VADD_16 killed $x0, killed $x6
-  ; CHECK-NEXT:   NOP
-  ; CHECK-NEXT:   VST_PACK_S8_S16_ag_idx_imm killed $p1, 0, killed $x0, implicit $crsat
   ; CHECK-NEXT:   RET implicit $lr
   ; CHECK-NEXT:   NOP
   ; CHECK-NEXT:   NOP
   ; CHECK-NEXT:   NOP
-  ; CHECK-NEXT:   NOP
+  ; CHECK-NEXT:   VST_PACK_S8_S16_ag_idx_imm killed $p1, 0, killed $x0, implicit $crsat
   ; CHECK-NEXT:   NOP
   ; CHECK-NEXT:   DelayedSchedBarrier
   bb.0:

--- a/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/round-war.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/round-war.mir
@@ -69,9 +69,9 @@
   ; CHECK-NEXT:    nop
   ; CHECK-NEXT:    vst.srs.d8.s32 cm2, s0, [p1], #32
   ; CHECK-NEXT:    vst.srs.d8.s32 cm3, s0, [p1], #32
+  ; CHECK-NEXT:    nop
+  ; CHECK-NEXT:    nop
   ; CHECK-NEXT:    mov crSRSSign, #0
-  ; CHECK-NEXT:    nop
-  ; CHECK-NEXT:    nop
   ; CHECK-NEXT:    .p2align 4
   ; CHECK-NEXT:  .LBB0_4: // %for.cond.cleanup
   ; CHECK-NEXT:    nopa ; ret lr

--- a/llvm/test/CodeGen/AIE/aie2/schedule/streams.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/streams.mir
@@ -4,8 +4,10 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2023-2024 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2023-2026 Advanced Micro Devices, Inc. or its affiliates
 # RUN: llc -march=aie2 %topdown-single -run-pass=postmisched %s -o - | FileCheck %s
+# RUN: llc -march=aie2 %topdown-single-negative-lat -run-pass=postmisched %s -o - \
+# RUN:   | FileCheck %s --check-prefix=CHECK-NEG-LAT
 
 
 ---
@@ -32,6 +34,23 @@ body:             |
     ; CHECK-NEXT: MOV_TLAST_mv_scl2ms killed renamable $r0
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
+    ; CHECK-NEG-LAT-LABEL: name: streams
+    ; CHECK-NEG-LAT: liveins: $r1
+    ; CHECK-NEG-LAT-NEXT: {{  $}}
+    ; CHECK-NEG-LAT-NEXT: renamable $r0 = MOV_mv_ss2scl implicit-def $srss0
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: $r28 = MOV_mv_scl $srss0
+    ; CHECK-NEG-LAT-NEXT: MOV_mv_scl2ms_doTlast_reg renamable $r0, killed renamable $r28
+    ; CHECK-NEG-LAT-NEXT: MOV_mv_scl2ms renamable $r0
+    ; CHECK-NEG-LAT-NEXT: MOV_TLAST_mv_scl2ms killed renamable $r0
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
     renamable $r0 = MOV_mv_ss2scl implicit-def $srss0
     $r28 = MOV_mv_scl $srss0
     MOV_mv_scl2ms_doTlast_reg renamable $r0, killed renamable $r28
@@ -66,6 +85,23 @@ body:             |
     ; CHECK-NEXT: MOV_NB_TLAST_mv_scl2ms killed renamable $r1, implicit-def $srms0
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
+    ; CHECK-NEG-LAT-LABEL: name: streams_nb
+    ; CHECK-NEG-LAT: liveins: $r1
+    ; CHECK-NEG-LAT-NEXT: {{  $}}
+    ; CHECK-NEG-LAT-NEXT: renamable $r1 = MOV_NB_mv_ss2scl implicit-def $srss0
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: $r28 = MOV_mv_scl $srss0
+    ; CHECK-NEG-LAT-NEXT: MOV_NB_mv_scl2ms_doTlast_reg renamable $r1, killed renamable $r28, implicit-def $srms0
+    ; CHECK-NEG-LAT-NEXT: MOV_NB_mv_scl2ms renamable $r1, implicit-def $srms0
+    ; CHECK-NEG-LAT-NEXT: MOV_NB_TLAST_mv_scl2ms killed renamable $r1, implicit-def $srms0
+    ; CHECK-NEG-LAT-NEXT: $r0 = MOV_mv_scl $srms0
+    ; CHECK-NEG-LAT-NEXT: NOP
     renamable $r1 = MOV_NB_mv_ss2scl implicit-def $srss0
     $r28 = MOV_mv_scl $srss0
     MOV_NB_mv_scl2ms_doTlast_reg renamable $r1, killed renamable $r28, implicit-def $srms0
@@ -97,6 +133,22 @@ body:             |
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
+    ; CHECK-NEG-LAT-LABEL: name: II_MOV_PH_B
+    ; CHECK-NEG-LAT: liveins: $r1
+    ; CHECK-NEG-LAT-NEXT: {{  $}}
+    ; CHECK-NEG-LAT-NEXT: $r0 = LDA_dms_lda_idx_imm killed $p1, 4
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: MOV_mv_ph2ms killed $r0, 1
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
     $r0 = LDA_dms_lda_idx_imm $p1, 4
     MOV_mv_ph2ms $r0, 1
 ...
@@ -117,6 +169,16 @@ body:             |
     ; CHECK-NEXT: $r1 = MOV_mv_scl $srms0
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
+    ; CHECK-NEG-LAT-LABEL: name: II_MOV_PH_NB
+    ; CHECK-NEG-LAT: liveins: $r1
+    ; CHECK-NEG-LAT-NEXT: {{  $}}
+    ; CHECK-NEG-LAT-NEXT: $r1 = MOV_mv_scl $srms0
+    ; CHECK-NEG-LAT-NEXT: MOV_NB_mv_ph2ms killed $r1, 1, implicit-def $srms0
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: $r1 = MOV_mv_scl $srms0
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
     $r1 = MOV_mv_scl $srms0
     MOV_NB_mv_ph2ms $r1, 1, implicit-def $srms0
     $r1 = MOV_mv_scl $srms0
@@ -142,6 +204,20 @@ body:             |
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
+    ; CHECK-NEG-LAT-LABEL: name: II_MOV_PH_NB_TLAST_REG
+    ; CHECK-NEG-LAT: liveins: $r1
+    ; CHECK-NEG-LAT-NEXT: {{  $}}
+    ; CHECK-NEG-LAT-NEXT: $r28 = MOV_mv_scl $srss0
+    ; CHECK-NEG-LAT-NEXT: MOV_NB_mv_ph2ms_doTlast_reg killed $r1, 1, $r28, implicit-def $srms0
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: $r1 = MOV_mv_scl $srms0
+    ; CHECK-NEG-LAT-NEXT: MOV_NB_mv_ph2ms_doTlast_reg killed $r1, 1, killed $r28, implicit-def $srms0
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
     $r28 = MOV_mv_scl $srss0
     MOV_NB_mv_ph2ms_doTlast_reg $r1, 1, $r28, implicit-def $srms0
     $r1 = MOV_mv_scl $srms0
@@ -178,6 +254,30 @@ body:             |
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
+    ; CHECK-NEG-LAT-LABEL: name: II_MOV_CPH_B
+    ; CHECK-NEG-LAT: liveins: $r1
+    ; CHECK-NEG-LAT-NEXT: {{  $}}
+    ; CHECK-NEG-LAT-NEXT: $r0 = LDA_dms_lda_idx_imm killed $p1, 4
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: MOV_mv_cph2ms killed $m0, 1, 2, $r0
+    ; CHECK-NEG-LAT-NEXT: $m0 = LDA_dms_lda_idx_imm killed $p2, 4
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: MOV_mv_cph2ms killed $m0, 1, 2, killed $r0
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
     $r0 = LDA_dms_lda_idx_imm $p1, 4
     MOV_mv_cph2ms $m0, 1, 2, $r0
     $m0 = LDA_dms_lda_idx_imm $p2, 4
@@ -204,6 +304,20 @@ body:             |
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
+    ; CHECK-NEG-LAT-LABEL: name: II_MOV_CPH_NB
+    ; CHECK-NEG-LAT: liveins: $r1
+    ; CHECK-NEG-LAT-NEXT: {{  $}}
+    ; CHECK-NEG-LAT-NEXT: $r1 = MOV_mv_scl $srms0
+    ; CHECK-NEG-LAT-NEXT: MOV_NB_mv_cph2ms killed $m1, 1, 2, $r1, implicit-def $srms0
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: $m1 = MOV_mv_scl $srms0
+    ; CHECK-NEG-LAT-NEXT: MOV_NB_mv_cph2ms killed $m1, 1, 2, killed $r1, implicit-def $srms0
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
     $r1 = MOV_mv_scl $srms0
     MOV_NB_mv_cph2ms $m1, 1, 2, $r1, implicit-def $srms0
     $m1 = MOV_mv_scl $srms0
@@ -234,6 +348,24 @@ body:             |
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
+    ; CHECK-NEG-LAT-LABEL: name: II_MOV_CPH_NB_TLAST_REG
+    ; CHECK-NEG-LAT: liveins: $r1
+    ; CHECK-NEG-LAT-NEXT: {{  $}}
+    ; CHECK-NEG-LAT-NEXT: $r28 = MOV_mv_scl $srss0
+    ; CHECK-NEG-LAT-NEXT: MOV_NB_mv_cph2ms_doTlast_reg $m1, 1, 2, killed $r1, $r28, implicit-def $srms0
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: $r1 = MOV_mv_scl $srms0
+    ; CHECK-NEG-LAT-NEXT: MOV_NB_mv_cph2ms_doTlast_reg killed $m1, 1, 2, $r1, $r28, implicit-def $srms0
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: $m1 = MOV_mv_scl $srms0
+    ; CHECK-NEG-LAT-NEXT: MOV_NB_mv_cph2ms_doTlast_reg killed $m1, 1, 2, killed $r1, killed $r28, implicit-def $srms0
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
     $r28 = MOV_mv_scl $srss0
     MOV_NB_mv_cph2ms_doTlast_reg $m1, 1, 2, $r1, $r28, implicit-def $srms0
     $r1 = MOV_mv_scl $srms0

--- a/llvm/test/CodeGen/AIE/aie2/schedule/vadd.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/vadd.mir
@@ -4,9 +4,11 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2023-2024 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2023-2026 Advanced Micro Devices, Inc. or its affiliates
 # RUN: llc -march=aie2 %topdown-single -run-pass=postmisched %s -o - \
 # RUN:   | FileCheck %s
+# RUN: llc -march=aie2 %topdown-single-negative-lat -run-pass=postmisched %s -o - \
+# RUN:   | FileCheck %s --check-prefix=CHECK-NEG-LAT
 
 ---
 name:            bypass
@@ -18,6 +20,11 @@ body:             |
     ; CHECK-NEXT: $x0 = VADD_16 killed $x0, $x1
     ; CHECK-NEXT: $x0 = VADD_32 killed $x0, killed $x1
     ; CHECK-NEXT: NOP
+    ; CHECK-NEG-LAT-LABEL: name: bypass
+    ; CHECK-NEG-LAT: $x0 = VADD_8 killed $x0, $x1
+    ; CHECK-NEG-LAT-NEXT: $x0 = VADD_16 killed $x0, $x1
+    ; CHECK-NEG-LAT-NEXT: $x0 = VADD_32 killed $x0, killed $x1
+    ; CHECK-NEG-LAT-NEXT: NOP
     $x0 = VADD_8 $x0, $x1
     $x0 = VADD_16 $x0, $x1
     $x0 = VADD_32 $x0, $x1
@@ -39,6 +46,15 @@ body:             |
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: VST_dmw_sts_w_ag_idx_imm killed $wl0, killed $p0, 0
     ; CHECK-NEXT: NOP
+    ; CHECK-NEG-LAT-LABEL: name: no_bypass
+    ; CHECK-NEG-LAT: $x0 = VADD_8 killed $x0, $x1
+    ; CHECK-NEG-LAT-NEXT: $x0 = VADD_16 killed $x0, $x1
+    ; CHECK-NEG-LAT-NEXT: VST_dmw_sts_w_ag_idx_imm $wl0, $p0, 0
+    ; CHECK-NEG-LAT-NEXT: VST_dmw_sts_w_ag_idx_imm $wl0, $p0, 0
+    ; CHECK-NEG-LAT-NEXT: $x0 = VADD_32 killed $x0, killed $x1
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: VST_dmw_sts_w_ag_idx_imm killed $wl0, killed $p0, 0
+    ; CHECK-NEG-LAT-NEXT: NOP
     $x0 = VADD_8 $x0, $x1
     VST_dmw_sts_w_ag_idx_imm $wl0, $p0, 0
     $x0 = VADD_16 $x0, $x1

--- a/llvm/test/CodeGen/AIE/aie2/schedule/vldb-compr.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/vldb-compr.mir
@@ -4,8 +4,9 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2023-2024 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2023-2026 Advanced Micro Devices, Inc. or its affiliates
 # RUN: llc -march=aie2 -run-pass=postmisched %topdown-multi --verify-machineinstrs %s -o - | FileCheck %s
+# RUN: llc -march=aie2 -run-pass=postmisched %topdown-multi-negative-lat %s -o - | FileCheck %s --check-prefix=CHECK-NEG-LAT
 
 
 ---
@@ -27,6 +28,20 @@ body:             |
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
+    ; CHECK-NEG-LAT-LABEL: name: II_VLDB_COMPR_FILL_input
+    ; CHECK-NEG-LAT: $p0 = LDA_dms_lda_idx_imm killed $p7, 0
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: $p0 = VLDB_COMPR_FILL killed $p0, implicit killed $dp
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
     $p0 = LDA_dms_lda_idx_imm $p7, 0
     $p0 = VLDB_COMPR_FILL $p0, implicit $dp
 ...
@@ -44,6 +59,14 @@ body:             |
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
+    ; CHECK-NEG-LAT-LABEL: name: II_VLDB_COMPR_FILL_output
+    ; CHECK-NEG-LAT: $p0 = VLDB_COMPR_FILL killed $p0, implicit $dp
+    ; CHECK-NEG-LAT-NEXT: $p0 = VLDB_COMPR_FILL killed $p0, implicit killed $dp
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
     $p0 = VLDB_COMPR_FILL $p0, implicit $dp
     $p0 = VLDB_COMPR_FILL $p0, implicit $dp
 ...
@@ -67,6 +90,20 @@ body:             |
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
+    ; CHECK-NEG-LAT-LABEL: name: II_VLDB_COMPR_RESET_input
+    ; CHECK-NEG-LAT: $p0 = LDA_dms_lda_idx_imm killed $p7, 0
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: $p0 = VLDB_COMPR_RESET killed $p0, implicit-def $dp, implicit killed $dp
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
     $p0 = LDA_dms_lda_idx_imm $p7, 0
     $p0 = VLDB_COMPR_RESET $p0, implicit-def $dp, implicit $dp
 ...
@@ -84,6 +121,14 @@ body:             |
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
+    ; CHECK-NEG-LAT-LABEL: name: II_VLDB_COMPR_RESET_output
+    ; CHECK-NEG-LAT: $p0 = VLDB_COMPR_RESET killed $p0, implicit-def $dp, implicit killed $dp
+    ; CHECK-NEG-LAT-NEXT: $p0 = VLDB_COMPR_RESET killed $p0, implicit-def $dp, implicit killed $dp
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
     $p0 = VLDB_COMPR_RESET $p0, implicit-def $dp, implicit $dp
     $p0 = VLDB_COMPR_RESET $p0, implicit-def $dp, implicit $dp
 ...
@@ -108,6 +153,21 @@ body:             |
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
+    ; CHECK-NEG-LAT-LABEL: name: II_VLDB_COMPR_PEEK_input
+    ; CHECK-NEG-LAT: $p0 = LDA_dms_lda_idx_imm killed $p7, 0
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: $p0, $wh0 = VLDB_COMPR_PEEK killed $p0, implicit-def $srcompr_uf, implicit killed $dp
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
     $p0 = LDA_dms_lda_idx_imm $p7, 0
     $p0, $wh0 = VLDB_COMPR_PEEK $p0, implicit-def $srcompr_uf, implicit $dp
 ...
@@ -130,6 +190,19 @@ body:             |
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
+    ; CHECK-NEG-LAT-LABEL: name: II_VLDB_COMPR_PEEK_output
+    ; CHECK-NEG-LAT: $p0, $wh0 = VLDB_COMPR_PEEK killed $p0, implicit-def $srcompr_uf, implicit killed $dp
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: $cm0 = VMAC_vmac_cm_core_sparse_narrow killed $cm1, killed $x4, killed $qx0, killed $r9
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
     $p0, $wh0 = VLDB_COMPR_PEEK $p0, implicit-def $srcompr_uf, implicit $dp
     $cm0 = VMAC_vmac_cm_core_sparse_narrow $cm1, $x4, $qx0, $r9
 ...
@@ -154,6 +227,21 @@ body:             |
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
+    ; CHECK-NEG-LAT-LABEL: name: II_VLDB_COMPR_POP_input
+    ; CHECK-NEG-LAT: $p0 = LDA_dms_lda_idx_imm killed $p7, 0
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: $p0, $wh0 = VLDB_COMPR_POP killed $p0, implicit-def $srcompr_uf, implicit-def $dp, implicit killed $dp
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
     $p0 = LDA_dms_lda_idx_imm $p7, 0
     $p0, $wh0 = VLDB_COMPR_POP $p0, implicit-def $srcompr_uf, implicit-def $dp, implicit $dp
 ...
@@ -176,6 +264,19 @@ body:             |
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
+    ; CHECK-NEG-LAT-LABEL: name: II_VLDB_COMPR_POP_output
+    ; CHECK-NEG-LAT: $p0, $wh0 = VLDB_COMPR_POP killed $p0, implicit-def $srcompr_uf, implicit-def $dp, implicit killed $dp
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: $cm0 = VMAC_vmac_cm_core_sparse_narrow killed $cm1, killed $x4, killed $qx0, killed $r9
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
     $p0, $wh0 = VLDB_COMPR_POP $p0, implicit-def $srcompr_uf, implicit-def $dp, implicit $dp
     $cm0 = VMAC_vmac_cm_core_sparse_narrow $cm1, $x4, $qx0, $r9
 ...
@@ -202,6 +303,19 @@ body:             |
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
+    ; CHECK-NEG-LAT-LABEL: name: II_VLDB_COMPR_implicit_ops
+    ; CHECK-NEG-LAT: $p1, $wh0 = VLDB_COMPR_POP killed $p1, implicit-def $srcompr_uf, implicit-def $dp, implicit killed $dp
+    ; CHECK-NEG-LAT-NEXT: $p0 = VLDB_COMPR_RESET killed $p0, implicit-def $dp, implicit killed $dp
+    ; CHECK-NEG-LAT-NEXT: $p1, $wh0 = VLDB_COMPR_POP killed $p1, implicit-def $srcompr_uf, implicit-def $dp, implicit killed $dp
+    ; CHECK-NEG-LAT-NEXT: $p1, $wh0 = VLDB_COMPR_PEEK killed $p1, implicit-def $srcompr_uf, implicit $dp
+    ; CHECK-NEG-LAT-NEXT: $p1, $wh0 = VLDB_COMPR_POP killed $p1, implicit-def $srcompr_uf, implicit-def $dp, implicit killed $dp
+    ; CHECK-NEG-LAT-NEXT: $p1, $wh0 = VLDB_COMPR_POP killed $p1, implicit-def $srcompr_uf, implicit-def $dp, implicit killed $dp
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
     $p1, $wh0 = VLDB_COMPR_POP $p1, implicit-def $srcompr_uf, implicit-def $dp, implicit $dp
     $p0 = VLDB_COMPR_RESET $p0, implicit-def $dp, implicit $dp
     $p1, $wh0 = VLDB_COMPR_POP $p1, implicit-def $srcompr_uf, implicit-def $dp, implicit $dp
@@ -223,6 +337,14 @@ body:             |
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: $r1 = MOV_mv_scl killed $dp
+    ; CHECK-NEG-LAT-LABEL: name: II_VLDB_COMPR_RESET_implicit_RAW
+    ; CHECK-NEG-LAT: $p0 = VLDB_COMPR_RESET killed $p0, implicit-def $dp, implicit killed $dp
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: $r1 = MOV_mv_scl killed $dp
     $p0 = VLDB_COMPR_RESET $p0, implicit-def $dp, implicit $dp
     $r1 = MOV_mv_scl $dp
 ...
@@ -239,6 +361,14 @@ body:             |
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: $r1 = MOV_mv_scl $srcompr_uf
     ; CHECK-NEXT: NOP
+    ; CHECK-NEG-LAT-LABEL: name: II_VLDB_COMPR_PEEK_implicit_RAW
+    ; CHECK-NEG-LAT: $p1, $wh0 = VLDB_COMPR_PEEK killed $p1, implicit-def $srcompr_uf, implicit killed $dp
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: $r1 = MOV_mv_scl $srcompr_uf
+    ; CHECK-NEG-LAT-NEXT: NOP
     $p1, $wh0 = VLDB_COMPR_PEEK $p1, implicit-def $srcompr_uf, implicit $dp
     $r1 = MOV_mv_scl $srcompr_uf
 ...
@@ -264,6 +394,15 @@ body:             |
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: $r1 = MOV_mv_scl $srcompr_uf
     ; CHECK-NEXT: NOP
+    ; CHECK-NEG-LAT-LABEL: name: II_VLDB_COMPR_POP_implicit_RAW
+    ; CHECK-NEG-LAT: $p1, $wh0 = VLDB_COMPR_POP killed $p1, implicit-def $srcompr_uf, implicit-def $dp, implicit killed $dp
+    ; CHECK-NEG-LAT-NEXT: $p1, $wh0 = VLDB_COMPR_POP killed $p1, implicit-def $srcompr_uf, implicit-def $dp, implicit killed $dp
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: $r1 = MOV_mv_scl killed $dp
+    ; CHECK-NEG-LAT-NEXT: $r1 = MOV_mv_scl $srcompr_uf
     $p1, $wh0 = VLDB_COMPR_POP $p1, implicit-def $srcompr_uf, implicit-def $dp, implicit $dp
     $r1 = MOV_mv_scl $dp
     $p1, $wh0 = VLDB_COMPR_POP $p1, implicit-def $srcompr_uf, implicit-def $dp, implicit $dp

--- a/llvm/test/CodeGen/AIE/aie2/schedule/vldb-sparse.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/vldb-sparse.mir
@@ -4,8 +4,9 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2023-2024 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2023-2026 Advanced Micro Devices, Inc. or its affiliates
 # RUN: llc -march=aie2 -run-pass=postmisched %topdown-multi %s -o - | FileCheck %s
+# RUN: llc -march=aie2 -run-pass=postmisched %topdown-multi-negative-lat %s -o - | FileCheck %s --check-prefix=CHECK-NEG-LAT
 
 
 ---
@@ -27,6 +28,20 @@ body:             |
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
+    ; CHECK-NEG-LAT-LABEL: name: II_VLDB_SPARSE_FILL_input
+    ; CHECK-NEG-LAT: $p0 = LDA_dms_lda_idx_imm killed $p7, 0
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: $p0 = VLDB_SPARSE_FILL_4 killed $p0, implicit-def $srsparse_of, implicit killed $dp
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
     $p0 = LDA_dms_lda_idx_imm $p7, 0
     $p0 = VLDB_SPARSE_FILL_4 $p0, implicit-def $srsparse_of, implicit $dp
 ...
@@ -44,6 +59,14 @@ body:             |
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
+    ; CHECK-NEG-LAT-LABEL: name: II_VLDB_SPARSE_FILL_output
+    ; CHECK-NEG-LAT: $p0 = VLDB_SPARSE_FILL_4 killed $p0, implicit-def $srsparse_of, implicit $dp
+    ; CHECK-NEG-LAT-NEXT: $p0 = VLDB_SPARSE_FILL_4 killed $p0, implicit-def $srsparse_of, implicit killed $dp
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
     $p0 = VLDB_SPARSE_FILL_4 $p0, implicit-def $srsparse_of, implicit $dp
     $p0 = VLDB_SPARSE_FILL_4 $p0, implicit-def $srsparse_of, implicit $dp
 ...
@@ -67,6 +90,20 @@ body:             |
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
+    ; CHECK-NEG-LAT-LABEL: name: II_VLDB_SPARSE_RESET_input
+    ; CHECK-NEG-LAT: $p0 = LDA_dms_lda_idx_imm killed $p7, 0
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: $p0 = VLDB_SPARSE_RESET_4 killed $p0, implicit-def $srsparse_of, implicit-def $dp, implicit killed $dp
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
     $p0 = LDA_dms_lda_idx_imm $p7, 0
     $p0 = VLDB_SPARSE_RESET_4 $p0, implicit-def $srsparse_of, implicit-def $dp, implicit $dp
 ...
@@ -84,6 +121,14 @@ body:             |
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
+    ; CHECK-NEG-LAT-LABEL: name: II_VLDB_SPARSE_RESET_output
+    ; CHECK-NEG-LAT: $p0 = VLDB_SPARSE_RESET_4 killed $p0, implicit-def $srsparse_of, implicit-def $dp, implicit killed $dp
+    ; CHECK-NEG-LAT-NEXT: $p0 = VLDB_SPARSE_RESET_4 killed $p0, implicit-def $srsparse_of, implicit-def $dp, implicit killed $dp
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
     $p0 = VLDB_SPARSE_RESET_4 $p0, implicit-def $srsparse_of, implicit-def $dp, implicit $dp
     $p0 = VLDB_SPARSE_RESET_4 $p0, implicit-def $srsparse_of, implicit-def $dp, implicit $dp
 ...
@@ -108,6 +153,21 @@ body:             |
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
+    ; CHECK-NEG-LAT-LABEL: name: II_VLDB_SPARSE_PEEK_input
+    ; CHECK-NEG-LAT: $p0 = LDA_dms_lda_idx_imm killed $p7, 0
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: $p0, $qwh0 = VLDB_SPARSE_PEEK_4 killed $p0, implicit-def $srsparse_of, implicit-def $srcompr_uf, implicit killed $dp
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
     $p0 = LDA_dms_lda_idx_imm $p7, 0
     $p0, $qwh0 = VLDB_SPARSE_PEEK_4 $p0, implicit-def $srsparse_of, implicit-def $srcompr_uf, implicit $dp
 ...
@@ -130,6 +190,19 @@ body:             |
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
+    ; CHECK-NEG-LAT-LABEL: name: II_VLDB_SPARSE_PEEK_output
+    ; CHECK-NEG-LAT: $p0, $qwh0 = VLDB_SPARSE_PEEK_4 killed $p0, implicit-def $srsparse_of, implicit-def $srcompr_uf, implicit killed $dp
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: $cm0 = VMAC_vmac_cm_core_sparse_narrow killed $cm1, killed $x4, killed $qx0, killed $r9
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
     $p0, $qwh0 = VLDB_SPARSE_PEEK_4 $p0, implicit-def $srsparse_of, implicit-def $srcompr_uf, implicit $dp
     $cm0 = VMAC_vmac_cm_core_sparse_narrow $cm1, $x4, $qx0, $r9
 ...
@@ -154,6 +227,21 @@ body:             |
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
+    ; CHECK-NEG-LAT-LABEL: name: II_VLDB_SPARSE_POP_input
+    ; CHECK-NEG-LAT: $p0 = LDA_dms_lda_idx_imm killed $p7, 0
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: $p0, $qwh0 = VLDB_SPARSE_POP_4 killed $p0, implicit-def $srsparse_of, implicit-def $srcompr_uf, implicit-def $dp, implicit killed $dp
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
     $p0 = LDA_dms_lda_idx_imm $p7, 0
     $p0, $qwh0 = VLDB_SPARSE_POP_4 $p0, implicit-def $srsparse_of, implicit-def $srcompr_uf, implicit-def $dp, implicit $dp
 ...
@@ -176,6 +264,19 @@ body:             |
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
+    ; CHECK-NEG-LAT-LABEL: name: II_VLDB_SPARSE_POP_output
+    ; CHECK-NEG-LAT: $p0, $qwh0 = VLDB_SPARSE_POP_4 killed $p0, implicit-def $srsparse_of, implicit-def $srcompr_uf, implicit-def $dp, implicit killed $dp
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: $cm0 = VMAC_vmac_cm_core_sparse_narrow killed $cm1, killed $x4, killed $qx0, killed $r9
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
     $p0, $qwh0 = VLDB_SPARSE_POP_4 $p0, implicit-def $srsparse_of, implicit-def $srcompr_uf, implicit-def $dp, implicit $dp
     $cm0 = VMAC_vmac_cm_core_sparse_narrow $cm1, $x4, $qx0, $r9
 ...
@@ -202,6 +303,19 @@ body:             |
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
+    ; CHECK-NEG-LAT-LABEL: name: II_VLDB_SPARSE_implicit_ops
+    ; CHECK-NEG-LAT: $p1, $qwh0 = VLDB_SPARSE_POP_4 killed $p1, implicit-def $srsparse_of, implicit-def $srcompr_uf, implicit-def $dp, implicit killed $dp
+    ; CHECK-NEG-LAT-NEXT: $p0 = VLDB_SPARSE_RESET_4 killed $p0, implicit-def $srsparse_of, implicit-def $dp, implicit killed $dp
+    ; CHECK-NEG-LAT-NEXT: $p1, $qwh0 = VLDB_SPARSE_POP_4 killed $p1, implicit-def $srsparse_of, implicit-def $srcompr_uf, implicit-def $dp, implicit killed $dp
+    ; CHECK-NEG-LAT-NEXT: $p1, $qwh0 = VLDB_SPARSE_PEEK_4 killed $p1, implicit-def $srsparse_of, implicit-def $srcompr_uf, implicit $dp
+    ; CHECK-NEG-LAT-NEXT: $p1, $qwh0 = VLDB_SPARSE_POP_4 killed $p1, implicit-def $srsparse_of, implicit-def $srcompr_uf, implicit-def $dp, implicit killed $dp
+    ; CHECK-NEG-LAT-NEXT: $p1, $qwh0 = VLDB_SPARSE_POP_4 killed $p1, implicit-def $srsparse_of, implicit-def $srcompr_uf, implicit-def $dp, implicit killed $dp
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
     $p1, $qwh0 = VLDB_SPARSE_POP_4 $p1, implicit-def $srsparse_of, implicit-def $srcompr_uf, implicit-def $dp, implicit $dp
     $p0 = VLDB_SPARSE_RESET_4 $p0, implicit-def $srsparse_of, implicit-def $dp, implicit $dp
     $p1, $qwh0 = VLDB_SPARSE_POP_4 $p1, implicit-def $srsparse_of, implicit-def $srcompr_uf, implicit-def $dp, implicit $dp
@@ -223,6 +337,14 @@ body:             |
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: $r1 = MOV_mv_scl $srsparse_of
+    ; CHECK-NEG-LAT-LABEL: name: II_VLDB_SPARSE_FILL_implicit_RAW
+    ; CHECK-NEG-LAT: $p0 = VLDB_SPARSE_FILL_4 killed $p0, implicit-def $srsparse_of, implicit killed $dp
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: $r1 = MOV_mv_scl $srsparse_of
     $p0 = VLDB_SPARSE_FILL_4 $p0, implicit-def $srsparse_of, implicit $dp
     $r1 = MOV_mv_scl $srsparse_of
 ...
@@ -249,6 +371,15 @@ body:             |
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: $r1 = MOV_mv_scl killed $dp
+    ; CHECK-NEG-LAT-LABEL: name: II_VLDB_SPARSE_RESET_implicit_RAW
+    ; CHECK-NEG-LAT: $p0 = VLDB_SPARSE_RESET_4 killed $p0, implicit-def $srsparse_of, implicit-def $dp, implicit killed $dp
+    ; CHECK-NEG-LAT-NEXT: $p0 = VLDB_SPARSE_RESET_4 killed $p0, implicit-def $srsparse_of, implicit-def $dp, implicit killed $dp
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: $r1 = MOV_mv_scl $srsparse_of
+    ; CHECK-NEG-LAT-NEXT: $r1 = MOV_mv_scl killed $dp
     $p0 = VLDB_SPARSE_RESET_4 $p0, implicit-def $srsparse_of, implicit-def $dp, implicit $dp
     $r1 = MOV_mv_scl $srsparse_of
     $p0 = VLDB_SPARSE_RESET_4 $p0, implicit-def $srsparse_of, implicit-def $dp, implicit $dp
@@ -276,6 +407,15 @@ body:             |
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: $r1 = MOV_mv_scl $srcompr_uf
     ; CHECK-NEXT: NOP
+    ; CHECK-NEG-LAT-LABEL: name: II_VLDB_SPARSE_PEEK_implicit_RAW
+    ; CHECK-NEG-LAT: $p1, $qwh0 = VLDB_SPARSE_PEEK_4 killed $p1, implicit-def $srsparse_of, implicit-def $srcompr_uf, implicit $dp
+    ; CHECK-NEG-LAT-NEXT: $p1, $qwh0 = VLDB_SPARSE_PEEK_4 killed $p1, implicit-def $srsparse_of, implicit-def $srcompr_uf, implicit killed $dp
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: $r1 = MOV_mv_scl $srsparse_of
+    ; CHECK-NEG-LAT-NEXT: $r1 = MOV_mv_scl $srcompr_uf
     $p1, $qwh0 = VLDB_SPARSE_PEEK_4 $p1, implicit-def $srsparse_of, implicit-def $srcompr_uf, implicit $dp
     $r1 = MOV_mv_scl $srsparse_of
     $p1, $qwh0 = VLDB_SPARSE_PEEK_4 $p1, implicit-def $srsparse_of, implicit-def $srcompr_uf, implicit $dp
@@ -312,6 +452,16 @@ body:             |
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: $r1 = MOV_mv_scl $srcompr_uf
     ; CHECK-NEXT: NOP
+    ; CHECK-NEG-LAT-LABEL: name: II_VLDB_SPARSE_POP_implicit_RAW
+    ; CHECK-NEG-LAT: $p1, $qwh0 = VLDB_SPARSE_POP_4 killed $p1, implicit-def $srsparse_of, implicit-def $srcompr_uf, implicit-def $dp, implicit killed $dp
+    ; CHECK-NEG-LAT-NEXT: $p1, $qwh0 = VLDB_SPARSE_POP_4 killed $p1, implicit-def $srsparse_of, implicit-def $srcompr_uf, implicit-def $dp, implicit killed $dp
+    ; CHECK-NEG-LAT-NEXT: $p1, $qwh0 = VLDB_SPARSE_POP_4 killed $p1, implicit-def $srsparse_of, implicit-def $srcompr_uf, implicit-def $dp, implicit killed $dp
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: $r1 = MOV_mv_scl $srsparse_of
+    ; CHECK-NEG-LAT-NEXT: $r1 = MOV_mv_scl killed $dp
+    ; CHECK-NEG-LAT-NEXT: $r1 = MOV_mv_scl $srcompr_uf
     $p1, $qwh0 = VLDB_SPARSE_POP_4 $p1, implicit-def $srsparse_of, implicit-def $srcompr_uf, implicit-def $dp, implicit $dp
     $r1 = MOV_mv_scl $srsparse_of
     $p1, $qwh0 = VLDB_SPARSE_POP_4 $p1, implicit-def $srsparse_of, implicit-def $srcompr_uf, implicit-def $dp, implicit $dp

--- a/llvm/test/CodeGen/AIE/aie2/schedule/vmax_lt.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/vmax_lt.mir
@@ -4,8 +4,9 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2023-2024 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2023-2026 Advanced Micro Devices, Inc. or its affiliates
 # RUN: llc -march=aie2 -run-pass=postmisched %topdown-multi %s -o - | FileCheck %s
+# RUN: llc -march=aie2 -run-pass=postmisched %topdown-multi-negative-lat %s -o - | FileCheck %s --check-prefix=CHECK-NEG-LAT
 
 ---
 name:            bypass
@@ -22,6 +23,16 @@ body:             |
     ; CHECK-NEXT: $x0, $r22 = VMAX_LT_BF16 killed $x5, killed $x3
     ; CHECK-NEXT: $r1 = VEXTRACT_S16 killed $x0, killed $r16
     ; CHECK-NEXT: NOP
+    ; CHECK-NEG-LAT-LABEL: name: bypass
+    ; CHECK-NEG-LAT: $x0, $l2 = VMAX_LT_D8 $x1, killed $x2, implicit $crvaddsign
+    ; CHECK-NEG-LAT-NEXT: $r1 = VEXTRACT_S8 killed $x0, $r16
+    ; CHECK-NEG-LAT-NEXT: $x0, $r21 = VMAX_LT_D16 killed $x4, killed $x1, implicit $crvaddsign
+    ; CHECK-NEG-LAT-NEXT: $r1 = VEXTRACT_S16 killed $x0, $r16
+    ; CHECK-NEG-LAT-NEXT: $x0, $r23 = VMAX_LT_S32 $x5, $x3
+    ; CHECK-NEG-LAT-NEXT: $r1 = VEXTRACT_S32 killed $x0, $r16
+    ; CHECK-NEG-LAT-NEXT: $x0, $r22 = VMAX_LT_BF16 killed $x5, killed $x3
+    ; CHECK-NEG-LAT-NEXT: $r1 = VEXTRACT_S16 killed $x0, killed $r16
+    ; CHECK-NEG-LAT-NEXT: NOP
     $x0, $l2  = VMAX_LT_D8  $x1, $x2, implicit $crvaddsign
     $r1 = VEXTRACT_S8  $x0, $r16
     $x0, $r21 = VMAX_LT_D16 $x4, $x1, implicit $crvaddsign
@@ -42,6 +53,11 @@ body:             |
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: VST_dmw_sts_w_ag_idx_imm killed $wl0, killed $p0, 0
     ; CHECK-NEXT: NOP
+    ; CHECK-NEG-LAT-LABEL: name: no_bypass_vecReg
+    ; CHECK-NEG-LAT: $x0, $l1 = VMAX_LT_S8 killed $x1, killed $x2
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: VST_dmw_sts_w_ag_idx_imm killed $wl0, killed $p0, 0
+    ; CHECK-NEG-LAT-NEXT: NOP
     $x0, $l1  = VMAX_LT_S8  $x1, $x2
     VST_dmw_sts_w_ag_idx_imm $wl0, $p0, 0
 ...
@@ -56,6 +72,11 @@ body:             |
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: VST_dmw_sts_w_ag_idx_imm killed $wl1, killed $p0, 0
     ; CHECK-NEXT: NOP
+    ; CHECK-NEG-LAT-LABEL: name: no_bypass_bf16_vecReg
+    ; CHECK-NEG-LAT: $x1, $r16 = VMAX_LT_BF16 killed $x5, killed $x3
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: VST_dmw_sts_w_ag_idx_imm killed $wl1, killed $p0, 0
+    ; CHECK-NEG-LAT-NEXT: NOP
     $x1, $r16 = VMAX_LT_BF16 $x5, $x3
     VST_dmw_sts_w_ag_idx_imm $wl1, $p0, 0
 ...
@@ -73,6 +94,12 @@ body:             |
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: $r1 = VEXTRACT_S16 killed $x1, killed $r16
     ; CHECK-NEXT: NOP
+    ; CHECK-NEG-LAT-LABEL: name: no_bypass_gprReg
+    ; CHECK-NEG-LAT: $x0, $r16 = VMAX_LT_S32 $x5, $x3
+    ; CHECK-NEG-LAT-NEXT: $x1, $r16 = VMAX_LT_BF16 killed $x5, killed $x3
+    ; CHECK-NEG-LAT-NEXT: $r1 = VEXTRACT_S8 killed $x0, $r16
+    ; CHECK-NEG-LAT-NEXT: $r1 = VEXTRACT_S16 killed $x1, killed $r16
+    ; CHECK-NEG-LAT-NEXT: NOP
     $x0, $r16 = VMAX_LT_S32 $x5, $x3
     $r1 = VEXTRACT_S8  $x0, $r16
     $x1, $r16 = VMAX_LT_BF16 $x5, $x3
@@ -89,6 +116,11 @@ body:             |
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: $x0 = VINSERT_64 killed $x0, killed $r29, killed $l2
     ; CHECK-NEXT: NOP
+    ; CHECK-NEG-LAT-LABEL: name: no_bypass_lReg
+    ; CHECK-NEG-LAT: $x0, $l2 = VMAX_LT_D8 killed $x1, killed $x2, implicit $crvaddsign
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: $x0 = VINSERT_64 killed $x0, killed $r29, killed $l2
+    ; CHECK-NEG-LAT-NEXT: NOP
     $x0, $l2  = VMAX_LT_D8  $x1, $x2, implicit $crvaddsign
     $x0 = VINSERT_64 $x0, $r29, $l2
 ...

--- a/llvm/test/CodeGen/AIE/aie2/schedule/vsub.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/vsub.mir
@@ -4,9 +4,11 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2023-2024 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2023-2026 Advanced Micro Devices, Inc. or its affiliates
 # RUN: llc -march=aie2 %topdown-single -run-pass=postmisched %s -o - \
 # RUN:   | FileCheck %s
+# RUN: llc -march=aie2 %topdown-single-negative-lat -run-pass=postmisched %s -o - \
+# RUN:   | FileCheck %s --check-prefix=CHECK-NEG-LAT
 
 ---
 name:            bypass
@@ -18,6 +20,11 @@ body:             |
     ; CHECK-NEXT: $x0 = VSUB_16 killed $x0, $x1
     ; CHECK-NEXT: $x0 = VSUB_32 killed $x0, killed $x1
     ; CHECK-NEXT: NOP
+    ; CHECK-NEG-LAT-LABEL: name: bypass
+    ; CHECK-NEG-LAT: $x0 = VSUB_8 killed $x0, $x1
+    ; CHECK-NEG-LAT-NEXT: $x0 = VSUB_16 killed $x0, $x1
+    ; CHECK-NEG-LAT-NEXT: $x0 = VSUB_32 killed $x0, killed $x1
+    ; CHECK-NEG-LAT-NEXT: NOP
     $x0 = VSUB_8 $x0, $x1
     $x0 = VSUB_16 $x0, $x1
     $x0 = VSUB_32 $x0, $x1
@@ -39,6 +46,15 @@ body:             |
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: VST_dmw_sts_w_ag_idx_imm killed $wl0, killed $p0, 0
     ; CHECK-NEXT: NOP
+    ; CHECK-NEG-LAT-LABEL: name: no_bypass
+    ; CHECK-NEG-LAT: $x0 = VSUB_8 killed $x0, $x1
+    ; CHECK-NEG-LAT-NEXT: $x0 = VSUB_16 killed $x0, $x1
+    ; CHECK-NEG-LAT-NEXT: VST_dmw_sts_w_ag_idx_imm $wl0, $p0, 0
+    ; CHECK-NEG-LAT-NEXT: VST_dmw_sts_w_ag_idx_imm $wl0, $p0, 0
+    ; CHECK-NEG-LAT-NEXT: $x0 = VSUB_32 killed $x0, killed $x1
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: VST_dmw_sts_w_ag_idx_imm killed $wl0, killed $p0, 0
+    ; CHECK-NEG-LAT-NEXT: NOP
     $x0 = VSUB_8 $x0, $x1
     VST_dmw_sts_w_ag_idx_imm $wl0, $p0, 0
     $x0 = VSUB_16 $x0, $x1

--- a/llvm/test/CodeGen/AIE/aie2/schedule/vunpack.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/vunpack.mir
@@ -4,9 +4,11 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2023-2024 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2023-2026 Advanced Micro Devices, Inc. or its affiliates
 # RUN: llc -march=aie2 %topdown-single -run-pass=postmisched %s -o - \
 # RUN:   | FileCheck %s
+# RUN: llc -march=aie2 %topdown-single-negative-lat -run-pass=postmisched %s -o - \
+# RUN:   | FileCheck %s --check-prefix=CHECK-NEG-LAT
 
 ---
 name:            vunpack
@@ -39,6 +41,18 @@ body:             |
     ; CHECK-NEXT: NOP
     ; CHECK-NEXT: $r1 = VEXTRACT_S32 killed $x0, killed $r16
     ; CHECK-NEXT: NOP
+    ; CHECK-NEG-LAT-LABEL: name: vunpack
+    ; CHECK-NEG-LAT: $x0 = VUNPACK_D16_D8 killed $wh1, implicit $crunpacksign
+    ; CHECK-NEG-LAT-NEXT: $x0 = VUNPACK_D8_D4 killed $wl4, implicit $crunpacksign
+    ; CHECK-NEG-LAT-NEXT: $x0 = VUNPACK_S16_S8 killed $wh5
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: NOP
+    ; CHECK-NEG-LAT-NEXT: $r1 = VEXTRACT_S8 $x0, $r16
+    ; CHECK-NEG-LAT-NEXT: $r1 = VEXTRACT_S16 $x0, $r16
+    ; CHECK-NEG-LAT-NEXT: $r1 = VEXTRACT_S32 killed $x0, killed $r16
+    ; CHECK-NEG-LAT-NEXT: NOP
     $x0 = VUNPACK_D16_D8  $wh1, implicit $crunpacksign
     $r1 = VEXTRACT_S8  $x0, $r16
     $x0 = VUNPACK_D8_D4 $wl4, implicit $crunpacksign

--- a/llvm/test/CodeGen/AIE/aie2p/AA-unroll-iterations.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/AA-unroll-iterations.mir
@@ -37,14 +37,13 @@
   ; CHECK-NEXT:  .L_LEnd0:
   ; CHECK-NEXT:    nopa ; nopb ; nops ; nopxm ; nopv
   ; CHECK-NEXT:  // %bb.2: // %for.cond.cleanup
-  ; CHECK-NEXT:    nopa ; nopb ; nopx ; st.2d r1, [p0], d0
+  ; CHECK-NEXT:    nopa ; nopb ; nopxm ; st.2d r1, [p0], d0
   ; CHECK-NEXT:    mul r1, r1, r0
   ; CHECK-NEXT:    nop
   ; CHECK-NEXT:    st.2d r1, [p0], d0
   ; CHECK-NEXT:    mul r1, r1, r0
   ; CHECK-NEXT:    nop
   ; CHECK-NEXT:    st.2d r1, [p0], d0
-  ; CHECK-NEXT:    nop
   ; CHECK-NEXT:    ret lr
   ; CHECK-NEXT:    nop // Delay Slot 5
   ; CHECK-NEXT:    nop // Delay Slot 4

--- a/llvm/test/CodeGen/AIE/aie2p/elongate/zol_phdr_loopbundles_112bytes.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/elongate/zol_phdr_loopbundles_112bytes.mir
@@ -40,20 +40,18 @@
   ; CHECK-NEXT:  .L_LEnd0:
   ; CHECK-NEXT:    nopa ; vldb x1, [p0], #128; nops ; nopxm ; nopv
   ; CHECK-NEXT:  // %bb.2: // %for.cond.cleanup
-  ; CHECK-NEXT:    nops ; vadd.16 x6, x4, x1
+  ; CHECK-NEXT:    nopa ; nopb ; nopx ; vadd.16 x6, x4, x1
   ; CHECK-NEXT:    vadd.16 x4, x6, x0
   ; CHECK-NEXT:    nop
   ; CHECK-NEXT:    vadd.16 x6, x4, x1
   ; CHECK-NEXT:    vadd.16 x4, x6, x0
   ; CHECK-NEXT:    nop
   ; CHECK-NEXT:    vadd.16 x6, x4, x1
-  ; CHECK-NEXT:    nop
-  ; CHECK-NEXT:    vmov x0, x6
   ; CHECK-NEXT:    ret lr
   ; CHECK-NEXT:    nop // Delay Slot 5
   ; CHECK-NEXT:    nop // Delay Slot 4
   ; CHECK-NEXT:    nop // Delay Slot 3
-  ; CHECK-NEXT:    nop // Delay Slot 2
+  ; CHECK-NEXT:    vmov x0, x6 // Delay Slot 2
   ; CHECK-NEXT:    nop // Delay Slot 1
   entry:
     call void @llvm.set.loop.iterations.i32(i32 %n)

--- a/llvm/test/CodeGen/AIE/aie2p/end-to-end/add-att-broadcasting-aa.ll
+++ b/llvm/test/CodeGen/AIE/aie2p/end-to-end/add-att-broadcasting-aa.ll
@@ -288,7 +288,7 @@ define dso_local void @add_attribute_bcast_epilogue1(ptr noalias %ifm2, ptr noal
 ; CHECK-NEXT:  .L_LEnd2:
 ; CHECK-NEXT:    vlda.conv.fp32.bf16 cml3, [p1], m0; nopb ; vst.conv.bf16.fp32 cml4, [p2], #64; nopxm ; vadd.f dm3, dm3, dm0, r1
 ; CHECK-NEXT:  // %bb.2: // %for.cond.cleanup
-; CHECK-NEXT:    nopa ; st r0, [p3, #0]; nopx
+; CHECK-NEXT:    nopa ; nopb ; nopx ; st r0, [p3, #0]
 ; CHECK-NEXT:    vst.conv.bf16.fp32 cml3, [p2], #64; vadd.f dm4, dm1, dm2, r1
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    vst.conv.bf16.fp32 cml4, [p2], #64; vadd.f dm3, dm3, dm0, r1
@@ -298,12 +298,11 @@ define dso_local void @add_attribute_bcast_epilogue1(ptr noalias %ifm2, ptr noal
 ; CHECK-NEXT:    vst.conv.bf16.fp32 cml4, [p2], #64
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    vst.conv.bf16.fp32 cml3, [p2], #64
-; CHECK-NEXT:    st r0, [p4, #0]
 ; CHECK-NEXT:    ret lr
 ; CHECK-NEXT:    nop // Delay Slot 5
 ; CHECK-NEXT:    nop // Delay Slot 4
 ; CHECK-NEXT:    nop // Delay Slot 3
-; CHECK-NEXT:    nop // Delay Slot 2
+; CHECK-NEXT:    st r0, [p4, #0] // Delay Slot 2
 ; CHECK-NEXT:    nop // Delay Slot 1
 newFuncRoot:
   br label %if.end

--- a/llvm/test/CodeGen/AIE/aie2p/end-to-end/gemm-bfp16.ll
+++ b/llvm/test/CodeGen/AIE/aie2p/end-to-end/gemm-bfp16.ll
@@ -103,10 +103,10 @@ define dso_local void @gemm_bfp16(ptr %ofm_ptr, ptr %ifm_ptr, ptr %wts_ptr, ptr 
 ; CHECK-NEXT:    nopa ; vldb x7, [p7, #0]; vconv.bfp16ebs8.fp32 ex6, dm2; nopx ; vshuffle x10, x7, x5, r0; vmac.f dm3, dm3, ex2, ex4, r3
 ; CHECK-NEXT:  // %bb.3: // %for.cond.cleanup45.i
 ; CHECK-NEXT:    // in Loop: Header=BB0_1 Depth=1
-; CHECK-NEXT:    nopa ; vldb x5, [p7, #64]; vconv.bfp16ebs8.fp32 ex4, dm2; nopx ; vshuffle x11, x7, x5, r1; vmul.f dm2, y5, y0, r2
-; CHECK-NEXT:    paddb [p1], m5; nopxm
+; CHECK-NEXT:    nopa ; vldb x5, [p7, #64]; vconv.bfp16ebs8.fp32 ex4, dm2; add r4, r4, #1; vshuffle x11, x7, x5, r1; vmul.f dm2, y5, y0, r2
+; CHECK-NEXT:    nopa ; paddb [p1], m5; nops ; nopx ; mov p4, p0; nopv
 ; CHECK-NEXT:    vlda.conv.fp32.bf16 cml2, [p1, #0]; vconv.bfp16ebs8.fp32 ex2, dm2; vmul.f dm2, y5, y0, r2
-; CHECK-NEXT:    vlda.conv.fp32.bf16 cmh2, [p1, #64]; add r4, r4, #1; mov p4, p0
+; CHECK-NEXT:    vlda.conv.fp32.bf16 cmh2, [p1, #64]
 ; CHECK-NEXT:    vlda.conv.fp32.bf16 cmh2, [p6, #64]; mov p1, p6; vmac.f dm1, dm1, ex3, ex6, r3
 ; CHECK-NEXT:    vlda.3d.conv.fp32.bf16 cml2, [p6], d1; vconv.bfp16ebs8.fp32 ex3, dm2; vshuffle x10, x9, x8, r0; vmac.f dm0, dm0, ex3, ex4, r3
 ; CHECK-NEXT:    mova m1, #84; vshuffle x11, x9, x8, r1; vmac.f dm4, dm4, ex2, ex6, r3

--- a/llvm/test/CodeGen/AIE/aie2p/schedule/events-and-post-swp.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/schedule/events-and-post-swp.mir
@@ -38,7 +38,7 @@
   ; CHECK-NEXT:  .L_LEnd0:
   ; CHECK-NEXT:    nopa ; vldb x2, [p0], #64; vst.srs.2x cml0, s0, srssign1, [p1], #64; nopxm ; vmul dm0, y1, y0,r0
   ; CHECK-NEXT:  // %bb.2: // %for.cond.cleanup
-  ; CHECK-NEXT:    nopa ; nopb ; nopx ; vst.srs.2x cml0, s0, srssign1, [p1], #64; vmul dm0, y1, y0,r0
+  ; CHECK-NEXT:    nopa ; nopb ; vst.srs.2x cml0, s0, srssign1, [p1], #64; nopxm ; vmul dm0, y1, y0,r0
   ; CHECK-NEXT:    vst.srs.2x cml0, s0, srssign1, [p1], #64; vmul dm0, y1, y0,r0
   ; CHECK-NEXT:    vst.srs.2x cml0, s0, srssign1, [p1], #64; vmul dm0, y1, y0,r0
   ; CHECK-NEXT:    vst.srs.2x cml0, s0, srssign1, [p1], #64; vmul dm0, y1, y0,r0
@@ -51,9 +51,8 @@
   ; CHECK-NEXT:    vst.srs.2x cml0, s0, srssign1, [p1], #64
   ; CHECK-NEXT:    vst.srs.2x cml0, s0, srssign1, [p1], #64
   ; CHECK-NEXT:    vst.srs.2x cml0, s0, srssign1, [p1], #64
-  ; CHECK-NEXT:    event #1
   ; CHECK-NEXT:    ret lr
-  ; CHECK-NEXT:    nop // Delay Slot 5
+  ; CHECK-NEXT:    event #1 // Delay Slot 5
   ; CHECK-NEXT:    event #0 // Delay Slot 4
   ; CHECK-NEXT:    event #1 // Delay Slot 3
   ; CHECK-NEXT:    event #0 // Delay Slot 2

--- a/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/end-to-end.ll
+++ b/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/end-to-end.ll
@@ -30,20 +30,18 @@ define <32 x i16> @zol(i32 %n, ptr %p) {
 ; CHECK-NEXT:  .L_LEnd0:
 ; CHECK-NEXT:    nopa ; vldb x4, [p0], #64; nops ; nopx ; vadd.16 x6, x4, x6; nopv
 ; CHECK-NEXT:  // %bb.2: // %for.cond.cleanup
+; CHECK-NEXT:    nops ; vadd.16 x6, x4, x6
 ; CHECK-NEXT:    vadd.16 x6, x4, x6
 ; CHECK-NEXT:    vadd.16 x6, x4, x6
 ; CHECK-NEXT:    vadd.16 x6, x4, x6
 ; CHECK-NEXT:    vadd.16 x6, x4, x6
 ; CHECK-NEXT:    vadd.16 x6, x4, x6
 ; CHECK-NEXT:    vadd.16 x6, x4, x6
-; CHECK-NEXT:    vadd.16 x6, x4, x6
-; CHECK-NEXT:    nop
-; CHECK-NEXT:    vmov x0, x6
 ; CHECK-NEXT:    ret lr
 ; CHECK-NEXT:    nop // Delay Slot 5
 ; CHECK-NEXT:    nop // Delay Slot 4
 ; CHECK-NEXT:    nop // Delay Slot 3
-; CHECK-NEXT:    nop // Delay Slot 2
+; CHECK-NEXT:    vmov x0, x6 // Delay Slot 2
 ; CHECK-NEXT:    nop // Delay Slot 1
 entry:
   br label %for.body

--- a/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/epilogue-lock-after-store.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/epilogue-lock-after-store.mir
@@ -51,12 +51,9 @@ body:             |
   ; CHECK-NEXT:   $p1 = VST_dmx_sts_x_pstm_nrm_imm $x0, killed $p1, 64
   ; CHECK-NEXT:   $p1 = VST_dmx_sts_x_pstm_nrm_imm killed $x0, killed $p1, 64
   ; CHECK-NEXT:   NOP
-  ; CHECK-NEXT:   NOP
-  ; CHECK-NEXT:   NOP
-  ; CHECK-NEXT:   REL_mLockId_imm 49, killed renamable $r18
   ; CHECK-NEXT:   RET implicit $lr
   ; CHECK-NEXT:   NOP
-  ; CHECK-NEXT:   NOP
+  ; CHECK-NEXT:   REL_mLockId_imm 49, killed renamable $r18
   ; CHECK-NEXT:   NOP
   ; CHECK-NEXT:   NOP
   ; CHECK-NEXT:   NOP

--- a/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/softmax-aa.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/softmax-aa.mir
@@ -56,14 +56,14 @@
   ; CHECK-NEXT:    nopa ; nopb ; nops ; nopxm ; vmul.f dm0, x2, x0, r2
   ; CHECK-NEXT:  // %bb.4: // %for.cond.cleanup4
   ; CHECK-NEXT:    // in Loop: Header=BB0_2 Depth=1
-  ; CHECK-NEXT:    nopx
+  ; CHECK-NEXT:    nopa ; add r0, r0, #-1
   ; CHECK-NEXT:    vst.conv.bf16.fp32 bmll0, [p0], #32
   ; CHECK-NEXT:    nop
   ; CHECK-NEXT:    vmul.f dm0, x2, x0, r2
   ; CHECK-NEXT:    nop
   ; CHECK-NEXT:    vst.conv.bf16.fp32 bmll0, [p0], #32
   ; CHECK-NEXT:    nop
-  ; CHECK-NEXT:    add r0, r0, #-1
+  ; CHECK-NEXT:    nop
   ; CHECK-NEXT:    nop
   ; CHECK-NEXT:    vst.conv.bf16.fp32 bmll0, [p0], #32
   ; CHECK-NEXT:    jnz r0, #.LBB0_2
@@ -165,14 +165,14 @@
   ; CHECK-NEXT:    nopa ; nopb ; nops ; nopxm ; vmul.f dm0, x2, x0, r2
   ; CHECK-NEXT:  // %bb.4: // %for.cond.cleanup4
   ; CHECK-NEXT:    // in Loop: Header=BB1_2 Depth=1
-  ; CHECK-NEXT:    nopx
+  ; CHECK-NEXT:    nopa ; add r0, r0, #-1
   ; CHECK-NEXT:    vst.conv.bf16.fp32 bmll0, [p0], #32
   ; CHECK-NEXT:    nop
   ; CHECK-NEXT:    vmul.f dm0, x2, x0, r2
   ; CHECK-NEXT:    nop
   ; CHECK-NEXT:    vst.conv.bf16.fp32 bmll0, [p0], #32
   ; CHECK-NEXT:    nop
-  ; CHECK-NEXT:    add r0, r0, #-1
+  ; CHECK-NEXT:    nop
   ; CHECK-NEXT:    nop
   ; CHECK-NEXT:    vst.conv.bf16.fp32 bmll0, [p0], #32
   ; CHECK-NEXT:    jnz r0, #.LBB1_2

--- a/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/speculative-first-stage.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/speculative-first-stage.mir
@@ -37,14 +37,13 @@
   ; CHECK-NEXT:  .L_LEnd0:
   ; CHECK-NEXT:    nopa ; nopb ; nops ; nopx ; vshuffle x3, x1, x2, r10; nopv
   ; CHECK-NEXT:  // %bb.2: // %for.cond.cleanup
-  ; CHECK-NEXT:    nopa ; nopb ; nopx ; vmax_lt.32 x0, r16, x0, x3, vaddsign1
+  ; CHECK-NEXT:    nopa ; nopb ; nopx ; vmax_lt.32 x0, r16, x0, x3, vaddsign1; nops
   ; CHECK-NEXT:    nop
   ; CHECK-NEXT:    vshuffle x3, x1, x2, r10
   ; CHECK-NEXT:    vmax_lt.32 x0, r16, x0, x3, vaddsign1
   ; CHECK-NEXT:    nop
   ; CHECK-NEXT:    vshuffle x3, x1, x2, r10
   ; CHECK-NEXT:    vmax_lt.32 x0, r16, x0, x3, vaddsign1
-  ; CHECK-NEXT:    nop
   ; CHECK-NEXT:    ret lr
   ; CHECK-NEXT:    nop // Delay Slot 5
   ; CHECK-NEXT:    nop // Delay Slot 4
@@ -84,14 +83,12 @@
   ; CHECK-NEXT:  .L_LEnd1:
   ; CHECK-NEXT:    vlda x1, [p0, #64]; nopb ; nops ; nopx ; vmax_lt.32 x0, r16, x0, x3, vaddsign1; nopv
   ; CHECK-NEXT:  // %bb.2: // %for.cond.cleanup
-  ; CHECK-NEXT:    nopa ; nopb ; nopxm
+  ; CHECK-NEXT:    nopa ; nopb ; nops ; nopxm ; nopv
   ; CHECK-NEXT:    vshuffle x3, x1, x2, r10
   ; CHECK-NEXT:    vmax_lt.32 x0, r16, x0, x3, vaddsign1
   ; CHECK-NEXT:    nop
   ; CHECK-NEXT:    vshuffle x3, x1, x2, r10
   ; CHECK-NEXT:    vmax_lt.32 x0, r16, x0, x3, vaddsign1
-  ; CHECK-NEXT:    nop
-  ; CHECK-NEXT:    nop
   ; CHECK-NEXT:    ret lr
   ; CHECK-NEXT:    nop // Delay Slot 5
   ; CHECK-NEXT:    nop // Delay Slot 4

--- a/llvm/test/CodeGen/AIE/schedule/pointer-hazard.mir
+++ b/llvm/test/CodeGen/AIE/schedule/pointer-hazard.mir
@@ -40,7 +40,7 @@
   ; CHECK-NEXT:    nopb ; vlda wl2, [p0], #64; vst.srs.s16.s32 bmh0, s0, [p1, #32]; nopxm ; nopv
   ; CHECK-NEXT:  // %bb.2: // %for.cond.cleanup
   ; CHECK-NEXT:    nopb ; nopa ; vst.srs.s16.s32 bml0, s0, [p1], #64; nopxm ; vmul cm0, x2, x0, r0
-  ; CHECK-NEXT:    vst.srs.s16.s32 bmh0, s0, [p1, #32]; nopx
+  ; CHECK-NEXT:    vst.srs.s16.s32 bmh0, s0, [p1, #32]; nopb ; nopx
   ; CHECK-NEXT:    vst.srs.s16.s32 bml0, s0, [p1], #64; vmul cm0, x2, x0, r0
   ; CHECK-NEXT:    vst.srs.s16.s32 bmh0, s0, [p1, #32]
   ; CHECK-NEXT:    vst.srs.s16.s32 bml0, s0, [p1], #64; vmul cm0, x2, x0, r0
@@ -52,13 +52,12 @@
   ; CHECK-NEXT:    vst.srs.s16.s32 bml0, s0, [p1], #64
   ; CHECK-NEXT:    vst.srs.s16.s32 bmh0, s0, [p1, #32]
   ; CHECK-NEXT:    vst.srs.s16.s32 bml0, s0, [p1], #64
-  ; CHECK-NEXT:    event #1
   ; CHECK-NEXT:    ret lr
   ; CHECK-NEXT:    nop // Delay Slot 5
   ; CHECK-NEXT:    nop // Delay Slot 4
   ; CHECK-NEXT:    nop // Delay Slot 3
   ; CHECK-NEXT:    nop // Delay Slot 2
-  ; CHECK-NEXT:    nop // Delay Slot 1
+  ; CHECK-NEXT:    event #1 // Delay Slot 1
   entry:
     tail call void @llvm.aie2.event(i32 0)
     %div8 = lshr i32 %N, 5

--- a/llvm/test/CodeGen/AIE/schedule/sched-initialize-topscb-once.ll
+++ b/llvm/test/CodeGen/AIE/schedule/sched-initialize-topscb-once.ll
@@ -25,23 +25,19 @@ define void @load_store_with_call() {
 ; CHECK-NEXT:  .L_LEnd0:
 ; CHECK-NEXT:    nopa ; vldb x2, [p5, #0]; vst x2, [p5, #0]; nopxm ; nopv
 ; CHECK-NEXT:  // %bb.2: // %exit
-; CHECK-NEXT:    vst x2, [p5, #0]; nopb ; nopx
+; CHECK-NEXT:    mova p0, #0; nopb ; vst x2, [p5, #0]; nopxm ; nopv
+; CHECK-NEXT:    mova p1, #0; nopb ; vst x2, [p5, #0]
+; CHECK-NEXT:    mova p2, #0; vst x2, [p5, #0]
+; CHECK-NEXT:    mova p3, #0; vst x2, [p5, #0]
+; CHECK-NEXT:    mova p4, #0; vst x2, [p5, #0]
 ; CHECK-NEXT:    vst x2, [p5, #0]
 ; CHECK-NEXT:    vst x2, [p5, #0]
-; CHECK-NEXT:    vst x2, [p5, #0]
-; CHECK-NEXT:    vst x2, [p5, #0]
-; CHECK-NEXT:    vst x2, [p5, #0]
-; CHECK-NEXT:    vst x2, [p5, #0]
-; CHECK-NEXT:    nop
-; CHECK-NEXT:    nop
-; CHECK-NEXT:    nop
-; CHECK-NEXT:    mova p0, #0
 ; CHECK-NEXT:    jl p5
 ; CHECK-NEXT:    nop // Delay Slot 5
-; CHECK-NEXT:    mova p1, #0 // Delay Slot 4
-; CHECK-NEXT:    mova p2, #0 // Delay Slot 3
-; CHECK-NEXT:    mova p3, #0 // Delay Slot 2
-; CHECK-NEXT:    mova p4, #0 // Delay Slot 1
+; CHECK-NEXT:    nop // Delay Slot 4
+; CHECK-NEXT:    nop // Delay Slot 3
+; CHECK-NEXT:    nop // Delay Slot 2
+; CHECK-NEXT:    nop // Delay Slot 1
 ; CHECK-NEXT:    lda lr, [sp, #-64]; nopb ; nops ; nopxm ; nopv // 4-byte Folded Reload
 ; CHECK-NEXT:    nopx
 ; CHECK-NEXT:    nop


### PR DESCRIPTION
Three correctness and quality improvements to the AIE post-RA machine scheduler:

- __Fix scoreboard init order__ (`initializeTopScoreBoard`): block unknown cycles before replaying the loop body so that in-flight pipeline stages land at the correct positions for the epilogue scheduler, preventing premature instruction placement.

- __Exploit negative latencies__ in top-down scheduling: honour signed (negative) WAR/WAW edge latencies when releasing successors, allowing dependent instructions to be scheduled earlier and eliminating unnecessary NOPs.

- __Improve top→bottom-up switch__: `mustSwitchToBottomUp()` now also triggers when the Available queue is empty and all pending progressable instructions have a `TopReadyCycle` beyond the top-fixed bundle region, preventing wasted cycles and degraded VLIW bundle packing.
