### PR TITLE
[AIEX] Drop stderr warning for missing memory bank

### DIFF
--- a/llvm/lib/Target/AIE/AIEMultiSlotInstrMaterializer.cpp
+++ b/llvm/lib/Target/AIE/AIEMultiSlotInstrMaterializer.cpp
@@ -23,7 +23,6 @@
 #include "llvm/CodeGen/MachineInstr.h"
 #include "llvm/CodeGen/MachineOptimizationRemarkEmitter.h"
 #include "llvm/Support/ErrorHandling.h"
-#include "llvm/Support/WithColor.h"
 
 using namespace llvm;
 
@@ -36,33 +35,16 @@ static cl::opt<bool> SkipSingleSlotAssignment(
 
 namespace llvm::AIE {
 
-/// Emit a warning and an optimization remark for a load without a memory bank.
-/// The warning goes to stderr (always visible); the remark is available via
-/// -Rpass-missed=aie-multi-slot-pseudo.
-static void reportMissingMemoryBank(const MachineInstr &MI) {
-  const MachineBasicBlock *MBB = MI.getParent();
+/// Emit a missed-optimization remark for a load without a memory bank.
+static void reportMissingMemoryBank(MachineInstr &MI) {
+  MachineBasicBlock *MBB = MI.getParent();
+  MachineFunction &MF = *MBB->getParent();
 
-  // Build the shared message: function name, block name, debug location.
-  std::string Msg;
-  raw_string_ostream MsgOS(Msg);
-  MsgOS << "No memory bank assigned to load in function '"
-        << MBB->getParent()->getName() << "', block '" << MBB->getName() << "'";
-  if (const DebugLoc &DL = MI.getDebugLoc())
-    MsgOS << " at " << DL;
-
-  // Per-instruction stderr warning (includes the instruction itself).
-  auto &WarnOS = WithColor::warning();
-  WarnOS << Msg << ": ";
-  MI.print(WarnOS, /*IsStandalone=*/true, /*SkipOpers=*/false,
-           /*SkipDebugLoc=*/true);
-
-  // Per-instruction optimization remark.
-  MachineOptimizationRemarkEmitter MORE(
-      const_cast<MachineFunction &>(*MBB->getParent()), nullptr);
+  MachineOptimizationRemarkEmitter MORE(MF, nullptr);
   MORE.emit([&]() {
     return MachineOptimizationRemarkMissed(DEBUG_TYPE, "missing-memory-bank",
                                            MI.getDebugLoc(), MBB)
-           << Msg;
+           << ore::MNV("Instruction", MI);
   });
 }
 
@@ -110,7 +92,7 @@ public:
 
   /// \return whether a Slot can be assigned to \b MI and assign it in the
   /// mapping.
-  bool isSlotAssignable(const MachineInstr &MI, const AIEHazardRecognizer &HR) {
+  bool isSlotAssignable(MachineInstr &MI, const AIEHazardRecognizer &HR) {
     auto MemBankBits = HR.getMemoryBanks(&MI);
     LLVM_DEBUG(dbgs() << "Memory Bank: " << MemBankBits << " " << MI);
     if (!MemBankBits) {
@@ -201,17 +183,20 @@ SlotMapping getAssignedSlots(const MachineBasicBlock &MBB,
 /// Multi-Slot pseudo load instructions in \p MBB get a Slot assigned, according
 /// to the MemoyBankBits that is attached to the MachineInstr. Existing mappings
 /// in \p SlotToBanks are used and updated.
-bool assignSlots(SlotMapping &SlotToBanks, const MachineBasicBlock &MBB,
+bool assignSlots(SlotMapping &SlotToBanks, MachineBasicBlock &MBB,
                  const AIEBaseInstrInfo *TII, const AIEHazardRecognizer &HR) {
   LLVM_DEBUG(dbgs() << "Assigning Slots\n");
-  for (const auto &MI : MBB) {
+  // Visit every load so each missing-memory-bank gets its own remark.
+  bool AllAssignable = true;
+  for (auto &MI : MBB) {
     if (!MI.mayLoad() || !TII->isMultiSlotPseudo(MI))
       continue;
 
-    if (!SlotToBanks.isSlotAssignable(MI, HR)) {
-      return false;
-    }
+    if (!SlotToBanks.isSlotAssignable(MI, HR))
+      AllAssignable = false;
   }
+  if (!AllAssignable)
+    return false;
 
   const bool SingleSlotAssignment = SlotToBanks.hasSingleMapping();
   if (SingleSlotAssignment)

--- a/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/multiSlotAssignment/missing_memory_bank.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/multiSlotAssignment/missing_memory_bank.mir
@@ -12,31 +12,39 @@
 # RUN:   --aie-loop-min-tripcount=10 \
 # RUN:   -pass-remarks-output=%t.yaml \
 # RUN:   -pass-remarks-filter=aie-multi-slot-pseudo \
-# RUN:   %s -o - 2> %t.stderr | FileCheck %s --check-prefix=ASM
-# RUN: FileCheck %s --check-prefix=STDERR --input-file=%t.stderr --allow-empty
+# RUN:   %s -o - | FileCheck %s --check-prefix=ASM
 # RUN: FileCheck %s --check-prefix=REMARK --input-file=%t.yaml --allow-empty
 
 
-# Multi-slot pseudo loads whose memory operands carry no addrspace annotation
-# fall through `AIEHazardRecognizer::getMemoryBanks()` with an empty memory
-# bank set (default `-aie-addrspace-none-is-safe=1`). The static materializer
-# cannot pre-assign a slot in that case and falls back to round-robin slot
-# assignment. This test pins the diagnostic surface for that path: codegen
-# still produces valid asm, a `WithColor::warning()` line is emitted on
-# stderr, and a matching `aie-multi-slot-pseudo` / `missing-memory-bank`
-# optimization remark is written to the ORE YAML output.
-
-# STDERR: warning: No memory bank assigned to load in function 'missing_memory_bank'
+# Multi-slot pseudo load with no memory bank falls back to round-robin slot
+# assignment and emits a missed-optimization remark to the ORE YAML output.
 
 # REMARK:      --- !Missed
 # REMARK-NEXT: Pass:{{ +}}aie-multi-slot-pseudo
 # REMARK-NEXT: Name:{{ +}}missing-memory-bank
+# REMARK-NEXT: DebugLoc:{{ +}}{ File: missing_memory_bank.c, Line: 5, Column: 3 }
 # REMARK-NEXT: Function:{{ +}}missing_memory_bank
+# REMARK-NEXT: Args:
+# REMARK-NEXT:   - Instruction:{{ +}}'$p0, $lf0, $r24 = VLD_FILL_512_pseudo killed $p0, killed $lf0, killed $r24 :: (load (<32 x s16>))'
+# REMARK-NEXT: ...
+# REMARK-NEXT: --- !Missed
+# REMARK-NEXT: Pass:{{ +}}aie-multi-slot-pseudo
+# REMARK-NEXT: Name:{{ +}}missing-memory-bank
+# REMARK-NEXT: DebugLoc:{{ +}}{ File: missing_memory_bank.c, Line: 6, Column: 3 }
+# REMARK-NEXT: Function:{{ +}}missing_memory_bank
+# REMARK-NEXT: Args:
+# REMARK-NEXT:   - Instruction:{{ +}}'$p1, $lf1, $r25 = VLD_FILL_512_pseudo killed $p1, killed $lf1, killed $r25 :: (load (<32 x s16>))'
+# REMARK-NEXT: ...
 
 --- |
-  define dso_local void @missing_memory_bank(ptr noalias nocapture writeonly %d, ptr noalias nocapture readonly %s, i32 noundef %n) local_unnamed_addr #0 {
+  define dso_local void @missing_memory_bank(ptr noalias nocapture writeonly %d, ptr noalias nocapture readonly %s, i32 noundef %n) local_unnamed_addr !dbg !6 {
   ; ASM-LABEL: missing_memory_bank:
-  ; ASM:         .p2align 4
+  ; ASM:       .Lfunc_begin0:
+  ; ASM-NEXT:    .file 1 "." "missing_memory_bank.c"
+  ; ASM-NEXT:    .loc 1 1 0 // missing_memory_bank.c:1:0
+  ; ASM-NEXT:    .loc 1 0 0 is_stmt 0 // :0:0
+  ; ASM-NEXT:  .Ltmp0:
+  ; ASM-NEXT:    .p2align 4
   ; ASM-NEXT:  // %bb.0:
   ; ASM-NEXT:    mova r1, #0; nopb ; nops ; nopxm ; nopv
   ; ASM-NEXT:    nopa ; ge r1, r1, r0
@@ -57,10 +65,16 @@
   ; ASM-NEXT:    nopa ; nopb ; nops ; nopxm ; nopv
   ; ASM-NEXT:    nopa ; nopb ; nops ; nopxm ; nopv
   ; ASM-NEXT:    .p2align 4
-  ; ASM-NEXT:  .LBB0_2: // =>This Inner Loop Header: Depth=1
+  ; ASM-NEXT:  .LBB0_2: // %loop_body
+  ; ASM-NEXT:    // =>This Inner Loop Header: Depth=1
   ; ASM-NEXT:  .L_LEnd0:
+  ; ASM-NEXT:  .Ltmp1:
+  ; ASM-NEXT:    .loc 1 6 3 prologue_end is_stmt 1 // missing_memory_bank.c:6:3
   ; ASM-NEXT:    vlda.fill.512 [p1, lf1, r25]; vldb.fill.512 [p0, lf0, r24]; nops ; nopxm ; nopv
+  ; ASM-NEXT:  .Ltmp2:
   ; ASM-NEXT:  // %bb.3:
+  ; ASM-NEXT:    .loc 1 0 3 is_stmt 0 // :0:3
+  ; ASM-NEXT:  .Ltmp3:
   ; ASM-NEXT:    .p2align 4
   ; ASM-NEXT:  .LBB0_4:
   ; ASM-NEXT:    nopa ; ret lr
@@ -70,8 +84,24 @@
   ; ASM-NEXT:    nop // Delay Slot 2
   ; ASM-NEXT:    nop // Delay Slot 1
   entry:
-    ret void
+    br label %loop_body
+  loop_body:
+    br label %loop_body
   }
+
+  !llvm.dbg.cu = !{!0}
+  !llvm.module.flags = !{!2, !3, !4}
+
+  !0 = distinct !DICompileUnit(language: DW_LANG_C11, file: !1, producer: "clang", isOptimized: true, runtimeVersion: 0, emissionKind: LineTablesOnly)
+  !1 = !DIFile(filename: "missing_memory_bank.c", directory: ".")
+  !2 = !{i32 7, !"Dwarf Version", i32 4}
+  !3 = !{i32 2, !"Debug Info Version", i32 3}
+  !4 = !{i32 1, !"wchar_size", i32 4}
+  !6 = distinct !DISubprogram(name: "missing_memory_bank", scope: !1, file: !1, line: 1, type: !7, scopeLine: 1, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !0, retainedNodes: !8)
+  !7 = !DISubroutineType(types: !8)
+  !8 = !{}
+  !9 = !DILocation(line: 5, column: 3, scope: !6)
+  !10 = !DILocation(line: 6, column: 3, scope: !6)
 ...
 ---
 name:            missing_memory_bank
@@ -95,12 +125,12 @@ body:             |
     $ls = MOVXM %bb.2
     $le = MOVXM <mcsymbol .L_LEnd0>
 
-  bb.2 (align 16):
+  bb.2.loop_body (align 16):
    successors: %bb.2(0x7c000000), %bb.3(0x04000000)
     liveins: $dc1, $dc5, $dm0, $dm1, $dm2, $dm3, $ex1, $ex2, $ex3, $ex4, $ex5, $ex6, $ex8, $ex10, $lf0, $lf1, $m4, $m5, $m7, $p0, $p1, $p3, $p4, $p5, $p6, $p7, $r3, $r6, $r7, $r8, $r9, $r16, $r17, $r24, $r25, $d3_3d:0x0001800000200C00
 
-    $p0, $lf0, $r24 = VLD_FILL_512_pseudo killed $p0, killed $lf0, killed $r24 :: (load (<32 x s16>))
-    $p1, $lf1, $r25 = VLD_FILL_512_pseudo killed $p1, killed $lf1, killed $r25 :: (load (<32 x s16>))
+    $p0, $lf0, $r24 = VLD_FILL_512_pseudo killed $p0, killed $lf0, killed $r24, debug-location !9 :: (load (<32 x s16>))
+    $p1, $lf1, $r25 = VLD_FILL_512_pseudo killed $p1, killed $lf1, killed $r25, debug-location !10 :: (load (<32 x s16>))
 
     PseudoLoopEnd <mcsymbol .L_LEnd0>, %bb.2
 


### PR DESCRIPTION
Keep only the missed-optimization remark for loads without an assigned memory bank, removing the duplicate stderr warning emitted via WithColor::warning.