### PR TITLE
[AIEX] Recursively order nested epilogues in Phase 2 scheduling.

### DIFF
--- a/llvm/lib/Target/AIE/AIEInterBlockScheduling.cpp
+++ b/llvm/lib/Target/AIE/AIEInterBlockScheduling.cpp
@@ -475,13 +475,13 @@ public:
       : IBS(IBS), Emitted(Emitted), Processing(Processing), Push(Push) {}
 
   void operator()(MachineBasicBlock *EpilogueRoot) const {
-    if (!Processing.insert(EpilogueRoot).second)
+    if (Emitted.contains(EpilogueRoot) ||
+        !Processing.insert(EpilogueRoot).second)
       return;
 
     for (MachineBasicBlock *Sub : post_order(EpilogueRoot)) {
       if (Sub != EpilogueRoot &&
-          IBS.getBlockState(Sub).Kind == BlockType::Epilogue &&
-          !Emitted.contains(Sub) && !Processing.contains(Sub)) {
+          IBS.getBlockState(Sub).Kind == BlockType::Epilogue) {
         (*this)(Sub);
       }
       Push(Sub);
@@ -826,8 +826,6 @@ void InterBlockScheduling::defineSchedulingOrder(MachineFunction *MF) {
 
   for (MachineBasicBlock *MBB : post_order(MF)) {
     if (getBlockState(MBB).Kind != BlockType::Epilogue)
-      continue;
-    if (Emitted.contains(MBB))
       continue;
     ProcessEpilogue(MBB);
   }

--- a/llvm/lib/Target/AIE/AIEInterBlockScheduling.cpp
+++ b/llvm/lib/Target/AIE/AIEInterBlockScheduling.cpp
@@ -784,11 +784,41 @@ void InterBlockScheduling::defineSchedulingOrder(MachineFunction *MF) {
   // post-order. post_order(E) ends with E itself, so E is scheduled AFTER
   // everything reachable from it (its successors are already done -> precise
   // inter-block latency for E) and BEFORE its non-loop predecessors.
+  //
+  // When an outer epilogue's forward walk reaches a nested epilogue inside a
+  // cyclic region, post-order rooted at the outer epilogue can emit the inner
+  // epilogue before its prologue (loop-back). Recursively process nested
+  // epilogues with their own root so post_order picks the correct order.
+  SmallPtrSet<const MachineBasicBlock *, 16> Processing;
+  struct EpilogueProcessor {
+    InterBlockScheduling &IBS;
+    SmallPtrSet<const MachineBasicBlock *, 16> &Emitted;
+    SmallPtrSet<const MachineBasicBlock *, 16> &Processing;
+    llvm::function_ref<void(MachineBasicBlock *)> Push;
+
+    void operator()(MachineBasicBlock *EpilogueRoot) const {
+      if (!Processing.insert(EpilogueRoot).second)
+        return;
+
+      for (MachineBasicBlock *Sub : post_order(EpilogueRoot)) {
+        if (Sub != EpilogueRoot &&
+            IBS.getBlockState(Sub).Kind == BlockType::Epilogue &&
+            !Emitted.contains(Sub) && !Processing.contains(Sub)) {
+          (*this)(Sub);
+        }
+        Push(Sub);
+      }
+
+      Processing.erase(EpilogueRoot);
+    }
+  } ProcessEpilogue{*this, Emitted, Processing, Push};
+
   for (MachineBasicBlock *MBB : post_order(MF)) {
     if (getBlockState(MBB).Kind != BlockType::Epilogue)
       continue;
-    for (MachineBasicBlock *Sub : post_order(MBB))
-      Push(Sub);
+    if (Emitted.contains(MBB))
+      continue;
+    ProcessEpilogue(MBB);
   }
 
   // Phase 3: everything else in post-order to optimize the number of already

--- a/llvm/lib/Target/AIE/AIEInterBlockScheduling.cpp
+++ b/llvm/lib/Target/AIE/AIEInterBlockScheduling.cpp
@@ -459,6 +459,38 @@ public:
   const BlockState *getEpilogue() const { return Epilogue; }
 };
 
+/// Recursive post-order walker for epilogue scheduling in
+/// defineSchedulingOrder.
+class EpilogueProcessor {
+  InterBlockScheduling &IBS;
+  SmallPtrSet<const MachineBasicBlock *, 16> &Emitted;
+  SmallPtrSet<const MachineBasicBlock *, 16> &Processing;
+  llvm::function_ref<void(MachineBasicBlock *)> Push;
+
+public:
+  EpilogueProcessor(InterBlockScheduling &IBS,
+                    SmallPtrSet<const MachineBasicBlock *, 16> &Emitted,
+                    SmallPtrSet<const MachineBasicBlock *, 16> &Processing,
+                    llvm::function_ref<void(MachineBasicBlock *)> Push)
+      : IBS(IBS), Emitted(Emitted), Processing(Processing), Push(Push) {}
+
+  void operator()(MachineBasicBlock *EpilogueRoot) const {
+    if (!Processing.insert(EpilogueRoot).second)
+      return;
+
+    for (MachineBasicBlock *Sub : post_order(EpilogueRoot)) {
+      if (Sub != EpilogueRoot &&
+          IBS.getBlockState(Sub).Kind == BlockType::Epilogue &&
+          !Emitted.contains(Sub) && !Processing.contains(Sub)) {
+        (*this)(Sub);
+      }
+      Push(Sub);
+    }
+
+    Processing.erase(EpilogueRoot);
+  }
+};
+
 } // namespace
 
 bool InterBlockScheduling::leaveBlock() {
@@ -790,28 +822,7 @@ void InterBlockScheduling::defineSchedulingOrder(MachineFunction *MF) {
   // epilogue before its prologue (loop-back). Recursively process nested
   // epilogues with their own root so post_order picks the correct order.
   SmallPtrSet<const MachineBasicBlock *, 16> Processing;
-  struct EpilogueProcessor {
-    InterBlockScheduling &IBS;
-    SmallPtrSet<const MachineBasicBlock *, 16> &Emitted;
-    SmallPtrSet<const MachineBasicBlock *, 16> &Processing;
-    llvm::function_ref<void(MachineBasicBlock *)> Push;
-
-    void operator()(MachineBasicBlock *EpilogueRoot) const {
-      if (!Processing.insert(EpilogueRoot).second)
-        return;
-
-      for (MachineBasicBlock *Sub : post_order(EpilogueRoot)) {
-        if (Sub != EpilogueRoot &&
-            IBS.getBlockState(Sub).Kind == BlockType::Epilogue &&
-            !Emitted.contains(Sub) && !Processing.contains(Sub)) {
-          (*this)(Sub);
-        }
-        Push(Sub);
-      }
-
-      Processing.erase(EpilogueRoot);
-    }
-  } ProcessEpilogue{*this, Emitted, Processing, Push};
+  EpilogueProcessor ProcessEpilogue{*this, Emitted, Processing, Push};
 
   for (MachineBasicBlock *MBB : post_order(MF)) {
     if (getBlockState(MBB).Kind != BlockType::Epilogue)

--- a/llvm/test/CodeGen/AIE/aie2/schedule/interblock/order.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/interblock/order.mir
@@ -196,11 +196,17 @@ body:             |
 name:            nestedEpilogueCycle
 tracksRegLiveness: true
 body:             |
-  ; Entry reaches outer prologue (bb.4) and inner loop (bb.1) separately. Outer
-  ; epilogue (bb.6) forward-reaches inner epilogue (bb.2) via bb.6->bb.2. Phase-2
-  ; post_order(bb.6) pushes epilogue (bb.6) before prologue (bb.4).
+  ; bb.1 nest ($r0): loop bb.1, prologue bb.0, epilogue bb.2.
+  ; bb.5 nest ($r1): loop bb.5, prologue bb.4, epilogue bb.6 (loop-back bb.6->bb.4,
+  ; dedicated exit bb.7).
+  ; Main pipeline: bb.0 -> bb.1 -> bb.2 -> bb.3 -> bb.4 -> bb.5 -> bb.6.
+  ; bb.0 also branches directly to bb.4 (JNZ); bb.6 also jumps to bb.2 (bb.6->bb.2).
+  ; Phase-2 post_order(bb.6) can visit bb.2 (bb.1 epilogue) before bb.4 (bb.5
+  ; prologue); without nested-epilogue recursion bb.6 may be pushed before bb.4
+  ; (wrong). Recursive ProcessEpilogue(bb.2) schedules the bb.1 subtree first so
+  ; bb.4 precedes bb.6.
   ; CHECK-LABEL: nestedEpilogueCycle
-  ; CHECK: MBB scheduling sequence : 1 -> 5 -> 7 -> 6 -> 4 -> 3 -> 2 -> 0 ->
+  ; CHECK: MBB scheduling sequence : 1 -> 5 -> 7 -> 4 -> 3 -> 2 -> 6 -> 0 ->
   bb.0:
     liveins: $r0, $r1
     successors: %bb.4, %bb.1

--- a/llvm/test/CodeGen/AIE/aie2/schedule/interblock/order.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/interblock/order.mir
@@ -3,7 +3,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# (c) Copyright 2023-2024 Advanced Micro Devices, Inc. or its affiliates
+# (c) Copyright 2023-2026 Advanced Micro Devices, Inc. or its affiliates
 # RUN: llc --mtriple=aie2 --start-before=postmisched --debug-only=sched-blocks \
 # RUN: --aie-loop-aware=1 %s -o /dev/null |& FileCheck %s
 # REQUIRES: asserts
@@ -189,6 +189,61 @@ body:             |
     JNZ $r0, %bb.4
     DelayedSchedBarrier
   bb.9:
+    RET implicit $lr
+    DelayedSchedBarrier
+...
+---
+name:            nestedEpilogueCycle
+tracksRegLiveness: true
+body:             |
+  ; Entry reaches outer prologue (bb.4) and inner loop (bb.1) separately. Outer
+  ; epilogue (bb.6) forward-reaches inner epilogue (bb.2) via bb.6->bb.2. Phase-2
+  ; post_order(bb.6) pushes epilogue (bb.6) before prologue (bb.4).
+  ; CHECK-LABEL: nestedEpilogueCycle
+  ; CHECK: MBB scheduling sequence : 1 -> 5 -> 7 -> 6 -> 4 -> 3 -> 2 -> 0 ->
+  bb.0:
+    liveins: $r0, $r1
+    successors: %bb.4, %bb.1
+    JNZ $r0, %bb.4
+    DelayedSchedBarrier
+    J_jump_imm %bb.1
+    DelayedSchedBarrier
+  bb.1:
+    liveins: $r0, $r1
+    successors: %bb.1, %bb.2
+    $r0 = ADD_add_r_ri $r0, -1, implicit-def $srcarry
+    JNZ $r0, %bb.1
+    DelayedSchedBarrier
+  bb.2:
+    liveins: $r1
+    successors: %bb.3
+    J_jump_imm %bb.3
+    DelayedSchedBarrier
+  bb.3:
+    successors: %bb.4
+    J_jump_imm %bb.4
+    DelayedSchedBarrier
+  bb.4:
+    liveins: $r1
+    successors: %bb.5
+    J_jump_imm %bb.5
+    DelayedSchedBarrier
+  bb.5:
+    liveins: $r1
+    successors: %bb.5, %bb.6
+    $r1 = ADD_add_r_ri $r1, -1, implicit-def $srcarry
+    JNZ $r1, %bb.5
+    DelayedSchedBarrier
+  bb.6:
+    liveins: $r1
+    successors: %bb.4, %bb.7, %bb.2
+    JNZ $r1, %bb.4
+    DelayedSchedBarrier
+    J_jump_imm %bb.7
+    DelayedSchedBarrier
+    J_jump_imm %bb.2
+    DelayedSchedBarrier
+  bb.7:
     RET implicit $lr
     DelayedSchedBarrier
 ...


### PR DESCRIPTION
When an upstream epilogue's forward post_order walk reaches a nested epilogue
inside another pipelined loop whose epilogue branches back to its prologue,
the prologue can be pushed after that epilogue and freeze the wrong MBBSequence.
Process nested epilogues with their own root and guard against re-entrancy so
loop-back successors are scheduled before epilogue scheduling.