### PR TITLE
[AIE] Implement top-down delay slot fixup for regions with top-fixed …

### DIFF
--- a/llvm/lib/Target/AIE/AIEHazardRecognizer.cpp
+++ b/llvm/lib/Target/AIE/AIEHazardRecognizer.cpp
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// (c) Copyright 2023-2025 Advanced Micro Devices, Inc. or its affiliates
+// (c) Copyright 2023-2026 Advanced Micro Devices, Inc. or its affiliates
 //
 //===----------------------------------------------------------------------===//
 //
@@ -557,6 +557,11 @@ bool AIEHazardRecognizer::checkConflict(
       getConflictSet(Desc, *TII->getFormatInterface()), MemoryBanks,
       MemObjectsBits, TII->getMemoryCycles(SchedClass), DeltaCycles,
       std::nullopt);
+}
+
+bool AIEHazardRecognizer::checkConflict(MachineInstr &MI,
+                                        int DeltaCycles) const {
+  return checkConflict(Scoreboard, MI, DeltaCycles);
 }
 
 bool AIEHazardRecognizer::checkConflict(

--- a/llvm/lib/Target/AIE/AIEHazardRecognizer.h
+++ b/llvm/lib/Target/AIE/AIEHazardRecognizer.h
@@ -269,6 +269,8 @@ public:
   bool checkConflict(const ResourceScoreboard<FuncUnitWrapper> &Scoreboard,
                      MachineInstr &MI, int DeltaCycles) const;
 
+  bool checkConflict(MachineInstr &MI, int DeltaCycles) const;
+
 protected:
   ScheduleHazardRecognizer::HazardType getHazardType(const MCInstrDesc &Desc,
                                                      int DeltaCycles) const;

--- a/llvm/lib/Target/AIE/AIEMachineScheduler.cpp
+++ b/llvm/lib/Target/AIE/AIEMachineScheduler.cpp
@@ -73,6 +73,13 @@ static cl::opt<unsigned> ReservedDelaySlots(
     "aie-reserved-delay-slots", cl::init(0),
     cl::desc("[AIE] Number of delay slots to be left empty"));
 
+static cl::opt<bool> EnableDelaySlotTopDown(
+    "aie-delay-slot-topdown", cl::init(true),
+    cl::desc("[AIE] When top-fixed bundles and a delay slot instruction "
+             "coexist, schedule the whole region top-down and fix up the "
+             "branch position in leaveRegion() instead of forcing bottom-up "
+             "cycles"));
+
 /// This is a testing option. Resetting it prevents inter-block conflicts from
 /// the scoreboard, so that all interblock scheduling effects can be blamed on
 /// the latencies.
@@ -420,24 +427,41 @@ void AIEPostRASchedStrategy::initialize(ScheduleDAGMI *Dag) {
                                        : NonConservative);
   initializeTopScoreBoard();
 
-  // Delay slots are scheduled bottom up to be sure the control-flow instruction
-  // is issued exactly TII->getNumDelaySlots() before the end of the region.
+  // Compute RegionTopDownCycles first so the delay slot logic can inspect it.
+  const Region &Reg = InterBlock.getBlockState(CurMBB).getCurrentRegion();
+  RegionTopDownCycles = Reg.getTopFixedBundles().size();
+
+  // Delay slots are normally scheduled bottom-up so the control-flow
+  // instruction is issued exactly TII->getNumDelaySlots() before the end of
+  // the region.  However, when top-fixed bundles are present and
+  // -aie-delay-slot-topdown is enabled, we schedule the whole region top-down
+  // and rely on fixupDelaySlotPosition() (called from leaveRegion) to move
+  // the branch to the correct position afterwards.
   unsigned DelaySlotCycles = 0;
+  PersistentTopDown = false;
   if (MachineInstr *MI = getDelaySlotInstr(RegionBegin, RegionEnd)) {
     auto *TII = getTII(CurMBB);
     assert(RegionEnd != MI->getParent()->instr_end() &&
            TII->isDelayedSchedBarrier(*RegionEnd));
-    // Schedule bottom-up for at least getNumDelaySlots() cycles, and an extra
-    // one for the delay slot instruction itself.
-    DelaySlotCycles = TII->getNumDelaySlots(*MI) + 1;
     unsigned Reserved = std::max(ReservedDelaySlots.getValue(),
                                  TII->getNumReservedDelaySlots(*MI));
     getAIEHazardRecognizer(Bot)->setReservedCycles(Reserved);
+
+    if (RegionTopDownCycles > 0 && EnableDelaySlotTopDown &&
+        Reg.getBotFixedBundles().empty()) {
+      // Top-fixed bundles present, no bot-fixed bundles, and the option is
+      // enabled: schedule fully top-down and fix up the branch position in
+      // leaveRegion(). Bot-fixed bundles are incompatible with this path
+      // because fixupDelaySlotPosition requires BotBundles to be empty.
+      PersistentTopDown = true;
+    } else {
+      // Normal case: force enough bottom-up cycles to place the branch at the
+      // correct distance from the end of the region.
+      DelaySlotCycles = TII->getNumDelaySlots(*MI) + 1;
+    }
   }
 
   RegionBottomUpCycles = std::max(BottomUpCycles.getValue(), DelaySlotCycles);
-  const Region &Reg = InterBlock.getBlockState(CurMBB).getCurrentRegion();
-  RegionTopDownCycles = Reg.getTopFixedBundles().size();
   // Start with top-down when we have TopInsert bundles.
   IsTopDown = (RegionBottomUpCycles == 0) || (RegionTopDownCycles > 0);
   if (!IsTopDown) {
@@ -478,8 +502,11 @@ bool AIEPostRASchedStrategy::doesNotProgressInZone(const SchedBoundary &Zone,
   if (isFixedSU(SU, !Zone.isTop()))
     return true;
 
-  // We cannot proceed with delay slot instructions in the top zone.
-  return Zone.isTop() && SU.getInstr()->hasDelaySlot();
+  // We cannot proceed with delay slot instructions in the top zone, unless we
+  // are using the post-scheduling fixup path (PersistentTopDown).  In that
+  // case the branch is allowed to be scheduled anywhere and its position will
+  // be corrected in leaveRegion().
+  return Zone.isTop() && SU.getInstr()->hasDelaySlot() && !PersistentTopDown;
 }
 
 // This function returns true when it is impossible to continue with top-down
@@ -528,11 +555,14 @@ SUnit *AIEPostRASchedStrategy::pickNodeAndCycle(
     // RegionBottomUpCycles.
     LLVM_DEBUG(dbgs() << "*** Switching to top-down ***\n");
     IsTopDown = true;
-  } else if (IsTopDown && RegionTopDownCycles &&
+  } else if (IsTopDown && RegionTopDownCycles && !PersistentTopDown &&
              (Top.getCurrCycle() >= RegionTopDownCycles ||
               mustSwitchToBottomUp())) {
     // We have scheduled all top-fixed instructions, filling as many slots as
     // possible. Now it is time to proceed with the bottom-up approach.
+    // Note: when PersistentTopDown is true (top-fixed bundles + delay slot),
+    // we stay top-down for the entire region and fix up the branch position
+    // in leaveRegion().
     LLVM_DEBUG(dbgs() << "*** Switching to bottom-up ***\n");
     IsTopDown = false;
   }
@@ -842,6 +872,157 @@ void AIEPostRASchedStrategy::enterRegion(MachineBasicBlock *BB,
   RegionEnd = End;
 }
 
+/// Return the index of the first bundle in \p Bundles that contains \p MI,
+/// or -1 if not found.
+static int findInBundles(ArrayRef<AIE::MachineBundle> Bundles,
+                         const MachineInstr *MI) {
+  auto It = llvm::find_if(Bundles, [MI](const AIE::MachineBundle &B) {
+    return llvm::is_contained(B.getInstrs(), MI);
+  });
+  assert(It != Bundles.end() && "MI not found in any bundle");
+  return static_cast<unsigned>(std::distance(Bundles.begin(), It));
+}
+
+/// Return the MBB iterator at which \p BranchMI should be spliced: just after
+/// the last non-BranchMI instruction in bundles[0..\p PlacedIdx], searching
+/// backward from \p PlacedIdx.
+static MachineBasicBlock::iterator
+computeSplicePoint(ArrayRef<AIE::MachineBundle> Bundles, unsigned PlacedIdx,
+                   MachineInstr *BranchMI, MachineBasicBlock *MBB) {
+  for (int I = static_cast<int>(PlacedIdx); I >= 0; --I) {
+    const auto &Instrs = Bundles[I].getInstrs();
+    auto It =
+        llvm::find_if(llvm::reverse(Instrs),
+                      [BranchMI](MachineInstr *MI) { return MI != BranchMI; });
+    if (It != Instrs.rend())
+      return getBundleEnd((*It)->getIterator());
+  }
+  return MBB->end();
+}
+
+/// Remove \p MI from \p Bundle, keeping Instrs, SlotMap and OccupiedSlots
+/// in sync.
+static void removeFromBundle(AIE::MachineBundle &Bundle, MachineInstr *MI) {
+  auto &Instrs = Bundle.Instrs;
+  Instrs.erase(std::remove(Instrs.begin(), Instrs.end(), MI), Instrs.end());
+  // Remove from SlotMap and update OccupiedSlots.
+  auto MapIt = llvm::find_if(Bundle.SlotMap,
+                             [MI](const auto &P) { return P.second == MI; });
+  assert(MapIt != Bundle.SlotMap.end() && "MI not found in bundle SlotMap");
+  const auto *SlotInfo = Bundle.FormatInterface->getSlotInfo(MapIt->first);
+  assert(SlotInfo && "No SlotInfo for slot containing MI");
+  Bundle.OccupiedSlots &= ~SlotInfo->getSlotSet();
+  Bundle.SlotMap.erase(MapIt);
+}
+
+void AIEPostRASchedStrategy::fixupDelaySlotPosition(
+    std::vector<AIE::MachineBundle> &TopBundles,
+    std::vector<AIE::MachineBundle> &BotBundles, MachineInstr *BranchMI,
+    unsigned NumDelaySlots) {
+
+  // Only reached when PersistentTopDown is true: fully top-down region,
+  // no bot-fixed bundles. All NOPs go into TopBundles, keeping
+  // Top.getCurrCycle() in sync.
+  assert(BotBundles.empty() &&
+         "fixupDelaySlotPosition: BotBundles must be empty on entry");
+
+  const AIEBaseMCFormats *FmtIface = getTII(CurMBB)->getFormatInterface();
+  AIEHazardRecognizer *TopHR = getAIEHazardRecognizer(Top);
+  // Appends one empty NOP to TopBundles and advances Top's scoreboard.
+  auto AppendNop = [&]() {
+    Top.bumpCycle(Top.getCurrCycle() + 1);
+    TopBundles.emplace_back(FmtIface);
+  };
+
+  const int BranchIdx = findInBundles(TopBundles, BranchMI);
+
+  // May increase as NOPs are appended or before the re-placement runs.
+  unsigned BundlesAfterBranch =
+      TopBundles.size() - static_cast<unsigned>(BranchIdx) - 1;
+
+  LLVM_DEBUG({
+    dbgs() << "fixupDelaySlotPosition: BranchIdx=" << BranchIdx
+           << " BundlesAfterBranch=" << BundlesAfterBranch
+           << " NumDelaySlots=" << NumDelaySlots << "\n";
+    for (unsigned I = 0; I < TopBundles.size(); ++I) {
+      dbgs() << "  Bundle[" << I << "]:";
+      for (MachineInstr *MI : TopBundles[I].getInstrs())
+        dbgs() << " "
+               << MI->getMF()->getSubtarget().getInstrInfo()->getName(
+                      MI->getOpcode());
+      dbgs() << "\n";
+    }
+  });
+
+  // Append NOPs until exactly NumDelaySlots bundles follow the branch.
+  // If the inter-zone scoreboard is also clean afterwards, we are done.
+  // Otherwise fall through to resolve the conflict by moving the branch
+  // forward.
+  while (BundlesAfterBranch < NumDelaySlots) {
+    LLVM_DEBUG(dbgs() << "fixupDelaySlotPosition: appending empty bundle\n");
+    AppendNop();
+    BundlesAfterBranch++;
+  }
+
+  if (BundlesAfterBranch == NumDelaySlots &&
+      !checkInterZoneConflicts(BotBundles)) {
+    LLVM_DEBUG(dbgs() << "fixupDelaySlotPosition: done, position is correct "
+                         "and scoreboard are aligned.\n");
+    return;
+  }
+
+  // Branch too early (or inter-zone conflict after NOP padding) – extract it
+  // and re-place at a conflict-free slot. Each conflict appends a NOP
+  // (advancing Top's scoreboard), maintaining exactly NumDelaySlots bundles
+  // after the final placement.
+  const unsigned MoveDown = BundlesAfterBranch - NumDelaySlots;
+  const unsigned TargetIdx = static_cast<unsigned>(BranchIdx) + MoveDown;
+
+  LLVM_DEBUG(dbgs() << "fixupDelaySlotPosition: extracting branch from bundle "
+                    << BranchIdx << " and placing at/after bundle " << TargetIdx
+                    << "\n");
+
+  // Remove BranchMI from its current bundle.
+  removeFromBundle(TopBundles[BranchIdx], BranchMI);
+
+  // Scan forward from TargetIdx. Delta = -(NumDelaySlots + 1) is constant:
+  // each AppendNop advances the Top scoreboard ring by one slot, so successive
+  // checks probe cycles TargetIdx, TargetIdx+1, ... The branch never conflicts
+  // with its own old booking at a later cycle.
+  const int Delta = -(static_cast<int>(NumDelaySlots) + 1);
+  unsigned PlacedIdx = TargetIdx;
+  while (TopHR->checkConflict(*BranchMI, Delta) ||
+         checkInterZoneConflicts(BotBundles)) {
+    LLVM_DEBUG(dbgs() << "fixupDelaySlotPosition: conflict at bundle "
+                      << PlacedIdx << ", appending empty bundle\n");
+    AppendNop();
+    ++PlacedIdx;
+  }
+
+  LLVM_DEBUG(dbgs() << "fixupDelaySlotPosition: placing branch at bundle "
+                    << PlacedIdx << "\n");
+
+  // Add BranchMI to the chosen bundle and record its resource bookings in the
+  // Top scoreboard so subsequent inter-zone checks are accurate.
+  TopBundles[PlacedIdx].add(BranchMI);
+  TopHR->emitInScoreboard(*BranchMI, BranchMI->getDesc(), Delta);
+
+  // Physically move BranchMI to its correct position in the MBB.
+  CurMBB->splice(computeSplicePoint(TopBundles, PlacedIdx, BranchMI, CurMBB),
+                 CurMBB, BranchMI->getIterator());
+
+  // Now that the branch's resource bookings are in the Top scoreboard,
+  // re-check for inter-zone conflicts caused by the branch itself. If one is
+  // found, append a NOP and recurse (MoveDown = 1). Terminates because the
+  // scoreboard has finite depth.
+  if (checkInterZoneConflicts(BotBundles)) {
+    LLVM_DEBUG(dbgs() << "fixupDelaySlotPosition: post-placement inter-zone "
+                         "conflict, appending NOP and retrying\n");
+    AppendNop();
+    fixupDelaySlotPosition(TopBundles, BotBundles, BranchMI, NumDelaySlots);
+  }
+}
+
 void AIEPostRASchedStrategy::leaveRegion(const SUnit &ExitSU) {
   LLVM_DEBUG(dbgs() << "    << leaveRegion\n");
 
@@ -863,6 +1044,19 @@ void AIEPostRASchedStrategy::leaveRegion(const SUnit &ExitSU) {
   std::vector<AIE::MachineBundle> TopBundles = computeAndFinalizeBundles(Top);
   std::vector<AIE::MachineBundle> BotBundles = computeAndFinalizeBundles(Bot);
   handleRegionConflicts(ExitSU, TopBundles, BotBundles);
+
+  // When the delay slot instruction was scheduled top-down (because top-fixed
+  // bundles were present), fix up its position in the bundle sequence so that
+  // exactly NumDelaySlots bundles follow it.
+  if (PersistentTopDown) {
+    if (MachineInstr *BranchMI = getDelaySlotInstr(RegionBegin, RegionEnd)) {
+      const auto *TII = getTII(CurMBB);
+      const unsigned NumDelaySlots = TII->getNumDelaySlots(*BranchMI);
+      fixupDelaySlotPosition(TopBundles, BotBundles, BranchMI, NumDelaySlots);
+    }
+    PersistentTopDown = false;
+  }
+
   assert(BS.getCurrentRegion().Bundles.empty());
   BS.addBundles(TopBundles);
   BS.addBundles(BotBundles);

--- a/llvm/lib/Target/AIE/AIEMachineScheduler.h
+++ b/llvm/lib/Target/AIE/AIEMachineScheduler.h
@@ -144,6 +144,11 @@ protected:
   /// Keeps track of the current zone used for scheduling. See getSchedZone().
   bool IsTopDown = true;
 
+  /// When true, the delay slot instruction was allowed to be scheduled in the
+  /// top-down phase (because top-fixed bundles are present).  After scheduling,
+  /// fixupDelaySlotPosition() will reposition it correctly.
+  bool PersistentTopDown = false;
+
   MachineBasicBlock *CurMBB = nullptr;
   MachineBasicBlock::iterator RegionBegin = nullptr;
   MachineBasicBlock::iterator RegionEnd = nullptr;
@@ -175,6 +180,19 @@ protected:
 
   // After scheduling a block, fill in nops, apply bundling, etc.
   void commitBlockSchedule(MachineBasicBlock *BB);
+
+  /// After top-down scheduling of a region that contains a delay slot
+  /// instruction, fix up its position in the bundle sequence so that exactly
+  /// NumDelaySlots bundles follow it.
+  ///
+  /// If the branch ended up too early (too many bundles after it), we try to
+  /// move it down toward the end, checking for resource hazards at each step.
+  /// If moving is not possible, we fall back to appending empty (NOP) bundles
+  /// at the end.  If the branch ended up too late (too few bundles after it),
+  /// we simply append the missing empty bundles.
+  void fixupDelaySlotPosition(std::vector<AIE::MachineBundle> &TopBundles,
+                              std::vector<AIE::MachineBundle> &BotBundles,
+                              MachineInstr *BranchMI, unsigned NumDelaySlots);
 
   // This function returns true when it is impossible to continue with top-down
   // without entering an infinite loop because the only remaining instructions

--- a/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/bitwisenot.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/bitwisenot.mir
@@ -66,7 +66,7 @@ body:             |
   ; CHECK-NEXT:   - Prologue:        bb.0
   ; CHECK-NEXT:   - PrologueBundles: '10'
   ; CHECK-NEXT:   - Epilogue:        bb.2.for.cond.cleanup
-  ; CHECK-NEXT:   - EpilogueBundles: '16'
+  ; CHECK-NEXT:   - EpilogueBundles: '11'
   ; CHECK-NEXT: ...
   bb.0:
     successors: %bb.1(0x80000000)

--- a/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/conv2d.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/conv2d.mir
@@ -420,7 +420,7 @@ body:             |
   ; CHECK-NEXT:   - Prologue:        bb.1.outer.loop.header
   ; CHECK-NEXT:   - PrologueBundles: '28'
   ; CHECK-NEXT:   - Epilogue:        bb.3.outer.loop.latch
-  ; CHECK-NEXT:   - EpilogueBundles: '33'
+  ; CHECK-NEXT:   - EpilogueBundles: '37'
   ; CHECK-NEXT: ...
   bb.0.newFuncRoot (align 16):
     successors: %bb.1(0x80000000)

--- a/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/hardsigmoid-templated-double.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/hardsigmoid-templated-double.mir
@@ -70,7 +70,7 @@
   ; CHECK-NEXT:  .L_LEnd1:
   ; CHECK-NEXT:    nopb ; nopa ; vst.srs.s8.s32 cm1, s0, [p1], #32; nopx ; vmin_ge.s16 x8, r16, x6, x0; nopv
   ; CHECK-NEXT:  // %bb.4: // %for.cond.cleanup
-  ; CHECK-NEXT:    nopx ; vmax_lt.s16 x10, r16, x8, x2; vmac cm1, cm0, x10, x4, r0
+  ; CHECK-NEXT:    nopb ; nopa ; nops ; nopx ; vmax_lt.s16 x10, r16, x8, x2; vmac cm1, cm0, x10, x4, r0
   ; CHECK-NEXT:    vst.srs.s8.s32 cm1, s0, [p1], #32; vmin_ge.s16 x8, r16, x6, x0
   ; CHECK-NEXT:    vmax_lt.s16 x10, r16, x8, x2; vmac cm1, cm0, x10, x4, r0
   ; CHECK-NEXT:    vst.srs.s8.s32 cm1, s0, [p1], #32; vmin_ge.s16 x8, r16, x6, x0
@@ -81,12 +81,9 @@
   ; CHECK-NEXT:    vmac cm1, cm0, x10, x4, r0
   ; CHECK-NEXT:    vst.srs.s8.s32 cm1, s0, [p1], #32
   ; CHECK-NEXT:    nop
-  ; CHECK-NEXT:    vst.srs.s8.s32 cm1, s0, [p1], #32
-  ; CHECK-NEXT:    nop
-  ; CHECK-NEXT:    vst.srs.s8.s32 cm1, s0, [p1], #32
-  ; CHECK-NEXT:    ret lr
+  ; CHECK-NEXT:    vst.srs.s8.s32 cm1, s0, [p1], #32; ret lr
   ; CHECK-NEXT:    nop // Delay Slot 5
-  ; CHECK-NEXT:    nop // Delay Slot 4
+  ; CHECK-NEXT:    vst.srs.s8.s32 cm1, s0, [p1], #32 // Delay Slot 4
   ; CHECK-NEXT:    nop // Delay Slot 3
   ; CHECK-NEXT:    nop // Delay Slot 2
   ; CHECK-NEXT:    nop // Delay Slot 1

--- a/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/hardsigmoid-templated.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/hardsigmoid-templated.mir
@@ -65,7 +65,7 @@ body:             |
   ; CHECK-NEXT:   - Prologue:        bb.0
   ; CHECK-NEXT:   - PrologueBundles: '14'
   ; CHECK-NEXT:   - Epilogue:        bb.2.for.cond.cleanup
-  ; CHECK-NEXT:   - EpilogueBundles: '20'
+  ; CHECK-NEXT:   - EpilogueBundles: '17'
   ; CHECK-NEXT: ...
   bb.0:
     successors: %bb.1(0x80000000)

--- a/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/interleave-prologue.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/interleave-prologue.mir
@@ -55,12 +55,12 @@ body:             |
   ; CHECK-NEXT:   $x0 = VADD_16 killed $x0, $x6
   ; CHECK-NEXT:   $x0 = VADD_16 killed $x0, $x6
   ; CHECK-NEXT:   $x0 = VADD_16 killed $x0, $x6
-  ; CHECK-NEXT:   $x0 = VADD_16 killed $x0, $x6
+  ; CHECK-NEXT:   BUNDLE implicit-def $x0, implicit-def $wl0, implicit-def $wh0, implicit $lr, implicit killed $x0, implicit $x6 {
+  ; CHECK-NEXT:     RET implicit $lr
+  ; CHECK-NEXT:     $x0 = VADD_16 killed $x0, $x6
+  ; CHECK-NEXT:   }
   ; CHECK-NEXT:   $x0 = VADD_16 killed $x0, $x6
   ; CHECK-NEXT:   $x0 = VADD_16 killed $x0, killed $x6
-  ; CHECK-NEXT:   RET implicit $lr
-  ; CHECK-NEXT:   NOP
-  ; CHECK-NEXT:   NOP
   ; CHECK-NEXT:   NOP
   ; CHECK-NEXT:   VST_PACK_S8_S16_ag_idx_imm killed $p1, 0, killed $x0, implicit $crsat
   ; CHECK-NEXT:   NOP
@@ -162,12 +162,12 @@ body:             |
   ; CHECK-NEXT:   $x0 = VADD_16 killed $x0, $x6
   ; CHECK-NEXT:   $x0 = VADD_16 killed $x0, $x6
   ; CHECK-NEXT:   $x0 = VADD_16 killed $x0, $x6
-  ; CHECK-NEXT:   $x0 = VADD_16 killed $x0, $x6
+  ; CHECK-NEXT:   BUNDLE implicit-def $x0, implicit-def $wl0, implicit-def $wh0, implicit $lr, implicit killed $x0, implicit $x6 {
+  ; CHECK-NEXT:     RET implicit $lr
+  ; CHECK-NEXT:     $x0 = VADD_16 killed $x0, $x6
+  ; CHECK-NEXT:   }
   ; CHECK-NEXT:   $x0 = VADD_16 killed $x0, $x6
   ; CHECK-NEXT:   $x0 = VADD_16 killed $x0, killed $x6
-  ; CHECK-NEXT:   RET implicit $lr
-  ; CHECK-NEXT:   NOP
-  ; CHECK-NEXT:   NOP
   ; CHECK-NEXT:   NOP
   ; CHECK-NEXT:   VST_PACK_S8_S16_ag_idx_imm killed $p1, 0, killed $x0, implicit $crsat
   ; CHECK-NEXT:   NOP
@@ -263,12 +263,12 @@ body:             |
   ; CHECK-NEXT:   $x0 = VADD_16 killed $x0, $x6
   ; CHECK-NEXT:   $x0 = VADD_16 killed $x0, $x6
   ; CHECK-NEXT:   $x0 = VADD_16 killed $x0, $x6
-  ; CHECK-NEXT:   $x0 = VADD_16 killed $x0, $x6
+  ; CHECK-NEXT:   BUNDLE implicit-def $x0, implicit-def $wl0, implicit-def $wh0, implicit $lr, implicit killed $x0, implicit $x6 {
+  ; CHECK-NEXT:     RET implicit $lr
+  ; CHECK-NEXT:     $x0 = VADD_16 killed $x0, $x6
+  ; CHECK-NEXT:   }
   ; CHECK-NEXT:   $x0 = VADD_16 killed $x0, $x6
   ; CHECK-NEXT:   $x0 = VADD_16 killed $x0, killed $x6
-  ; CHECK-NEXT:   RET implicit $lr
-  ; CHECK-NEXT:   NOP
-  ; CHECK-NEXT:   NOP
   ; CHECK-NEXT:   NOP
   ; CHECK-NEXT:   VST_PACK_S8_S16_ag_idx_imm killed $p1, 0, killed $x0, implicit $crsat
   ; CHECK-NEXT:   NOP
@@ -480,12 +480,12 @@ body:             |
   ; CHECK-NEXT:   $x0 = VADD_16 killed $x0, $x6
   ; CHECK-NEXT:   $x0 = VADD_16 killed $x0, $x6
   ; CHECK-NEXT:   $x0 = VADD_16 killed $x0, $x6
-  ; CHECK-NEXT:   $x0 = VADD_16 killed $x0, $x6
+  ; CHECK-NEXT:   BUNDLE implicit-def $x0, implicit-def $wl0, implicit-def $wh0, implicit $lr, implicit killed $x0, implicit $x6 {
+  ; CHECK-NEXT:     RET implicit $lr
+  ; CHECK-NEXT:     $x0 = VADD_16 killed $x0, $x6
+  ; CHECK-NEXT:   }
   ; CHECK-NEXT:   $x0 = VADD_16 killed $x0, $x6
   ; CHECK-NEXT:   $x0 = VADD_16 killed $x0, killed $x6
-  ; CHECK-NEXT:   RET implicit $lr
-  ; CHECK-NEXT:   NOP
-  ; CHECK-NEXT:   NOP
   ; CHECK-NEXT:   NOP
   ; CHECK-NEXT:   VST_PACK_S8_S16_ag_idx_imm killed $p1, 0, killed $x0, implicit $crsat
   ; CHECK-NEXT:   NOP

--- a/llvm/test/CodeGen/AIE/aie2p/AA-unroll-iterations.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/AA-unroll-iterations.mir
@@ -37,18 +37,13 @@
   ; CHECK-NEXT:  .L_LEnd0:
   ; CHECK-NEXT:    nopa ; nopb ; nops ; nopxm ; nopv
   ; CHECK-NEXT:  // %bb.2: // %for.cond.cleanup
-  ; CHECK-NEXT:    nopa ; nopb ; nopxm ; st.2d r1, [p0], d0
+  ; CHECK-NEXT:    st.2d r1, [p0], d0; nopb ; nopx
   ; CHECK-NEXT:    mul r1, r1, r0
-  ; CHECK-NEXT:    nop
-  ; CHECK-NEXT:    st.2d r1, [p0], d0
-  ; CHECK-NEXT:    mul r1, r1, r0
-  ; CHECK-NEXT:    nop
-  ; CHECK-NEXT:    st.2d r1, [p0], d0
   ; CHECK-NEXT:    ret lr
-  ; CHECK-NEXT:    nop // Delay Slot 5
-  ; CHECK-NEXT:    nop // Delay Slot 4
+  ; CHECK-NEXT:    st.2d r1, [p0], d0 // Delay Slot 5
+  ; CHECK-NEXT:    mul r1, r1, r0 // Delay Slot 4
   ; CHECK-NEXT:    nop // Delay Slot 3
-  ; CHECK-NEXT:    nop // Delay Slot 2
+  ; CHECK-NEXT:    st.2d r1, [p0], d0 // Delay Slot 2
   ; CHECK-NEXT:    nop // Delay Slot 1
   entry:
     call void @llvm.set.loop.iterations.i32(i32 4)

--- a/llvm/test/CodeGen/AIE/aie2p/elongate/zol_phdr_loopbundles_112bytes.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/elongate/zol_phdr_loopbundles_112bytes.mir
@@ -40,16 +40,13 @@
   ; CHECK-NEXT:  .L_LEnd0:
   ; CHECK-NEXT:    nopa ; vldb x1, [p0], #128; nops ; nopxm ; nopv
   ; CHECK-NEXT:  // %bb.2: // %for.cond.cleanup
-  ; CHECK-NEXT:    nopa ; nopb ; nopx ; vadd.16 x6, x4, x1
-  ; CHECK-NEXT:    vadd.16 x4, x6, x0
+  ; CHECK-NEXT:    nopa ; nopb ; nops ; nopx ; vadd.16 x6, x4, x1; nopv
+  ; CHECK-NEXT:    nopx ; vadd.16 x4, x6, x0
   ; CHECK-NEXT:    nop
   ; CHECK-NEXT:    vadd.16 x6, x4, x1
-  ; CHECK-NEXT:    vadd.16 x4, x6, x0
-  ; CHECK-NEXT:    nop
-  ; CHECK-NEXT:    vadd.16 x6, x4, x1
-  ; CHECK-NEXT:    ret lr
+  ; CHECK-NEXT:    ret lr; vadd.16 x4, x6, x0
   ; CHECK-NEXT:    nop // Delay Slot 5
-  ; CHECK-NEXT:    nop // Delay Slot 4
+  ; CHECK-NEXT:    vadd.16 x6, x4, x1 // Delay Slot 4
   ; CHECK-NEXT:    nop // Delay Slot 3
   ; CHECK-NEXT:    vmov x0, x6 // Delay Slot 2
   ; CHECK-NEXT:    nop // Delay Slot 1

--- a/llvm/test/CodeGen/AIE/aie2p/end-to-end/add-att-broadcasting-aa.ll
+++ b/llvm/test/CodeGen/AIE/aie2p/end-to-end/add-att-broadcasting-aa.ll
@@ -48,21 +48,16 @@ define dso_local void @add_attribute_bcast_prologue1(ptr %ifm2, ptr %ifm1, i32 %
 ; CHECK-NEXT:  .L_LEnd0:
 ; CHECK-NEXT:    vlda.conv.fp32.bf16 cml3, [p1], m0; nopb ; vst.conv.bf16.fp32 cml4, [p2], #64; nopxm ; vadd.f dm3, dm3, dm0, r1
 ; CHECK-NEXT:  // %bb.2: // %for.cond.cleanup
-; CHECK-NEXT:    nopa ; nopb ; nopxm ; nops
+; CHECK-NEXT:    nopa ; nopb ; nopx
 ; CHECK-NEXT:    vst.conv.bf16.fp32 cml3, [p2], #64; vadd.f dm4, dm1, dm2, r1
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    vst.conv.bf16.fp32 cml4, [p2], #64; vadd.f dm3, dm3, dm0, r1
 ; CHECK-NEXT:    nop
-; CHECK-NEXT:    vst.conv.bf16.fp32 cml3, [p2], #64
-; CHECK-NEXT:    nop
-; CHECK-NEXT:    vst.conv.bf16.fp32 cml4, [p2], #64
-; CHECK-NEXT:    nop
-; CHECK-NEXT:    vst.conv.bf16.fp32 cml3, [p2], #64
-; CHECK-NEXT:    ret lr
+; CHECK-NEXT:    vst.conv.bf16.fp32 cml3, [p2], #64; ret lr
 ; CHECK-NEXT:    nop // Delay Slot 5
-; CHECK-NEXT:    nop // Delay Slot 4
+; CHECK-NEXT:    vst.conv.bf16.fp32 cml4, [p2], #64 // Delay Slot 4
 ; CHECK-NEXT:    nop // Delay Slot 3
-; CHECK-NEXT:    nop // Delay Slot 2
+; CHECK-NEXT:    vst.conv.bf16.fp32 cml3, [p2], #64 // Delay Slot 2
 ; CHECK-NEXT:    nop // Delay Slot 1
 newFuncRoot:
   br label %if.end
@@ -171,21 +166,16 @@ define dso_local void @add_attribute_bcast_prologue2(ptr %ifm2, ptr %ifm1, i32 %
 ; CHECK-NEXT:  .L_LEnd1:
 ; CHECK-NEXT:    vlda.conv.fp32.bf16 cml3, [p1], m0; nopb ; vst.conv.bf16.fp32 cml4, [p2], #64; nopxm ; vadd.f dm3, dm3, dm0, r1
 ; CHECK-NEXT:  // %bb.2: // %for.cond.cleanup
-; CHECK-NEXT:    nopa ; nopb ; nopxm ; nops
+; CHECK-NEXT:    nopa ; nopb ; nopx
 ; CHECK-NEXT:    vst.conv.bf16.fp32 cml3, [p2], #64; vadd.f dm4, dm1, dm2, r1
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    vst.conv.bf16.fp32 cml4, [p2], #64; vadd.f dm3, dm3, dm0, r1
 ; CHECK-NEXT:    nop
-; CHECK-NEXT:    vst.conv.bf16.fp32 cml3, [p2], #64
-; CHECK-NEXT:    nop
-; CHECK-NEXT:    vst.conv.bf16.fp32 cml4, [p2], #64
-; CHECK-NEXT:    nop
-; CHECK-NEXT:    vst.conv.bf16.fp32 cml3, [p2], #64
-; CHECK-NEXT:    ret lr
+; CHECK-NEXT:    vst.conv.bf16.fp32 cml3, [p2], #64; ret lr
 ; CHECK-NEXT:    nop // Delay Slot 5
-; CHECK-NEXT:    nop // Delay Slot 4
+; CHECK-NEXT:    vst.conv.bf16.fp32 cml4, [p2], #64 // Delay Slot 4
 ; CHECK-NEXT:    nop // Delay Slot 3
-; CHECK-NEXT:    nop // Delay Slot 2
+; CHECK-NEXT:    vst.conv.bf16.fp32 cml3, [p2], #64 // Delay Slot 2
 ; CHECK-NEXT:    nop // Delay Slot 1
 newFuncRoot:
   br label %if.end
@@ -288,20 +278,16 @@ define dso_local void @add_attribute_bcast_epilogue1(ptr noalias %ifm2, ptr noal
 ; CHECK-NEXT:  .L_LEnd2:
 ; CHECK-NEXT:    vlda.conv.fp32.bf16 cml3, [p1], m0; nopb ; vst.conv.bf16.fp32 cml4, [p2], #64; nopxm ; vadd.f dm3, dm3, dm0, r1
 ; CHECK-NEXT:  // %bb.2: // %for.cond.cleanup
-; CHECK-NEXT:    nopa ; nopb ; nopx ; st r0, [p3, #0]
+; CHECK-NEXT:    st r0, [p3, #0]
 ; CHECK-NEXT:    vst.conv.bf16.fp32 cml3, [p2], #64; vadd.f dm4, dm1, dm2, r1
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    vst.conv.bf16.fp32 cml4, [p2], #64; vadd.f dm3, dm3, dm0, r1
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    vst.conv.bf16.fp32 cml3, [p2], #64
-; CHECK-NEXT:    nop
-; CHECK-NEXT:    vst.conv.bf16.fp32 cml4, [p2], #64
-; CHECK-NEXT:    nop
-; CHECK-NEXT:    vst.conv.bf16.fp32 cml3, [p2], #64
 ; CHECK-NEXT:    ret lr
-; CHECK-NEXT:    nop // Delay Slot 5
+; CHECK-NEXT:    vst.conv.bf16.fp32 cml4, [p2], #64 // Delay Slot 5
 ; CHECK-NEXT:    nop // Delay Slot 4
-; CHECK-NEXT:    nop // Delay Slot 3
+; CHECK-NEXT:    vst.conv.bf16.fp32 cml3, [p2], #64 // Delay Slot 3
 ; CHECK-NEXT:    st r0, [p4, #0] // Delay Slot 2
 ; CHECK-NEXT:    nop // Delay Slot 1
 newFuncRoot:

--- a/llvm/test/CodeGen/AIE/aie2p/end-to-end/add-att-broadcasting.ll
+++ b/llvm/test/CodeGen/AIE/aie2p/end-to-end/add-att-broadcasting.ll
@@ -51,21 +51,16 @@ define dso_local void @add_attribute_bcast(ptr noalias %ifm2, ptr noalias %ifm1,
 ; CHECK-NEXT:  .L_LEnd0:
 ; CHECK-NEXT:    vlda.conv.fp32.bf16 cml3, [p1], m0; nopb ; vst.conv.bf16.fp32 cml4, [p3], #64; nopxm ; vadd.f dm3, dm3, dm0, r1
 ; CHECK-NEXT:  // %bb.2: // %for.cond.cleanup
-; CHECK-NEXT:    nopa ; nopb ; nopxm ; nops
+; CHECK-NEXT:    nopa ; nopb ; nopx
 ; CHECK-NEXT:    vst.conv.bf16.fp32 cml3, [p3], #64; vadd.f dm4, dm1, dm2, r1
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    vst.conv.bf16.fp32 cml4, [p3], #64; vadd.f dm3, dm3, dm0, r1
 ; CHECK-NEXT:    nop
-; CHECK-NEXT:    vst.conv.bf16.fp32 cml3, [p3], #64
-; CHECK-NEXT:    nop
-; CHECK-NEXT:    vst.conv.bf16.fp32 cml4, [p3], #64
-; CHECK-NEXT:    nop
-; CHECK-NEXT:    vst.conv.bf16.fp32 cml3, [p3], #64
-; CHECK-NEXT:    ret lr
+; CHECK-NEXT:    vst.conv.bf16.fp32 cml3, [p3], #64; ret lr
 ; CHECK-NEXT:    nop // Delay Slot 5
-; CHECK-NEXT:    nop // Delay Slot 4
+; CHECK-NEXT:    vst.conv.bf16.fp32 cml4, [p3], #64 // Delay Slot 4
 ; CHECK-NEXT:    nop // Delay Slot 3
-; CHECK-NEXT:    nop // Delay Slot 2
+; CHECK-NEXT:    vst.conv.bf16.fp32 cml3, [p3], #64 // Delay Slot 2
 ; CHECK-NEXT:    nop // Delay Slot 1
 newFuncRoot:
   br label %if.end

--- a/llvm/test/CodeGen/AIE/aie2p/end-to-end/conv2d_bfp16_convert.ll
+++ b/llvm/test/CodeGen/AIE/aie2p/end-to-end/conv2d_bfp16_convert.ll
@@ -43,8 +43,8 @@ define weak_odr dso_local void @convert_bf16_to_bfp16(ptr noalias %in, ptr noali
 ; CHECK-NEXT:  .L_LEnd0:
 ; CHECK-NEXT:    nopa ; nopb ; nops ; nopxm ; nopv
 ; CHECK-NEXT:  // %bb.2: // %for.cond.cleanup
-; CHECK-NEXT:    nopa ; nopb ; nopxm ; vst.push.576.conv.bfp16ebs8.fp32 dm1, [p2, sf, r26]
-; CHECK-NEXT:    vst.flush.512.conv [p2, sf, r26]; vconv.fp32.bf16 cml1, x6
+; CHECK-NEXT:    nopa ; nopb ; vst.push.576.conv.bfp16ebs8.fp32 dm1, [p2, sf, r26]; nopxm ; nopv
+; CHECK-NEXT:    vst.flush.512.conv [p2, sf, r26]; nopx ; vconv.fp32.bf16 cml1, x6
 ; CHECK-NEXT:    vst.flush.512.conv.2d [p2, sf, r26, d0]; vconv.fp32.bf16 cmh1, x4
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    vst.push.576.conv.bfp16ebs8.fp32 dm1, [p2, sf, r26]
@@ -52,10 +52,8 @@ define weak_odr dso_local void @convert_bf16_to_bfp16(ptr noalias %in, ptr noali
 ; CHECK-NEXT:    vst.flush.512.conv.2d [p2, sf, r26, d0]; vconv.fp32.bf16 cmh1, x4
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    vst.push.576.conv.bfp16ebs8.fp32 dm1, [p2, sf, r26]
-; CHECK-NEXT:    vst.flush.512.conv [p2, sf, r26]
-; CHECK-NEXT:    vst.flush.512.conv.2d [p2, sf, r26, d0]
-; CHECK-NEXT:    ret lr
-; CHECK-NEXT:    nop // Delay Slot 5
+; CHECK-NEXT:    vst.flush.512.conv [p2, sf, r26]; ret lr
+; CHECK-NEXT:    vst.flush.512.conv.2d [p2, sf, r26, d0] // Delay Slot 5
 ; CHECK-NEXT:    nop // Delay Slot 4
 ; CHECK-NEXT:    nop // Delay Slot 3
 ; CHECK-NEXT:    nop // Delay Slot 2

--- a/llvm/test/CodeGen/AIE/aie2p/end-to-end/conv2d_bfp16_kernel_red.ll
+++ b/llvm/test/CodeGen/AIE/aie2p/end-to-end/conv2d_bfp16_kernel_red.ll
@@ -67,7 +67,7 @@ define dso_local void @conv2d_bfp16.for.body90.i(<32 x i32> %fW.sroa.0.1489.i, i
 ; CHECK-NEXT:    vlda.pop.576 ex5, [p0, lf0, r24]; vldb.pop.576.3d ex7, [p1, lf1, r25, d0]; nops ; nopx ; vshuffle ex11, ex9, ex7, r4; vmac.f dm0, dm0, ex11, ex3, r0
 ; CHECK-NEXT:  // %bb.2: // %for.cond.cleanup89.i.exitStub
 ; CHECK-NEXT:    nopa ; nopb ; nops ; nopx ; vshuffle ex1, ex9, ex7, r5; vmac.f dm4, dm4, ex1, ex3, r0
-; CHECK-NEXT:    vlda.pop.576 ex3, [p0, lf0, r24, m1]; nopx ; vmac.f dm2, dm2, ex11, ex5, r0
+; CHECK-NEXT:    vlda.pop.576 ex3, [p0, lf0, r24, m1]; vmac.f dm2, dm2, ex11, ex5, r0
 ; CHECK-NEXT:    mov p0, r3; vmac.f dm1, dm1, ex1, ex5, r0
 ; CHECK-NEXT:    vshuffle ex11, ex9, ex7, r4; vmac.f dm0, dm0, ex11, ex3, r0
 ; CHECK-NEXT:    vshuffle ex1, ex9, ex7, r5; vmac.f dm4, dm4, ex1, ex3, r0
@@ -78,7 +78,7 @@ define dso_local void @conv2d_bfp16.for.body90.i(<32 x i32> %fW.sroa.0.1489.i, i
 ; CHECK-NEXT:    vmac.f dm2, dm2, ex11, ex5, r0
 ; CHECK-NEXT:    vmac.f dm1, dm1, ex1, ex5, r0
 ; CHECK-NEXT:    vmac.f dm0, dm0, ex11, ex3, r0
-; CHECK-NEXT:    vmac.f dm4, dm4, ex1, ex3, r0
+; CHECK-NEXT:    lda p7, [sp, #-60]; vmac.f dm4, dm4, ex1, ex3, r0 // 4-byte Folded Reload
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    vst bmhh2, [p7, #192]
@@ -90,13 +90,13 @@ define dso_local void @conv2d_bfp16.for.body90.i(<32 x i32> %fW.sroa.0.1489.i, i
 ; CHECK-NEXT:    vst bmlh1, [p0, #64]
 ; CHECK-NEXT:    vst bmll1, [p0, #0]; mov p0, r2
 ; CHECK-NEXT:    vst bmhh0, [p0, #192]
-; CHECK-NEXT:    lda p7, [sp, #-60]; vst bmhl0, [p0, #128] // 4-byte Folded Reload
-; CHECK-NEXT:    lda p6, [sp, #-64]; vst bmlh0, [p0, #64] // 4-byte Folded Reload
+; CHECK-NEXT:    lda p6, [sp, #-64]; vst bmhl0, [p0, #128] // 4-byte Folded Reload
+; CHECK-NEXT:    vst bmlh0, [p0, #64]; paddxm [sp], #-64
 ; CHECK-NEXT:    vst bmll0, [p0, #0]; ret lr
 ; CHECK-NEXT:    vst bmhh4, [p6, #192] // Delay Slot 5
 ; CHECK-NEXT:    vst bmhl4, [p6, #128] // Delay Slot 4
 ; CHECK-NEXT:    vst bmlh4, [p6, #64] // Delay Slot 3
-; CHECK-NEXT:    vst bmll4, [p6, #0]; paddxm [sp], #-64 // Delay Slot 2
+; CHECK-NEXT:    vst bmll4, [p6, #0] // Delay Slot 2
 ; CHECK-NEXT:    nop // Delay Slot 1
 newFuncRoot:
   br label %for.body90.i

--- a/llvm/test/CodeGen/AIE/aie2p/end-to-end/gemm-bfp16.ll
+++ b/llvm/test/CodeGen/AIE/aie2p/end-to-end/gemm-bfp16.ll
@@ -104,7 +104,7 @@ define dso_local void @gemm_bfp16(ptr %ofm_ptr, ptr %ifm_ptr, ptr %wts_ptr, ptr 
 ; CHECK-NEXT:  // %bb.3: // %for.cond.cleanup45.i
 ; CHECK-NEXT:    // in Loop: Header=BB0_1 Depth=1
 ; CHECK-NEXT:    nopa ; vldb x5, [p7, #64]; vconv.bfp16ebs8.fp32 ex4, dm2; add r4, r4, #1; vshuffle x11, x7, x5, r1; vmul.f dm2, y5, y0, r2
-; CHECK-NEXT:    nopa ; paddb [p1], m5; nops ; nopx ; mov p4, p0; nopv
+; CHECK-NEXT:    nopa ; paddb [p1], m5; nopx ; mov p4, p0
 ; CHECK-NEXT:    vlda.conv.fp32.bf16 cml2, [p1, #0]; vconv.bfp16ebs8.fp32 ex2, dm2; vmul.f dm2, y5, y0, r2
 ; CHECK-NEXT:    vlda.conv.fp32.bf16 cmh2, [p1, #64]
 ; CHECK-NEXT:    vlda.conv.fp32.bf16 cmh2, [p6, #64]; mov p1, p6; vmac.f dm1, dm1, ex3, ex6, r3
@@ -145,26 +145,26 @@ define dso_local void @gemm_bfp16(ptr %ofm_ptr, ptr %ifm_ptr, ptr %wts_ptr, ptr 
 ; CHECK-NEXT:    vst bmll0, [p4, #0]
 ; CHECK-NEXT:    vst bmlh0, [p4, #64]
 ; CHECK-NEXT:    vst bmhl0, [p4, #128]
-; CHECK-NEXT:    vst bmhh0, [p4, #192]
+; CHECK-NEXT:    vst bmhh0, [p4, #192]; mov p4, p0
 ; CHECK-NEXT:    lda m1, [p1, #0]
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
-; CHECK-NEXT:    mov p4, p0
+; CHECK-NEXT:    nop
 ; CHECK-NEXT:    padda [p4], m1
 ; CHECK-NEXT:    vst bmll4, [p4, #0]
 ; CHECK-NEXT:    vst bmlh4, [p4, #64]
 ; CHECK-NEXT:    vst bmhl4, [p4, #128]
 ; CHECK-NEXT:    vst bmhh4, [p4, #192]
-; CHECK-NEXT:    lda m1, [p1, #4]
+; CHECK-NEXT:    lda m1, [p1, #4]; paddb.2d [p0], d3; mov p1, p0
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
-; CHECK-NEXT:    mov p1, p0
+; CHECK-NEXT:    nop
 ; CHECK-NEXT:    padda [p1], m1
 ; CHECK-NEXT:    vst bmll3, [p1, #0]
 ; CHECK-NEXT:    vst bmlh3, [p1, #64]
@@ -183,7 +183,7 @@ define dso_local void @gemm_bfp16(ptr %ofm_ptr, ptr %ifm_ptr, ptr %wts_ptr, ptr 
 ; CHECK-NEXT:    nop // Delay Slot 4
 ; CHECK-NEXT:    nop // Delay Slot 3
 ; CHECK-NEXT:    nop // Delay Slot 2
-; CHECK-NEXT:    paddb.2d [p0], d3 // Delay Slot 1
+; CHECK-NEXT:    nop // Delay Slot 1
 ; CHECK-NEXT:  // %bb.4: // %exit.exitStub
 ; CHECK-NEXT:    lda p7, [sp, #-60] // 4-byte Folded Reload
 ; CHECK-NEXT:    lda p6, [sp, #-64] // 4-byte Folded Reload

--- a/llvm/test/CodeGen/AIE/aie2p/end-to-end/ore-hardware-loops.ll
+++ b/llvm/test/CodeGen/AIE/aie2p/end-to-end/ore-hardware-loops.ll
@@ -5,10 +5,10 @@
 ;
 ; (c) Copyright 2025-2026 Advanced Micro Devices, Inc. or its affiliates
 ; RUN: llc -mtriple=aie2p --aie-force-postpipeliner %s -o - | FileCheck %s --check-prefix ASM
-
 ; RUN: llc -mtriple=aie2p --aie-force-postpipeliner \
 ; RUN:   -pass-remarks-output=- \
 ; RUN:   -pass-remarks-filter='aie-hardware-loops|aie-asm-printer' %s -o /dev/null | FileCheck %s --check-prefix REMARKS
+
 
 ; This unit-test is based on conv2d_bfp16_convert.ll
 
@@ -50,7 +50,7 @@ define weak_odr dso_local void @convert_bf16_to_bfp16(ptr noalias %in, ptr noali
 ; REMARKS-NEXT: Function:        convert_bf16_to_bfp16
 ; REMARKS-NEXT: Args:
 ; REMARKS-NEXT:   - BasicBlock:      for.cond.cleanup
-; REMARKS-NEXT:   - BundleCount:     '17'
+; REMARKS-NEXT:   - BundleCount:     '15'
 ; REMARKS-NEXT:   - ByteCount:       '80'
 ; REMARKS-NEXT: ...
 ;
@@ -84,8 +84,8 @@ define weak_odr dso_local void @convert_bf16_to_bfp16(ptr noalias %in, ptr noali
 ; ASM-NEXT:  .L_LEnd0:
 ; ASM-NEXT:    nopa ; nopb ; nops ; nopxm ; nopv
 ; ASM-NEXT:  // %bb.2: // %for.cond.cleanup
-; ASM-NEXT:    nopa ; nopb ; nopxm ; vst.push.576.conv.bfp16ebs8.fp32 dm1, [p2, sf, r26]
-; ASM-NEXT:    vst.flush.512.conv [p2, sf, r26]; vconv.fp32.bf16 cml1, x6
+; ASM-NEXT:    nopa ; nopb ; vst.push.576.conv.bfp16ebs8.fp32 dm1, [p2, sf, r26]; nopxm ; nopv
+; ASM-NEXT:    vst.flush.512.conv [p2, sf, r26]; nopx ; vconv.fp32.bf16 cml1, x6
 ; ASM-NEXT:    vst.flush.512.conv.2d [p2, sf, r26, d0]; vconv.fp32.bf16 cmh1, x4
 ; ASM-NEXT:    nop
 ; ASM-NEXT:    vst.push.576.conv.bfp16ebs8.fp32 dm1, [p2, sf, r26]
@@ -93,10 +93,8 @@ define weak_odr dso_local void @convert_bf16_to_bfp16(ptr noalias %in, ptr noali
 ; ASM-NEXT:    vst.flush.512.conv.2d [p2, sf, r26, d0]; vconv.fp32.bf16 cmh1, x4
 ; ASM-NEXT:    nop
 ; ASM-NEXT:    vst.push.576.conv.bfp16ebs8.fp32 dm1, [p2, sf, r26]
-; ASM-NEXT:    vst.flush.512.conv [p2, sf, r26]
-; ASM-NEXT:    vst.flush.512.conv.2d [p2, sf, r26, d0]
-; ASM-NEXT:    ret lr
-; ASM-NEXT:    nop // Delay Slot 5
+; ASM-NEXT:    vst.flush.512.conv [p2, sf, r26]; ret lr
+; ASM-NEXT:    vst.flush.512.conv.2d [p2, sf, r26, d0] // Delay Slot 5
 ; ASM-NEXT:    nop // Delay Slot 4
 ; ASM-NEXT:    nop // Delay Slot 3
 ; ASM-NEXT:    nop // Delay Slot 2

--- a/llvm/test/CodeGen/AIE/aie2p/end-to-end/sigmoid_int8_1.ll
+++ b/llvm/test/CodeGen/AIE/aie2p/end-to-end/sigmoid_int8_1.ll
@@ -38,7 +38,7 @@ define void @sigmoid_int8_1() {
 ; CHECK-NEXT:  .L_LEnd0:
 ; CHECK-NEXT:    nopa ; nopb ; vsrs.4x wh11, cml4, s0, srssign0; nopx ; vmov x9, x8; nopv
 ; CHECK-NEXT:  // %bb.2: // %for.cond.cleanup
-; CHECK-NEXT:    nopa ; nopb ; nopxm ; nops
+; CHECK-NEXT:    nopx
 ; CHECK-NEXT:    vmac dm3, dm0, y4, y3,r0
 ; CHECK-NEXT:    vmin_ge.16 x9, r16, x3, x0, vaddsign0
 ; CHECK-NEXT:    vmax_lt.16 x8, r16, x9, x2, vaddsign0; vmsc dm4, dm3, y2, y4,r0
@@ -50,12 +50,9 @@ define void @sigmoid_int8_1() {
 ; CHECK-NEXT:    vsrs.4x wh11, cml4, s0, srssign0
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
-; CHECK-NEXT:    nop
-; CHECK-NEXT:    nop
-; CHECK-NEXT:    vsrs.4x wh11, cml4, s0, srssign0
 ; CHECK-NEXT:    ret lr
 ; CHECK-NEXT:    nop // Delay Slot 5
-; CHECK-NEXT:    nop // Delay Slot 4
+; CHECK-NEXT:    vsrs.4x wh11, cml4, s0, srssign0 // Delay Slot 4
 ; CHECK-NEXT:    nop // Delay Slot 3
 ; CHECK-NEXT:    nop // Delay Slot 2
 ; CHECK-NEXT:    nop // Delay Slot 1

--- a/llvm/test/CodeGen/AIE/aie2p/schedule/events-and-post-swp.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/schedule/events-and-post-swp.mir
@@ -39,7 +39,7 @@
   ; CHECK-NEXT:    nopa ; vldb x2, [p0], #64; vst.srs.2x cml0, s0, srssign1, [p1], #64; nopxm ; vmul dm0, y1, y0,r0
   ; CHECK-NEXT:  // %bb.2: // %for.cond.cleanup
   ; CHECK-NEXT:    nopa ; nopb ; vst.srs.2x cml0, s0, srssign1, [p1], #64; nopxm ; vmul dm0, y1, y0,r0
-  ; CHECK-NEXT:    vst.srs.2x cml0, s0, srssign1, [p1], #64; vmul dm0, y1, y0,r0
+  ; CHECK-NEXT:    vst.srs.2x cml0, s0, srssign1, [p1], #64; nopx ; vmul dm0, y1, y0,r0
   ; CHECK-NEXT:    vst.srs.2x cml0, s0, srssign1, [p1], #64; vmul dm0, y1, y0,r0
   ; CHECK-NEXT:    vst.srs.2x cml0, s0, srssign1, [p1], #64; vmul dm0, y1, y0,r0
   ; CHECK-NEXT:    vst.srs.2x cml0, s0, srssign1, [p1], #64; vmul dm0, y1, y0,r0
@@ -50,8 +50,7 @@
   ; CHECK-NEXT:    vst.srs.2x cml0, s0, srssign1, [p1], #64
   ; CHECK-NEXT:    vst.srs.2x cml0, s0, srssign1, [p1], #64
   ; CHECK-NEXT:    vst.srs.2x cml0, s0, srssign1, [p1], #64
-  ; CHECK-NEXT:    vst.srs.2x cml0, s0, srssign1, [p1], #64
-  ; CHECK-NEXT:    ret lr
+  ; CHECK-NEXT:    vst.srs.2x cml0, s0, srssign1, [p1], #64; ret lr
   ; CHECK-NEXT:    event #1 // Delay Slot 5
   ; CHECK-NEXT:    event #0 // Delay Slot 4
   ; CHECK-NEXT:    event #1 // Delay Slot 3

--- a/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/end-to-end.ll
+++ b/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/end-to-end.ll
@@ -34,7 +34,7 @@ define <32 x i16> @zol(i32 %n, ptr %p) {
 ; CHECK-NEXT:   - Prologue:        bb.0.entry
 ; CHECK-NEXT:   - PrologueBundles: '9'
 ; CHECK-NEXT:   - Epilogue:        bb.2.for.cond.cleanup
-; CHECK-NEXT:   - EpilogueBundles: '13'
+; CHECK-NEXT:   - EpilogueBundles: '10'
 ; CHECK-NEXT: ...
 entry:
   br label %for.body

--- a/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/reduce-mean-templated.ll
+++ b/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/reduce-mean-templated.ll
@@ -43,7 +43,7 @@ define void @reduceMeanTemplated(ptr noalias %ifm, ptr addrspace(6) noalias %ofm
 ; CHECK-NEXT:   - Prologue:        bb.0.entry
 ; CHECK-NEXT:   - PrologueBundles: '18'
 ; CHECK-NEXT:   - Epilogue:        bb.2.for.cond.cleanup67
-; CHECK-NEXT:   - EpilogueBundles: '17'
+; CHECK-NEXT:   - EpilogueBundles: '11'
 ; CHECK-NEXT: ...
 entry:
   call void @llvm.set.loop.iterations.i32(i32 1)

--- a/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/scale.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/scale.mir
@@ -75,7 +75,7 @@ body:             |
   ; CHECK-NEXT:   - Prologue:        bb.0.entry
   ; CHECK-NEXT:   - PrologueBundles: '13'
   ; CHECK-NEXT:   - Epilogue:        bb.2.for.cond.cleanup
-  ; CHECK-NEXT:   - EpilogueBundles: '19'
+  ; CHECK-NEXT:   - EpilogueBundles: '16'
   ; CHECK-NEXT: ...
   bb.0.entry (align 16):
     successors: %bb.1(0x80000000)

--- a/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/softmax-aa.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/softmax-aa.mir
@@ -280,7 +280,7 @@ body:             |
   ; CHECK-NEXT:   - Prologue:        bb.2.for.cond2.preheader
   ; CHECK-NEXT:   - PrologueBundles: '12'
   ; CHECK-NEXT:   - Epilogue:        bb.4.for.cond.cleanup4
-  ; CHECK-NEXT:   - EpilogueBundles: '16'
+  ; CHECK-NEXT:   - EpilogueBundles: '11'
   ; CHECK-NEXT: ...
   bb.0.entry (align 16):
     successors: %bb.1(0x50000000), %bb.5(0x30000000)
@@ -398,7 +398,7 @@ body:             |
   ; CHECK-NEXT:   - Prologue:        bb.2.for.cond2.preheader
   ; CHECK-NEXT:   - PrologueBundles: '13'
   ; CHECK-NEXT:   - Epilogue:        bb.4.for.cond.cleanup4
-  ; CHECK-NEXT:   - EpilogueBundles: '16'
+  ; CHECK-NEXT:   - EpilogueBundles: '11'
   ; CHECK-NEXT: ...
   bb.0.entry (align 16):
     successors: %bb.1(0x50000000), %bb.5(0x30000000)

--- a/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/speculative-first-stage.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/speculative-first-stage.mir
@@ -37,18 +37,13 @@
   ; CHECK-NEXT:  .L_LEnd0:
   ; CHECK-NEXT:    nopa ; nopb ; nops ; nopx ; vshuffle x3, x1, x2, r10; nopv
   ; CHECK-NEXT:  // %bb.2: // %for.cond.cleanup
-  ; CHECK-NEXT:    nopa ; nopb ; nopx ; vmax_lt.32 x0, r16, x0, x3, vaddsign1; nops
+  ; CHECK-NEXT:    nops ; vmax_lt.32 x0, r16, x0, x3, vaddsign1
   ; CHECK-NEXT:    nop
-  ; CHECK-NEXT:    vshuffle x3, x1, x2, r10
-  ; CHECK-NEXT:    vmax_lt.32 x0, r16, x0, x3, vaddsign1
-  ; CHECK-NEXT:    nop
-  ; CHECK-NEXT:    vshuffle x3, x1, x2, r10
-  ; CHECK-NEXT:    vmax_lt.32 x0, r16, x0, x3, vaddsign1
-  ; CHECK-NEXT:    ret lr
-  ; CHECK-NEXT:    nop // Delay Slot 5
+  ; CHECK-NEXT:    ret lr; vshuffle x3, x1, x2, r10
+  ; CHECK-NEXT:    vmax_lt.32 x0, r16, x0, x3, vaddsign1 // Delay Slot 5
   ; CHECK-NEXT:    nop // Delay Slot 4
-  ; CHECK-NEXT:    nop // Delay Slot 3
-  ; CHECK-NEXT:    nop // Delay Slot 2
+  ; CHECK-NEXT:    vshuffle x3, x1, x2, r10 // Delay Slot 3
+  ; CHECK-NEXT:    vmax_lt.32 x0, r16, x0, x3, vaddsign1 // Delay Slot 2
   ; CHECK-NEXT:    nop // Delay Slot 1
   entry:
     call void @llvm.set.loop.iterations.i32(i32 16)
@@ -83,17 +78,12 @@
   ; CHECK-NEXT:  .L_LEnd1:
   ; CHECK-NEXT:    vlda x1, [p0, #64]; nopb ; nops ; nopx ; vmax_lt.32 x0, r16, x0, x3, vaddsign1; nopv
   ; CHECK-NEXT:  // %bb.2: // %for.cond.cleanup
-  ; CHECK-NEXT:    nopa ; nopb ; nops ; nopxm ; nopv
-  ; CHECK-NEXT:    vshuffle x3, x1, x2, r10
-  ; CHECK-NEXT:    vmax_lt.32 x0, r16, x0, x3, vaddsign1
-  ; CHECK-NEXT:    nop
-  ; CHECK-NEXT:    vshuffle x3, x1, x2, r10
-  ; CHECK-NEXT:    vmax_lt.32 x0, r16, x0, x3, vaddsign1
-  ; CHECK-NEXT:    ret lr
-  ; CHECK-NEXT:    nop // Delay Slot 5
+  ; CHECK-NEXT:    nopa ; nopxm
+  ; CHECK-NEXT:    ret lr; vshuffle x3, x1, x2, r10
+  ; CHECK-NEXT:    vmax_lt.32 x0, r16, x0, x3, vaddsign1 // Delay Slot 5
   ; CHECK-NEXT:    nop // Delay Slot 4
-  ; CHECK-NEXT:    nop // Delay Slot 3
-  ; CHECK-NEXT:    nop // Delay Slot 2
+  ; CHECK-NEXT:    vshuffle x3, x1, x2, r10 // Delay Slot 3
+  ; CHECK-NEXT:    vmax_lt.32 x0, r16, x0, x3, vaddsign1 // Delay Slot 2
   ; CHECK-NEXT:    nop // Delay Slot 1
   entry:
     call void @llvm.set.loop.iterations.i32(i32 16)

--- a/llvm/test/CodeGen/AIE/aie2ps/end-to-end/conv2d_int8_outerloop_pipelined.ll
+++ b/llvm/test/CodeGen/AIE/aie2ps/end-to-end/conv2d_int8_outerloop_pipelined.ll
@@ -102,28 +102,31 @@ define dso_local void @conv2d(i32 %0, ptr %add.ptr3, ptr %cond, ptr %cond.i, ptr
 ; CHECK-NEXT:    // in Loop: Header=BB0_1 Depth=1
 ; CHECK-NEXT:    vlda x4, [p3], #64; nopb ; movs dj0, r20; add r0, r0, #-1; vshuffle x0, x6, x6, r6; vmac dm1, dm1, x0, x4, r8
 ; CHECK-NEXT:    vlda x2, [p3], #64; nopb ; movs m5, r17; nopx ; mov srssign0, r4; vmac dm0, dm0, x0, x2, r8
-; CHECK-NEXT:    padda [p1], m5; nopb ; movs p3, p2; nopx ; vshuffle x0, x6, x6, r6; vmac dm1, dm1, x0, x4, r8
-; CHECK-NEXT:    padda [p3], m6; nopb ; movs dc4, r7; nopx ; mov m7, r20; vmac dm0, dm0, x0, x2, r8
-; CHECK-NEXT:    nopa ; paddb.3d [p1], d3; movs m5, p5; nopx ; vshuffle x0, x6, x6, r6; vmac dm1, dm1, x0, x4, r8
-; CHECK-NEXT:    movs dj4, r26; nopx ; mov dn4, r22; vmac dm0, dm0, x0, x2, r8
-; CHECK-NEXT:    movs m0, r23; vshuffle x0, x6, x6, r6; vmac dm1, dm1, x0, x4, r8
-; CHECK-NEXT:    vmac dm0, dm0, x0, x2, r8
+; CHECK-NEXT:    padda [p1], m5; movs p3, p2; vshuffle x0, x6, x6, r6; vmac dm1, dm1, x0, x4, r8
+; CHECK-NEXT:    padda [p3], m6; movs dc4, r7; mov m7, r20; vmac dm0, dm0, x0, x2, r8
+; CHECK-NEXT:    movs m5, p5; paddb.3d [p1], d3; vshuffle x0, x6, x6, r6; vmac dm1, dm1, x0, x4, r8
+; CHECK-NEXT:    movs dn4, r22; vmac dm0, dm0, x0, x2, r8
+; CHECK-NEXT:    movs dj4, r26; vshuffle x0, x6, x6, r6; vmac dm1, dm1, x0, x4, r8
+; CHECK-NEXT:    mov m0, r23; vmac dm0, dm0, x0, x2, r8
 ; CHECK-NEXT:    vmac dm1, dm1, x0, x4, r8
 ; CHECK-NEXT:    vmac dm0, dm0, x0, x2, r8
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
-; CHECK-NEXT:    vst.srs.4x cmh1, s1, srssign0, [p2, dj0]
+; CHECK-NEXT:    vst.srs.4x cmh1, s1, srssign0, [p2, dj0]; mov dj0, r29
 ; CHECK-NEXT:    vst.srs.4x cml1, s1, srssign0, [p2, #0]; mov p2, p3
-; CHECK-NEXT:    padda [p2], m7; mov m7, p4
-; CHECK-NEXT:    vlda.ups.2x cml1, s0, upssign1, [p1], m7; vst.srs.4x cml0, s1, srssign0, [p3, #0]; mov dj0, r29
-; CHECK-NEXT:    vlda.ups.2x cmh1, s0, upssign1, [p1], m5; vst.2d.srs.4x cmh0, s1, srssign0, [p2], d4; jnz r0, #.LBB0_1
-; CHECK-NEXT:    padda [p1], m7; movs dj4, r25; mov r7, dc4 // Delay Slot 5
-; CHECK-NEXT:    padda [p1], m0; movs dn4, r27; mov m5, r19 // Delay Slot 4
-; CHECK-NEXT:    vlda.ups.2x cml0, s0, upssign1, [p1, #0]; movs dc4, r5; mov m0, r21 // Delay Slot 3
-; CHECK-NEXT:    padda [p1], m7; paddb.3d [p0], d0; padds [p6], m5 // Delay Slot 2
-; CHECK-NEXT:    vlda.ups.2x cmh0, s0, upssign1, [p1, #0]; paddb.3d [p6], d1; movx srssign0, #0; mov r5, dc4 // Delay Slot 1
+; CHECK-NEXT:    padda [p2], m7; vst.srs.4x cml0, s1, srssign0, [p3, #0]; mov m7, p4
+; CHECK-NEXT:    vlda.ups.2x cml1, s0, upssign1, [p1], m7; vst.2d.srs.4x cmh0, s1, srssign0, [p2], d4; movx srssign0, #0; mov dj4, r25
+; CHECK-NEXT:    vlda.ups.2x cmh1, s0, upssign1, [p1], m5; movs m5, r19; mov r7, dc4
+; CHECK-NEXT:    padda [p1], m7; paddb [p6], m5; movs dc4, r5; mov dn4, r27
+; CHECK-NEXT:    padda [p1], m0; paddb.3d [p6], d1; mov m0, r21
+; CHECK-NEXT:    vlda.ups.2x cml0, s0, upssign1, [p1, #0]; paddb [p1], m7; jnz r0, #.LBB0_1; padds.3d [p0], d0
+; CHECK-NEXT:    vlda.ups.2x cmh0, s0, upssign1, [p1, #0]; mov r5, dc4 // Delay Slot 5
+; CHECK-NEXT:    nop // Delay Slot 4
+; CHECK-NEXT:    nop // Delay Slot 3
+; CHECK-NEXT:    nop // Delay Slot 2
+; CHECK-NEXT:    nop // Delay Slot 1
 ; CHECK-NEXT:  // %bb.4: // %cooldown.entry
 ; CHECK-NEXT:    vldb.popx x6, [p0, lf0, r24]
 ; CHECK-NEXT:    padds.3d [p0], d2
@@ -141,8 +144,8 @@ define dso_local void @conv2d(i32 %0, ptr %add.ptr3, ptr %cond, ptr %cond.i, ptr
 ; CHECK-NEXT:  .L_LEnd0:
 ; CHECK-NEXT:    vlda x2, [p6], #64; nopb ; padds.3d [p0], d2; nopxm ; vmac dm0, dm0, x0, x2, r8
 ; CHECK-NEXT:  // %bb.6: // %cooldown.exit
-; CHECK-NEXT:    vlda x4, [p6], #64; nopb ; movs dj0, r20; movx crsrsmode, #0; vshuffle x0, x6, x6, r6; vmac dm1, dm1, x0, x4, r8
-; CHECK-NEXT:    vlda x2, [p6], #64; nopb ; nops ; nopx ; mov s0, r3; vmac dm0, dm0, x0, x2, r8
+; CHECK-NEXT:    vlda x4, [p6], #64; nopb ; movs dj0, r20; nopx ; vshuffle x0, x6, x6, r6; vmac dm1, dm1, x0, x4, r8
+; CHECK-NEXT:    vlda x2, [p6], #64; nopb ; nops ; movx crsrsmode, #0; mov s0, r3; vmac dm0, dm0, x0, x2, r8
 ; CHECK-NEXT:    lda p6, [sp, #-64]; nopb ; nopx ; vshuffle x0, x6, x6, r6; vmac dm1, dm1, x0, x4, r8 // 4-byte Folded Reload
 ; CHECK-NEXT:    paddxm [sp], #-64; mov srssign0, r4; vmac dm0, dm0, x0, x2, r8
 ; CHECK-NEXT:    vshuffle x0, x6, x6, r6; vmac dm1, dm1, x0, x4, r8
@@ -151,17 +154,17 @@ define dso_local void @conv2d(i32 %0, ptr %add.ptr3, ptr %cond, ptr %cond.i, ptr
 ; CHECK-NEXT:    vmac dm0, dm0, x0, x2, r8
 ; CHECK-NEXT:    vmac dm1, dm1, x0, x4, r8
 ; CHECK-NEXT:    vmac dm0, dm0, x0, x2, r8
-; CHECK-NEXT:    nop
+; CHECK-NEXT:    mov r8, r28
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    vst.srs.4x cmh1, s0, srssign0, [p2, dj0]
 ; CHECK-NEXT:    padda [p2], m6; vst.srs.4x cml1, s0, srssign0, [p2, #0]; ret lr
 ; CHECK-NEXT:    vst.srs.4x cmh0, s0, srssign0, [p2, dj0] // Delay Slot 5
-; CHECK-NEXT:    vst.srs.4x cml0, s0, srssign0, [p2, #0] // Delay Slot 4
+; CHECK-NEXT:    vst.srs.4x cml0, s0, srssign0, [p2, #0]; movx srssign0, #0 // Delay Slot 4
 ; CHECK-NEXT:    nop // Delay Slot 3
 ; CHECK-NEXT:    nop // Delay Slot 2
-; CHECK-NEXT:    movx srssign0, #0; mov r8, r28 // Delay Slot 1
+; CHECK-NEXT:    nop // Delay Slot 1
 newFuncRoot:
   br label %for.body.i.peel.pro
 

--- a/llvm/test/CodeGen/AIE/aie2ps/end-to-end/conv2d_opt_outerloop_blocks.ll
+++ b/llvm/test/CodeGen/AIE/aie2ps/end-to-end/conv2d_opt_outerloop_blocks.ll
@@ -110,22 +110,23 @@ define dso_local void @conv2d(i32 %0, ptr %add.ptr3, ptr %ofm, ptr %psum_0_tdm, 
 ; CHECK-NEXT:  // %bb.3: // %for.cond.cleanup54.i
 ; CHECK-NEXT:    // in Loop: Header=BB0_1 Depth=1
 ; CHECK-NEXT:    vlda x4, [p4, #192]; paddb.3d [p1], d1; padds [p4], #128; add r0, r0, #-1; mov dc4, dc7; vmac dm0, dm0, x2, x4, r8
-; CHECK-NEXT:    vlda x6, [p4, #128]; paddb [p0], m4; nops ; nopx ; vshuffle x2, x10, x8, r2; vmac dm1, dm1, x2, x6, r8
+; CHECK-NEXT:    vlda x6, [p4, #128]; paddb [p0], m4; nopx ; vshuffle x2, x10, x8, r2; vmac dm1, dm1, x2, x6, r8
 ; CHECK-NEXT:    vlda x4, [p4, #192]; vldb.popx x10, [p1, lf1, r25]; padds [p4], #128; nopx ; mov srssign0, r6; vmac dm0, dm0, x2, x4, r8
 ; CHECK-NEXT:    vlda.pop.3d x1, [p1, lf1, r25, d0]; paddb.3d [p0], d2; vshuffle x2, x10, x8, r2; vmac dm1, dm1, x2, x6, r8
 ; CHECK-NEXT:    vldb x8, [p0, #0]; mov r16, dc6; vmac dm0, dm0, x2, x4, r8
 ; CHECK-NEXT:    vldb x6, [p0, #64]; lshl r16, r16, r18; vshuffle x2, x10, x8, r2; vmac dm1, dm1, x2, x6, r8
 ; CHECK-NEXT:    or r24, r16, r22; mov dj7, r16; vmac dm0, dm0, x2, x4, r8
 ; CHECK-NEXT:    movs dj7, r24; vldb.128 wl2, [p5, dj7]; eq r16, r0, r20; vshuffle x2, x10, x8, r2; vmac dm1, dm1, x2, x6, r8
-; CHECK-NEXT:    vldb.128 wl4, [p5, dj7]; vmac dm0, dm0, x2, x4, r8
-; CHECK-NEXT:    vmac dm1, dm1, x2, x6, r8
-; CHECK-NEXT:    vmac dm0, dm0, x2, x4, r8
-; CHECK-NEXT:    vlda.ups.2x cml1, s0, upssign1, [p2], #64; jz r16, #.LBB0_1
-; CHECK-NEXT:    vlda.ups.2x cmh1, s0, upssign1, [p2], #64 // Delay Slot 5
-; CHECK-NEXT:    vlda.ups.2x cml0, s0, upssign1, [p3], #64 // Delay Slot 4
-; CHECK-NEXT:    vlda.ups.2x cmh0, s0, upssign1, [p3], #64 // Delay Slot 3
-; CHECK-NEXT:    vst.srs.4x dm1, s1, srssign0, [p6], m5; vshuffle x10, x10, x1, r2 // Delay Slot 2
-; CHECK-NEXT:    vst.2d.srs.4x dm0, s1, srssign0, [p6], d3; movx srssign0, #0 // Delay Slot 1
+; CHECK-NEXT:    vlda.ups.2x cml0, s0, upssign1, [p3], #64; vldb.128 wl4, [p5, dj7]; vmac dm0, dm0, x2, x4, r8
+; CHECK-NEXT:    vlda.ups.2x cml1, s0, upssign1, [p2], #64; vmac dm1, dm1, x2, x6, r8
+; CHECK-NEXT:    vlda.ups.2x cmh1, s0, upssign1, [p2], #64; vmac dm0, dm0, x2, x4, r8
+; CHECK-NEXT:    vlda.ups.2x cmh0, s0, upssign1, [p3], #64; vshuffle x10, x10, x1, r2
+; CHECK-NEXT:    jz r16, #.LBB0_1
+; CHECK-NEXT:    nop // Delay Slot 5
+; CHECK-NEXT:    nop // Delay Slot 4
+; CHECK-NEXT:    vst.srs.4x dm1, s1, srssign0, [p6], m5 // Delay Slot 3
+; CHECK-NEXT:    vst.2d.srs.4x dm0, s1, srssign0, [p6], d3; movx srssign0, #0 // Delay Slot 2
+; CHECK-NEXT:    nop // Delay Slot 1
 ; CHECK-NEXT:  // %bb.4: // %cooldown.entry
 ; CHECK-NEXT:    vldb.popx x8, [p1, lf1, r25]
 ; CHECK-NEXT:    vldb.pop.3d x6, [p1, lf1, r25, d0]
@@ -145,26 +146,26 @@ define dso_local void @conv2d(i32 %0, ptr %add.ptr3, ptr %ofm, ptr %psum_0_tdm, 
 ; CHECK-NEXT:  .L_LEnd0:
 ; CHECK-NEXT:    vlda x4, [p0, #128]; vldb.pop.3d x6, [p1, lf1, r25, d0]; nops ; nopx ; vshuffle x0, x8, x6, r2; vmac dm1, dm1, x0, x4, r8
 ; CHECK-NEXT:  // %bb.6: // %cooldown.exit
-; CHECK-NEXT:    vlda x2, [p0, #192]; nopb ; padds [p0], #128; movx crsrsmode, #0; mov s0, r5; vmac dm0, dm0, x0, x2, r8
-; CHECK-NEXT:    vlda x4, [p0, #128]; nopb ; movs dj0, r17; or r12, r23, r23; vshuffle x0, x8, x6, r2; vmac dm1, dm1, x0, x4, r8
-; CHECK-NEXT:    vlda x2, [p0, #192]; nopb ; padds [p0], #128; or r10, r21, r21; mov srssign0, r6; vmac dm0, dm0, x0, x2, r8
-; CHECK-NEXT:    nopx ; vshuffle x0, x8, x6, r2; vmac dm1, dm1, x0, x4, r8
-; CHECK-NEXT:    vmac dm0, dm0, x0, x2, r8
+; CHECK-NEXT:    vlda x2, [p0, #192]; padds [p0], #128; nopx ; vmac dm0, dm0, x0, x2, r8
+; CHECK-NEXT:    vlda x4, [p0, #128]; nopb ; movs dj0, r17; movx crsrsmode, #0; vshuffle x0, x8, x6, r2; vmac dm1, dm1, x0, x4, r8
+; CHECK-NEXT:    vlda x2, [p0, #192]; nopb ; padds [p0], #128; or r12, r23, r23; mov s0, r5; vmac dm0, dm0, x0, x2, r8
+; CHECK-NEXT:    or r10, r21, r21; vshuffle x0, x8, x6, r2; vmac dm1, dm1, x0, x4, r8
+; CHECK-NEXT:    mov srssign0, r6; vmac dm0, dm0, x0, x2, r8
 ; CHECK-NEXT:    vshuffle x0, x8, x6, r2; vmac dm1, dm1, x0, x4, r8
 ; CHECK-NEXT:    vmac dm0, dm0, x0, x2, r8
 ; CHECK-NEXT:    vshuffle x0, x8, x6, r2; vmac dm1, dm1, x0, x4, r8
 ; CHECK-NEXT:    vmac dm0, dm0, x0, x2, r8
 ; CHECK-NEXT:    vmac dm1, dm1, x0, x4, r8
-; CHECK-NEXT:    vmac dm0, dm0, x0, x2, r8
+; CHECK-NEXT:    lda p6, [sp, #-64]; vmac dm0, dm0, x0, x2, r8 // 4-byte Folded Reload
+; CHECK-NEXT:    paddxm [sp], #-64; mov r8, r19
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
-; CHECK-NEXT:    lda p6, [sp, #-64] // 4-byte Folded Reload
 ; CHECK-NEXT:    ret lr
 ; CHECK-NEXT:    vst.srs.4x dm1, s0, srssign0, [p6, #0] // Delay Slot 5
-; CHECK-NEXT:    vst.srs.4x dm0, s0, srssign0, [p6, dj0] // Delay Slot 4
+; CHECK-NEXT:    vst.srs.4x dm0, s0, srssign0, [p6, dj0]; movx srssign0, #0 // Delay Slot 4
 ; CHECK-NEXT:    nop // Delay Slot 3
 ; CHECK-NEXT:    nop // Delay Slot 2
-; CHECK-NEXT:    paddxm [sp], #-64; movx srssign0, #0; mov r8, r19 // Delay Slot 1
+; CHECK-NEXT:    nop // Delay Slot 1
 ;
 ; NO-PROLOGUE-SPLIT-LABEL: conv2d:
 ; NO-PROLOGUE-SPLIT:       // %bb.0: // %newFuncRoot
@@ -239,23 +240,20 @@ define dso_local void @conv2d(i32 %0, ptr %add.ptr3, ptr %ofm, ptr %psum_0_tdm, 
 ; NO-PROLOGUE-SPLIT-NEXT:    vlda x1, [p7, #64]; vldb.popx x4, [p1, lf1, r25]; nops ; or r24, r16, r22; mov dj7, r16; vmac dm0, dm0, x2, x4, r8
 ; NO-PROLOGUE-SPLIT-NEXT:    vlda.128 wl2, [p0, dj7]; vldb.pop.3d x6, [p1, lf1, r25, d0]; movs dj7, r24; eq r16, r0, r20; vshuffle x2, x10, x8, r2; vmac dm1, dm1, x2, x6, r8
 ; NO-PROLOGUE-SPLIT-NEXT:    vlda.128 wl8, [p0, dj7]; nopb ; nops ; nopx ; mov srssign0, r6; vmac dm0, dm0, x2, x4, r8
-; NO-PROLOGUE-SPLIT-NEXT:    vshuffle x2, x10, x8, r2; vmac dm1, dm1, x2, x6, r8
-; NO-PROLOGUE-SPLIT-NEXT:    vmac dm0, dm0, x2, x4, r8
-; NO-PROLOGUE-SPLIT-NEXT:    vmac dm1, dm1, x2, x6, r8
-; NO-PROLOGUE-SPLIT-NEXT:    vmac dm0, dm0, x2, x4, r8
-; NO-PROLOGUE-SPLIT-NEXT:    vlda.ups.2x cml1, s0, upssign1, [p2, #128]
-; NO-PROLOGUE-SPLIT-NEXT:    vlda.ups.2x cmh1, s0, upssign1, [p2, #192]
+; NO-PROLOGUE-SPLIT-NEXT:    vlda.ups.2x cml1, s0, upssign1, [p2, #128]; nopx ; vshuffle x2, x10, x8, r2; vmac dm1, dm1, x2, x6, r8
+; NO-PROLOGUE-SPLIT-NEXT:    vlda.ups.2x cmh1, s0, upssign1, [p2, #192]; movs p2, p5; vmac dm0, dm0, x2, x4, r8
+; NO-PROLOGUE-SPLIT-NEXT:    vlda.ups.2x cml0, s0, upssign1, [p3, #128]; vmac dm1, dm1, x2, x6, r8
+; NO-PROLOGUE-SPLIT-NEXT:    vlda.ups.2x cmh0, s0, upssign1, [p3, #192]; mov p3, p4; vmac dm0, dm0, x2, x4, r8
 ; NO-PROLOGUE-SPLIT-NEXT:    nop
+; NO-PROLOGUE-SPLIT-NEXT:    vmul dm2, x0, x2, r12
+; NO-PROLOGUE-SPLIT-NEXT:    vshuffle x2, x4, x6, r2; vmul dm3, x0, x8, r12
 ; NO-PROLOGUE-SPLIT-NEXT:    nop
-; NO-PROLOGUE-SPLIT-NEXT:    vlda.ups.2x cml0, s0, upssign1, [p3, #128]
-; NO-PROLOGUE-SPLIT-NEXT:    vlda.ups.2x cmh0, s0, upssign1, [p3, #192]; vshuffle x2, x4, x6, r2; vmul dm2, x0, x2, r12
-; NO-PROLOGUE-SPLIT-NEXT:    vmul dm3, x0, x8, r12
-; NO-PROLOGUE-SPLIT-NEXT:    jz r16, #.LBB0_1; vaddmac dm1, dm1, dm2, x2, x10, r10
-; NO-PROLOGUE-SPLIT-NEXT:    vst.srs.4x dm1, s1, srssign0, [p6], m5 // Delay Slot 5
+; NO-PROLOGUE-SPLIT-NEXT:    vst.srs.4x dm1, s1, srssign0, [p6], m5; jz r16, #.LBB0_1; vaddmac dm1, dm1, dm2, x2, x10, r10
+; NO-PROLOGUE-SPLIT-NEXT:    vst.2d.srs.4x dm0, s1, srssign0, [p6], d3; movx srssign0, #0; vaddmac dm0, dm0, dm3, x2, x1, r10 // Delay Slot 5
 ; NO-PROLOGUE-SPLIT-NEXT:    nop // Delay Slot 4
 ; NO-PROLOGUE-SPLIT-NEXT:    nop // Delay Slot 3
-; NO-PROLOGUE-SPLIT-NEXT:    mov p2, p5; vaddmac dm0, dm0, dm3, x2, x1, r10 // Delay Slot 2
-; NO-PROLOGUE-SPLIT-NEXT:    vst.2d.srs.4x dm0, s1, srssign0, [p6], d3; movx srssign0, #0; mov p3, p4 // Delay Slot 1
+; NO-PROLOGUE-SPLIT-NEXT:    nop // Delay Slot 2
+; NO-PROLOGUE-SPLIT-NEXT:    nop // Delay Slot 1
 ; NO-PROLOGUE-SPLIT-NEXT:  // %bb.4: // %cooldown.entry
 ; NO-PROLOGUE-SPLIT-NEXT:    vldb.popx x8, [p1, lf1, r25]
 ; NO-PROLOGUE-SPLIT-NEXT:    vldb.pop.3d x6, [p1, lf1, r25, d0]
@@ -275,26 +273,26 @@ define dso_local void @conv2d(i32 %0, ptr %add.ptr3, ptr %ofm, ptr %psum_0_tdm, 
 ; NO-PROLOGUE-SPLIT-NEXT:  .L_LEnd0:
 ; NO-PROLOGUE-SPLIT-NEXT:    vlda x4, [p7, #128]; vldb.pop.3d x6, [p1, lf1, r25, d0]; nops ; nopx ; vshuffle x0, x8, x6, r2; vmac dm1, dm1, x0, x4, r8
 ; NO-PROLOGUE-SPLIT-NEXT:  // %bb.6: // %cooldown.exit
-; NO-PROLOGUE-SPLIT-NEXT:    vlda x2, [p7, #192]; nopb ; padds [p7], #128; movx crsrsmode, #0; mov s0, r5; vmac dm0, dm0, x0, x2, r8
-; NO-PROLOGUE-SPLIT-NEXT:    vlda x4, [p7, #128]; nopb ; movs dj0, r17; or r12, r23, r23; vshuffle x0, x8, x6, r2; vmac dm1, dm1, x0, x4, r8
-; NO-PROLOGUE-SPLIT-NEXT:    vlda x2, [p7, #192]; nopb ; padds [p7], #128; or r10, r21, r21; mov srssign0, r6; vmac dm0, dm0, x0, x2, r8
-; NO-PROLOGUE-SPLIT-NEXT:    lda p7, [sp, #-60]; vshuffle x0, x8, x6, r2; vmac dm1, dm1, x0, x4, r8 // 4-byte Folded Reload
-; NO-PROLOGUE-SPLIT-NEXT:    vmac dm0, dm0, x0, x2, r8
+; NO-PROLOGUE-SPLIT-NEXT:    vlda x2, [p7, #192]; padds [p7], #128; vmac dm0, dm0, x0, x2, r8
+; NO-PROLOGUE-SPLIT-NEXT:    vlda x4, [p7, #128]; nopb ; movs dj0, r17; movx crsrsmode, #0; vshuffle x0, x8, x6, r2; vmac dm1, dm1, x0, x4, r8
+; NO-PROLOGUE-SPLIT-NEXT:    vlda x2, [p7, #192]; nopb ; padds [p7], #128; or r12, r23, r23; mov s0, r5; vmac dm0, dm0, x0, x2, r8
+; NO-PROLOGUE-SPLIT-NEXT:    lda p7, [sp, #-60]; or r10, r21, r21; vshuffle x0, x8, x6, r2; vmac dm1, dm1, x0, x4, r8 // 4-byte Folded Reload
+; NO-PROLOGUE-SPLIT-NEXT:    mov srssign0, r6; vmac dm0, dm0, x0, x2, r8
 ; NO-PROLOGUE-SPLIT-NEXT:    vshuffle x0, x8, x6, r2; vmac dm1, dm1, x0, x4, r8
 ; NO-PROLOGUE-SPLIT-NEXT:    vmac dm0, dm0, x0, x2, r8
 ; NO-PROLOGUE-SPLIT-NEXT:    vshuffle x0, x8, x6, r2; vmac dm1, dm1, x0, x4, r8
 ; NO-PROLOGUE-SPLIT-NEXT:    vmac dm0, dm0, x0, x2, r8
 ; NO-PROLOGUE-SPLIT-NEXT:    vmac dm1, dm1, x0, x4, r8
-; NO-PROLOGUE-SPLIT-NEXT:    vmac dm0, dm0, x0, x2, r8
+; NO-PROLOGUE-SPLIT-NEXT:    lda p6, [sp, #-64]; vmac dm0, dm0, x0, x2, r8 // 4-byte Folded Reload
+; NO-PROLOGUE-SPLIT-NEXT:    paddxm [sp], #-64; mov r8, r19
 ; NO-PROLOGUE-SPLIT-NEXT:    nop
 ; NO-PROLOGUE-SPLIT-NEXT:    nop
-; NO-PROLOGUE-SPLIT-NEXT:    lda p6, [sp, #-64] // 4-byte Folded Reload
 ; NO-PROLOGUE-SPLIT-NEXT:    ret lr
 ; NO-PROLOGUE-SPLIT-NEXT:    vst.srs.4x dm1, s0, srssign0, [p6, #0] // Delay Slot 5
-; NO-PROLOGUE-SPLIT-NEXT:    vst.srs.4x dm0, s0, srssign0, [p6, dj0] // Delay Slot 4
+; NO-PROLOGUE-SPLIT-NEXT:    vst.srs.4x dm0, s0, srssign0, [p6, dj0]; movx srssign0, #0 // Delay Slot 4
 ; NO-PROLOGUE-SPLIT-NEXT:    nop // Delay Slot 3
 ; NO-PROLOGUE-SPLIT-NEXT:    nop // Delay Slot 2
-; NO-PROLOGUE-SPLIT-NEXT:    paddxm [sp], #-64; movx srssign0, #0; mov r8, r19 // Delay Slot 1
+; NO-PROLOGUE-SPLIT-NEXT:    nop // Delay Slot 1
 ;
 ; USE-JNZD-LABEL: conv2d:
 ; USE-JNZD:       // %bb.0: // %newFuncRoot
@@ -356,21 +354,21 @@ define dso_local void @conv2d(i32 %0, ptr %add.ptr3, ptr %ofm, ptr %psum_0_tdm, 
 ; USE-JNZD-NEXT:    vlda x6, [p7, #128]; vldb.pop.3d x8, [p1, lf1, r25, d0]; nops ; nopx ; vshuffle x2, x10, x8, r2; vmac dm1, dm1, x2, x6, r8
 ; USE-JNZD-NEXT:  // %bb.3: // %for.cond.cleanup54.i
 ; USE-JNZD-NEXT:    // in Loop: Header=BB0_1 Depth=1
-; USE-JNZD-NEXT:    vlda x4, [p7, #192]; paddb.3d [p1], d1; padds [p7], #128; nopx ; mov dc4, dc7; vmac dm0, dm0, x2, x4, r8
-; USE-JNZD-NEXT:    vlda x6, [p7, #128]; vldb.popx x10, [p1, lf1, r25]; padds [p0], m4; nopx ; vshuffle x2, x10, x8, r2; vmac dm1, dm1, x2, x6, r8
-; USE-JNZD-NEXT:    vlda x4, [p7, #192]; vldb.pop.3d x1, [p1, lf1, r25, d0]; padds [p7], #128; nopx ; mov srssign0, r6; vmac dm0, dm0, x2, x4, r8
-; USE-JNZD-NEXT:    nopa ; paddb.3d [p0], d2; nops ; nopx ; vshuffle x2, x10, x8, r2; vmac dm1, dm1, x2, x6, r8
-; USE-JNZD-NEXT:    vldb x8, [p0, #0]; nopx ; mov r0, dc6; vmac dm0, dm0, x2, x4, r8
+; USE-JNZD-NEXT:    vlda x4, [p7, #192]; paddb.3d [p1], d1; padds [p7], #128; nopxm ; vmac dm0, dm0, x2, x4, r8
+; USE-JNZD-NEXT:    vlda x6, [p7, #128]; vldb.popx x10, [p1, lf1, r25]; movs dc4, dc7; nopx ; vshuffle x2, x10, x8, r2; vmac dm1, dm1, x2, x6, r8
+; USE-JNZD-NEXT:    vlda x4, [p7, #192]; paddb [p0], m4; padds [p7], #128; nopx ; mov srssign0, r6; vmac dm0, dm0, x2, x4, r8
+; USE-JNZD-NEXT:    padds.3d [p0], d2; vldb.pop.3d x1, [p1, lf1, r25, d0]; nopx ; vshuffle x2, x10, x8, r2; vmac dm1, dm1, x2, x6, r8
+; USE-JNZD-NEXT:    vlda x8, [p0, #0]; mov r0, dc6; vmac dm0, dm0, x2, x4, r8
 ; USE-JNZD-NEXT:    vldb x6, [p0, #64]; lshl r0, r0, r16; vshuffle x2, x10, x8, r2; vmac dm1, dm1, x2, x6, r8
 ; USE-JNZD-NEXT:    or r20, r0, r18; mov dj7, r0; vmac dm0, dm0, x2, x4, r8
 ; USE-JNZD-NEXT:    movs dj7, r20; vldb.128 wl2, [p5, dj7]; vshuffle x2, x10, x8, r2; vmac dm1, dm1, x2, x6, r8
-; USE-JNZD-NEXT:    vldb.128 wl4, [p5, dj7]; vmac dm0, dm0, x2, x4, r8
-; USE-JNZD-NEXT:    vmac dm1, dm1, x2, x6, r8
-; USE-JNZD-NEXT:    vshuffle x10, x10, x1, r2; vmac dm0, dm0, x2, x4, r8
-; USE-JNZD-NEXT:    vlda.ups.2x cml1, s0, upssign1, [p2], #64; jnzd r1, r1, p4
-; USE-JNZD-NEXT:    vlda.ups.2x cmh1, s0, upssign1, [p2], #64 // Delay Slot 5
-; USE-JNZD-NEXT:    vlda.ups.2x cml0, s0, upssign1, [p3], #64 // Delay Slot 4
-; USE-JNZD-NEXT:    vlda.ups.2x cmh0, s0, upssign1, [p3], #64 // Delay Slot 3
+; USE-JNZD-NEXT:    vlda.ups.2x cml0, s0, upssign1, [p3], #64; vldb.128 wl4, [p5, dj7]; vmac dm0, dm0, x2, x4, r8
+; USE-JNZD-NEXT:    vlda.ups.2x cml1, s0, upssign1, [p2], #64; vmac dm1, dm1, x2, x6, r8
+; USE-JNZD-NEXT:    vlda.ups.2x cmh1, s0, upssign1, [p2], #64; vmac dm0, dm0, x2, x4, r8
+; USE-JNZD-NEXT:    vlda.ups.2x cmh0, s0, upssign1, [p3], #64; jnzd r1, r1, p4; vshuffle x10, x10, x1, r2
+; USE-JNZD-NEXT:    nop // Delay Slot 5
+; USE-JNZD-NEXT:    nop // Delay Slot 4
+; USE-JNZD-NEXT:    nop // Delay Slot 3
 ; USE-JNZD-NEXT:    vst.srs.4x dm1, s1, srssign0, [p6], m5 // Delay Slot 2
 ; USE-JNZD-NEXT:    vst.2d.srs.4x dm0, s1, srssign0, [p6], d3; movx srssign0, #0 // Delay Slot 1
 ; USE-JNZD-NEXT:  // %bb.4: // %cooldown.entry
@@ -392,26 +390,26 @@ define dso_local void @conv2d(i32 %0, ptr %add.ptr3, ptr %ofm, ptr %psum_0_tdm, 
 ; USE-JNZD-NEXT:  .L_LEnd0:
 ; USE-JNZD-NEXT:    vlda x4, [p0, #128]; vldb.pop.3d x6, [p1, lf1, r25, d0]; nops ; nopx ; vshuffle x0, x8, x6, r2; vmac dm1, dm1, x0, x4, r8
 ; USE-JNZD-NEXT:  // %bb.6: // %cooldown.exit
-; USE-JNZD-NEXT:    vlda x2, [p0, #192]; nopb ; padds [p0], #128; movx crsrsmode, #0; mov s0, r5; vmac dm0, dm0, x0, x2, r8
-; USE-JNZD-NEXT:    vlda x4, [p0, #128]; nopb ; movs dj0, r17; or r12, r22, r22; vshuffle x0, x8, x6, r2; vmac dm1, dm1, x0, x4, r8
-; USE-JNZD-NEXT:    vlda x2, [p0, #192]; nopb ; padds [p0], #128; or r10, r21, r21; mov srssign0, r6; vmac dm0, dm0, x0, x2, r8
-; USE-JNZD-NEXT:    lda p7, [sp, #-60]; vshuffle x0, x8, x6, r2; vmac dm1, dm1, x0, x4, r8 // 4-byte Folded Reload
-; USE-JNZD-NEXT:    vmac dm0, dm0, x0, x2, r8
+; USE-JNZD-NEXT:    vlda x2, [p0, #192]; padds [p0], #128; vmac dm0, dm0, x0, x2, r8
+; USE-JNZD-NEXT:    vlda x4, [p0, #128]; nopb ; movs dj0, r17; movx crsrsmode, #0; vshuffle x0, x8, x6, r2; vmac dm1, dm1, x0, x4, r8
+; USE-JNZD-NEXT:    vlda x2, [p0, #192]; nopb ; padds [p0], #128; or r12, r22, r22; mov s0, r5; vmac dm0, dm0, x0, x2, r8
+; USE-JNZD-NEXT:    lda p7, [sp, #-60]; or r10, r21, r21; vshuffle x0, x8, x6, r2; vmac dm1, dm1, x0, x4, r8 // 4-byte Folded Reload
+; USE-JNZD-NEXT:    mov srssign0, r6; vmac dm0, dm0, x0, x2, r8
 ; USE-JNZD-NEXT:    vshuffle x0, x8, x6, r2; vmac dm1, dm1, x0, x4, r8
 ; USE-JNZD-NEXT:    vmac dm0, dm0, x0, x2, r8
 ; USE-JNZD-NEXT:    vshuffle x0, x8, x6, r2; vmac dm1, dm1, x0, x4, r8
 ; USE-JNZD-NEXT:    vmac dm0, dm0, x0, x2, r8
 ; USE-JNZD-NEXT:    vmac dm1, dm1, x0, x4, r8
-; USE-JNZD-NEXT:    vmac dm0, dm0, x0, x2, r8
+; USE-JNZD-NEXT:    lda p6, [sp, #-64]; vmac dm0, dm0, x0, x2, r8 // 4-byte Folded Reload
+; USE-JNZD-NEXT:    paddxm [sp], #-64; mov r8, r19
 ; USE-JNZD-NEXT:    nop
 ; USE-JNZD-NEXT:    nop
-; USE-JNZD-NEXT:    lda p6, [sp, #-64] // 4-byte Folded Reload
 ; USE-JNZD-NEXT:    ret lr
 ; USE-JNZD-NEXT:    vst.srs.4x dm1, s0, srssign0, [p6, #0] // Delay Slot 5
-; USE-JNZD-NEXT:    vst.srs.4x dm0, s0, srssign0, [p6, dj0] // Delay Slot 4
+; USE-JNZD-NEXT:    vst.srs.4x dm0, s0, srssign0, [p6, dj0]; movx srssign0, #0 // Delay Slot 4
 ; USE-JNZD-NEXT:    nop // Delay Slot 3
 ; USE-JNZD-NEXT:    nop // Delay Slot 2
-; USE-JNZD-NEXT:    paddxm [sp], #-64; movx srssign0, #0; mov r8, r19 // Delay Slot 1
+; USE-JNZD-NEXT:    nop // Delay Slot 1
 newFuncRoot:
   br label %for.body.i
 

--- a/llvm/test/CodeGen/AIE/aie2ps/end-to-end/gemm_int8_outerloop_blocks.ll
+++ b/llvm/test/CodeGen/AIE/aie2ps/end-to-end/gemm_int8_outerloop_blocks.ll
@@ -110,22 +110,24 @@ define dso_local void @gemm(i32 %0, ptr addrspace(5) %1, ptr addrspace(5) %2, pt
 ; CHECK-NEXT:    nopa ; vldb.128 wl1, [p4, #16]; ne r26, r0, r22; vshuffle x8, x7, x0, r18; vmac dm0, dm0, x3, x6, r8
 ; CHECK-NEXT:    vldb.128 wl10, [p4, #0]; vshuffle x6, x8, x0, r20; vmac dm3, dm3, x5, x10, r8
 ; CHECK-NEXT:    vshuffle x1, x9, x0, r7; vmac dm2, dm2, x3, x10, r8
-; CHECK-NEXT:    vldb x3, [p1], m4; vshuffle x10, x1, x0, r16; vmac dm1, dm1, x5, x6, r8
-; CHECK-NEXT:    vldb.3d x5, [p1], d1; vshuffle x8, x7, x0, r18; vmac dm0, dm0, x3, x6, r8
-; CHECK-NEXT:    vldb x6, [p0], #64; vshuffle x6, x8, x0, r20; vmac dm3, dm3, x5, x10, r8
-; CHECK-NEXT:    vldb.3d x8, [p0], d0; mov srssign0, r19; vmac dm2, dm2, x3, x10, r8
-; CHECK-NEXT:    vsel.32 x2, x2, x1, r24; vmac dm1, dm1, x5, x6, r8
-; CHECK-NEXT:    vsel.32 x4, x4, x10, r24; vmac dm0, dm0, x3, x6, r8
-; CHECK-NEXT:    vlda.ups.2x cml3, s0, upssign1, [p2], #64
-; CHECK-NEXT:    vlda.ups.2x cmh3, s0, upssign1, [p2], #64
-; CHECK-NEXT:    vlda.ups.2x cml2, s0, upssign1, [p2], #64
-; CHECK-NEXT:    vlda.ups.2x cmh2, s0, upssign1, [p2], #64
-; CHECK-NEXT:    vlda.ups.2x cml1, s0, upssign1, [p2], #64; jnz r26, #.LBB0_1
-; CHECK-NEXT:    vlda.ups.2x cmh1, s0, upssign1, [p2], #64 // Delay Slot 5
-; CHECK-NEXT:    vlda.ups.2x cml0, s0, upssign1, [p2], #64; vst.srs.4x dm3, s1, srssign0, [p3], #64; vshuffle x10, x3, x0, r1 // Delay Slot 4
-; CHECK-NEXT:    vlda.ups.2x cmh0, s0, upssign1, [p2], #64; vst.srs.4x dm2, s1, srssign0, [p3], m5; vshuffle x10, x10, x0, r2 // Delay Slot 3
-; CHECK-NEXT:    vst.srs.4x dm1, s1, srssign0, [p3], #64; vshuffle x1, x5, x0, r3 // Delay Slot 2
-; CHECK-NEXT:    vst.2d.srs.4x dm0, s1, srssign0, [p3], d2; movx srssign0, #0; vshuffle x1, x1, x0, r4 // Delay Slot 1
+; CHECK-NEXT:    vlda.ups.2x cml3, s0, upssign1, [p2], #64; vldb x3, [p1], m4; vshuffle x10, x1, x0, r16; vmac dm1, dm1, x5, x6, r8
+; CHECK-NEXT:    vlda.ups.2x cmh3, s0, upssign1, [p2], #64; vldb.3d x5, [p1], d1; vshuffle x8, x7, x0, r18; vmac dm0, dm0, x3, x6, r8
+; CHECK-NEXT:    vlda.ups.2x cml2, s0, upssign1, [p2], #64; vldb x6, [p0], #64; vshuffle x6, x8, x0, r20; vmac dm3, dm3, x5, x10, r8
+; CHECK-NEXT:    vlda.ups.2x cmh2, s0, upssign1, [p2], #64; vldb.3d x8, [p0], d0; mov srssign0, r19; vmac dm2, dm2, x3, x10, r8
+; CHECK-NEXT:    vlda.ups.2x cml1, s0, upssign1, [p2], #64; vmac dm1, dm1, x5, x6, r8
+; CHECK-NEXT:    vlda.ups.2x cmh1, s0, upssign1, [p2], #64; vsel.32 x4, x4, x10, r24; vmac dm0, dm0, x3, x6, r8
+; CHECK-NEXT:    vlda.ups.2x cml0, s0, upssign1, [p2], #64; vsel.32 x2, x2, x1, r24
+; CHECK-NEXT:    vlda.ups.2x cmh0, s0, upssign1, [p2], #64; vshuffle x10, x3, x0, r1
+; CHECK-NEXT:    vst.srs.4x dm3, s1, srssign0, [p3], #64; vshuffle x1, x5, x0, r3
+; CHECK-NEXT:    vst.srs.4x dm2, s1, srssign0, [p3], m5; vshuffle x10, x10, x0, r2
+; CHECK-NEXT:    vst.srs.4x dm1, s1, srssign0, [p3], #64; vshuffle x1, x1, x0, r4
+; CHECK-NEXT:    vst.2d.srs.4x dm0, s1, srssign0, [p3], d2; movx srssign0, #0
+; CHECK-NEXT:    jnz r26, #.LBB0_1
+; CHECK-NEXT:    nop // Delay Slot 5
+; CHECK-NEXT:    nop // Delay Slot 4
+; CHECK-NEXT:    nop // Delay Slot 3
+; CHECK-NEXT:    nop // Delay Slot 2
+; CHECK-NEXT:    nop // Delay Slot 1
 ; CHECK-NEXT:  // %bb.4: // %cooldown.entry
 ; CHECK-NEXT:    vldb x3, [p1], m4; vmul dm4, x0, x4, r12
 ; CHECK-NEXT:    vlda.3d x1, [p1], d1
@@ -147,25 +149,25 @@ define dso_local void @gemm(i32 %0, ptr addrspace(5) %1, ptr addrspace(5) %2, pt
 ; CHECK-NEXT:  .L_LEnd0:
 ; CHECK-NEXT:    vlda.3d x8, [p0], d0; nopb ; nops ; nopx ; vshuffle x6, x3, x0, r7; vmac dm2, dm2, x8, x4, r8
 ; CHECK-NEXT:  // %bb.6: // %cooldown.exit
-; CHECK-NEXT:    lda p6, [sp, #-64]; nopb ; nops ; movx crsrsmode, #0; vshuffle x4, x6, x0, r16; vmac dm1, dm1, x10, x0, r8 // 4-byte Folded Reload
-; CHECK-NEXT:    paddxm [sp], #-64; nopb ; nops ; or r12, r25, r25; vshuffle x2, x1, x0, r18; vmac dm0, dm0, x8, x0, r8
-; CHECK-NEXT:    nopa ; or r10, r23, r23; vshuffle x0, x2, x0, r20; vmac dm3, dm3, x10, x4, r8
-; CHECK-NEXT:    vshuffle x6, x3, x0, r7; vmac dm2, dm2, x8, x4, r8
+; CHECK-NEXT:    lda p6, [sp, #-64]; nopb ; nops ; nopx ; vshuffle x4, x6, x0, r16; vmac dm1, dm1, x10, x0, r8 // 4-byte Folded Reload
+; CHECK-NEXT:    paddxm [sp], #-64; nopb ; nops ; movx crsrsmode, #0; vshuffle x2, x1, x0, r18; vmac dm0, dm0, x8, x0, r8
+; CHECK-NEXT:    or r12, r25, r25; vshuffle x0, x2, x0, r20; vmac dm3, dm3, x10, x4, r8
+; CHECK-NEXT:    or r10, r23, r23; vshuffle x6, x3, x0, r7; vmac dm2, dm2, x8, x4, r8
 ; CHECK-NEXT:    vshuffle x4, x6, x0, r16; vmac dm1, dm1, x10, x0, r8
 ; CHECK-NEXT:    vshuffle x2, x1, x0, r18; vmac dm0, dm0, x8, x0, r8
 ; CHECK-NEXT:    vshuffle x0, x2, x0, r20; vmac dm3, dm3, x10, x4, r8
 ; CHECK-NEXT:    mov s0, r17; vmac dm2, dm2, x8, x4, r8
 ; CHECK-NEXT:    mov srssign0, r19; vmac dm1, dm1, x10, x0, r8
 ; CHECK-NEXT:    vmac dm0, dm0, x8, x0, r8
-; CHECK-NEXT:    nop
+; CHECK-NEXT:    mov r8, r21
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    vst.srs.4x dm3, s0, srssign0, [p3], #64
 ; CHECK-NEXT:    vst.srs.4x dm2, s0, srssign0, [p3], m5; ret lr
 ; CHECK-NEXT:    vst.srs.4x dm1, s0, srssign0, [p3, #0] // Delay Slot 5
-; CHECK-NEXT:    vst.srs.4x dm0, s0, srssign0, [p3, #64] // Delay Slot 4
+; CHECK-NEXT:    vst.srs.4x dm0, s0, srssign0, [p3, #64]; movx srssign0, #0 // Delay Slot 4
 ; CHECK-NEXT:    nop // Delay Slot 3
 ; CHECK-NEXT:    nop // Delay Slot 2
-; CHECK-NEXT:    movx srssign0, #0; mov r8, r21 // Delay Slot 1
+; CHECK-NEXT:    nop // Delay Slot 1
 ;
 ; NO-PROLOGUE-SPLIT-LABEL: gemm:
 ; NO-PROLOGUE-SPLIT:       // %bb.0: // %newFuncRoot
@@ -238,31 +240,26 @@ define dso_local void @gemm(i32 %0, ptr addrspace(5) %1, ptr addrspace(5) %2, pt
 ; NO-PROLOGUE-SPLIT-NEXT:    nopa ; paddb.2d [p4], d7; movs p7, p2; add r0, r0, #-1; vshuffle x10, x1, x0, r16; vmac dm1, dm1, x5, x6, r8
 ; NO-PROLOGUE-SPLIT-NEXT:    padda [p7], m6; vldb.128 wl8, [p4, #0]; movs m0, p5; ne r26, r0, r22; vshuffle x8, x7, x0, r18; vmac dm0, dm0, x3, x6, r8
 ; NO-PROLOGUE-SPLIT-NEXT:    nopa ; vldb x10, [p1], m4; nops ; nopx ; vshuffle x6, x8, x0, r20; vmac dm3, dm3, x5, x10, r8
-; NO-PROLOGUE-SPLIT-NEXT:    vldb.3d x5, [p1], d1; vshuffle x1, x9, x0, r7; vmac dm2, dm2, x3, x10, r8
+; NO-PROLOGUE-SPLIT-NEXT:    nopa ; vldb.3d x5, [p1], d1; nopx ; vshuffle x1, x9, x0, r7; vmac dm2, dm2, x3, x10, r8
 ; NO-PROLOGUE-SPLIT-NEXT:    vlda x6, [p0], #64; vldb.128 wl3, [p4, #16]; vshuffle x10, x1, x0, r16; vmac dm1, dm1, x5, x6, r8
-; NO-PROLOGUE-SPLIT-NEXT:    vldb.3d x1, [p0], d0; vshuffle x8, x7, x0, r18; vmac dm0, dm0, x3, x6, r8
-; NO-PROLOGUE-SPLIT-NEXT:    vshuffle x6, x8, x0, r20; vmac dm3, dm3, x5, x10, r8
-; NO-PROLOGUE-SPLIT-NEXT:    mov srssign0, r19; vmac dm2, dm2, x3, x10, r8
-; NO-PROLOGUE-SPLIT-NEXT:    vsel.32 x2, x2, x8, r24; vmac dm1, dm1, x5, x6, r8
-; NO-PROLOGUE-SPLIT-NEXT:    vshuffle x8, x10, x0, r1; vmac dm0, dm0, x3, x6, r8
-; NO-PROLOGUE-SPLIT-NEXT:    vlda.ups.2x cml3, s0, upssign1, [p2, dj2]
-; NO-PROLOGUE-SPLIT-NEXT:    vlda.ups.2x cmh3, s0, upssign1, [p7], #64
-; NO-PROLOGUE-SPLIT-NEXT:    vlda.ups.2x cml2, s0, upssign1, [p7], #64
-; NO-PROLOGUE-SPLIT-NEXT:    vlda.ups.2x cmh2, s0, upssign1, [p7], #64
-; NO-PROLOGUE-SPLIT-NEXT:    vlda.ups.2x cml1, s0, upssign1, [p7], #64
-; NO-PROLOGUE-SPLIT-NEXT:    vlda.ups.2x cmh1, s0, upssign1, [p7], #64
-; NO-PROLOGUE-SPLIT-NEXT:    vlda.ups.2x cmh0, s0, upssign1, [p7, #64]
-; NO-PROLOGUE-SPLIT-NEXT:    vlda.ups.2x cml0, s0, upssign1, [p7, #0]
-; NO-PROLOGUE-SPLIT-NEXT:    vst.srs.4x dm3, s1, srssign0, [p3], #64; vshuffle x8, x8, x0, r2; vmul dm4, x0, x2, r12
-; NO-PROLOGUE-SPLIT-NEXT:    vsel.32 x4, x4, x3, r24
+; NO-PROLOGUE-SPLIT-NEXT:    vlda.ups.2x cmh3, s0, upssign1, [p7], #64; vldb.3d x1, [p0], d0; vshuffle x8, x7, x0, r18; vmac dm0, dm0, x3, x6, r8
+; NO-PROLOGUE-SPLIT-NEXT:    vlda.ups.2x cml3, s0, upssign1, [p2, dj2]; movs p2, p6; vshuffle x6, x8, x0, r20; vmac dm3, dm3, x5, x10, r8
+; NO-PROLOGUE-SPLIT-NEXT:    vlda.ups.2x cml2, s0, upssign1, [p7], #64; mov srssign0, r19; vmac dm2, dm2, x3, x10, r8
+; NO-PROLOGUE-SPLIT-NEXT:    vlda.ups.2x cmh2, s0, upssign1, [p7], #64; vsel.32 x2, x2, x8, r24; vmac dm1, dm1, x5, x6, r8
+; NO-PROLOGUE-SPLIT-NEXT:    vlda.ups.2x cml1, s0, upssign1, [p7], #64; vshuffle x8, x10, x0, r1; vmac dm0, dm0, x3, x6, r8
+; NO-PROLOGUE-SPLIT-NEXT:    vlda.ups.2x cmh1, s0, upssign1, [p7], #64; vmul dm4, x0, x2, r12
+; NO-PROLOGUE-SPLIT-NEXT:    vlda.ups.2x cmh0, s0, upssign1, [p7, #64]; vshuffle x8, x8, x0, r2
+; NO-PROLOGUE-SPLIT-NEXT:    vlda.ups.2x cml0, s0, upssign1, [p7, #0]; vst.srs.4x dm3, s1, srssign0, [p3], #64; vsel.32 x4, x4, x3, r24
 ; NO-PROLOGUE-SPLIT-NEXT:    vst.srs.4x dm2, s1, srssign0, [p3], m5; vshuffle x10, x5, x0, r3; vaddmac dm3, dm3, dm4, x6, x8, r10
-; NO-PROLOGUE-SPLIT-NEXT:    vshuffle x8, x10, x0, r4; vmul dm4, x0, x4, r12
-; NO-PROLOGUE-SPLIT-NEXT:    vst.srs.4x dm1, s1, srssign0, [p3], #64; jnz r26, #.LBB0_1; vaddmac dm2, dm2, dm4, x1, x8, r10
+; NO-PROLOGUE-SPLIT-NEXT:    vst.srs.4x dm1, s1, srssign0, [p3], #64; vshuffle x8, x10, x0, r4; vaddmac dm2, dm2, dm4, x1, x8, r10
+; NO-PROLOGUE-SPLIT-NEXT:    vst.2d.srs.4x dm0, s1, srssign0, [p3], d3; movx srssign0, #0; vmul dm4, x0, x4, r12
+; NO-PROLOGUE-SPLIT-NEXT:    nop
+; NO-PROLOGUE-SPLIT-NEXT:    jnz r26, #.LBB0_1; vaddmac dm1, dm1, dm4, x6, x8, r10
 ; NO-PROLOGUE-SPLIT-NEXT:    vaddmac dm0, dm0, dm4, x1, x8, r10 // Delay Slot 5
-; NO-PROLOGUE-SPLIT-NEXT:    vst.2d.srs.4x dm0, s1, srssign0, [p3], d3 // Delay Slot 4
-; NO-PROLOGUE-SPLIT-NEXT:    vaddmac dm1, dm1, dm4, x6, x8, r10 // Delay Slot 3
+; NO-PROLOGUE-SPLIT-NEXT:    nop // Delay Slot 4
+; NO-PROLOGUE-SPLIT-NEXT:    nop // Delay Slot 3
 ; NO-PROLOGUE-SPLIT-NEXT:    nop // Delay Slot 2
-; NO-PROLOGUE-SPLIT-NEXT:    movx srssign0, #0; mov p2, p6 // Delay Slot 1
+; NO-PROLOGUE-SPLIT-NEXT:    nop // Delay Slot 1
 ; NO-PROLOGUE-SPLIT-NEXT:  // %bb.4: // %cooldown.entry
 ; NO-PROLOGUE-SPLIT-NEXT:    vldb x3, [p1], m4
 ; NO-PROLOGUE-SPLIT-NEXT:    vlda.3d x1, [p1], d1
@@ -284,25 +281,25 @@ define dso_local void @gemm(i32 %0, ptr addrspace(5) %1, ptr addrspace(5) %2, pt
 ; NO-PROLOGUE-SPLIT-NEXT:  .L_LEnd0:
 ; NO-PROLOGUE-SPLIT-NEXT:    vlda.3d x8, [p0], d0; nopb ; nops ; nopx ; vshuffle x6, x3, x0, r7; vmac dm2, dm2, x8, x4, r8
 ; NO-PROLOGUE-SPLIT-NEXT:  // %bb.6: // %cooldown.exit
-; NO-PROLOGUE-SPLIT-NEXT:    lda p7, [sp, #-60]; nopb ; nops ; movx crsrsmode, #0; vshuffle x4, x6, x0, r16; vmac dm1, dm1, x10, x0, r8 // 4-byte Folded Reload
-; NO-PROLOGUE-SPLIT-NEXT:    lda p6, [sp, #-64]; nopb ; nops ; or r12, r25, r25; vshuffle x2, x1, x0, r18; vmac dm0, dm0, x8, x0, r8 // 4-byte Folded Reload
-; NO-PROLOGUE-SPLIT-NEXT:    paddxm [sp], #-64; or r10, r23, r23; vshuffle x0, x2, x0, r20; vmac dm3, dm3, x10, x4, r8
-; NO-PROLOGUE-SPLIT-NEXT:    vshuffle x6, x3, x0, r7; vmac dm2, dm2, x8, x4, r8
+; NO-PROLOGUE-SPLIT-NEXT:    lda p7, [sp, #-60]; nopb ; nops ; nopx ; vshuffle x4, x6, x0, r16; vmac dm1, dm1, x10, x0, r8 // 4-byte Folded Reload
+; NO-PROLOGUE-SPLIT-NEXT:    lda p6, [sp, #-64]; nopb ; movx crsrsmode, #0; vshuffle x2, x1, x0, r18; vmac dm0, dm0, x8, x0, r8 // 4-byte Folded Reload
+; NO-PROLOGUE-SPLIT-NEXT:    paddxm [sp], #-64; or r12, r25, r25; vshuffle x0, x2, x0, r20; vmac dm3, dm3, x10, x4, r8
+; NO-PROLOGUE-SPLIT-NEXT:    or r10, r23, r23; vshuffle x6, x3, x0, r7; vmac dm2, dm2, x8, x4, r8
 ; NO-PROLOGUE-SPLIT-NEXT:    vshuffle x4, x6, x0, r16; vmac dm1, dm1, x10, x0, r8
 ; NO-PROLOGUE-SPLIT-NEXT:    vshuffle x2, x1, x0, r18; vmac dm0, dm0, x8, x0, r8
 ; NO-PROLOGUE-SPLIT-NEXT:    vshuffle x0, x2, x0, r20; vmac dm3, dm3, x10, x4, r8
 ; NO-PROLOGUE-SPLIT-NEXT:    mov s0, r17; vmac dm2, dm2, x8, x4, r8
 ; NO-PROLOGUE-SPLIT-NEXT:    mov srssign0, r19; vmac dm1, dm1, x10, x0, r8
 ; NO-PROLOGUE-SPLIT-NEXT:    vmac dm0, dm0, x8, x0, r8
-; NO-PROLOGUE-SPLIT-NEXT:    nop
+; NO-PROLOGUE-SPLIT-NEXT:    mov r8, r21
 ; NO-PROLOGUE-SPLIT-NEXT:    nop
 ; NO-PROLOGUE-SPLIT-NEXT:    vst.srs.4x dm3, s0, srssign0, [p3], #64
 ; NO-PROLOGUE-SPLIT-NEXT:    vst.srs.4x dm2, s0, srssign0, [p3], m5; ret lr
 ; NO-PROLOGUE-SPLIT-NEXT:    vst.srs.4x dm1, s0, srssign0, [p3, #0] // Delay Slot 5
-; NO-PROLOGUE-SPLIT-NEXT:    vst.srs.4x dm0, s0, srssign0, [p3, #64] // Delay Slot 4
+; NO-PROLOGUE-SPLIT-NEXT:    vst.srs.4x dm0, s0, srssign0, [p3, #64]; movx srssign0, #0 // Delay Slot 4
 ; NO-PROLOGUE-SPLIT-NEXT:    nop // Delay Slot 3
 ; NO-PROLOGUE-SPLIT-NEXT:    nop // Delay Slot 2
-; NO-PROLOGUE-SPLIT-NEXT:    movx srssign0, #0; mov r8, r21 // Delay Slot 1
+; NO-PROLOGUE-SPLIT-NEXT:    nop // Delay Slot 1
 ;
 ; USE-JNZD-LABEL: gemm:
 ; USE-JNZD:       // %bb.0: // %newFuncRoot
@@ -368,26 +365,23 @@ define dso_local void @gemm(i32 %0, ptr addrspace(5) %1, ptr addrspace(5) %2, pt
 ; USE-JNZD-NEXT:    vlda.3d x3, [p0], d0; nopb ; nops ; nopx ; vshuffle x1, x9, x0, r7; vmac dm2, dm2, x3, x10, r8
 ; USE-JNZD-NEXT:  // %bb.3: // %for.cond.cleanup99
 ; USE-JNZD-NEXT:    // in Loop: Header=BB0_1 Depth=1
-; USE-JNZD-NEXT:    nopa ; paddb.2d [p4], d3; movs m0, p5; nopx ; vshuffle x10, x1, x0, r16; vmac dm1, dm1, x5, x6, r8
-; USE-JNZD-NEXT:    nopa ; vldb.128 wl1, [p4, #16]; nops ; nopx ; vshuffle x8, x7, x0, r18; vmac dm0, dm0, x3, x6, r8
-; USE-JNZD-NEXT:    vldb.128 wl10, [p4, #0]; nopx ; vshuffle x6, x8, x0, r20; vmac dm3, dm3, x5, x10, r8
+; USE-JNZD-NEXT:    movs m0, p5; paddb.2d [p4], d3; nopx ; vshuffle x10, x1, x0, r16; vmac dm1, dm1, x5, x6, r8
+; USE-JNZD-NEXT:    vldb.128 wl1, [p4, #16]; vshuffle x8, x7, x0, r18; vmac dm0, dm0, x3, x6, r8
+; USE-JNZD-NEXT:    vldb.128 wl10, [p4, #0]; vshuffle x6, x8, x0, r20; vmac dm3, dm3, x5, x10, r8
 ; USE-JNZD-NEXT:    vshuffle x1, x9, x0, r7; vmac dm2, dm2, x3, x10, r8
-; USE-JNZD-NEXT:    vldb x3, [p1], m4; vshuffle x10, x1, x0, r16; vmac dm1, dm1, x5, x6, r8
-; USE-JNZD-NEXT:    vldb.3d x5, [p1], d1; vshuffle x8, x7, x0, r18; vmac dm0, dm0, x3, x6, r8
-; USE-JNZD-NEXT:    vldb x6, [p0], #64; vshuffle x6, x8, x0, r20; vmac dm3, dm3, x5, x10, r8
-; USE-JNZD-NEXT:    vldb.3d x8, [p0], d0; mov srssign0, r19; vmac dm2, dm2, x3, x10, r8
-; USE-JNZD-NEXT:    vsel.32 x2, x2, x1, r22; vmac dm1, dm1, x5, x6, r8
-; USE-JNZD-NEXT:    vsel.32 x4, x4, x10, r22; vmac dm0, dm0, x3, x6, r8
-; USE-JNZD-NEXT:    vlda.ups.2x cml3, s0, upssign1, [p2], #64
-; USE-JNZD-NEXT:    vlda.ups.2x cmh3, s0, upssign1, [p2], #64
-; USE-JNZD-NEXT:    vlda.ups.2x cml2, s0, upssign1, [p2], #64
-; USE-JNZD-NEXT:    vlda.ups.2x cmh2, s0, upssign1, [p2], #64
-; USE-JNZD-NEXT:    vlda.ups.2x cml1, s0, upssign1, [p2], #64; jnzd r5, r5, p6
-; USE-JNZD-NEXT:    vlda.ups.2x cmh1, s0, upssign1, [p2], #64 // Delay Slot 5
-; USE-JNZD-NEXT:    vlda.ups.2x cml0, s0, upssign1, [p2], #64; vst.srs.4x dm3, s1, srssign0, [p3], #64; vshuffle x10, x3, x0, r1 // Delay Slot 4
-; USE-JNZD-NEXT:    vlda.ups.2x cmh0, s0, upssign1, [p2], #64; vst.srs.4x dm2, s1, srssign0, [p3], m5; vshuffle x1, x10, x0, r2 // Delay Slot 3
-; USE-JNZD-NEXT:    vst.srs.4x dm1, s1, srssign0, [p3], #64; vshuffle x10, x5, x0, r3 // Delay Slot 2
-; USE-JNZD-NEXT:    vst.2d.srs.4x dm0, s1, srssign0, [p3], d2; movx srssign0, #0; vshuffle x10, x10, x0, r4 // Delay Slot 1
+; USE-JNZD-NEXT:    vlda.ups.2x cml3, s0, upssign1, [p2], #64; vldb x3, [p1], m4; vshuffle x10, x1, x0, r16; vmac dm1, dm1, x5, x6, r8
+; USE-JNZD-NEXT:    vlda.ups.2x cmh3, s0, upssign1, [p2], #64; vldb.3d x5, [p1], d1; vshuffle x8, x7, x0, r18; vmac dm0, dm0, x3, x6, r8
+; USE-JNZD-NEXT:    vlda.ups.2x cml2, s0, upssign1, [p2], #64; vldb x6, [p0], #64; vshuffle x6, x8, x0, r20; vmac dm3, dm3, x5, x10, r8
+; USE-JNZD-NEXT:    vlda.ups.2x cmh2, s0, upssign1, [p2], #64; vldb.3d x8, [p0], d0; mov srssign0, r19; vmac dm2, dm2, x3, x10, r8
+; USE-JNZD-NEXT:    vlda.ups.2x cml1, s0, upssign1, [p2], #64; vsel.32 x2, x2, x1, r22; vmac dm1, dm1, x5, x6, r8
+; USE-JNZD-NEXT:    vlda.ups.2x cmh1, s0, upssign1, [p2], #64; vsel.32 x4, x4, x10, r22; vmac dm0, dm0, x3, x6, r8
+; USE-JNZD-NEXT:    vlda.ups.2x cml0, s0, upssign1, [p2], #64
+; USE-JNZD-NEXT:    vlda.ups.2x cmh0, s0, upssign1, [p2], #64; jnzd r5, r5, p6; vshuffle x10, x3, x0, r1
+; USE-JNZD-NEXT:    vst.srs.4x dm3, s1, srssign0, [p3], #64; vshuffle x1, x10, x0, r2 // Delay Slot 5
+; USE-JNZD-NEXT:    vst.srs.4x dm2, s1, srssign0, [p3], m5; vshuffle x10, x5, x0, r3 // Delay Slot 4
+; USE-JNZD-NEXT:    vst.srs.4x dm1, s1, srssign0, [p3], #64; vshuffle x10, x10, x0, r4 // Delay Slot 3
+; USE-JNZD-NEXT:    vst.2d.srs.4x dm0, s1, srssign0, [p3], d2; movx srssign0, #0 // Delay Slot 2
+; USE-JNZD-NEXT:    nop // Delay Slot 1
 ; USE-JNZD-NEXT:  // %bb.4: // %cooldown.entry
 ; USE-JNZD-NEXT:    vldb x3, [p1], m4
 ; USE-JNZD-NEXT:    vlda.3d x1, [p1], d1; vmul dm4, x0, x4, r12
@@ -409,25 +403,25 @@ define dso_local void @gemm(i32 %0, ptr addrspace(5) %1, ptr addrspace(5) %2, pt
 ; USE-JNZD-NEXT:  .L_LEnd0:
 ; USE-JNZD-NEXT:    vlda.3d x8, [p0], d0; nopb ; nops ; nopx ; vshuffle x6, x3, x0, r7; vmac dm2, dm2, x8, x4, r8
 ; USE-JNZD-NEXT:  // %bb.6: // %cooldown.exit
-; USE-JNZD-NEXT:    lda p6, [sp, #-64]; nopb ; nops ; movx crsrsmode, #0; vshuffle x4, x6, x0, r16; vmac dm1, dm1, x10, x0, r8 // 4-byte Folded Reload
-; USE-JNZD-NEXT:    paddxm [sp], #-64; nopb ; nops ; or r12, r24, r24; vshuffle x2, x1, x0, r18; vmac dm0, dm0, x8, x0, r8
-; USE-JNZD-NEXT:    nopa ; or r10, r23, r23; vshuffle x0, x2, x0, r20; vmac dm3, dm3, x10, x4, r8
-; USE-JNZD-NEXT:    vshuffle x6, x3, x0, r7; vmac dm2, dm2, x8, x4, r8
+; USE-JNZD-NEXT:    lda p6, [sp, #-64]; nopb ; nops ; nopx ; vshuffle x4, x6, x0, r16; vmac dm1, dm1, x10, x0, r8 // 4-byte Folded Reload
+; USE-JNZD-NEXT:    paddxm [sp], #-64; nopb ; nops ; movx crsrsmode, #0; vshuffle x2, x1, x0, r18; vmac dm0, dm0, x8, x0, r8
+; USE-JNZD-NEXT:    or r12, r24, r24; vshuffle x0, x2, x0, r20; vmac dm3, dm3, x10, x4, r8
+; USE-JNZD-NEXT:    or r10, r23, r23; vshuffle x6, x3, x0, r7; vmac dm2, dm2, x8, x4, r8
 ; USE-JNZD-NEXT:    vshuffle x4, x6, x0, r16; vmac dm1, dm1, x10, x0, r8
 ; USE-JNZD-NEXT:    vshuffle x2, x1, x0, r18; vmac dm0, dm0, x8, x0, r8
 ; USE-JNZD-NEXT:    vshuffle x0, x2, x0, r20; vmac dm3, dm3, x10, x4, r8
 ; USE-JNZD-NEXT:    mov s0, r17; vmac dm2, dm2, x8, x4, r8
 ; USE-JNZD-NEXT:    mov srssign0, r19; vmac dm1, dm1, x10, x0, r8
 ; USE-JNZD-NEXT:    vmac dm0, dm0, x8, x0, r8
-; USE-JNZD-NEXT:    nop
+; USE-JNZD-NEXT:    mov r8, r21
 ; USE-JNZD-NEXT:    nop
 ; USE-JNZD-NEXT:    vst.srs.4x dm3, s0, srssign0, [p3], #64
 ; USE-JNZD-NEXT:    vst.srs.4x dm2, s0, srssign0, [p3], m5; ret lr
 ; USE-JNZD-NEXT:    vst.srs.4x dm1, s0, srssign0, [p3, #0] // Delay Slot 5
-; USE-JNZD-NEXT:    vst.srs.4x dm0, s0, srssign0, [p3, #64] // Delay Slot 4
+; USE-JNZD-NEXT:    vst.srs.4x dm0, s0, srssign0, [p3, #64]; movx srssign0, #0 // Delay Slot 4
 ; USE-JNZD-NEXT:    nop // Delay Slot 3
 ; USE-JNZD-NEXT:    nop // Delay Slot 2
-; USE-JNZD-NEXT:    movx srssign0, #0; mov r8, r21 // Delay Slot 1
+; USE-JNZD-NEXT:    nop // Delay Slot 1
 newFuncRoot:
   br label %for.body
 

--- a/llvm/test/CodeGen/AIE/aie2ps/end-to-end/gemm_int8_outerloop_pipelined-aa.ll
+++ b/llvm/test/CodeGen/AIE/aie2ps/end-to-end/gemm_int8_outerloop_pipelined-aa.ll
@@ -106,33 +106,30 @@ define dso_local void @gemm(i32 %0, ptr addrspace(5) %1, ptr addrspace(5) %2, pt
 ; CHECK-NEXT:  // %bb.3: // %for.cond.cleanup99
 ; CHECK-NEXT:    // in Loop: Header=BB0_1 Depth=1
 ; CHECK-NEXT:    padda [p2], m5; paddb.2d [p4], d7; movs m0, p5; add r0, r0, #-1; vshuffle x10, x1, x0, r16; vmac dm1, dm1, x5, x6, r8
-; CHECK-NEXT:    movs p6, p2; vldb x8, [p0], #64; vshuffle x8, x7, x0, r18; vmac dm0, dm0, x3, x6, r8
-; CHECK-NEXT:    vldb x10, [p1], m4; vshuffle x6, x8, x0, r20; vmac dm3, dm3, x5, x10, r8
-; CHECK-NEXT:    vldb.3d x5, [p1], d1; vshuffle x1, x9, x0, r7; vmac dm2, dm2, x3, x10, r8
+; CHECK-NEXT:    nopa ; vldb x8, [p0], #64; movs p6, p2; nopx ; vshuffle x8, x7, x0, r18; vmac dm0, dm0, x3, x6, r8
+; CHECK-NEXT:    nopa ; vldb x10, [p1], m4; nops ; nopx ; vshuffle x6, x8, x0, r20; vmac dm3, dm3, x5, x10, r8
+; CHECK-NEXT:    nopa ; vldb.3d x5, [p1], d1; nopx ; vshuffle x1, x9, x0, r7; vmac dm2, dm2, x3, x10, r8
 ; CHECK-NEXT:    vlda.3d x1, [p0], d0; vldb.128 wl6, [p4, #0]; vshuffle x10, x1, x0, r16; vmac dm1, dm1, x5, x6, r8
-; CHECK-NEXT:    vldb.128 wl3, [p4, #16]; vshuffle x8, x7, x0, r18; vmac dm0, dm0, x3, x6, r8
-; CHECK-NEXT:    vshuffle x6, x8, x0, r20; vmac dm3, dm3, x5, x10, r8
-; CHECK-NEXT:    mov srssign0, r19; vmac dm2, dm2, x3, x10, r8
-; CHECK-NEXT:    vmac dm1, dm1, x5, x6, r8
-; CHECK-NEXT:    vmac dm0, dm0, x3, x6, r8
-; CHECK-NEXT:    vlda.ups.2x cml3, s0, upssign1, [p6], #64
-; CHECK-NEXT:    vlda.ups.2x cmh3, s0, upssign1, [p6], #64
-; CHECK-NEXT:    vlda.ups.2x cml2, s0, upssign1, [p6], #64
-; CHECK-NEXT:    vlda.ups.2x cmh2, s0, upssign1, [p6], #64
-; CHECK-NEXT:    vlda.ups.2x cml1, s0, upssign1, [p6], #64
+; CHECK-NEXT:    vlda.ups.2x cml3, s0, upssign1, [p6], #64; vldb.128 wl3, [p4, #16]; vshuffle x8, x7, x0, r18; vmac dm0, dm0, x3, x6, r8
+; CHECK-NEXT:    vlda.ups.2x cmh3, s0, upssign1, [p6], #64; vshuffle x6, x8, x0, r20; vmac dm3, dm3, x5, x10, r8
+; CHECK-NEXT:    vlda.ups.2x cml2, s0, upssign1, [p6], #64; mov srssign0, r19; vmac dm2, dm2, x3, x10, r8
+; CHECK-NEXT:    vlda.ups.2x cmh2, s0, upssign1, [p6], #64; vmac dm1, dm1, x5, x6, r8
+; CHECK-NEXT:    vlda.ups.2x cml1, s0, upssign1, [p6], #64; vmac dm0, dm0, x3, x6, r8
 ; CHECK-NEXT:    vlda.ups.2x cmh1, s0, upssign1, [p6], #64
 ; CHECK-NEXT:    vlda.ups.2x cmh0, s0, upssign1, [p6, #64]; vsel.32 x2, x2, x6, r22
-; CHECK-NEXT:    vlda.ups.2x cml0, s0, upssign1, [p6, #0]; vshuffle x6, x10, x0, r1
-; CHECK-NEXT:    vst.srs.4x dm3, s1, srssign0, [p3], #64; vshuffle x6, x6, x0, r2; vmul dm4, x0, x2, r10
-; CHECK-NEXT:    vsel.32 x4, x4, x3, r22
-; CHECK-NEXT:    vst.srs.4x dm2, s1, srssign0, [p3], m2; vshuffle x10, x5, x0, r3; vaddmac dm3, dm3, dm4, x8, x6, r12
-; CHECK-NEXT:    vshuffle x6, x10, x0, r4; vmul dm4, x0, x4, r10
-; CHECK-NEXT:    vst.srs.4x dm1, s1, srssign0, [p3], #64; jnz r0, #.LBB0_1; vaddmac dm2, dm2, dm4, x1, x6, r12
+; CHECK-NEXT:    vlda.ups.2x cml0, s0, upssign1, [p6, #0]; vst.srs.4x dm3, s1, srssign0, [p3], #64; vshuffle x6, x10, x0, r1
+; CHECK-NEXT:    vst.srs.4x dm2, s1, srssign0, [p3], m2; vshuffle x6, x6, x0, r2; vmul dm4, x0, x2, r10
+; CHECK-NEXT:    vst.srs.4x dm1, s1, srssign0, [p3], #64; vsel.32 x4, x4, x3, r22
+; CHECK-NEXT:    vst.2d.srs.4x dm0, s1, srssign0, [p3], d3; movx srssign0, #0; vshuffle x10, x5, x0, r3; vaddmac dm3, dm3, dm4, x8, x6, r12
+; CHECK-NEXT:    vshuffle x6, x10, x0, r4; vaddmac dm2, dm2, dm4, x1, x6, r12
+; CHECK-NEXT:    vmul dm4, x0, x4, r10
+; CHECK-NEXT:    nop
+; CHECK-NEXT:    jnz r0, #.LBB0_1; vaddmac dm1, dm1, dm4, x8, x6, r12
 ; CHECK-NEXT:    vaddmac dm0, dm0, dm4, x1, x6, r12 // Delay Slot 5
-; CHECK-NEXT:    vst.2d.srs.4x dm0, s1, srssign0, [p3], d3 // Delay Slot 4
-; CHECK-NEXT:    vaddmac dm1, dm1, dm4, x8, x6, r12 // Delay Slot 3
+; CHECK-NEXT:    nop // Delay Slot 4
+; CHECK-NEXT:    nop // Delay Slot 3
 ; CHECK-NEXT:    nop // Delay Slot 2
-; CHECK-NEXT:    movx srssign0, #0 // Delay Slot 1
+; CHECK-NEXT:    nop // Delay Slot 1
 ; CHECK-NEXT:  // %bb.4: // %cooldown.entry
 ; CHECK-NEXT:    vldb x3, [p1], m4
 ; CHECK-NEXT:    vlda.3d x1, [p1], d1
@@ -154,25 +151,25 @@ define dso_local void @gemm(i32 %0, ptr addrspace(5) %1, ptr addrspace(5) %2, pt
 ; CHECK-NEXT:  .L_LEnd0:
 ; CHECK-NEXT:    vlda.3d x8, [p0], d0; nopb ; nops ; nopx ; vshuffle x6, x3, x0, r7; vmac dm2, dm2, x8, x4, r8
 ; CHECK-NEXT:  // %bb.6: // %cooldown.exit
-; CHECK-NEXT:    lda p7, [sp, #-60]; nopb ; nops ; movx crsrsmode, #0; vshuffle x4, x6, x0, r16; vmac dm1, dm1, x10, x0, r8 // 4-byte Folded Reload
-; CHECK-NEXT:    lda p6, [sp, #-64]; nopb ; nops ; or r12, r24, r24; vshuffle x2, x1, x0, r18; vmac dm0, dm0, x8, x0, r8 // 4-byte Folded Reload
-; CHECK-NEXT:    paddxm [sp], #-64; or r10, r23, r23; vshuffle x0, x2, x0, r20; vmac dm3, dm3, x10, x4, r8
-; CHECK-NEXT:    vshuffle x6, x3, x0, r7; vmac dm2, dm2, x8, x4, r8
+; CHECK-NEXT:    lda p7, [sp, #-60]; nopb ; nops ; nopx ; vshuffle x4, x6, x0, r16; vmac dm1, dm1, x10, x0, r8 // 4-byte Folded Reload
+; CHECK-NEXT:    lda p6, [sp, #-64]; nopb ; movx crsrsmode, #0; vshuffle x2, x1, x0, r18; vmac dm0, dm0, x8, x0, r8 // 4-byte Folded Reload
+; CHECK-NEXT:    paddxm [sp], #-64; or r12, r24, r24; vshuffle x0, x2, x0, r20; vmac dm3, dm3, x10, x4, r8
+; CHECK-NEXT:    or r10, r23, r23; vshuffle x6, x3, x0, r7; vmac dm2, dm2, x8, x4, r8
 ; CHECK-NEXT:    vshuffle x4, x6, x0, r16; vmac dm1, dm1, x10, x0, r8
 ; CHECK-NEXT:    vshuffle x2, x1, x0, r18; vmac dm0, dm0, x8, x0, r8
 ; CHECK-NEXT:    vshuffle x0, x2, x0, r20; vmac dm3, dm3, x10, x4, r8
 ; CHECK-NEXT:    mov s0, r17; vmac dm2, dm2, x8, x4, r8
 ; CHECK-NEXT:    mov srssign0, r19; vmac dm1, dm1, x10, x0, r8
 ; CHECK-NEXT:    vmac dm0, dm0, x8, x0, r8
-; CHECK-NEXT:    nop
+; CHECK-NEXT:    mov r8, r21
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    vst.srs.4x dm3, s0, srssign0, [p3], #64
 ; CHECK-NEXT:    vst.srs.4x dm2, s0, srssign0, [p3], m2; ret lr
 ; CHECK-NEXT:    vst.srs.4x dm1, s0, srssign0, [p3, #0] // Delay Slot 5
-; CHECK-NEXT:    vst.srs.4x dm0, s0, srssign0, [p3, #64] // Delay Slot 4
+; CHECK-NEXT:    vst.srs.4x dm0, s0, srssign0, [p3, #64]; movx srssign0, #0 // Delay Slot 4
 ; CHECK-NEXT:    nop // Delay Slot 3
 ; CHECK-NEXT:    nop // Delay Slot 2
-; CHECK-NEXT:    movx srssign0, #0; mov r8, r21 // Delay Slot 1
+; CHECK-NEXT:    nop // Delay Slot 1
 newFuncRoot:
   br label %for.body.peel.pro
 

--- a/llvm/test/CodeGen/AIE/aie2ps/end-to-end/gemm_int8_outerloop_pipelined.ll
+++ b/llvm/test/CodeGen/AIE/aie2ps/end-to-end/gemm_int8_outerloop_pipelined.ll
@@ -107,33 +107,30 @@ define dso_local void @gemm(i32 %0, ptr addrspace(5) %1, ptr addrspace(5) %2, pt
 ; CHECK-NEXT:  // %bb.3: // %for.cond.cleanup99
 ; CHECK-NEXT:    // in Loop: Header=BB0_1 Depth=1
 ; CHECK-NEXT:    padda [p2], m5; paddb.2d [p4], d7; movs m0, p5; add r0, r0, #-1; vshuffle x10, x1, x0, r16; vmac dm1, dm1, x5, x6, r8
-; CHECK-NEXT:    movs p6, p2; vldb x8, [p0], #64; vshuffle x8, x7, x0, r18; vmac dm0, dm0, x3, x6, r8
-; CHECK-NEXT:    vldb x10, [p1], m4; vshuffle x6, x8, x0, r20; vmac dm3, dm3, x5, x10, r8
-; CHECK-NEXT:    vldb.3d x5, [p1], d1; vshuffle x1, x9, x0, r7; vmac dm2, dm2, x3, x10, r8
+; CHECK-NEXT:    nopa ; vldb x8, [p0], #64; movs p6, p2; nopx ; vshuffle x8, x7, x0, r18; vmac dm0, dm0, x3, x6, r8
+; CHECK-NEXT:    nopa ; vldb x10, [p1], m4; nops ; nopx ; vshuffle x6, x8, x0, r20; vmac dm3, dm3, x5, x10, r8
+; CHECK-NEXT:    nopa ; vldb.3d x5, [p1], d1; nopx ; vshuffle x1, x9, x0, r7; vmac dm2, dm2, x3, x10, r8
 ; CHECK-NEXT:    vlda.3d x1, [p0], d0; vldb.128 wl6, [p4, #0]; vshuffle x10, x1, x0, r16; vmac dm1, dm1, x5, x6, r8
-; CHECK-NEXT:    vldb.128 wl3, [p4, #16]; vshuffle x8, x7, x0, r18; vmac dm0, dm0, x3, x6, r8
-; CHECK-NEXT:    vshuffle x6, x8, x0, r20; vmac dm3, dm3, x5, x10, r8
-; CHECK-NEXT:    mov srssign0, r19; vmac dm2, dm2, x3, x10, r8
-; CHECK-NEXT:    vmac dm1, dm1, x5, x6, r8
-; CHECK-NEXT:    vmac dm0, dm0, x3, x6, r8
-; CHECK-NEXT:    vlda.ups.2x cml3, s0, upssign1, [p6], #64
-; CHECK-NEXT:    vlda.ups.2x cmh3, s0, upssign1, [p6], #64
-; CHECK-NEXT:    vlda.ups.2x cml2, s0, upssign1, [p6], #64
-; CHECK-NEXT:    vlda.ups.2x cmh2, s0, upssign1, [p6], #64
-; CHECK-NEXT:    vlda.ups.2x cml1, s0, upssign1, [p6], #64
+; CHECK-NEXT:    vlda.ups.2x cml3, s0, upssign1, [p6], #64; vldb.128 wl3, [p4, #16]; vshuffle x8, x7, x0, r18; vmac dm0, dm0, x3, x6, r8
+; CHECK-NEXT:    vlda.ups.2x cmh3, s0, upssign1, [p6], #64; vshuffle x6, x8, x0, r20; vmac dm3, dm3, x5, x10, r8
+; CHECK-NEXT:    vlda.ups.2x cml2, s0, upssign1, [p6], #64; mov srssign0, r19; vmac dm2, dm2, x3, x10, r8
+; CHECK-NEXT:    vlda.ups.2x cmh2, s0, upssign1, [p6], #64; vmac dm1, dm1, x5, x6, r8
+; CHECK-NEXT:    vlda.ups.2x cml1, s0, upssign1, [p6], #64; vmac dm0, dm0, x3, x6, r8
 ; CHECK-NEXT:    vlda.ups.2x cmh1, s0, upssign1, [p6], #64
 ; CHECK-NEXT:    vlda.ups.2x cmh0, s0, upssign1, [p6, #64]; vsel.32 x2, x2, x6, r22
-; CHECK-NEXT:    vlda.ups.2x cml0, s0, upssign1, [p6, #0]; vshuffle x6, x10, x0, r1
-; CHECK-NEXT:    vst.srs.4x dm3, s1, srssign0, [p3], #64; vshuffle x6, x6, x0, r2; vmul dm4, x0, x2, r10
-; CHECK-NEXT:    vsel.32 x4, x4, x3, r22
-; CHECK-NEXT:    vst.srs.4x dm2, s1, srssign0, [p3], m2; vshuffle x10, x5, x0, r3; vaddmac dm3, dm3, dm4, x8, x6, r12
-; CHECK-NEXT:    vshuffle x6, x10, x0, r4; vmul dm4, x0, x4, r10
-; CHECK-NEXT:    vst.srs.4x dm1, s1, srssign0, [p3], #64; jnz r0, #.LBB0_1; vaddmac dm2, dm2, dm4, x1, x6, r12
+; CHECK-NEXT:    vlda.ups.2x cml0, s0, upssign1, [p6, #0]; vst.srs.4x dm3, s1, srssign0, [p3], #64; vshuffle x6, x10, x0, r1
+; CHECK-NEXT:    vst.srs.4x dm2, s1, srssign0, [p3], m2; vshuffle x6, x6, x0, r2; vmul dm4, x0, x2, r10
+; CHECK-NEXT:    vst.srs.4x dm1, s1, srssign0, [p3], #64; vsel.32 x4, x4, x3, r22
+; CHECK-NEXT:    vst.2d.srs.4x dm0, s1, srssign0, [p3], d3; movx srssign0, #0; vshuffle x10, x5, x0, r3; vaddmac dm3, dm3, dm4, x8, x6, r12
+; CHECK-NEXT:    vshuffle x6, x10, x0, r4; vaddmac dm2, dm2, dm4, x1, x6, r12
+; CHECK-NEXT:    vmul dm4, x0, x4, r10
+; CHECK-NEXT:    nop
+; CHECK-NEXT:    jnz r0, #.LBB0_1; vaddmac dm1, dm1, dm4, x8, x6, r12
 ; CHECK-NEXT:    vaddmac dm0, dm0, dm4, x1, x6, r12 // Delay Slot 5
-; CHECK-NEXT:    vst.2d.srs.4x dm0, s1, srssign0, [p3], d3 // Delay Slot 4
-; CHECK-NEXT:    vaddmac dm1, dm1, dm4, x8, x6, r12 // Delay Slot 3
+; CHECK-NEXT:    nop // Delay Slot 4
+; CHECK-NEXT:    nop // Delay Slot 3
 ; CHECK-NEXT:    nop // Delay Slot 2
-; CHECK-NEXT:    movx srssign0, #0 // Delay Slot 1
+; CHECK-NEXT:    nop // Delay Slot 1
 ; CHECK-NEXT:  // %bb.4: // %cooldown.entry
 ; CHECK-NEXT:    vldb x3, [p1], m4
 ; CHECK-NEXT:    vlda.3d x1, [p1], d1
@@ -155,25 +152,25 @@ define dso_local void @gemm(i32 %0, ptr addrspace(5) %1, ptr addrspace(5) %2, pt
 ; CHECK-NEXT:  .L_LEnd0:
 ; CHECK-NEXT:    vlda.3d x8, [p0], d0; nopb ; nops ; nopx ; vshuffle x6, x3, x0, r7; vmac dm2, dm2, x8, x4, r8
 ; CHECK-NEXT:  // %bb.6: // %cooldown.exit
-; CHECK-NEXT:    lda p7, [sp, #-60]; nopb ; nops ; movx crsrsmode, #0; vshuffle x4, x6, x0, r16; vmac dm1, dm1, x10, x0, r8 // 4-byte Folded Reload
-; CHECK-NEXT:    lda p6, [sp, #-64]; nopb ; nops ; or r12, r24, r24; vshuffle x2, x1, x0, r18; vmac dm0, dm0, x8, x0, r8 // 4-byte Folded Reload
-; CHECK-NEXT:    paddxm [sp], #-64; or r10, r23, r23; vshuffle x0, x2, x0, r20; vmac dm3, dm3, x10, x4, r8
-; CHECK-NEXT:    vshuffle x6, x3, x0, r7; vmac dm2, dm2, x8, x4, r8
+; CHECK-NEXT:    lda p7, [sp, #-60]; nopb ; nops ; nopx ; vshuffle x4, x6, x0, r16; vmac dm1, dm1, x10, x0, r8 // 4-byte Folded Reload
+; CHECK-NEXT:    lda p6, [sp, #-64]; nopb ; movx crsrsmode, #0; vshuffle x2, x1, x0, r18; vmac dm0, dm0, x8, x0, r8 // 4-byte Folded Reload
+; CHECK-NEXT:    paddxm [sp], #-64; or r12, r24, r24; vshuffle x0, x2, x0, r20; vmac dm3, dm3, x10, x4, r8
+; CHECK-NEXT:    or r10, r23, r23; vshuffle x6, x3, x0, r7; vmac dm2, dm2, x8, x4, r8
 ; CHECK-NEXT:    vshuffle x4, x6, x0, r16; vmac dm1, dm1, x10, x0, r8
 ; CHECK-NEXT:    vshuffle x2, x1, x0, r18; vmac dm0, dm0, x8, x0, r8
 ; CHECK-NEXT:    vshuffle x0, x2, x0, r20; vmac dm3, dm3, x10, x4, r8
 ; CHECK-NEXT:    mov s0, r17; vmac dm2, dm2, x8, x4, r8
 ; CHECK-NEXT:    mov srssign0, r19; vmac dm1, dm1, x10, x0, r8
 ; CHECK-NEXT:    vmac dm0, dm0, x8, x0, r8
-; CHECK-NEXT:    nop
+; CHECK-NEXT:    mov r8, r21
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    vst.srs.4x dm3, s0, srssign0, [p3], #64
 ; CHECK-NEXT:    vst.srs.4x dm2, s0, srssign0, [p3], m2; ret lr
 ; CHECK-NEXT:    vst.srs.4x dm1, s0, srssign0, [p3, #0] // Delay Slot 5
-; CHECK-NEXT:    vst.srs.4x dm0, s0, srssign0, [p3, #64] // Delay Slot 4
+; CHECK-NEXT:    vst.srs.4x dm0, s0, srssign0, [p3, #64]; movx srssign0, #0 // Delay Slot 4
 ; CHECK-NEXT:    nop // Delay Slot 3
 ; CHECK-NEXT:    nop // Delay Slot 2
-; CHECK-NEXT:    movx srssign0, #0; mov r8, r21 // Delay Slot 1
+; CHECK-NEXT:    nop // Delay Slot 1
 newFuncRoot:
   br label %for.body.peel.pro
 

--- a/llvm/test/CodeGen/AIE/aie2ps/schedule/postpipeliner/avgpool2d_bf16.ll
+++ b/llvm/test/CodeGen/AIE/aie2ps/schedule/postpipeliner/avgpool2d_bf16.ll
@@ -127,8 +127,8 @@ define weak_odr dso_local void @_Z9avgpool2dILh1E8bfloat16Qsr5mllib5utilsE11is_o
 ; CHECK-NEXT:  .L_LEnd0:
 ; CHECK-NEXT:    nopa ; nopb ; nops ; nopx ; vshift x8, x5, x9, r18; nopv
 ; CHECK-NEXT:  // %bb.2: // %for.cond.cleanup
-; CHECK-NEXT:    lda lr, [sp, #-64]; nopb ; nopx ; vshuffle x11, x7, x10, r4 // 4-byte Folded Reload
-; CHECK-NEXT:    lda p6, [sp, #-44]; vshift x1, x6, x5, r0; vmac.f cml7, cml7, x6, x2, r8 // 4-byte Folded Reload
+; CHECK-NEXT:    lda lr, [sp, #-64]; nopb ; nops ; nopx ; vshuffle x11, x7, x10, r4; nopv // 4-byte Folded Reload
+; CHECK-NEXT:    lda p6, [sp, #-44]; nopb ; nopx ; vshift x1, x6, x5, r0; vmac.f cml7, cml7, x6, x2, r8 // 4-byte Folded Reload
 ; CHECK-NEXT:    lda r12, [sp, #-48]; vshift x7, x5, x9, r0; vmac.f cml6, cml6, x8, x2, r8 // 4-byte Folded Reload
 ; CHECK-NEXT:    lda r10, [sp, #-52]; vshift x7, x7, x11, r20 // 4-byte Folded Reload
 ; CHECK-NEXT:    lda r9, [sp, #-56]; vshift x3, x6, x5, r6; vmac.f cml7, cml7, x1, x2, r8 // 4-byte Folded Reload
@@ -141,14 +141,10 @@ define weak_odr dso_local void @_Z9avgpool2dILh1E8bfloat16Qsr5mllib5utilsE11is_o
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    lda p7, [sp, #-40] // 4-byte Folded Reload
 ; CHECK-NEXT:    paddxm [sp], #-64
-; CHECK-NEXT:    nop
-; CHECK-NEXT:    nop
-; CHECK-NEXT:    vst.conv.bf16.fp32 cml7, [p7], #64
-; CHECK-NEXT:    vst.conv.bf16.fp32 cml6, [p7], #64
 ; CHECK-NEXT:    ret lr
 ; CHECK-NEXT:    nop // Delay Slot 5
-; CHECK-NEXT:    nop // Delay Slot 4
-; CHECK-NEXT:    nop // Delay Slot 3
+; CHECK-NEXT:    vst.conv.bf16.fp32 cml7, [p7], #64 // Delay Slot 4
+; CHECK-NEXT:    vst.conv.bf16.fp32 cml6, [p7], #64 // Delay Slot 3
 ; CHECK-NEXT:    nop // Delay Slot 2
 ; CHECK-NEXT:    nop // Delay Slot 1
 entry:

--- a/llvm/test/CodeGen/AIE/aie2ps/schedule/postpipeliner/fifo-fill-no-sef-peel.mir
+++ b/llvm/test/CodeGen/AIE/aie2ps/schedule/postpipeliner/fifo-fill-no-sef-peel.mir
@@ -31,8 +31,8 @@
   target triple = "aie2ps"
 
   define void @maxpool_fifo_5instr(ptr addrspace(5) noalias %ifm, ptr addrspace(6) noalias %ofm_load, ptr addrspace(6) noalias %ofm_write, i32 %n) {
-  ; CHECK-LABEL: maxpool_fifo_5instr: // @maxpool_fifo_5instr
-  ; CHECK-NEXT:    // %bb.0: // %preheader
+  ; CHECK-LABEL: maxpool_fifo_5instr:
+  ; CHECK:       // %bb.0: // %preheader
   ; CHECK-NEXT:    vldb.fill [p0, lf0, r24]; mov p6, p1
   ; CHECK-NEXT:    vlda x4, [p6], #64; vldb.pop.3d x6, [p0, lf0, r24, d0]; nopx
   ; CHECK-NEXT:    vldb.fill [p0, lf0, r24]; add.nc lc, r2, #-5
@@ -43,27 +43,22 @@
   ; CHECK-NEXT:    vlda x4, [p6], #64; vldb.pop.3d x6, [p0, lf0, r24, d0]; nops ; nopxm ; nopv
   ; CHECK-NEXT:    nopa ; vldb.fill [p0, lf0, r24]; nops ; nopxm ; nopv
   ; CHECK-NEXT:    vlda x4, [p6], #64; vldb.pop.3d x6, [p0, lf0, r24, d0]; movs p7, p2; nopx ; vmax_lt.bf16 x2, r16, x4, x6; nopv
-  ; CHECK-NEXT:    .LBB0_1: // %loop_body
+  ; CHECK-NEXT:  .LBB0_1: // %loop_body
   ; CHECK-NEXT:    // =>This Inner Loop Header: Depth=1
   ; CHECK-NEXT:    nopa ; vldb.fill [p0, lf0, r24]; nops ; nopxm ; nopv
-  ; CHECK-NEXT:    .L_LEnd0:
+  ; CHECK-NEXT:  .L_LEnd0:
   ; CHECK-NEXT:    vlda x4, [p6], #64; vldb.pop.3d x6, [p0, lf0, r24, d0]; vst x2, [p7], #64; nopx ; vmax_lt.bf16 x2, r16, x4, x6; nopv
-  ; CHECK-NEXT:    // %bb.2: // %exit
-  ; CHECK-NEXT:    nopa ; nopx
+  ; CHECK-NEXT:  // %bb.2: // %exit
+  ; CHECK-NEXT:    nopa ; nopb ; nops ; nopxm ; nopv
   ; CHECK-NEXT:    vst x2, [p7], #64; vmax_lt.bf16 x2, r16, x4, x6
   ; CHECK-NEXT:    nop
   ; CHECK-NEXT:    vst x2, [p7], #64; vmax_lt.bf16 x2, r16, x4, x6
   ; CHECK-NEXT:    nop
-  ; CHECK-NEXT:    vst x2, [p7], #64; vmax_lt.bf16 x2, r16, x4, x6
-  ; CHECK-NEXT:    nop
-  ; CHECK-NEXT:    vst x2, [p7], #64; vmax_lt.bf16 x2, r16, x4, x6
-  ; CHECK-NEXT:    nop
-  ; CHECK-NEXT:    vst x2, [p7], #64
-  ; CHECK-NEXT:    ret lr
+  ; CHECK-NEXT:    vst x2, [p7], #64; ret lr; vmax_lt.bf16 x2, r16, x4, x6
   ; CHECK-NEXT:    nop // Delay Slot 5
-  ; CHECK-NEXT:    nop // Delay Slot 4
+  ; CHECK-NEXT:    vst x2, [p7], #64; vmax_lt.bf16 x2, r16, x4, x6 // Delay Slot 4
   ; CHECK-NEXT:    nop // Delay Slot 3
-  ; CHECK-NEXT:    nop // Delay Slot 2
+  ; CHECK-NEXT:    vst x2, [p7], #64 // Delay Slot 2
   ; CHECK-NEXT:    nop // Delay Slot 1
   preheader:
     call void @llvm.set.loop.iterations.i32(i32 %n)

--- a/llvm/test/CodeGen/AIE/aie2ps/schedule/postpipeliner/maxpool-10instr.mir
+++ b/llvm/test/CodeGen/AIE/aie2ps/schedule/postpipeliner/maxpool-10instr.mir
@@ -40,22 +40,17 @@
   ; CHECK-NEXT:  .L_LEnd0:
   ; CHECK-NEXT:    nopa ; nopb ; movs p0, p5; nopx ; vmax_lt.8 x1, r17:r16, x7, x3, vaddsign1; nopv
   ; CHECK-NEXT:  // %bb.2: // %exit
-  ; CHECK-NEXT:    nopa ; and r26, r24, r18; vshift x5, x9, x0, r26
-  ; CHECK-NEXT:    nop
+  ; CHECK-NEXT:    nopa ; nopb ; nops ; and r26, r24, r18; vshift x5, x9, x0, r26; nopv
+  ; CHECK-NEXT:    nopa ; nopx
   ; CHECK-NEXT:    vst wl1, [p4], #32; vsel.8 x3, x0, x5, r5:r4
   ; CHECK-NEXT:    vmax_lt.8 x1, r17:r16, x7, x3, vaddsign1
   ; CHECK-NEXT:    vshift x5, x9, x0, r26
   ; CHECK-NEXT:    nop
-  ; CHECK-NEXT:    vst wl1, [p4], #32; vsel.8 x3, x0, x5, r5:r4
-  ; CHECK-NEXT:    vmax_lt.8 x1, r17:r16, x7, x3, vaddsign1
-  ; CHECK-NEXT:    nop
-  ; CHECK-NEXT:    nop
-  ; CHECK-NEXT:    vst wl1, [p4], #32
-  ; CHECK-NEXT:    ret lr
-  ; CHECK-NEXT:    nop // Delay Slot 5
+  ; CHECK-NEXT:    vst wl1, [p4], #32; ret lr; vsel.8 x3, x0, x5, r5:r4
+  ; CHECK-NEXT:    vmax_lt.8 x1, r17:r16, x7, x3, vaddsign1 // Delay Slot 5
   ; CHECK-NEXT:    nop // Delay Slot 4
   ; CHECK-NEXT:    nop // Delay Slot 3
-  ; CHECK-NEXT:    nop // Delay Slot 2
+  ; CHECK-NEXT:    vst wl1, [p4], #32 // Delay Slot 2
   ; CHECK-NEXT:    nop // Delay Slot 1
   preheader:
     call void @llvm.set.loop.iterations.i32(i32 %n)

--- a/llvm/test/CodeGen/AIE/aie2ps/schedule/postpipeliner/maxpool-9instr.mir
+++ b/llvm/test/CodeGen/AIE/aie2ps/schedule/postpipeliner/maxpool-9instr.mir
@@ -19,8 +19,8 @@
   target triple = "aie2ps"
 
   define void @maxpool_inner_9instr(ptr addrspace(5) noalias %data, ptr addrspace(6) noalias %weights, ptr addrspace(7) noalias %out, i32 %n) {
-  ; CHECK-LABEL: maxpool_inner_9instr: // @maxpool_inner_9instr
-  ; CHECK-NEXT:    // %bb.0: // %preheader
+  ; CHECK-LABEL: maxpool_inner_9instr:
+  ; CHECK:       // %bb.0: // %preheader
   ; CHECK-NEXT:    movs p5, p1; nopx ; mov p3, p0
   ; CHECK-NEXT:    vlda wl3, [p5], #32; vldb wh5, [p3, #32]; mov p7, p0
   ; CHECK-NEXT:    vldb.3d wl5, [p7], d0; mov r22, p3
@@ -34,28 +34,23 @@
   ; CHECK-NEXT:    nopa ; vldb.3d wl5, [p7], d0; nops ; and r24, r22, r20; mov r22, p3; nopv
   ; CHECK-NEXT:    nopa ; nopb ; movs p3, p7; nopx ; vmax_lt.8 x10, r17:r16, x3, x1, vaddsign1; nopv
   ; CHECK-NEXT:    nopa ; nopb ; nops ; nopx ; mov p6, p2; nopv
-  ; CHECK-NEXT:    .LBB0_1: // %loop_body
+  ; CHECK-NEXT:  .LBB0_1: // %loop_body
   ; CHECK-NEXT:    // =>This Inner Loop Header: Depth=1
   ; CHECK-NEXT:    vlda wl3, [p5], #32; vldb wh5, [p3, #32]; vst wl10, [p6], #32; nopx ; vshift x1, x5, x0, r24; nopv
   ; CHECK-NEXT:    nopa ; vldb.3d wl5, [p7], d0; nops ; and r24, r22, r20; mov r22, p3; nopv
   ; CHECK-NEXT:    nopa ; nopb ; movs p3, p7; nopx ; vmax_lt.8 x10, r17:r16, x3, x1, vaddsign1; nopv
-  ; CHECK-NEXT:    .L_LEnd0:
+  ; CHECK-NEXT:  .L_LEnd0:
   ; CHECK-NEXT:    nopa ; nopb ; nops ; nopxm ; nopv
-  ; CHECK-NEXT:    // %bb.2: // %exit
-  ; CHECK-NEXT:    nopa ; nopb ; vst wl10, [p6], #32; nopx ; vshift x1, x5, x0, r24; nopv
-  ; CHECK-NEXT:    nopa ; nopb ; and r24, r22, r20
+  ; CHECK-NEXT:  // %bb.2: // %exit
+  ; CHECK-NEXT:    nopa ; nopb ; nopx ; vshift x1, x5, x0, r24; vst wl10, [p6], #32
+  ; CHECK-NEXT:    and r24, r22, r20
   ; CHECK-NEXT:    vmax_lt.8 x10, r17:r16, x3, x1, vaddsign1
   ; CHECK-NEXT:    nop
-  ; CHECK-NEXT:    vst wl10, [p6], #32; vshift x1, x5, x0, r24
-  ; CHECK-NEXT:    nop
-  ; CHECK-NEXT:    vmax_lt.8 x10, r17:r16, x3, x1, vaddsign1
-  ; CHECK-NEXT:    nop
-  ; CHECK-NEXT:    vst wl10, [p6], #32
-  ; CHECK-NEXT:    ret lr
+  ; CHECK-NEXT:    vst wl10, [p6], #32; ret lr; vshift x1, x5, x0, r24
   ; CHECK-NEXT:    nop // Delay Slot 5
-  ; CHECK-NEXT:    nop // Delay Slot 4
+  ; CHECK-NEXT:    vmax_lt.8 x10, r17:r16, x3, x1, vaddsign1 // Delay Slot 4
   ; CHECK-NEXT:    nop // Delay Slot 3
-  ; CHECK-NEXT:    nop // Delay Slot 2
+  ; CHECK-NEXT:    vst wl10, [p6], #32 // Delay Slot 2
   ; CHECK-NEXT:    nop // Delay Slot 1
   preheader:
     call void @llvm.set.loop.iterations.i32(i32 %n)

--- a/llvm/test/CodeGen/AIE/schedule/pointer-hazard.mir
+++ b/llvm/test/CodeGen/AIE/schedule/pointer-hazard.mir
@@ -39,8 +39,8 @@
   ; CHECK-NEXT:  .L_LEnd0:
   ; CHECK-NEXT:    nopb ; vlda wl2, [p0], #64; vst.srs.s16.s32 bmh0, s0, [p1, #32]; nopxm ; nopv
   ; CHECK-NEXT:  // %bb.2: // %for.cond.cleanup
-  ; CHECK-NEXT:    nopb ; nopa ; vst.srs.s16.s32 bml0, s0, [p1], #64; nopxm ; vmul cm0, x2, x0, r0
-  ; CHECK-NEXT:    vst.srs.s16.s32 bmh0, s0, [p1, #32]; nopb ; nopx
+  ; CHECK-NEXT:    vst.srs.s16.s32 bml0, s0, [p1], #64; nopx ; vmul cm0, x2, x0, r0
+  ; CHECK-NEXT:    vst.srs.s16.s32 bmh0, s0, [p1, #32]
   ; CHECK-NEXT:    vst.srs.s16.s32 bml0, s0, [p1], #64; vmul cm0, x2, x0, r0
   ; CHECK-NEXT:    vst.srs.s16.s32 bmh0, s0, [p1, #32]
   ; CHECK-NEXT:    vst.srs.s16.s32 bml0, s0, [p1], #64; vmul cm0, x2, x0, r0
@@ -49,15 +49,12 @@
   ; CHECK-NEXT:    vst.srs.s16.s32 bmh0, s0, [p1, #32]
   ; CHECK-NEXT:    vst.srs.s16.s32 bml0, s0, [p1], #64
   ; CHECK-NEXT:    vst.srs.s16.s32 bmh0, s0, [p1, #32]
-  ; CHECK-NEXT:    vst.srs.s16.s32 bml0, s0, [p1], #64
-  ; CHECK-NEXT:    vst.srs.s16.s32 bmh0, s0, [p1, #32]
-  ; CHECK-NEXT:    vst.srs.s16.s32 bml0, s0, [p1], #64
-  ; CHECK-NEXT:    ret lr
-  ; CHECK-NEXT:    nop // Delay Slot 5
-  ; CHECK-NEXT:    nop // Delay Slot 4
-  ; CHECK-NEXT:    nop // Delay Slot 3
+  ; CHECK-NEXT:    vst.srs.s16.s32 bml0, s0, [p1], #64; ret lr
+  ; CHECK-NEXT:    vst.srs.s16.s32 bmh0, s0, [p1, #32] // Delay Slot 5
+  ; CHECK-NEXT:    vst.srs.s16.s32 bml0, s0, [p1], #64 // Delay Slot 4
+  ; CHECK-NEXT:    event #1 // Delay Slot 3
   ; CHECK-NEXT:    nop // Delay Slot 2
-  ; CHECK-NEXT:    event #1 // Delay Slot 1
+  ; CHECK-NEXT:    nop // Delay Slot 1
   entry:
     tail call void @llvm.aie2.event(i32 0)
     %div8 = lshr i32 %N, 5

--- a/llvm/test/CodeGen/AIE/schedule/sched-initialize-topscb-once.ll
+++ b/llvm/test/CodeGen/AIE/schedule/sched-initialize-topscb-once.ll
@@ -25,18 +25,13 @@ define void @load_store_with_call() {
 ; CHECK-NEXT:  .L_LEnd0:
 ; CHECK-NEXT:    nopa ; vldb x2, [p5, #0]; vst x2, [p5, #0]; nopxm ; nopv
 ; CHECK-NEXT:  // %bb.2: // %exit
-; CHECK-NEXT:    mova p0, #0; nopb ; vst x2, [p5, #0]; nopxm ; nopv
-; CHECK-NEXT:    mova p1, #0; nopb ; vst x2, [p5, #0]
-; CHECK-NEXT:    mova p2, #0; vst x2, [p5, #0]
-; CHECK-NEXT:    mova p3, #0; vst x2, [p5, #0]
-; CHECK-NEXT:    mova p4, #0; vst x2, [p5, #0]
-; CHECK-NEXT:    vst x2, [p5, #0]
-; CHECK-NEXT:    vst x2, [p5, #0]
-; CHECK-NEXT:    jl p5
-; CHECK-NEXT:    nop // Delay Slot 5
-; CHECK-NEXT:    nop // Delay Slot 4
-; CHECK-NEXT:    nop // Delay Slot 3
-; CHECK-NEXT:    nop // Delay Slot 2
+; CHECK-NEXT:    mova p0, #0; vst x2, [p5, #0]; nopx
+; CHECK-NEXT:    mova p1, #0; vst x2, [p5, #0]
+; CHECK-NEXT:    mova p2, #0; vst x2, [p5, #0]; jl p5
+; CHECK-NEXT:    mova p3, #0; vst x2, [p5, #0] // Delay Slot 5
+; CHECK-NEXT:    mova p4, #0; vst x2, [p5, #0] // Delay Slot 4
+; CHECK-NEXT:    vst x2, [p5, #0] // Delay Slot 3
+; CHECK-NEXT:    vst x2, [p5, #0] // Delay Slot 2
 ; CHECK-NEXT:    nop // Delay Slot 1
 ; CHECK-NEXT:    lda lr, [sp, #-64]; nopb ; nops ; nopxm ; nopv // 4-byte Folded Reload
 ; CHECK-NEXT:    nopx


### PR DESCRIPTION
…bundles

When a region contains both top-fixed bundles and a delay-slot instruction, and no bot-fixed bundles are present, schedule the entire region top-down and correct the branch position afterwards via `fixupDelaySlotPosition()` instead of forcing bottom-up cycles.

The fixup locates the branch in `TopBundles` and moves it so that exactly `NumDelaySlots` bundles follow it:

Case 1: Already correct — return immediately.

Case 2: Too few trailing bundles — append NOPs, then fall through to Case 3 if inter-zone conflicts arise.

Case 3: Too many trailing bundles — extract the branch and re-place it at the first slot (scanning forward from `TargetIdx`) where neither a resource conflict (checked via the Top scoreboard at constant delta `−(NumDelaySlots + 1)`) nor an inter-zone conflict exists. Each failed attempt appends one NOP to `TopBundles`, advancing Top's scoreboard ring and preserving the `NumDelaySlots` invariant. A post-placement safety check handles any residual inter-zone conflict by appending a NOP and recursing.