### PR TITLE
[PDLL] add `true` and `false` keywords

### DIFF
--- a/mlir/docs/PDLL.md
+++ b/mlir/docs/PDLL.md
@@ -819,6 +819,15 @@ let trueConstant = op<arith.constant> {value = attr<"true">};
 let applyResult = op<affine.apply>(args: ValueRange) {map = attr<"affine_map<(d0, d1) -> (d1 - 3)>">}
 ```
 
+The `true` and `false` keywords are provided as shorthand for the boolean
+attributes `attr<"true">` and `attr<"false">` respectively:
+
+```pdll
+let trueConstant = op<arith.constant> {value = true};
+
+let falseConstant = op<arith.constant> {value = false};
+```
+
 ### Type Expression
 
 A type expression represents a literal MLIR type. It allows for statically

--- a/mlir/lib/Tools/PDLL/Parser/Lexer.cpp
+++ b/mlir/lib/Tools/PDLL/Parser/Lexer.cpp
@@ -395,6 +395,8 @@ Token Lexer::lexIdentifier(const char *tokStart) {
                          .Case("type", Token::kw_type)
                          .Case("Type", Token::kw_Type)
                          .Case("TypeRange", Token::kw_TypeRange)
+                         .Case("true", Token::kw_true)
+                         .Case("false", Token::kw_false)
                          .Case("Value", Token::kw_Value)
                          .Case("ValueRange", Token::kw_ValueRange)
                          .Case("with", Token::kw_with)

--- a/mlir/lib/Tools/PDLL/Parser/Lexer.h
+++ b/mlir/lib/Tools/PDLL/Parser/Lexer.h
@@ -66,6 +66,8 @@ public:
     kw_Rewrite,
     kw_Type,
     kw_TypeRange,
+    kw_true,
+    kw_false,
     kw_Value,
     kw_ValueRange,
     kw_with,

--- a/mlir/lib/Tools/PDLL/Parser/Parser.cpp
+++ b/mlir/lib/Tools/PDLL/Parser/Parser.cpp
@@ -348,6 +348,7 @@ private:
   /// Identifier expressions.
   FailureOr<ast::Expr *> parseArrayAttrExpr();
   FailureOr<ast::Expr *> parseAttributeExpr();
+  FailureOr<ast::Expr *> parseBooleanExpr();
   FailureOr<ast::Expr *> parseCallExpr(ast::Expr *parentExpr,
                                        bool isNegated = false);
   FailureOr<ast::Expr *> parseDeclRefExpr(StringRef name, SMRange loc);
@@ -2302,6 +2303,10 @@ FailureOr<ast::Expr *> Parser::parseOtherExpr() {
   case Token::integer:
     lhsExpr = parseIntegerExpr();
     break;
+  case Token::kw_true:
+  case Token::kw_false:
+    lhsExpr = parseBooleanExpr();
+    break;
   case Token::string:
     lhsExpr = parseStringExpr();
     break;
@@ -2584,6 +2589,13 @@ FailureOr<ast::Expr *> Parser::parseIntegerExpr() {
 
   auto allocated = copyStringWithNull(ctx, (Twine(value) + ":" + type).str());
   return ast::AttributeExpr::create(ctx, loc, allocated);
+}
+
+FailureOr<ast::Expr *> Parser::parseBooleanExpr() {
+  SMRange loc = curToken.getLoc();
+  StringRef value = curToken.getSpelling();
+  consumeToken();
+  return ast::AttributeExpr::create(ctx, loc, value);
 }
 
 FailureOr<ast::Expr *> Parser::parseStringExpr() {

--- a/mlir/test/mlir-pdll/CodeGen/MLIR/expr.pdll
+++ b/mlir/test/mlir-pdll/CodeGen/MLIR/expr.pdll
@@ -11,6 +11,16 @@ Pattern AttrExpr => erase op<> { attr = attr<"10"> };
 
 // -----
 
+// `true`/`false` keywords desugar to the same boolean attribute as
+// `attr<"true">`/`attr<"false">`.
+// CHECK: pdl.pattern @BoolAttrExpr
+// CHECK: %[[TRUE:.*]] = attribute = true
+// CHECK: %[[FALSE:.*]] = attribute = false
+// CHECK: operation({{.*}}) {"t" = %[[TRUE]], "f" = %[[FALSE]]}
+Pattern BoolAttrExpr => erase op<> { t = true, f = false };
+
+// -----
+
 //===----------------------------------------------------------------------===//
 // CallExpr
 //===----------------------------------------------------------------------===//

--- a/mlir/test/mlir-pdll/Parser/expr.pdll
+++ b/mlir/test/mlir-pdll/Parser/expr.pdll
@@ -33,6 +33,34 @@ Pattern {
 // -----
 
 // CHECK-LABEL: Module
+// CHECK: `-AttributeExpr {{.*}} Value<"true">
+Pattern {
+  let attr = true;
+  erase _: Op;
+}
+
+// -----
+
+// CHECK-LABEL: Module
+// CHECK: `-AttributeExpr {{.*}} Value<"false">
+Pattern {
+  let attr = false;
+  erase _: Op;
+}
+
+// -----
+
+// `true`/`false` keywords are still usable as attribute names in a dictionary.
+// CHECK-LABEL: Module
+// CHECK: NamedAttributeDecl {{.*}} Name<true>
+// CHECK: NamedAttributeDecl {{.*}} Name<false>
+Pattern {
+  erase op<test.op> { true = attr<"1">, false = attr<"0"> };
+}
+
+// -----
+
+// CHECK-LABEL: Module
 // CHECK: |-NamedAttributeDecl {{.*}}  Name<some_array>
 // CHECK: `-UserRewriteDecl {{.*}} Name<__builtin_addElemToArrayAttrRewriter> ResultType<Attr>
 // CHECK:   `Arguments`


### PR DESCRIPTION
These 2 new keywords are just syntactic sugar on top of `attr<"true">` and `attr<"false">`.