### PR TITLE
[AIE2PS] Fix shouldCoalesce to block coalescing in both directions for ePSRFLdF

### DIFF
--- a/llvm/lib/Target/AIE/aie2ps/AIE2PSRegisterInfo.cpp
+++ b/llvm/lib/Target/AIE/aie2ps/AIE2PSRegisterInfo.cpp
@@ -601,9 +601,12 @@ bool AIE2PSRegisterInfo::shouldCoalesce(
   // disjoint control-flow regions can share the same two physical registers
   // (plfr0, plfr1) without interference and without any spilling.
 
-  if (AIE2PS::ePSRFLdFRegClass.hasSubClassEq(NewRC) &&
-      SubReg != AIE2PS::NoSubRegister && SubReg != AIE2PS::sub_fifo) {
-    return false;
+  if (AIE2PS::ePSRFLdFRegClass.hasSubClassEq(NewRC)) {
+    // Block coalescing into sub_ptr or sub_avail from either direction
+    if ((SubReg != AIE2PS::NoSubRegister && SubReg != AIE2PS::sub_fifo) ||
+        (DstSubReg != AIE2PS::NoSubRegister && DstSubReg != AIE2PS::sub_fifo)) {
+      return false;
+    }
   }
 
   return AIEBaseRegisterInfo::shouldCoalesce(MI, SrcRC, SubReg, DstRC,

--- a/llvm/test/CodeGen/AIE/aie2ps/ra/fifo-coalesce-sub-ptr.mir
+++ b/llvm/test/CodeGen/AIE/aie2ps/ra/fifo-coalesce-sub-ptr.mir
@@ -39,3 +39,89 @@ body: |
     %state.sub_ptr:epsrfldf, %state.sub_fifo:epsrfldf, %state.sub_avail:epsrfldf = VLD_FILL_512_pseudo %state.sub_ptr:epsrfldf, %state.sub_fifo:epsrfldf, %state.sub_avail:epsrfldf :: (load unknown-size, align 1, addrspace 5)
     PseudoRET implicit $lr, implicit %state
 ...
+
+
+---
+name:  fifo_no_coalesce_sub_ptr_reverse
+alignment: 16
+legalized: true
+regBankSelected: true
+selected: true
+tracksRegLiveness: true
+body: |
+  ; CHECK-LABEL: name: fifo_no_coalesce_sub_ptr_reverse
+  ; CHECK: bb.0.entry:
+  ; CHECK-NEXT:   successors: %bb.1(0x80000000)
+  ; CHECK-NEXT:   liveins: $p0, $r0
+  ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT:   [[COPY:%[0-9]+]]:ep = COPY $p0
+  ; CHECK-NEXT:   [[COPY1:%[0-9]+]]:mlockid_reg = COPY $r0
+  ; CHECK-NEXT:   [[MOV_RLC_imm11_pseudo:%[0-9]+]]:mrf2a = MOV_RLC_imm11_pseudo 0
+  ; CHECK-NEXT:   [[VBCST_32_:%[0-9]+]]:mxs = VBCST_32 [[MOV_RLC_imm11_pseudo]]
+  ; CHECK-NEXT:   undef [[COPY2:%[0-9]+]].sub_1024_acc_lo:acc2048 = COPY [[VBCST_32_]]
+  ; CHECK-NEXT:   [[COPY2:%[0-9]+]].sub_1024_acc_hi:acc2048 = COPY [[COPY2]].sub_1024_acc_lo
+  ; CHECK-NEXT:   [[MOV_PD_imm11_pseudo:%[0-9]+]]:em = MOV_PD_imm11_pseudo 0
+  ; CHECK-NEXT:   [[MOV_PD_imm11_pseudo1:%[0-9]+]]:ep = MOV_PD_imm11_pseudo 0
+  ; CHECK-NEXT:   [[COPY3:%[0-9]+]]:eldfiforeg = COPY [[COPY2]]
+  ; CHECK-NEXT:   [[MOV_RLC_imm11_pseudo1:%[0-9]+]]:mlockid_reg = MOV_RLC_imm11_pseudo 1
+  ; CHECK-NEXT:   [[XOR:%[0-9]+]]:mlockid_reg = XOR [[COPY1]], [[MOV_RLC_imm11_pseudo1]]
+  ; CHECK-NEXT:   [[AND:%[0-9]+]]:mlockid_reg = AND [[XOR]], [[MOV_RLC_imm11_pseudo1]]
+  ; CHECK-NEXT:   undef [[COPY4:%[0-9]+]].sub_ptr:epsrfldf = COPY [[MOV_PD_imm11_pseudo1]]
+  ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT: bb.1:
+  ; CHECK-NEXT:   successors: %bb.2(0x04000000), %bb.1(0x7c000000)
+  ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT:   [[COPY4:%[0-9]+]].sub_fifo:epsrfldf = COPY [[COPY3]]
+  ; CHECK-NEXT:   [[COPY4:%[0-9]+]].sub_avail:epsrfldf = COPY [[MOV_RLC_imm11_pseudo]]
+  ; CHECK-NEXT:   dead [[VLD_POP_512_fifo_1d_pop_pseudo:%[0-9]+]]:mxs, [[COPY4:%[0-9]+]].sub_ptr:epsrfldf, [[COPY4:%[0-9]+]].sub_fifo:epsrfldf, [[COPY4:%[0-9]+]].sub_avail:epsrfldf = VLD_POP_512_fifo_1d_pop_pseudo [[COPY4]].sub_ptr, [[COPY4]].sub_fifo, [[COPY4]].sub_avail, [[MOV_PD_imm11_pseudo]], implicit-def $srfifo_uf :: (load unknown-size, align 1)
+  ; CHECK-NEXT:   PseudoJNZ [[AND]], %bb.1
+  ; CHECK-NEXT:   PseudoJ_jump_imm %bb.2
+  ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT: bb.2:
+  ; CHECK-NEXT:   successors: %bb.3(0x80000000)
+  ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT: bb.3:
+  ; CHECK-NEXT:   successors: %bb.3(0x80000000)
+  ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT:   ST_dms_sts_scalar_st_idx_imm [[COPY4]].sub_ptr, [[COPY]], 0 :: (store (p0), align 4)
+  ; CHECK-NEXT:   PseudoJ_jump_imm %bb.3
+  bb.0.entry:
+    successors: %bb.1(0x80000000); %bb.1(100.00%)
+    liveins: $p0, $r0
+    %0:ep = COPY $p0
+    %2:mlockid_reg = COPY $r0
+    %9:mrf2a = MOV_RLC_imm11_pseudo 0
+    %20:mxs = VBCST_32 %9:mrf2a
+    %22:mcmm = COPY %20:mxs
+    undef %8.sub_1024_acc_lo:acc2048 = COPY %22:mcmm
+    %8.sub_1024_acc_hi:acc2048 = COPY %22:mcmm
+    %10:em = MOV_PD_imm11_pseudo 0
+    %11:ep = MOV_PD_imm11_pseudo 0
+    %19:eldfiforeg = COPY %8:acc2048
+    %18:mlockid_reg = MOV_RLC_imm11_pseudo 1
+    %17:mlockid_reg = XOR %2:mlockid_reg, %18:mlockid_reg
+    %14:mlockid_reg = AND %17:mlockid_reg, %18:mlockid_reg
+    %24:eps = COPY %11:ep
+
+  bb.1:
+    successors: %bb.2(0x04000000), %bb.1(0x7c000000); %bb.2(3.12%), %bb.1(96.88%)
+
+    %3:eps = COPY %24:eps
+    undef %25.sub_ptr:epsrfldf = COPY %3:eps
+    %25.sub_fifo:epsrfldf = COPY %19:eldfiforeg
+    %25.sub_avail:epsrfldf = COPY %9:mrf2a
+    dead %4:mxs, %25.sub_ptr:epsrfldf, %25.sub_fifo:epsrfldf, %25.sub_avail:epsrfldf = VLD_POP_512_fifo_1d_pop_pseudo %25.sub_ptr:epsrfldf, %25.sub_fifo:epsrfldf, %25.sub_avail:epsrfldf, %10:em, implicit-def $srfifo_uf :: (load unknown-size, align 1)
+    %24:eps = COPY %25.sub_ptr:epsrfldf
+    PseudoJNZ %14:mlockid_reg, %bb.1
+    PseudoJ_jump_imm %bb.2
+
+  bb.2:
+    successors: %bb.3(0x80000000); %bb.3(100.00%)
+
+
+  bb.3:
+    successors: %bb.3(0x80000000); %bb.3(100.00%)
+
+    ST_dms_sts_scalar_st_idx_imm %25.sub_ptr:epsrfldf, %0:ep, 0 :: (store (p0), align 4)
+    PseudoJ_jump_imm %bb.3
+...

--- a/llvm/test/CodeGen/AIE/aie2ps/ra/fifo-coalesce-sub-ptr.mir
+++ b/llvm/test/CodeGen/AIE/aie2ps/ra/fifo-coalesce-sub-ptr.mir
@@ -61,19 +61,20 @@ body: |
   ; CHECK-NEXT:   undef [[COPY2:%[0-9]+]].sub_1024_acc_lo:acc2048 = COPY [[VBCST_32_]]
   ; CHECK-NEXT:   [[COPY2:%[0-9]+]].sub_1024_acc_hi:acc2048 = COPY [[COPY2]].sub_1024_acc_lo
   ; CHECK-NEXT:   [[MOV_PD_imm11_pseudo:%[0-9]+]]:em = MOV_PD_imm11_pseudo 0
-  ; CHECK-NEXT:   [[MOV_PD_imm11_pseudo1:%[0-9]+]]:ep = MOV_PD_imm11_pseudo 0
+  ; CHECK-NEXT:   [[MOV_PD_imm11_pseudo1:%[0-9]+]]:ep_as_32bit = MOV_PD_imm11_pseudo 0
   ; CHECK-NEXT:   [[COPY3:%[0-9]+]]:eldfiforeg = COPY [[COPY2]]
   ; CHECK-NEXT:   [[MOV_RLC_imm11_pseudo1:%[0-9]+]]:mlockid_reg = MOV_RLC_imm11_pseudo 1
   ; CHECK-NEXT:   [[XOR:%[0-9]+]]:mlockid_reg = XOR [[COPY1]], [[MOV_RLC_imm11_pseudo1]]
   ; CHECK-NEXT:   [[AND:%[0-9]+]]:mlockid_reg = AND [[XOR]], [[MOV_RLC_imm11_pseudo1]]
-  ; CHECK-NEXT:   undef [[COPY4:%[0-9]+]].sub_ptr:epsrfldf = COPY [[MOV_PD_imm11_pseudo1]]
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT: bb.1:
   ; CHECK-NEXT:   successors: %bb.2(0x04000000), %bb.1(0x7c000000)
   ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT:   undef [[COPY4:%[0-9]+]].sub_ptr:epsrfldf = COPY [[MOV_PD_imm11_pseudo1]]
   ; CHECK-NEXT:   [[COPY4:%[0-9]+]].sub_fifo:epsrfldf = COPY [[COPY3]]
   ; CHECK-NEXT:   [[COPY4:%[0-9]+]].sub_avail:epsrfldf = COPY [[MOV_RLC_imm11_pseudo]]
   ; CHECK-NEXT:   dead [[VLD_POP_512_fifo_1d_pop_pseudo:%[0-9]+]]:mxs, [[COPY4:%[0-9]+]].sub_ptr:epsrfldf, [[COPY4:%[0-9]+]].sub_fifo:epsrfldf, [[COPY4:%[0-9]+]].sub_avail:epsrfldf = VLD_POP_512_fifo_1d_pop_pseudo [[COPY4]].sub_ptr, [[COPY4]].sub_fifo, [[COPY4]].sub_avail, [[MOV_PD_imm11_pseudo]], implicit-def $srfifo_uf :: (load unknown-size, align 1)
+  ; CHECK-NEXT:   [[MOV_PD_imm11_pseudo1:%[0-9]+]]:ep_as_32bit = COPY [[COPY4]].sub_ptr
   ; CHECK-NEXT:   PseudoJNZ [[AND]], %bb.1
   ; CHECK-NEXT:   PseudoJ_jump_imm %bb.2
   ; CHECK-NEXT: {{  $}}


### PR DESCRIPTION
The shouldCoalesce hook was only blocking coalescing when a register was
being written INTO sub_ptr/sub_avail of ePSRFLdF (e.g., %25.sub_ptr = COPY %src).
However, it failed to block coalescing when a register was READING from
sub_ptr/sub_avail and the reader gets merged back into the composite
(e.g., %dst = COPY %25.sub_ptr). This second case causes the reader's
earlier definitions to become sub_ptr definitions, extending the live
range of the ePSRFLdF register back to the entry block.
Fix by checking both SubReg and DstSubReg to block coalescing in both
directions, preventing the artificial extension of the FIFO load state
register's live range.