### PR TITLE
[mlir] Add opt-in genOptionsParser to generate a free options-parsing…

### DIFF
--- a/mlir/include/mlir/Pass/PassBase.td
+++ b/mlir/include/mlir/Pass/PassBase.td
@@ -4,6 +4,9 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// Modifications (c) Copyright 2026 Advanced Micro Devices, Inc. or its
+// affiliates
+//
 //===----------------------------------------------------------------------===//
 //
 // This file contains definitions for defining pass registration and other
@@ -86,6 +89,9 @@ class PassBase<string passArg, string base> {
 
   // A set of options provided by this pass.
   list<Option> options = [];
+
+  // Generate a free function that parses a string into the generated options struct.
+  bit genOptionsParser = 0;
 
   // A set of statistics provided by this pass.
   list<Statistic> statistics = [];

--- a/mlir/include/mlir/TableGen/Pass.h
+++ b/mlir/include/mlir/TableGen/Pass.h
@@ -4,6 +4,9 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// Modifications (c) Copyright 2026 Advanced Micro Devices, Inc. or its
+// affiliates
+//
 //===----------------------------------------------------------------------===//
 
 #ifndef MLIR_TABLEGEN_PASS_H_
@@ -99,6 +102,10 @@ public:
 
   /// Return the options provided by this pass.
   ArrayRef<PassOption> getOptions() const;
+
+  /// Return whether to generate a free function to parse this pass's
+  /// options.
+  bool getGenOptionsParser() const;
 
   /// Return the statistics provided by this pass.
   ArrayRef<PassStatistic> getStatistics() const;

--- a/mlir/lib/TableGen/Pass.cpp
+++ b/mlir/lib/TableGen/Pass.cpp
@@ -4,6 +4,9 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// Modifications (c) Copyright 2026 Advanced Micro Devices, Inc. or its
+// affiliates
+//
 //===----------------------------------------------------------------------===//
 
 #include "mlir/TableGen/Pass.h"
@@ -96,5 +99,9 @@ ArrayRef<StringRef> Pass::getDependentDialects() const {
 }
 
 ArrayRef<PassOption> Pass::getOptions() const { return options; }
+
+bool Pass::getGenOptionsParser() const {
+  return def->getValueAsBit("genOptionsParser");
+}
 
 ArrayRef<PassStatistic> Pass::getStatistics() const { return statistics; }

--- a/mlir/test/mlir-tblgen/pass.td
+++ b/mlir/test/mlir-tblgen/pass.td
@@ -1,0 +1,64 @@
+// Modifications (c) Copyright 2026 Advanced Micro Devices, Inc. or its
+// affiliates
+
+// RUN: mlir-tblgen -gen-pass-decls -name Test -I %S/../../include %s | FileCheck %s
+
+include "mlir/Pass/PassBase.td"
+
+def TestPassWithOptions : Pass<"test-pass-with-options"> {
+  let summary = "Test pass with options";
+  let genOptionsParser = 1;
+
+  let options = [
+    Option<"testOption", "test-option", "int", "0", "Test option">,
+    ListOption<"testListOption", "test-list-option", "int64_t",
+               "Test list option">
+  ];
+}
+
+def TestPassWithoutOptionsParser : Pass<"test-pass-without-options-parser"> {
+  let summary = "Test pass without options parser";
+
+  let options = [
+    Option<"testOption", "test-option", "int", "0", "Test option">,
+  ];
+}
+
+// CHECK-LABEL: struct TestPassWithOptionsOptions {
+// CHECK: int testOption = 0;
+// CHECK: ::llvm::SmallVector<int64_t> testListOption;
+
+// CHECK: ::mlir::FailureOr<TestPassWithOptionsOptions> parseTestPassWithOptionsOptions(
+// CHECK-NEXT: ::llvm::StringRef options,
+// CHECK-NEXT: ::llvm::function_ref<::mlir::LogicalResult(const ::llvm::Twine &)> errorHandler);
+
+// CHECK-LABEL: class TestPassWithOptionsBase
+// CHECK: protected:
+// CHECK: ::mlir::Pass::Option<int> testOption
+// CHECK-SAME: "test-option"
+// CHECK-SAME: ::llvm::cl::init(0)
+// CHECK: ::mlir::Pass::ListOption<int64_t> testListOption
+// CHECK-SAME: "test-list-option"
+
+// CHECK: ::mlir::FailureOr<TestPassWithOptionsOptions> parseTestPassWithOptionsOptions(
+// CHECK-NEXT: ::llvm::StringRef options,
+// CHECK-NEXT: ::llvm::function_ref<::mlir::LogicalResult(const ::llvm::Twine &)> errorHandler) {
+// CHECK: struct OptionsParser : public ::mlir::detail::PassOptions {
+// CHECK: ::mlir::detail::PassOptions::Option<int> testOption
+// CHECK-SAME: "test-option"
+// CHECK-SAME: ::llvm::cl::init(0)
+// CHECK: ::mlir::detail::PassOptions::ListOption<int64_t> testListOption
+// CHECK-SAME: "test-list-option"
+// CHECK: if (::mlir::failed(parser.parseFromString(options, errorStream))) {
+// CHECK: return errorHandler(error);
+// CHECK: TestPassWithOptionsOptions parsedOptions;
+// CHECK: parsedOptions.testOption = parser.testOption.getValue();
+// CHECK: parsedOptions.testListOption.assign((*parser.testListOption).begin(), (*parser.testListOption).end());
+// CHECK: return parsedOptions;
+
+// CHECK-LABEL: struct TestPassWithoutOptionsParserOptions {
+// CHECK: int testOption = 0;
+// CHECK-NOT: parseTestPassWithoutOptionsParserOptions
+// CHECK-LABEL: class TestPassWithoutOptionsParserBase
+// CHECK-NOT: parseTestPassWithoutOptionsParserOptions
+// CHECK: std::unique_ptr<::mlir::Pass> createTestPassWithoutOptionsParser()

--- a/mlir/tools/mlir-tblgen/PassGen.cpp
+++ b/mlir/tools/mlir-tblgen/PassGen.cpp
@@ -4,6 +4,9 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// Modifications (c) Copyright 2026 Advanced Micro Devices, Inc. or its
+// affiliates
+//
 //===----------------------------------------------------------------------===//
 //
 // PassGen uses the description of passes to generate base classes for passes
@@ -123,6 +126,18 @@ static void emitPassDecls(const Pass &pass, raw_ostream &os) {
 
   os << "#ifdef " << enableVarName << "\n";
   emitPassOptionsStruct(pass, os);
+
+  if (pass.getGenOptionsParser()) {
+    if (ArrayRef<PassOption> options = pass.getOptions(); !options.empty())
+      os << formatv(
+          R"(/// Parse the options string into the generated options struct.
+/// This only performs option parsing and does not call pass initialization hooks.
+::mlir::FailureOr<{0}Options> parse{0}Options(
+    ::llvm::StringRef options,
+    ::llvm::function_ref<::mlir::LogicalResult(const ::llvm::Twine &)> errorHandler);
+)",
+          passName);
+  }
 
   if (StringRef constructor = pass.getConstructor(); constructor.empty()) {
     // Default constructor declaration.
@@ -266,10 +281,12 @@ std::unique_ptr<::mlir::Pass> create{0}({0}Options options) {{
 )";
 
 /// Emit the declarations for each of the pass options.
-static void emitPassOptionDecls(const Pass &pass, raw_ostream &os) {
+static void emitPassOptionDecls(const Pass &pass, raw_ostream &os,
+                                StringRef optionClassPrefix,
+                                unsigned indent = 2) {
   for (const PassOption &opt : pass.getOptions()) {
-    os.indent(2) << "::mlir::Pass::"
-                 << (opt.isListOption() ? "ListOption" : "Option");
+    os.indent(indent) << optionClassPrefix
+                      << (opt.isListOption() ? "ListOption" : "Option");
 
     os << formatv(R"(<{0}> {1}{{*this, "{2}", ::llvm::cl::desc("{3}"))",
                   opt.getType(), opt.getCppVariableName(), opt.getArgument(),
@@ -280,6 +297,48 @@ static void emitPassOptionDecls(const Pass &pass, raw_ostream &os) {
       os << ", " << *additionalFlags;
     os << "};\n";
   }
+}
+
+/// Emit a function that parses options into the generated option struct.
+static void emitParsePassOptionsDef(const Pass &pass, raw_ostream &os) {
+  StringRef passName = pass.getDef()->getName();
+  ArrayRef<PassOption> options = pass.getOptions();
+  if (!pass.getGenOptionsParser() || options.empty())
+    return;
+
+  os << formatv(R"(
+::mlir::FailureOr<{0}Options> parse{0}Options(
+    ::llvm::StringRef options,
+    ::llvm::function_ref<::mlir::LogicalResult(const ::llvm::Twine &)> errorHandler) {{
+)",
+                passName);
+  os.indent(2) << "struct OptionsParser : public "
+                  "::mlir::detail::PassOptions {\n";
+  emitPassOptionDecls(pass, os, "::mlir::detail::PassOptions::",
+                      /*indent=*/4);
+  os.indent(2) << "};\n";
+  os.indent(2) << "OptionsParser parser;\n";
+  os.indent(2) << "std::string error;\n";
+  os.indent(2) << "::llvm::raw_string_ostream errorStream(error);\n";
+  os.indent(2) << "if (::mlir::failed(parser.parseFromString(options, "
+                  "errorStream))) {\n";
+  os.indent(4) << "errorStream.flush();\n";
+  os.indent(4) << "return errorHandler(error);\n";
+  os.indent(2) << "}\n";
+  os.indent(2) << formatv("{0}Options parsedOptions;\n", passName);
+  for (const PassOption &opt : options) {
+    StringRef cppName = opt.getCppVariableName();
+    if (opt.isListOption()) {
+      os.indent(2) << formatv("parsedOptions.{0}.assign((*parser.{0}).begin(), "
+                              "(*parser.{0}).end());\n",
+                              cppName);
+      continue;
+    }
+    os.indent(2) << formatv("parsedOptions.{0} = parser.{0}.getValue();\n",
+                            cppName);
+  }
+  os.indent(2) << "return parsedOptions;\n";
+  os << "}\n";
 }
 
 /// Emit the declarations for each of the pass statistics.
@@ -336,7 +395,7 @@ static void emitPassDefs(const Pass &pass, raw_ostream &os) {
 
   // Protected content
   os << "protected:\n";
-  emitPassOptionDecls(pass, os);
+  emitPassOptionDecls(pass, os, "::mlir::Pass::");
   emitPassStatisticDecls(pass, os);
 
   // Private content
@@ -351,6 +410,8 @@ static void emitPassDefs(const Pass &pass, raw_ostream &os) {
 
   os << "};\n";
   os << "} // namespace impl\n";
+
+  emitParsePassOptionsDef(pass, os);
 
   if (emitDefaultConstructors) {
     os << formatv(defaultConstructorDefTemplate, passName);
@@ -441,7 +502,7 @@ static void emitOldPassDecl(const Pass &pass, raw_ostream &os) {
   os << formatv(oldPassDeclBegin, defName, pass.getBaseClass(),
                 pass.getArgument(), pass.getSummary(),
                 dependentDialectRegistrations);
-  emitPassOptionDecls(pass, os);
+  emitPassOptionDecls(pass, os, "::mlir::Pass::");
   emitPassStatisticDecls(pass, os);
   os << "};\n";
 }

--- a/mlir/unittests/TableGen/PassGenTest.cpp
+++ b/mlir/unittests/TableGen/PassGenTest.cpp
@@ -4,6 +4,9 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// Modifications (c) Copyright 2026 Advanced Micro Devices, Inc. or its
+// affiliates
+//
 //===----------------------------------------------------------------------===//
 
 #include "mlir/Pass/Pass.h"
@@ -83,6 +86,37 @@ TEST(PassGenTest, PassOptions) {
   EXPECT_EQ(unwrap(pass)->getTestOption(), 57);
   EXPECT_EQ(unwrap(pass)->getTestListOption()[0], 1);
   EXPECT_EQ(unwrap(pass)->getTestListOption()[1], 2);
+}
+
+TEST(PassGenTest, PassOptionsParse) {
+  mlir::MLIRContext context;
+
+  auto parsedOptions = parseTestPassWithOptionsOptions(
+      "testOption=57 test-list-option={1,2}",
+      [](const llvm::Twine &) { return mlir::failure(); });
+  ASSERT_TRUE(mlir::succeeded(parsedOptions));
+
+  const auto unwrap = [](const std::unique_ptr<mlir::Pass> &pass) {
+    return static_cast<const TestPassWithOptions *>(pass.get());
+  };
+
+  const auto pass = createTestPassWithOptions(std::move(*parsedOptions));
+
+  EXPECT_EQ(unwrap(pass)->getTestOption(), 57);
+  EXPECT_EQ(unwrap(pass)->getTestListOption()[0], 1);
+  EXPECT_EQ(unwrap(pass)->getTestListOption()[1], 2);
+}
+
+TEST(PassGenTest, PassOptionsParseFailure) {
+  std::string error;
+  auto parsedOptions = parseTestPassWithOptionsOptions(
+      "unknown-option=57", [&](const llvm::Twine &message) {
+        error = message.str();
+        return mlir::failure();
+      });
+
+  EXPECT_TRUE(mlir::failed(parsedOptions));
+  EXPECT_THAT(error, testing::HasSubstr("no such option unknown-option"));
 }
 
 struct TestPassWithCustomConstructor

--- a/mlir/unittests/TableGen/passes.td
+++ b/mlir/unittests/TableGen/passes.td
@@ -4,6 +4,9 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// Modifications (c) Copyright 2026 Advanced Micro Devices, Inc. or its
+// affiliates
+//
 //===----------------------------------------------------------------------===//
 
 include "mlir/Pass/PassBase.td"
@@ -16,6 +19,7 @@ def TestPass : Pass<"test"> {
 
 def TestPassWithOptions : Pass<"test"> {
   let summary = "Test pass with options";
+  let genOptionsParser = 1;
 
   let options = [
     Option<"testOption", "testOption", "int", "0", "Test option">,


### PR DESCRIPTION
… function

Add a new `genOptionsParser` bit to `PassBase` (default 0). When set tblgen emits a free function

`parse<PassName>Options`:

  FailureOr<FooOptions> parseFooOptions(
      StringRef options,
      function_ref<LogicalResult(const Twine &)> errorHandler);

This function parses the textual options string into the `<Pass>Options` struct.

This allows drivers to parse options independently of pass construction, which is useful for inspecting and manipulating options before creating a pass.