### PR TITLE
[AIE] Improve AA in MaxLatencyFinder

### DIFF
--- a/llvm/lib/Target/AIE/AIEBaseSubtarget.cpp
+++ b/llvm/lib/Target/AIE/AIEBaseSubtarget.cpp
@@ -257,6 +257,8 @@ class BiasDepth : public ScheduleDAGMutation {
 };
 
 class RegionEndEdges : public ScheduleDAGMutation {
+  AAResults *AA;
+
   void removeExitSUPreds(ScheduleDAGInstrs *DAG) {
     SUnit &ExitSU = DAG->ExitSU;
     while (!ExitSU.Preds.empty()) {
@@ -264,7 +266,7 @@ class RegionEndEdges : public ScheduleDAGMutation {
     }
   }
   void apply(ScheduleDAGInstrs *DAG) override {
-    AIE::MaxLatencyFinder MaxLatency(DAG);
+    AIE::MaxLatencyFinder MaxLatency(DAG, AA);
     MachineBasicBlock *PrologueMBB = DAG->getBB();
     unsigned int ZOLBundlesCount = 0;
 
@@ -333,6 +335,9 @@ class RegionEndEdges : public ScheduleDAGMutation {
     }
     DAG->ExitSU.setDepthDirty();
   };
+
+public:
+  RegionEndEdges(AAResults *AA = nullptr) : AA(AA) {}
 };
 
 /// This Mutator is responsible for emitting "fixed" SUnits at the top or bottom
@@ -895,7 +900,7 @@ AIEBaseSubtarget::getPostRAMutationsImpl(const Triple &TT, AAResults *AA) {
   if (!TT.isAIE1()) {
     if (EnableWAWStickyRegisters)
       Mutations.emplace_back(std::make_unique<WAWStickyRegistersEdges>());
-    Mutations.emplace_back(std::make_unique<RegionEndEdges>());
+    Mutations.emplace_back(std::make_unique<RegionEndEdges>(AA));
     Mutations.emplace_back(std::make_unique<MemoryEdges>(true));
     Mutations.emplace_back(std::make_unique<MachineSchedWAWEdges>());
     Mutations.emplace_back(std::make_unique<BiasDepth>());

--- a/llvm/lib/Target/AIE/AIEMaxLatencyFinder.cpp
+++ b/llvm/lib/Target/AIE/AIEMaxLatencyFinder.cpp
@@ -171,16 +171,17 @@ MaxLatencyFinder::MaxLatencyFinder(
     const AIEPostRASchedStrategy *const Scheduler,
     const AIEBaseInstrInfo *const TII,
     const InstrItineraryData *const Itineraries,
-    const MCRegisterInfo *const TRI, MachineBasicBlock *const CurBB)
+    const MCRegisterInfo *const TRI, MachineBasicBlock *const CurBB,
+    AAResults *AA)
     : Scheduler(Scheduler), TII(TII), Itineraries(Itineraries), TRI(TRI),
-      CurBB(CurBB), InterBlock(true) {}
+      CurBB(CurBB), InterBlock(true), AA(AA) {}
 
 // This is called from different contexts, so we need some case analysis
 // If we have a basic block, we are in a regular MachineScheduler invocation,
 // and we will be able to retrieve its strategy,
 // Otherwise we are an abstract region; Scheduler will be nullptr, which
 // will not be derefenced.
-MaxLatencyFinder::MaxLatencyFinder(ScheduleDAGInstrs *DAG)
+MaxLatencyFinder::MaxLatencyFinder(ScheduleDAGInstrs *DAG, AAResults *AA)
     : Scheduler(DAG->getBB()
                     ? static_cast<AIEScheduleDAGMI *>(DAG)->getSchedImpl()
                     : nullptr),
@@ -189,7 +190,8 @@ MaxLatencyFinder::MaxLatencyFinder(ScheduleDAGInstrs *DAG)
       TRI(DAG->MF.getSubtarget().getRegisterInfo()), CurBB(DAG->getBB()),
       InterBlock(InterBlockLatency && CurBB &&
                  isBottomRegion(DAG->ExitSU.getInstr()) &&
-                 Scheduler->successorsAreScheduled(CurBB)) {}
+                 Scheduler->successorsAreScheduled(CurBB)),
+      AA(AA) {}
 
 unsigned MaxLatencyFinder::operator()(MachineInstr &MI) {
   LLVM_DEBUG(dbgs() << MI << "\n");
@@ -232,7 +234,7 @@ unsigned MaxLatencyFinder::operator()(MachineInstr &MI) {
       continue;
     }
     const std::vector<AIE::MachineBundle> &TopBundles = SBS.getTop().Bundles;
-    Earliest = findEarliestRef(MI, TopBundles, Earliest).Cycle;
+    Earliest = findEarliestRef(MI, TopBundles, Earliest, AA).Cycle;
   }
 
   LLVM_DEBUG(dbgs() << "   Earliest=" << Earliest << "\n");

--- a/llvm/lib/Target/AIE/AIEMaxLatencyFinder.cpp
+++ b/llvm/lib/Target/AIE/AIEMaxLatencyFinder.cpp
@@ -87,7 +87,8 @@ static bool overlap(const MachineOperand &SrcOp, const MachineOperand &DstOp,
 
 /// Check whether Dst depends on Src
 static bool depends(const MachineInstr &Src, const MachineInstr &Dst,
-                    const TargetRegisterInfo *TRI, AAResults *AA) {
+                    const TargetRegisterInfo *TRI, AAResults *AA,
+                    bool SafeToIgnoreMemDeps) {
 
   const AIEBaseInstrInfo *const TII = static_cast<const AIEBaseInstrInfo *>(
       Src.getMF()->getSubtarget().getInstrInfo());
@@ -132,8 +133,14 @@ static bool depends(const MachineInstr &Src, const MachineInstr &Dst,
              TII->isPartWordMemoryInst(MaybePartStore);
     };
 
-    if (AA && !IsPartWordStore(Src)) {
-      return Src.mayAlias(AA, Dst, true);
+    if (!IsPartWordStore(Src)) {
+
+      // If it's safe to ignore memory dependencies, skip memory checks.
+      if (SafeToIgnoreMemDeps)
+        return false;
+
+      if (AA)
+        return Src.mayAlias(AA, Dst, true);
     }
 
     // Conservative: assume dependency for part-word instructions or when AA
@@ -146,7 +153,7 @@ static bool depends(const MachineInstr &Src, const MachineInstr &Dst,
 
 InstrAndCycle findEarliestRef(const MachineInstr &SrcMI,
                               ArrayRef<MachineBundle> Bundles, int Prune,
-                              AAResults *AA) {
+                              AAResults *AA, bool SafeToIgnoreMemDeps) {
   const TargetRegisterInfo *TRI =
       SrcMI.getMF()->getSubtarget().getRegisterInfo();
   int Cycle = 0;
@@ -157,7 +164,7 @@ InstrAndCycle findEarliestRef(const MachineInstr &SrcMI,
     }
     for (MachineInstr *DstMI : Bundle.getInstrs()) {
       LLVM_DEBUG(dbgs() << " " << *DstMI);
-      if (depends(SrcMI, *DstMI, TRI, AA)) {
+      if (depends(SrcMI, *DstMI, TRI, AA, SafeToIgnoreMemDeps)) {
         LLVM_DEBUG(dbgs() << "    depends in cycle=" << Cycle << "\n");
         return {DstMI, Cycle};
       }
@@ -174,7 +181,7 @@ MaxLatencyFinder::MaxLatencyFinder(
     const MCRegisterInfo *const TRI, MachineBasicBlock *const CurBB,
     AAResults *AA)
     : Scheduler(Scheduler), TII(TII), Itineraries(Itineraries), TRI(TRI),
-      CurBB(CurBB), InterBlock(true), AA(AA) {}
+      CurBB(CurBB), InterBlock(true), AA(AA), SafeToIgnoreMemDeps(false) {}
 
 // This is called from different contexts, so we need some case analysis
 // If we have a basic block, we are in a regular MachineScheduler invocation,
@@ -191,7 +198,19 @@ MaxLatencyFinder::MaxLatencyFinder(ScheduleDAGInstrs *DAG, AAResults *AA)
       InterBlock(InterBlockLatency && CurBB &&
                  isBottomRegion(DAG->ExitSU.getInstr()) &&
                  Scheduler->successorsAreScheduled(CurBB)),
-      AA(AA) {}
+      AA(AA),
+      // This is a current assumption needed to achieve a proper compact
+      // schedule.
+      // A loop is considered a candidate for outer loop pipelining if there are
+      // no memory-carried dependencies. The outer loop pipeliner attaches
+      // related metadata to the loop/epilogue, which we capture here. This
+      // metadata indicates that epilogue stores will not alias with loads from
+      // the peeled iteration. We will further analyze why AA is too
+      // conservative in some cases and remove this assumption when possible.
+      SafeToIgnoreMemDeps(Scheduler && CurBB &&
+                          Scheduler->getInterBlock()
+                              .getBlockState(CurBB)
+                              .isSafeToIgnoreMemDeps()) {}
 
 unsigned MaxLatencyFinder::operator()(MachineInstr &MI) {
   LLVM_DEBUG(dbgs() << MI << "\n");
@@ -234,7 +253,9 @@ unsigned MaxLatencyFinder::operator()(MachineInstr &MI) {
       continue;
     }
     const std::vector<AIE::MachineBundle> &TopBundles = SBS.getTop().Bundles;
-    Earliest = findEarliestRef(MI, TopBundles, Earliest, AA).Cycle;
+    Earliest =
+        findEarliestRef(MI, TopBundles, Earliest, AA, SafeToIgnoreMemDeps)
+            .Cycle;
   }
 
   LLVM_DEBUG(dbgs() << "   Earliest=" << Earliest << "\n");

--- a/llvm/lib/Target/AIE/AIEMaxLatencyFinder.h
+++ b/llvm/lib/Target/AIE/AIEMaxLatencyFinder.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// (c) Copyright 2024-2025 Advanced Micro Devices, Inc. or its affiliates
+// (c) Copyright 2024-2026 Advanced Micro Devices, Inc. or its affiliates
 //
 //===----------------------------------------------------------------------===//
 //
@@ -47,6 +47,7 @@ class MaxLatencyFinder {
   const MCRegisterInfo *const TRI;
   MachineBasicBlock *const CurBB;
   const bool InterBlock;
+  AAResults *AA;
 
   // Check whether this region connects to the successor blocks
   //
@@ -58,9 +59,9 @@ public:
                    const AIEBaseInstrInfo *const TII,
                    const InstrItineraryData *const Itineraries,
                    const MCRegisterInfo *const TRI,
-                   MachineBasicBlock *const CurBB);
+                   MachineBasicBlock *const CurBB, AAResults *AA = nullptr);
 
-  MaxLatencyFinder(ScheduleDAGInstrs *DAG);
+  MaxLatencyFinder(ScheduleDAGInstrs *DAG, AAResults *AA = nullptr);
 
   // Find the maximum latency of MI taking  successors into account
   unsigned operator()(MachineInstr &MI);

--- a/llvm/lib/Target/AIE/AIEMaxLatencyFinder.h
+++ b/llvm/lib/Target/AIE/AIEMaxLatencyFinder.h
@@ -38,7 +38,8 @@ struct InstrAndCycle {
 ///          found.
 InstrAndCycle findEarliestRef(const MachineInstr &SrcMI,
                               ArrayRef<MachineBundle> Bundles, int Prune,
-                              AAResults *AA = nullptr);
+                              AAResults *AA = nullptr,
+                              bool SafeToIgnoreMemDeps = false);
 
 class MaxLatencyFinder {
   const AIEPostRASchedStrategy *const Scheduler;
@@ -48,6 +49,7 @@ class MaxLatencyFinder {
   MachineBasicBlock *const CurBB;
   const bool InterBlock;
   AAResults *AA;
+  bool SafeToIgnoreMemDeps;
 
   // Check whether this region connects to the successor blocks
   //

--- a/llvm/test/CodeGen/AIE/aie2ps/conv2d-outer-loop.ll
+++ b/llvm/test/CodeGen/AIE/aie2ps/conv2d-outer-loop.ll
@@ -171,8 +171,8 @@ define void @conv2d_outer_loop(ptr noalias %ifm, ptr noalias %wts, ptr noalias %
 ; CHECK-NEXT:    // in Loop: Header=BB0_8 Depth=1
 ; CHECK-NEXT:    vlda x4, [p7, #192]; paddb [p1], m3; padds [p7], #128; add r4, r4, #-1; nopm ; vmac dm0, dm0, x2, x4, r8
 ; CHECK-NEXT:    vlda x6, [p7, #128]; paddb [p4], #128; padds [p6], #128; nopx ; vshuffle x2, x10, x8, r6; vmac dm1, dm1, x2, x6, r8
-; CHECK-NEXT:    vlda x4, [p7, #192]; paddb.3d [p0], d1; nopx ; padds [p7], #128; vmac dm0, dm0, x2, x4, r8
-; CHECK-NEXT:    paddb.3d [p1], d2; vshuffle x2, x10, x8, r6; vmac dm1, dm1, x2, x6, r8
+; CHECK-NEXT:    vlda x4, [p7, #192]; paddb.3d [p0], d1; padds [p7], #128; nopxm ; vmac dm0, dm0, x2, x4, r8
+; CHECK-NEXT:    nopa ; paddb.3d [p1], d2; nops ; nopx ; vshuffle x2, x10, x8, r6; vmac dm1, dm1, x2, x6, r8
 ; CHECK-NEXT:    vmac dm0, dm0, x2, x4, r8
 ; CHECK-NEXT:    vshuffle x2, x10, x8, r6; vmac dm1, dm1, x2, x6, r8
 ; CHECK-NEXT:    vmac dm0, dm0, x2, x4, r8
@@ -182,15 +182,12 @@ define void @conv2d_outer_loop(ptr noalias %ifm, ptr noalias %wts, ptr noalias %
 ; CHECK-NEXT:    vmac dm0, dm0, x2, x4, r8
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
-; CHECK-NEXT:    nop
-; CHECK-NEXT:    nop
-; CHECK-NEXT:    vst.srs.2x cml1, s1, srssign1, [p3], #64
-; CHECK-NEXT:    vst.srs.2x cmh1, s1, srssign1, [p3], #64; jnz r4, #.LBB0_8
-; CHECK-NEXT:    vst.srs.2x cml0, s1, srssign1, [p5], #64 // Delay Slot 5
-; CHECK-NEXT:    vst.srs.2x cmh0, s1, srssign1, [p5], #64 // Delay Slot 4
-; CHECK-NEXT:    nop // Delay Slot 3
-; CHECK-NEXT:    nop // Delay Slot 2
-; CHECK-NEXT:    nop // Delay Slot 1
+; CHECK-NEXT:    jnz r4, #.LBB0_8
+; CHECK-NEXT:    nop // Delay Slot 5
+; CHECK-NEXT:    vst.srs.2x cml1, s1, srssign1, [p3], #64 // Delay Slot 4
+; CHECK-NEXT:    vst.srs.2x cmh1, s1, srssign1, [p3], #64 // Delay Slot 3
+; CHECK-NEXT:    vst.srs.2x cml0, s1, srssign1, [p5], #64 // Delay Slot 2
+; CHECK-NEXT:    vst.srs.2x cmh0, s1, srssign1, [p5], #64 // Delay Slot 1
 ; CHECK-NEXT:  .LBB0_11: // %sw.epilog
 ; CHECK-NEXT:    lda p7, [sp, #-60] // 4-byte Folded Reload
 ; CHECK-NEXT:    lda p6, [sp, #-64] // 4-byte Folded Reload

--- a/llvm/test/CodeGen/AIE/aie2ps/end-to-end/conv2d_opt_outerloop_blocks.ll
+++ b/llvm/test/CodeGen/AIE/aie2ps/end-to-end/conv2d_opt_outerloop_blocks.ll
@@ -110,7 +110,7 @@ define dso_local void @conv2d(i32 %0, ptr %add.ptr3, ptr %ofm, ptr %psum_0_tdm, 
 ; CHECK-NEXT:  // %bb.3: // %for.cond.cleanup54.i
 ; CHECK-NEXT:    // in Loop: Header=BB0_1 Depth=1
 ; CHECK-NEXT:    vlda x4, [p4, #192]; paddb.3d [p1], d1; padds [p4], #128; add r0, r0, #-1; mov dc4, dc7; vmac dm0, dm0, x2, x4, r8
-; CHECK-NEXT:    vlda x6, [p4, #128]; paddb [p0], m4; vshuffle x2, x10, x8, r2; vmac dm1, dm1, x2, x6, r8
+; CHECK-NEXT:    vlda x6, [p4, #128]; paddb [p0], m4; nops ; nopx ; vshuffle x2, x10, x8, r2; vmac dm1, dm1, x2, x6, r8
 ; CHECK-NEXT:    vlda x4, [p4, #192]; vldb.popx x10, [p1, lf1, r25]; padds [p4], #128; nopx ; mov srssign0, r6; vmac dm0, dm0, x2, x4, r8
 ; CHECK-NEXT:    vlda.pop.3d x1, [p1, lf1, r25, d0]; paddb.3d [p0], d2; vshuffle x2, x10, x8, r2; vmac dm1, dm1, x2, x6, r8
 ; CHECK-NEXT:    vldb x8, [p0, #0]; mov r16, dc6; vmac dm0, dm0, x2, x4, r8
@@ -120,15 +120,12 @@ define dso_local void @conv2d(i32 %0, ptr %add.ptr3, ptr %ofm, ptr %psum_0_tdm, 
 ; CHECK-NEXT:    vldb.128 wl4, [p5, dj7]; vmac dm0, dm0, x2, x4, r8
 ; CHECK-NEXT:    vmac dm1, dm1, x2, x6, r8
 ; CHECK-NEXT:    vmac dm0, dm0, x2, x4, r8
-; CHECK-NEXT:    nop
-; CHECK-NEXT:    nop
-; CHECK-NEXT:    nop
 ; CHECK-NEXT:    vlda.ups.2x cml1, s0, upssign1, [p2], #64; jz r16, #.LBB0_1
-; CHECK-NEXT:    vlda.ups.2x cmh1, s0, upssign1, [p2], #64; vst.srs.4x dm1, s1, srssign0, [p6], m5 // Delay Slot 5
-; CHECK-NEXT:    vlda.ups.2x cml0, s0, upssign1, [p3], #64; vst.2d.srs.4x dm0, s1, srssign0, [p6], d3 // Delay Slot 4
+; CHECK-NEXT:    vlda.ups.2x cmh1, s0, upssign1, [p2], #64 // Delay Slot 5
+; CHECK-NEXT:    vlda.ups.2x cml0, s0, upssign1, [p3], #64 // Delay Slot 4
 ; CHECK-NEXT:    vlda.ups.2x cmh0, s0, upssign1, [p3], #64 // Delay Slot 3
-; CHECK-NEXT:    vshuffle x10, x10, x1, r2 // Delay Slot 2
-; CHECK-NEXT:    movx srssign0, #0 // Delay Slot 1
+; CHECK-NEXT:    vst.srs.4x dm1, s1, srssign0, [p6], m5; vshuffle x10, x10, x1, r2 // Delay Slot 2
+; CHECK-NEXT:    vst.2d.srs.4x dm0, s1, srssign0, [p6], d3; movx srssign0, #0 // Delay Slot 1
 ; CHECK-NEXT:  // %bb.4: // %cooldown.entry
 ; CHECK-NEXT:    vldb.popx x8, [p1, lf1, r25]
 ; CHECK-NEXT:    vldb.pop.3d x6, [p1, lf1, r25, d0]
@@ -242,7 +239,7 @@ define dso_local void @conv2d(i32 %0, ptr %add.ptr3, ptr %ofm, ptr %psum_0_tdm, 
 ; NO-PROLOGUE-SPLIT-NEXT:    vlda x1, [p7, #64]; vldb.popx x4, [p1, lf1, r25]; nops ; or r24, r16, r22; mov dj7, r16; vmac dm0, dm0, x2, x4, r8
 ; NO-PROLOGUE-SPLIT-NEXT:    vlda.128 wl2, [p0, dj7]; vldb.pop.3d x6, [p1, lf1, r25, d0]; movs dj7, r24; eq r16, r0, r20; vshuffle x2, x10, x8, r2; vmac dm1, dm1, x2, x6, r8
 ; NO-PROLOGUE-SPLIT-NEXT:    vlda.128 wl8, [p0, dj7]; nopb ; nops ; nopx ; mov srssign0, r6; vmac dm0, dm0, x2, x4, r8
-; NO-PROLOGUE-SPLIT-NEXT:    nopx ; vshuffle x2, x10, x8, r2; vmac dm1, dm1, x2, x6, r8
+; NO-PROLOGUE-SPLIT-NEXT:    vshuffle x2, x10, x8, r2; vmac dm1, dm1, x2, x6, r8
 ; NO-PROLOGUE-SPLIT-NEXT:    vmac dm0, dm0, x2, x4, r8
 ; NO-PROLOGUE-SPLIT-NEXT:    vmac dm1, dm1, x2, x6, r8
 ; NO-PROLOGUE-SPLIT-NEXT:    vmac dm0, dm0, x2, x4, r8
@@ -255,10 +252,10 @@ define dso_local void @conv2d(i32 %0, ptr %add.ptr3, ptr %ofm, ptr %psum_0_tdm, 
 ; NO-PROLOGUE-SPLIT-NEXT:    vmul dm3, x0, x8, r12
 ; NO-PROLOGUE-SPLIT-NEXT:    jz r16, #.LBB0_1; vaddmac dm1, dm1, dm2, x2, x10, r10
 ; NO-PROLOGUE-SPLIT-NEXT:    vst.srs.4x dm1, s1, srssign0, [p6], m5 // Delay Slot 5
-; NO-PROLOGUE-SPLIT-NEXT:    vst.2d.srs.4x dm0, s1, srssign0, [p6], d3 // Delay Slot 4
+; NO-PROLOGUE-SPLIT-NEXT:    nop // Delay Slot 4
 ; NO-PROLOGUE-SPLIT-NEXT:    nop // Delay Slot 3
-; NO-PROLOGUE-SPLIT-NEXT:    vaddmac dm0, dm0, dm3, x2, x1, r10 // Delay Slot 2
-; NO-PROLOGUE-SPLIT-NEXT:    movs p2, p5; movx srssign0, #0; mov p3, p4 // Delay Slot 1
+; NO-PROLOGUE-SPLIT-NEXT:    mov p2, p5; vaddmac dm0, dm0, dm3, x2, x1, r10 // Delay Slot 2
+; NO-PROLOGUE-SPLIT-NEXT:    vst.2d.srs.4x dm0, s1, srssign0, [p6], d3; movx srssign0, #0; mov p3, p4 // Delay Slot 1
 ; NO-PROLOGUE-SPLIT-NEXT:  // %bb.4: // %cooldown.entry
 ; NO-PROLOGUE-SPLIT-NEXT:    vldb.popx x8, [p1, lf1, r25]
 ; NO-PROLOGUE-SPLIT-NEXT:    vldb.pop.3d x6, [p1, lf1, r25, d0]
@@ -334,8 +331,8 @@ define dso_local void @conv2d(i32 %0, ptr %add.ptr3, ptr %ofm, ptr %psum_0_tdm, 
 ; USE-JNZD-NEXT:    vlda.ups.2x cml0, s0, upssign1, [p3], #64; vldb x6, [p0, #64]; add r0, r0, #-1; mov dc6, dc7; movs dc3, dc7
 ; USE-JNZD-NEXT:    vlda.ups.2x cmh1, s0, upssign1, [p2], #64; movs dc2, dc7; or r8, r7, r7; addm.nc r1, r0, #-1
 ; USE-JNZD-NEXT:    vlda.ups.2x cmh0, s0, upssign1, [p3], #64; vldb.128 wl4, [p5, #16]; movxm p4, #.LBB0_1; movs dc5, dc7
-; USE-JNZD-NEXT:    mova r18, #16; st p7, [sp, #-60]; movx crupsmode, #0; vshuffle x10, x10, x1, r2 // 4-byte Folded Spill
-; USE-JNZD-NEXT:    mova r12, #264; movs dc1, dc7; movx crsrsmode, #0; mov m5, r17
+; USE-JNZD-NEXT:    mova r18, #16; movs dc1, dc7; movx crupsmode, #0; vshuffle x10, x10, x1, r2
+; USE-JNZD-NEXT:    mova r12, #264; st p7, [sp, #-60]; movx crsrsmode, #0; mov m5, r17 // 4-byte Folded Spill
 ; USE-JNZD-NEXT:  .LBB0_1: // %for.body.i
 ; USE-JNZD-NEXT:    // =>This Loop Header: Depth=1
 ; USE-JNZD-NEXT:    // Child Loop BB0_2 Depth 2
@@ -362,23 +359,20 @@ define dso_local void @conv2d(i32 %0, ptr %add.ptr3, ptr %ofm, ptr %psum_0_tdm, 
 ; USE-JNZD-NEXT:    vlda x4, [p7, #192]; paddb.3d [p1], d1; padds [p7], #128; nopx ; mov dc4, dc7; vmac dm0, dm0, x2, x4, r8
 ; USE-JNZD-NEXT:    vlda x6, [p7, #128]; vldb.popx x10, [p1, lf1, r25]; padds [p0], m4; nopx ; vshuffle x2, x10, x8, r2; vmac dm1, dm1, x2, x6, r8
 ; USE-JNZD-NEXT:    vlda x4, [p7, #192]; vldb.pop.3d x1, [p1, lf1, r25, d0]; padds [p7], #128; nopx ; mov srssign0, r6; vmac dm0, dm0, x2, x4, r8
-; USE-JNZD-NEXT:    paddb.3d [p0], d2; nopx ; vshuffle x2, x10, x8, r2; vmac dm1, dm1, x2, x6, r8
-; USE-JNZD-NEXT:    vldb x8, [p0, #0]; mov r0, dc6; vmac dm0, dm0, x2, x4, r8
+; USE-JNZD-NEXT:    nopa ; paddb.3d [p0], d2; nops ; nopx ; vshuffle x2, x10, x8, r2; vmac dm1, dm1, x2, x6, r8
+; USE-JNZD-NEXT:    vldb x8, [p0, #0]; nopx ; mov r0, dc6; vmac dm0, dm0, x2, x4, r8
 ; USE-JNZD-NEXT:    vldb x6, [p0, #64]; lshl r0, r0, r16; vshuffle x2, x10, x8, r2; vmac dm1, dm1, x2, x6, r8
 ; USE-JNZD-NEXT:    or r20, r0, r18; mov dj7, r0; vmac dm0, dm0, x2, x4, r8
 ; USE-JNZD-NEXT:    movs dj7, r20; vldb.128 wl2, [p5, dj7]; vshuffle x2, x10, x8, r2; vmac dm1, dm1, x2, x6, r8
 ; USE-JNZD-NEXT:    vldb.128 wl4, [p5, dj7]; vmac dm0, dm0, x2, x4, r8
 ; USE-JNZD-NEXT:    vmac dm1, dm1, x2, x6, r8
 ; USE-JNZD-NEXT:    vshuffle x10, x10, x1, r2; vmac dm0, dm0, x2, x4, r8
-; USE-JNZD-NEXT:    nop
-; USE-JNZD-NEXT:    nop
-; USE-JNZD-NEXT:    nop
 ; USE-JNZD-NEXT:    vlda.ups.2x cml1, s0, upssign1, [p2], #64; jnzd r1, r1, p4
-; USE-JNZD-NEXT:    vlda.ups.2x cmh1, s0, upssign1, [p2], #64; vst.srs.4x dm1, s1, srssign0, [p6], m5 // Delay Slot 5
-; USE-JNZD-NEXT:    vlda.ups.2x cml0, s0, upssign1, [p3], #64; vst.2d.srs.4x dm0, s1, srssign0, [p6], d3 // Delay Slot 4
+; USE-JNZD-NEXT:    vlda.ups.2x cmh1, s0, upssign1, [p2], #64 // Delay Slot 5
+; USE-JNZD-NEXT:    vlda.ups.2x cml0, s0, upssign1, [p3], #64 // Delay Slot 4
 ; USE-JNZD-NEXT:    vlda.ups.2x cmh0, s0, upssign1, [p3], #64 // Delay Slot 3
-; USE-JNZD-NEXT:    nop // Delay Slot 2
-; USE-JNZD-NEXT:    movx srssign0, #0 // Delay Slot 1
+; USE-JNZD-NEXT:    vst.srs.4x dm1, s1, srssign0, [p6], m5 // Delay Slot 2
+; USE-JNZD-NEXT:    vst.2d.srs.4x dm0, s1, srssign0, [p6], d3; movx srssign0, #0 // Delay Slot 1
 ; USE-JNZD-NEXT:  // %bb.4: // %cooldown.entry
 ; USE-JNZD-NEXT:    vldb.popx x8, [p1, lf1, r25]
 ; USE-JNZD-NEXT:    vldb.pop.3d x6, [p1, lf1, r25, d0]

--- a/llvm/test/CodeGen/AIE/aie2ps/end-to-end/gemm_int8_outerloop_blocks.ll
+++ b/llvm/test/CodeGen/AIE/aie2ps/end-to-end/gemm_int8_outerloop_blocks.ll
@@ -107,8 +107,8 @@ define dso_local void @gemm(i32 %0, ptr addrspace(5) %1, ptr addrspace(5) %2, pt
 ; CHECK-NEXT:  // %bb.3: // %for.cond.cleanup99
 ; CHECK-NEXT:    // in Loop: Header=BB0_1 Depth=1
 ; CHECK-NEXT:    nopa ; paddb.2d [p4], d3; movs m0, p5; add r0, r0, #-1; vshuffle x10, x1, x0, r16; vmac dm1, dm1, x5, x6, r8
-; CHECK-NEXT:    nopa ; vldb.128 wl1, [p4, #16]; nops ; ne r26, r0, r22; vshuffle x8, x7, x0, r18; vmac dm0, dm0, x3, x6, r8
-; CHECK-NEXT:    nopa ; vldb.128 wl10, [p4, #0]; nopx ; vshuffle x6, x8, x0, r20; vmac dm3, dm3, x5, x10, r8
+; CHECK-NEXT:    nopa ; vldb.128 wl1, [p4, #16]; ne r26, r0, r22; vshuffle x8, x7, x0, r18; vmac dm0, dm0, x3, x6, r8
+; CHECK-NEXT:    vldb.128 wl10, [p4, #0]; vshuffle x6, x8, x0, r20; vmac dm3, dm3, x5, x10, r8
 ; CHECK-NEXT:    vshuffle x1, x9, x0, r7; vmac dm2, dm2, x3, x10, r8
 ; CHECK-NEXT:    vldb x3, [p1], m4; vshuffle x10, x1, x0, r16; vmac dm1, dm1, x5, x6, r8
 ; CHECK-NEXT:    vldb.3d x5, [p1], d1; vshuffle x8, x7, x0, r18; vmac dm0, dm0, x3, x6, r8
@@ -119,13 +119,13 @@ define dso_local void @gemm(i32 %0, ptr addrspace(5) %1, ptr addrspace(5) %2, pt
 ; CHECK-NEXT:    vlda.ups.2x cml3, s0, upssign1, [p2], #64
 ; CHECK-NEXT:    vlda.ups.2x cmh3, s0, upssign1, [p2], #64
 ; CHECK-NEXT:    vlda.ups.2x cml2, s0, upssign1, [p2], #64
-; CHECK-NEXT:    vlda.ups.2x cmh2, s0, upssign1, [p2], #64; vst.srs.4x dm3, s1, srssign0, [p3], #64
-; CHECK-NEXT:    vlda.ups.2x cml1, s0, upssign1, [p2], #64; vst.srs.4x dm2, s1, srssign0, [p3], m5; jnz r26, #.LBB0_1
-; CHECK-NEXT:    vlda.ups.2x cmh1, s0, upssign1, [p2], #64; vst.srs.4x dm1, s1, srssign0, [p3], #64 // Delay Slot 5
-; CHECK-NEXT:    vlda.ups.2x cml0, s0, upssign1, [p2], #64; vst.2d.srs.4x dm0, s1, srssign0, [p3], d2; vshuffle x10, x3, x0, r1 // Delay Slot 4
-; CHECK-NEXT:    vlda.ups.2x cmh0, s0, upssign1, [p2], #64; vshuffle x10, x10, x0, r2 // Delay Slot 3
-; CHECK-NEXT:    vshuffle x1, x5, x0, r3 // Delay Slot 2
-; CHECK-NEXT:    movx srssign0, #0; vshuffle x1, x1, x0, r4 // Delay Slot 1
+; CHECK-NEXT:    vlda.ups.2x cmh2, s0, upssign1, [p2], #64
+; CHECK-NEXT:    vlda.ups.2x cml1, s0, upssign1, [p2], #64; jnz r26, #.LBB0_1
+; CHECK-NEXT:    vlda.ups.2x cmh1, s0, upssign1, [p2], #64 // Delay Slot 5
+; CHECK-NEXT:    vlda.ups.2x cml0, s0, upssign1, [p2], #64; vst.srs.4x dm3, s1, srssign0, [p3], #64; vshuffle x10, x3, x0, r1 // Delay Slot 4
+; CHECK-NEXT:    vlda.ups.2x cmh0, s0, upssign1, [p2], #64; vst.srs.4x dm2, s1, srssign0, [p3], m5; vshuffle x10, x10, x0, r2 // Delay Slot 3
+; CHECK-NEXT:    vst.srs.4x dm1, s1, srssign0, [p3], #64; vshuffle x1, x5, x0, r3 // Delay Slot 2
+; CHECK-NEXT:    vst.2d.srs.4x dm0, s1, srssign0, [p3], d2; movx srssign0, #0; vshuffle x1, x1, x0, r4 // Delay Slot 1
 ; CHECK-NEXT:  // %bb.4: // %cooldown.entry
 ; CHECK-NEXT:    vldb x3, [p1], m4; vmul dm4, x0, x4, r12
 ; CHECK-NEXT:    vlda.3d x1, [p1], d1
@@ -368,9 +368,9 @@ define dso_local void @gemm(i32 %0, ptr addrspace(5) %1, ptr addrspace(5) %2, pt
 ; USE-JNZD-NEXT:    vlda.3d x3, [p0], d0; nopb ; nops ; nopx ; vshuffle x1, x9, x0, r7; vmac dm2, dm2, x3, x10, r8
 ; USE-JNZD-NEXT:  // %bb.3: // %for.cond.cleanup99
 ; USE-JNZD-NEXT:    // in Loop: Header=BB0_1 Depth=1
-; USE-JNZD-NEXT:    movs m0, p5; paddb.2d [p4], d3; vshuffle x10, x1, x0, r16; vmac dm1, dm1, x5, x6, r8
-; USE-JNZD-NEXT:    vldb.128 wl1, [p4, #16]; vshuffle x8, x7, x0, r18; vmac dm0, dm0, x3, x6, r8
-; USE-JNZD-NEXT:    vldb.128 wl10, [p4, #0]; vshuffle x6, x8, x0, r20; vmac dm3, dm3, x5, x10, r8
+; USE-JNZD-NEXT:    nopa ; paddb.2d [p4], d3; movs m0, p5; nopx ; vshuffle x10, x1, x0, r16; vmac dm1, dm1, x5, x6, r8
+; USE-JNZD-NEXT:    nopa ; vldb.128 wl1, [p4, #16]; nops ; nopx ; vshuffle x8, x7, x0, r18; vmac dm0, dm0, x3, x6, r8
+; USE-JNZD-NEXT:    vldb.128 wl10, [p4, #0]; nopx ; vshuffle x6, x8, x0, r20; vmac dm3, dm3, x5, x10, r8
 ; USE-JNZD-NEXT:    vshuffle x1, x9, x0, r7; vmac dm2, dm2, x3, x10, r8
 ; USE-JNZD-NEXT:    vldb x3, [p1], m4; vshuffle x10, x1, x0, r16; vmac dm1, dm1, x5, x6, r8
 ; USE-JNZD-NEXT:    vldb.3d x5, [p1], d1; vshuffle x8, x7, x0, r18; vmac dm0, dm0, x3, x6, r8
@@ -381,13 +381,13 @@ define dso_local void @gemm(i32 %0, ptr addrspace(5) %1, ptr addrspace(5) %2, pt
 ; USE-JNZD-NEXT:    vlda.ups.2x cml3, s0, upssign1, [p2], #64
 ; USE-JNZD-NEXT:    vlda.ups.2x cmh3, s0, upssign1, [p2], #64
 ; USE-JNZD-NEXT:    vlda.ups.2x cml2, s0, upssign1, [p2], #64
-; USE-JNZD-NEXT:    vlda.ups.2x cmh2, s0, upssign1, [p2], #64; vst.srs.4x dm3, s1, srssign0, [p3], #64
-; USE-JNZD-NEXT:    vlda.ups.2x cml1, s0, upssign1, [p2], #64; vst.srs.4x dm2, s1, srssign0, [p3], m5; jnzd r5, r5, p6
-; USE-JNZD-NEXT:    vlda.ups.2x cmh1, s0, upssign1, [p2], #64; vst.srs.4x dm1, s1, srssign0, [p3], #64 // Delay Slot 5
-; USE-JNZD-NEXT:    vlda.ups.2x cml0, s0, upssign1, [p2], #64; vst.2d.srs.4x dm0, s1, srssign0, [p3], d2; vshuffle x10, x3, x0, r1 // Delay Slot 4
-; USE-JNZD-NEXT:    vlda.ups.2x cmh0, s0, upssign1, [p2], #64; vshuffle x1, x10, x0, r2 // Delay Slot 3
-; USE-JNZD-NEXT:    vshuffle x10, x5, x0, r3 // Delay Slot 2
-; USE-JNZD-NEXT:    movx srssign0, #0; vshuffle x10, x10, x0, r4 // Delay Slot 1
+; USE-JNZD-NEXT:    vlda.ups.2x cmh2, s0, upssign1, [p2], #64
+; USE-JNZD-NEXT:    vlda.ups.2x cml1, s0, upssign1, [p2], #64; jnzd r5, r5, p6
+; USE-JNZD-NEXT:    vlda.ups.2x cmh1, s0, upssign1, [p2], #64 // Delay Slot 5
+; USE-JNZD-NEXT:    vlda.ups.2x cml0, s0, upssign1, [p2], #64; vst.srs.4x dm3, s1, srssign0, [p3], #64; vshuffle x10, x3, x0, r1 // Delay Slot 4
+; USE-JNZD-NEXT:    vlda.ups.2x cmh0, s0, upssign1, [p2], #64; vst.srs.4x dm2, s1, srssign0, [p3], m5; vshuffle x1, x10, x0, r2 // Delay Slot 3
+; USE-JNZD-NEXT:    vst.srs.4x dm1, s1, srssign0, [p3], #64; vshuffle x10, x5, x0, r3 // Delay Slot 2
+; USE-JNZD-NEXT:    vst.2d.srs.4x dm0, s1, srssign0, [p3], d2; movx srssign0, #0; vshuffle x10, x10, x0, r4 // Delay Slot 1
 ; USE-JNZD-NEXT:  // %bb.4: // %cooldown.entry
 ; USE-JNZD-NEXT:    vldb x3, [p1], m4
 ; USE-JNZD-NEXT:    vlda.3d x1, [p1], d1; vmul dm4, x0, x4, r12


### PR DESCRIPTION
__Change 1: Pass Alias Analysis to RegionEndEdges__

Threads `AAResults*` through `RegionEndEdges` → `MaxLatencyFinder` → `findEarliestRef()` → `depends()`. This enables the use of `MachineInstr::mayAlias()` to determine if two memory operations actually alias, instead of conservatively assuming all memory ops depend on each other.

__Change 2: Use isSafeToIgnoreMemDeps in dependency checks__

Queries `BlockState::isSafeToIgnoreMemDeps()` and skips memory dependency checks entirely when it returns true. This mirrors the pattern used in `AIEScheduleDAGMI::mayAlias()` and allows pipelined loops to avoid unnecessary memory constraints.

The second change is safe because the fall-through block (of the an outerloop pipelined block) will be a new copy of one iteration if the complete loop. If we have no memory-carried dependencies in the loop, they will be absent also in the epilogue to prologue back edge and and also epilogue to peeled iteration edge. Also, the second change is intended to be effective (test changes) once we merge https://github.com/Xilinx/llvm-aie/pull/997, to this PR should be merge after.