### PR TITLE
[AIE] Fix findPrologueEpilogue assert on loops with multiple non-loop preds

### DIFF
--- a/llvm/lib/Target/AIE/Utils/AIELoopUtils.cpp
+++ b/llvm/lib/Target/AIE/Utils/AIELoopUtils.cpp
@@ -267,20 +267,37 @@ std::pair<MachineBasicBlock *, MachineBasicBlock *>
 findPrologueEpilogue(const MachineBasicBlock &LoopBB) {
   assert(isSingleMBBLoop(&LoopBB) && "Expected a single-MBB loop");
 
+  // Return nullptr for the ambiguous side if the loop has multiple non-loop
+  // predecessors/successors. A valid do-while style outer loop may take its
+  // backedge from a different block than the one that enters it, producing
+  // two non-loop predecessors. Callers that require uniqueness (e.g. the
+  // pipeliner's PipelineExtractor) must check for nullptr themselves.
   MachineBasicBlock *Prologue = nullptr;
   MachineBasicBlock *Epilogue = nullptr;
+  bool MultiplePrologues = false;
+  bool MultipleEpilogues = false;
   for (MachineBasicBlock *P : LoopBB.predecessors()) {
     if (P == &LoopBB)
       continue;
-    assert(!Prologue && "Single-MBB loop has multiple non-loop predecessors");
+    if (Prologue) {
+      MultiplePrologues = true;
+      break;
+    }
     Prologue = P;
   }
   for (MachineBasicBlock *S : LoopBB.successors()) {
     if (S == &LoopBB)
       continue;
-    assert(!Epilogue && "Single-MBB loop has multiple non-loop successors");
+    if (Epilogue) {
+      MultipleEpilogues = true;
+      break;
+    }
     Epilogue = S;
   }
+  if (MultiplePrologues)
+    Prologue = nullptr;
+  if (MultipleEpilogues)
+    Epilogue = nullptr;
   return {Prologue, Epilogue};
 }
 

--- a/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/loop-remark-multi-pred.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/loop-remark-multi-pred.mir
@@ -1,0 +1,79 @@
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# (c) Copyright 2026 Advanced Micro Devices, Inc. or its affiliates
+
+# Regression test: AIELoopUtils::findPrologueEpilogue must not assert when a
+# single-MBB loop has multiple non-loop predecessors. The remark emitter
+# in InterBlockScheduling runs on every single-MBB loop -- not just
+# pipelined ones -- so the helper has to tolerate non-pipelined CFGs.
+#
+# Here bb.1 is a single-MBB loop (self-edge), reached both from the
+# function entry (bb.0) and from an end-of-iteration cleanup block (bb.3).
+# That gives bb.1 two non-loop predecessors -- {bb.0, bb.3} -- which used
+# to trip an assertion in findPrologueEpilogue once emitLoopRemarks
+# started visiting non-pipelined loops.
+
+# RUN: llc --mtriple=aie2 -O2 --start-before=postmisched %s -filetype=null \
+# RUN:   -pass-remarks-output=- -pass-remarks-filter=pipeliner \
+# RUN:   | FileCheck --allow-empty %s
+
+# Compilation must succeed (no assertion) and the ambiguous loop must not
+# get a "Schedule found" remark, since its prologue is not unique.
+# CHECK-NOT: Schedule found
+
+--- |
+  define dso_local void @multi_pred_loop(i32 noundef %n) local_unnamed_addr {
+  entry:
+    br label %loop_header
+
+  loop_header:
+    %i = phi i32 [ 0, %entry ], [ %i_next, %iter_end ], [ %i, %loop_header ]
+    %done = icmp sge i32 %i, %n
+    br i1 %done, label %loop_header, label %work
+
+  work:
+    br label %iter_end
+
+  iter_end:
+    %i_next = add nsw i32 %i, 1
+    br label %loop_header
+  }
+...
+---
+name:            multi_pred_loop
+alignment:       16
+tracksRegLiveness: true
+body:             |
+  bb.0.entry:
+    successors: %bb.1(0x80000000)
+    liveins: $r0
+
+    renamable $r1 = MOV_RLC_imm10_pseudo 0
+    J_jump_imm %bb.1
+    DelayedSchedBarrier
+
+  bb.1.loop_header (align 16):
+    successors: %bb.1(0x40000000), %bb.2(0x40000000)
+    liveins: $r0, $r1
+
+    renamable $r2 = GE renamable $r1, renamable $r0
+    JNZ killed renamable $r2, %bb.1
+    DelayedSchedBarrier
+
+  bb.2.work:
+    successors: %bb.3(0x80000000)
+    liveins: $r0, $r1
+
+    J_jump_imm %bb.3
+    DelayedSchedBarrier
+
+  bb.3.iter_end:
+    successors: %bb.1(0x80000000)
+    liveins: $r0, $r1
+
+    renamable $r1 = nsw ADD_add_r_ri killed renamable $r1, 1, implicit-def dead $srcarry
+    J_jump_imm %bb.1
+    DelayedSchedBarrier
+...


### PR DESCRIPTION
## Summary

Fix `llc` assertion failure on legitimate non-pipelined single-MBB loops whose loop header has multiple non-loop predecessors.

`AIELoopUtils::findPrologueEpilogue` (introduced in 5fbf2933) asserted that a single-MBB loop has at most one non-loop predecessor / successor. That invariant only holds for **pipelined** loops, which was fine when the only caller was `PipelineExtractor`'s constructor (gated by pipelining filters that guarantee uniqueness).

007425c ("[AIEX] Emit unified pipeliner optimization remarks for all loop types") added a second caller in `InterBlockScheduling::emitLoopRemarks` that runs on **every** single-MBB loop, pipelined or not. Non-pipelined loops can legitimately have multiple non-loop predecessors — e.g. an outer `do-while` loop reached both from a function-entry block and from an end-of-iteration cleanup block, or a halt-spin self-edge combined with normal entry paths. So the assertion now fires on legal CFGs.

## Fix

Make `findPrologueEpilogue` return `nullptr` for the ambiguous side instead of asserting. The remark-emitter call site already has `if (!PrologueMBB || !EpilogueMBB) continue;`. The pipeliner call site keeps its own `assert(PrologueMBB && EpilogueMBB && "Pipelined loop must have a unique prologue and epilogue")`, so pipelined code that ever violates the invariant still fails loudly at the only site where it actually matters.

## Crash signature

```
llc: llvm/lib/Target/AIE/Utils/AIELoopUtils.cpp:275:
  Assertion `!Prologue && "Single-MBB loop has multiple non-loop predecessors"' failed.

Running pass 'PostRA Machine Instruction Scheduler' on function '@core_0_2'
  llvm::AIELoopUtils::findPrologueEpilogue
  llvm::AIE::InterBlockScheduling::emitLoopRemarks
```

## Impact

Currently blocking the mlir-air Ryzen AI CI on **both** NPU Phoenix (amd8845hs, npu1) and NPU Strix (amdhx370, npu2) runners. Reference failing run: [Xilinx/mlir-air actions run 26049388494](https://github.com/Xilinx/mlir-air/actions/runs/26049388494).

**NPU Phoenix (npu1) — 9 failing tests:**
- `xrt/02_mul_shim_1x1/run_peano.lit`
- `xrt/03_mul_L1L2_1x1/run_peano.lit`
- `xrt/06_add_shim_bf16/run_peano.lit`
- `xrt/07_extern_linalg/run_npu1_peano.lit`
- `xrt/28_gemm_loop_nest_bf16/run_peano.lit`
- `xrt/29_gemm_4_level_tiling_extern_vec_4x4_bf16/run_peano.lit`
- `xrt/34_cascade_vecadd/run_npu1_peano.lit`
- `xrt/36_cascade_vecmat_i32/run_npu1_peano.lit`
- `xrt/38_cascade_vecmat_transform_2x4_i32/run_npu1_peano.lit`

**NPU Strix (npu2) — 11 failing tests** (superset of the npu1 list with `_npu2_peano` variants, plus 2 npu2-only tests: `03_mul_L1L2_1x1/run_peano_elf.lit` and `30_mul_rtp_1x1/run_npu2_peano.lit`).

All 9 npu1 tests verified to pass on real NPU Phoenix hardware with this patch applied to nightly `21.0.0.2026051801+55604435`. The npu2 failures share the same root cause (same llc binary, same `findPrologueEpilogue` assertion in the same crash stack), so the fix should unblock them as well.

## Bisect

| nightly | result |
|---|---|
| `2026051501+f4933ef7` (May 15) | OK — last good |
| `2026051601+55604435` (May 16) | CRASH — first bad |

## Test

Added `llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/loop-remark-multi-pred.mir`: minimal MIR with a single-MBB loop reached from two non-loop predecessors (function entry and end-of-iteration cleanup). Verified to fail on `aie-public` HEAD without the fix and pass with it.
