### PR TITLE
[AIEX] Disable foldImmediate peephole by default; rename opt-in flag

### DIFF
--- a/llvm/lib/Target/AIE/AIEBaseInstrInfo.cpp
+++ b/llvm/lib/Target/AIE/AIEBaseInstrInfo.cpp
@@ -51,10 +51,24 @@ static cl::opt<bool> AIEFoldImmRequireOneUse(
     cl::desc("Only fold immediate into COPY when the constant has a single "
              "non-debug use (so the def can be DCE'd)."));
 
-static cl::opt<bool> AIEDisableFoldImm(
-    "aie-disable-fold-imm", cl::init(false), cl::Hidden,
-    cl::desc("Completely disable the AIE foldImmediate override (fall back to "
-             "default no-op behaviour)."));
+// Opt-in flag for the foldImmediate peephole (disabled by default).
+//
+// foldImmediate collapses MOVA reg, #imm / COPY dst, reg pairs into a single
+// MOVA dst, #imm at the consumer site.  While functionally correct, it removes
+// a pre-RA scheduling constraint: the original COPY gave the post-RA scheduler
+// a data edge that kept the MOVA far from its downstream consumers.  Without
+// that edge, the post-RA scheduler may place a VBCST.16 write (which fills an
+// entire x-register) immediately before a VMOV that reads only the lower-half
+// wl sub-register.  The wl forwarding bypass modelled in the AIE2 itinerary
+// for VMOV_W_WMH_WML consumers does not apply when the producer is a VBCST,
+// so the 2-cycle output latency is insufficient and the hardware reads a stale
+// value.  The correct fix requires a more precise itinerary (either a new
+// bypass class or increased VBCST output latency for wl readers); this flag
+// provides a safe fallback in the meantime.
+static cl::opt<bool> AIEEnableFoldImm(
+    "aie-enable-fold-imm", cl::init(false), cl::Hidden,
+    cl::desc("Enable the AIE foldImmediate peephole that collapses "
+             "MOVA+COPY pairs into a single MOVA at the consumer site."));
 
 static cl::opt<bool>
     NoCheapInstHoisting("aie-no-cheap-inst-hoising",
@@ -510,7 +524,8 @@ unsigned AIEBaseInstrInfo::getRegionSizeInBytes(
     Size += getAIEMachineBundleSize(It);
   }
   LLVM_DEBUG(dbgs() << "---Region End---\n");
-  LLVM_DEBUG(dbgs() << "Region Size" << " " << Size << "\n");
+  LLVM_DEBUG(dbgs() << "Region Size"
+                    << " " << Size << "\n");
   return Size;
 }
 
@@ -560,7 +575,7 @@ bool AIEBaseInstrInfo::foldImmediate(MachineInstr &UseMI, MachineInstr &DefMI,
                                      Register Reg,
                                      MachineRegisterInfo *MRI) const {
 
-  if (AIEDisableFoldImm)
+  if (!AIEEnableFoldImm)
     return false;
 
   // Only handle COPY instructions as the use

--- a/llvm/test/CodeGen/AIE/aie2/live-reserved-regs-call.ll
+++ b/llvm/test/CodeGen/AIE/aie2/live-reserved-regs-call.ll
@@ -29,8 +29,9 @@ entry:
 define void @callee1() {
 ; CHECK-LABEL: callee1:
 ; CHECK:       // %bb.0: // %entry
-; CHECK-NEXT:    nopb ; nopa ; nops ; ret lr ; nopm ; nopv
-; CHECK-NEXT:    nopa ; mov s0, #1 // Delay Slot 5
+; CHECK-NEXT:    mova r0, #1; nopb ; nopxm ; nops
+; CHECK-NEXT:    ret lr
+; CHECK-NEXT:    mov s0, r0 // Delay Slot 5
 ; CHECK-NEXT:    vsrs.d8.s32 wh0, cm0, s0 // Delay Slot 4
 ; CHECK-NEXT:    nop // Delay Slot 3
 ; CHECK-NEXT:    nop // Delay Slot 2

--- a/llvm/test/CodeGen/AIE/aie2/vlda_ups.ll
+++ b/llvm/test/CodeGen/AIE/aie2/vlda_ups.ll
@@ -11,7 +11,7 @@
 define dso_local noundef <8 x i64> @_Z5test0Dv16_s(<16 x i16> noundef %arg0) local_unnamed_addr #0 {
 ; CHECK-LABEL: _Z5test0Dv16_s:
 ; CHECK:       // %bb.0: // %entry
-; CHECK-NEXT:    paddb [sp], #128; nopxm
+; CHECK-NEXT:    nopa ; paddb [sp], #128; nopx
 ; CHECK-NEXT:    mov p0, sp
 ; CHECK-NEXT:    vst wl0, [sp, #-64]
 ; CHECK-NEXT:    paddb [p0], #-64
@@ -19,8 +19,8 @@ define dso_local noundef <8 x i64> @_Z5test0Dv16_s(<16 x i16> noundef %arg0) loc
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
-; CHECK-NEXT:    nop
-; CHECK-NEXT:    mov s0, #4
+; CHECK-NEXT:    mova r0, #4
+; CHECK-NEXT:    mov s0, r0
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    mov p0, sp
 ; CHECK-NEXT:    paddb [p0], #-128
@@ -59,7 +59,7 @@ declare void @llvm.lifetime.end.p0(i64 immarg, ptr nocapture) #1
 define dso_local noundef <8 x i64> @_Z5test1Dv8_i(<8 x i32> noundef %arg0) local_unnamed_addr #0 {
 ; CHECK-LABEL: _Z5test1Dv8_i:
 ; CHECK:       // %bb.0: // %entry
-; CHECK-NEXT:    paddb [sp], #128; nopxm
+; CHECK-NEXT:    nopa ; paddb [sp], #128; nopx
 ; CHECK-NEXT:    mov p0, sp
 ; CHECK-NEXT:    vst wl0, [sp, #-64]
 ; CHECK-NEXT:    paddb [p0], #-64
@@ -67,8 +67,8 @@ define dso_local noundef <8 x i64> @_Z5test1Dv8_i(<8 x i32> noundef %arg0) local
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
-; CHECK-NEXT:    nop
-; CHECK-NEXT:    mov s0, #4
+; CHECK-NEXT:    mova r0, #4
+; CHECK-NEXT:    mov s0, r0
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    mov p0, sp
 ; CHECK-NEXT:    paddb [p0], #-128
@@ -101,7 +101,7 @@ entry:
 define dso_local noundef <16 x i64> @_Z5test2Dv32_a(<32 x i8> noundef %arg0) local_unnamed_addr #0 {
 ; CHECK-LABEL: _Z5test2Dv32_a:
 ; CHECK:       // %bb.0: // %entry
-; CHECK-NEXT:    paddb [sp], #256; nopxm
+; CHECK-NEXT:    nopa ; paddb [sp], #256; nopx
 ; CHECK-NEXT:    mov p0, sp
 ; CHECK-NEXT:    vst wl0, [sp, #-128]
 ; CHECK-NEXT:    paddb [p0], #-128
@@ -109,8 +109,8 @@ define dso_local noundef <16 x i64> @_Z5test2Dv32_a(<32 x i8> noundef %arg0) loc
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
-; CHECK-NEXT:    nop
-; CHECK-NEXT:    mov s0, #4
+; CHECK-NEXT:    mova r0, #4
+; CHECK-NEXT:    mov s0, r0
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    mov p0, sp
 ; CHECK-NEXT:    paddb [p0], #-256
@@ -147,7 +147,7 @@ entry:
 define dso_local noundef <8 x i64> @_Z5test3Dv16_s(<16 x i16> noundef %arg0) local_unnamed_addr #0 {
 ; CHECK-LABEL: _Z5test3Dv16_s:
 ; CHECK:       // %bb.0: // %entry
-; CHECK-NEXT:    paddb [sp], #128; nopxm
+; CHECK-NEXT:    nopa ; paddb [sp], #128; nopx
 ; CHECK-NEXT:    mov p0, sp
 ; CHECK-NEXT:    vst wl0, [sp, #-64]
 ; CHECK-NEXT:    paddb [p0], #-64
@@ -155,8 +155,8 @@ define dso_local noundef <8 x i64> @_Z5test3Dv16_s(<16 x i16> noundef %arg0) loc
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
-; CHECK-NEXT:    nop
-; CHECK-NEXT:    mov s0, #4
+; CHECK-NEXT:    mova r0, #4
+; CHECK-NEXT:    mov s0, r0
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    mov p0, sp
 ; CHECK-NEXT:    paddb [p0], #-128
@@ -189,7 +189,7 @@ entry:
 define dso_local noundef <16 x i64> @_Z5test4Dv16_s(<16 x i16> noundef %arg0) local_unnamed_addr #0 {
 ; CHECK-LABEL: _Z5test4Dv16_s:
 ; CHECK:       // %bb.0: // %entry
-; CHECK-NEXT:    paddb [sp], #256; nopxm
+; CHECK-NEXT:    nopa ; paddb [sp], #256; nopx
 ; CHECK-NEXT:    mov p0, sp
 ; CHECK-NEXT:    vst wl0, [sp, #-128]
 ; CHECK-NEXT:    paddb [p0], #-128
@@ -197,8 +197,8 @@ define dso_local noundef <16 x i64> @_Z5test4Dv16_s(<16 x i16> noundef %arg0) lo
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
-; CHECK-NEXT:    nop
-; CHECK-NEXT:    mov s0, #4
+; CHECK-NEXT:    mova r0, #4
+; CHECK-NEXT:    mov s0, r0
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    mov p0, sp
 ; CHECK-NEXT:    paddb [p0], #-256
@@ -235,7 +235,7 @@ entry:
 define dso_local noundef <16 x i64> @_Z5test5Dv16_s(<16 x i16> noundef %arg0) local_unnamed_addr #0 {
 ; CHECK-LABEL: _Z5test5Dv16_s:
 ; CHECK:       // %bb.0: // %entry
-; CHECK-NEXT:    paddb [sp], #256; nopxm
+; CHECK-NEXT:    nopa ; paddb [sp], #256; nopx
 ; CHECK-NEXT:    mov p0, sp
 ; CHECK-NEXT:    vst wl0, [sp, #-128]
 ; CHECK-NEXT:    paddb [p0], #-128
@@ -243,8 +243,8 @@ define dso_local noundef <16 x i64> @_Z5test5Dv16_s(<16 x i16> noundef %arg0) lo
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
-; CHECK-NEXT:    nop
-; CHECK-NEXT:    mov s0, #4
+; CHECK-NEXT:    mova r0, #4
+; CHECK-NEXT:    mov s0, r0
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    mov p0, sp
 ; CHECK-NEXT:    paddb [p0], #-256
@@ -281,7 +281,7 @@ entry:
 define dso_local noundef <16 x i64> @_Z5test6Dv16_s(<16 x i16> noundef %arg0) local_unnamed_addr #0 {
 ; CHECK-LABEL: _Z5test6Dv16_s:
 ; CHECK:       // %bb.0: // %entry
-; CHECK-NEXT:    paddb [sp], #256; nopxm
+; CHECK-NEXT:    nopa ; paddb [sp], #256; nopx
 ; CHECK-NEXT:    mov p0, sp
 ; CHECK-NEXT:    vst wl0, [sp, #-128]
 ; CHECK-NEXT:    paddb [p0], #-128
@@ -289,8 +289,8 @@ define dso_local noundef <16 x i64> @_Z5test6Dv16_s(<16 x i16> noundef %arg0) lo
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
-; CHECK-NEXT:    nop
-; CHECK-NEXT:    mov s0, #4
+; CHECK-NEXT:    mova r0, #4
+; CHECK-NEXT:    mov s0, r0
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    mov p0, sp
 ; CHECK-NEXT:    paddb [p0], #-256
@@ -327,7 +327,7 @@ entry:
 define dso_local noundef <8 x i64> @_Z5test7Dv16_s(<16 x i16> noundef %arg0) local_unnamed_addr #0 {
 ; CHECK-LABEL: _Z5test7Dv16_s:
 ; CHECK:       // %bb.0: // %entry
-; CHECK-NEXT:    paddb [sp], #128; nopxm
+; CHECK-NEXT:    nopa ; paddb [sp], #128; nopx
 ; CHECK-NEXT:    mov p0, sp
 ; CHECK-NEXT:    vst wl0, [sp, #-64]
 ; CHECK-NEXT:    paddb [p0], #-64
@@ -335,8 +335,8 @@ define dso_local noundef <8 x i64> @_Z5test7Dv16_s(<16 x i16> noundef %arg0) loc
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
-; CHECK-NEXT:    nop
-; CHECK-NEXT:    mov s0, #4
+; CHECK-NEXT:    mova r0, #4
+; CHECK-NEXT:    mov s0, r0
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    mov p0, sp
 ; CHECK-NEXT:    paddb [p0], #-128
@@ -369,7 +369,7 @@ entry:
 define dso_local noundef <8 x i64> @_Z5test8Dv16_t(<16 x i16> noundef %arg0) local_unnamed_addr #0 {
 ; CHECK-LABEL: _Z5test8Dv16_t:
 ; CHECK:       // %bb.0: // %entry
-; CHECK-NEXT:    paddb [sp], #128; nopxm
+; CHECK-NEXT:    nopa ; paddb [sp], #128; nopx
 ; CHECK-NEXT:    mov p0, sp
 ; CHECK-NEXT:    vst wl0, [sp, #-64]
 ; CHECK-NEXT:    paddb [p0], #-64
@@ -377,8 +377,8 @@ define dso_local noundef <8 x i64> @_Z5test8Dv16_t(<16 x i16> noundef %arg0) loc
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
-; CHECK-NEXT:    nop
-; CHECK-NEXT:    mov s0, #4
+; CHECK-NEXT:    mova r0, #4
+; CHECK-NEXT:    mov s0, r0
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    mov p0, sp
 ; CHECK-NEXT:    paddb [p0], #-128

--- a/llvm/test/CodeGen/AIE/aie2/vst_srs.ll
+++ b/llvm/test/CodeGen/AIE/aie2/vst_srs.ll
@@ -12,9 +12,10 @@
 define dso_local noundef <16 x i16> @_Z5test0Dv16_u7__acc32(<8 x i64> noundef %acc) local_unnamed_addr #0 {
 ; CHECK-LABEL: _Z5test0Dv16_u7__acc32:
 ; CHECK:       // %bb.0: // %entry
-; CHECK-NEXT:    nopa ; paddb [sp], #32; nopx
-; CHECK-NEXT:    mov s0, #2
+; CHECK-NEXT:    paddb [sp], #32
+; CHECK-NEXT:    mova r0, #2
 ; CHECK-NEXT:    mov p0, sp
+; CHECK-NEXT:    mov s0, r0
 ; CHECK-NEXT:    paddb [p0], #-32
 ; CHECK-NEXT:    vst.srs.d16.s32 bml0, s0, [p0, #0]
 ; CHECK-NEXT:    nop
@@ -46,9 +47,10 @@ declare void @llvm.lifetime.end.p0(i64 immarg, ptr nocapture) #1
 define dso_local noundef <8 x i32> @_Z5test1Dv8_u7__acc64(<8 x i64> noundef %acc) local_unnamed_addr #0 {
 ; CHECK-LABEL: _Z5test1Dv8_u7__acc64:
 ; CHECK:       // %bb.0: // %entry
-; CHECK-NEXT:    nopa ; paddb [sp], #32; nopx
-; CHECK-NEXT:    mov s0, #2
+; CHECK-NEXT:    paddb [sp], #32
+; CHECK-NEXT:    mova r0, #2
 ; CHECK-NEXT:    mov p0, sp
+; CHECK-NEXT:    mov s0, r0
 ; CHECK-NEXT:    paddb [p0], #-32
 ; CHECK-NEXT:    vst.srs.d32.s64 bml0, s0, [p0, #0]
 ; CHECK-NEXT:    nop
@@ -74,9 +76,10 @@ entry:
 define dso_local noundef <16 x i16> @_Z5test2Dv16_u7__acc32(<8 x i64> noundef %acc) local_unnamed_addr #0 {
 ; CHECK-LABEL: _Z5test2Dv16_u7__acc32:
 ; CHECK:       // %bb.0: // %entry
-; CHECK-NEXT:    nopa ; paddb [sp], #32; nopx
-; CHECK-NEXT:    mov s0, #2
+; CHECK-NEXT:    paddb [sp], #32
+; CHECK-NEXT:    mova r0, #2
 ; CHECK-NEXT:    mov p0, sp
+; CHECK-NEXT:    mov s0, r0
 ; CHECK-NEXT:    paddb [p0], #-32
 ; CHECK-NEXT:    vst.srs.s16.s32 bml0, s0, [p0, #0]
 ; CHECK-NEXT:    nop
@@ -102,9 +105,10 @@ entry:
 define dso_local noundef <8 x i32> @_Z5test3Dv8_u7__acc64(<8 x i64> noundef %acc) local_unnamed_addr #0 {
 ; CHECK-LABEL: _Z5test3Dv8_u7__acc64:
 ; CHECK:       // %bb.0: // %entry
-; CHECK-NEXT:    nopa ; paddb [sp], #32; nopx
-; CHECK-NEXT:    mov s0, #2
+; CHECK-NEXT:    paddb [sp], #32
+; CHECK-NEXT:    mova r0, #2
 ; CHECK-NEXT:    mov p0, sp
+; CHECK-NEXT:    mov s0, r0
 ; CHECK-NEXT:    paddb [p0], #-32
 ; CHECK-NEXT:    vst.srs.s32.s64 bml0, s0, [p0, #0]
 ; CHECK-NEXT:    nop
@@ -130,9 +134,10 @@ entry:
 define dso_local noundef <16 x i16> @_Z5test4Dv16_u7__acc64(<16 x i64> noundef %acc) local_unnamed_addr #0 {
 ; CHECK-LABEL: _Z5test4Dv16_u7__acc64:
 ; CHECK:       // %bb.0: // %entry
-; CHECK-NEXT:    nopa ; paddb [sp], #32; nopx
-; CHECK-NEXT:    mov s0, #2
+; CHECK-NEXT:    paddb [sp], #32
+; CHECK-NEXT:    mova r0, #2
 ; CHECK-NEXT:    mov p0, sp
+; CHECK-NEXT:    mov s0, r0
 ; CHECK-NEXT:    paddb [p0], #-32
 ; CHECK-NEXT:    vst.srs.s16.s64 cm0, s0, [p0, #0]
 ; CHECK-NEXT:    nop
@@ -158,9 +163,10 @@ entry:
 define dso_local noundef <32 x i8> @_Z5test5Dv32_u7__acc32(<16 x i64> noundef %acc) local_unnamed_addr #0 {
 ; CHECK-LABEL: _Z5test5Dv32_u7__acc32:
 ; CHECK:       // %bb.0: // %entry
-; CHECK-NEXT:    nopa ; paddb [sp], #32; nopx
-; CHECK-NEXT:    mov s0, #2
+; CHECK-NEXT:    paddb [sp], #32
+; CHECK-NEXT:    mova r0, #2
 ; CHECK-NEXT:    mov p0, sp
+; CHECK-NEXT:    mov s0, r0
 ; CHECK-NEXT:    paddb [p0], #-32
 ; CHECK-NEXT:    vst.srs.s8.s32 cm0, s0, [p0, #0]
 ; CHECK-NEXT:    nop
@@ -186,9 +192,10 @@ entry:
 define dso_local noundef <16 x i16> @_Z5test6Dv16_u7__acc64(<16 x i64> noundef %acc) local_unnamed_addr #0 {
 ; CHECK-LABEL: _Z5test6Dv16_u7__acc64:
 ; CHECK:       // %bb.0: // %entry
-; CHECK-NEXT:    nopa ; paddb [sp], #32; nopx
-; CHECK-NEXT:    mov s0, #2
+; CHECK-NEXT:    paddb [sp], #32
+; CHECK-NEXT:    mova r0, #2
 ; CHECK-NEXT:    mov p0, sp
+; CHECK-NEXT:    mov s0, r0
 ; CHECK-NEXT:    paddb [p0], #-32
 ; CHECK-NEXT:    vst.srs.d16.s64 cm0, s0, [p0, #0]
 ; CHECK-NEXT:    nop
@@ -214,9 +221,10 @@ entry:
 define dso_local noundef <32 x i8> @_Z5test7Dv32_u7__acc32(<16 x i64> noundef %acc) local_unnamed_addr #0 {
 ; CHECK-LABEL: _Z5test7Dv32_u7__acc32:
 ; CHECK:       // %bb.0: // %entry
-; CHECK-NEXT:    nopa ; paddb [sp], #32; nopx
-; CHECK-NEXT:    mov s0, #2
+; CHECK-NEXT:    paddb [sp], #32
+; CHECK-NEXT:    mova r0, #2
 ; CHECK-NEXT:    mov p0, sp
+; CHECK-NEXT:    mov s0, r0
 ; CHECK-NEXT:    paddb [p0], #-32
 ; CHECK-NEXT:    vst.srs.d8.s32 cm0, s0, [p0, #0]
 ; CHECK-NEXT:    nop
@@ -242,9 +250,10 @@ entry:
 define dso_local noundef <16 x i16> @_Z5test8Dv16_u7__acc64(<16 x i64> noundef %acc) local_unnamed_addr #0 {
 ; CHECK-LABEL: _Z5test8Dv16_u7__acc64:
 ; CHECK:       // %bb.0: // %entry
-; CHECK-NEXT:    nopa ; paddb [sp], #32; nopx
-; CHECK-NEXT:    mov s0, #2
+; CHECK-NEXT:    paddb [sp], #32
+; CHECK-NEXT:    mova r0, #2
 ; CHECK-NEXT:    mov p0, sp
+; CHECK-NEXT:    mov s0, r0
 ; CHECK-NEXT:    paddb [p0], #-32
 ; CHECK-NEXT:    vst.srs.s16.s64 cm0, s0, [p0, #0]
 ; CHECK-NEXT:    nop
@@ -270,9 +279,10 @@ entry:
 define dso_local noundef <32 x i8> @_Z5test9Dv32_u7__acc32(<16 x i64> noundef %acc) local_unnamed_addr #0 {
 ; CHECK-LABEL: _Z5test9Dv32_u7__acc32:
 ; CHECK:       // %bb.0: // %entry
-; CHECK-NEXT:    nopa ; paddb [sp], #32; nopx
-; CHECK-NEXT:    mov s0, #2
+; CHECK-NEXT:    paddb [sp], #32
+; CHECK-NEXT:    mova r0, #2
 ; CHECK-NEXT:    mov p0, sp
+; CHECK-NEXT:    mov s0, r0
 ; CHECK-NEXT:    paddb [p0], #-32
 ; CHECK-NEXT:    vst.srs.s8.s32 cm0, s0, [p0, #0]
 ; CHECK-NEXT:    nop
@@ -298,9 +308,10 @@ entry:
 define dso_local noundef <16 x i16> @_Z6test10Dv16_u7__acc32(<8 x i64> noundef %acc) local_unnamed_addr #0 {
 ; CHECK-LABEL: _Z6test10Dv16_u7__acc32:
 ; CHECK:       // %bb.0: // %entry
-; CHECK-NEXT:    nopa ; paddb [sp], #32; nopx
-; CHECK-NEXT:    mov s0, #4
+; CHECK-NEXT:    paddb [sp], #32
+; CHECK-NEXT:    mova r0, #4
 ; CHECK-NEXT:    mov p0, sp
+; CHECK-NEXT:    mov s0, r0
 ; CHECK-NEXT:    paddb [p0], #-32
 ; CHECK-NEXT:    vst.srs.d16.s32 bml0, s0, [p0, #0]
 ; CHECK-NEXT:    nop
@@ -326,9 +337,10 @@ entry:
 define dso_local noundef <8 x i32> @_Z6test11Dv8_u7__acc64(<8 x i64> noundef %acc) local_unnamed_addr #0 {
 ; CHECK-LABEL: _Z6test11Dv8_u7__acc64:
 ; CHECK:       // %bb.0: // %entry
-; CHECK-NEXT:    nopa ; paddb [sp], #32; nopx
-; CHECK-NEXT:    mov s0, #4
+; CHECK-NEXT:    paddb [sp], #32
+; CHECK-NEXT:    mova r0, #4
 ; CHECK-NEXT:    mov p0, sp
+; CHECK-NEXT:    mov s0, r0
 ; CHECK-NEXT:    paddb [p0], #-32
 ; CHECK-NEXT:    vst.srs.d32.s64 bml0, s0, [p0, #0]
 ; CHECK-NEXT:    nop
@@ -354,7 +366,8 @@ entry:
 define dso_local noundef <16 x i16> @test_postincrement(ptr %array, <8 x i64> noundef %acc) local_unnamed_addr #0 {
 ; CHECK-LABEL: test_postincrement:
 ; CHECK:       // %bb.0: // %entry
-; CHECK-NEXT:    nopa ; mov s0, #2
+; CHECK-NEXT:    nopb ; mova r0, #2; nops ; nopxm ; nopv
+; CHECK-NEXT:    nopa ; mov s0, r0
 ; CHECK-NEXT:    vst.srs.d16.s32 bml0, s0, [p0, #0]
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop

--- a/llvm/test/CodeGen/AIE/aie2p/cnvf2f.ll
+++ b/llvm/test/CodeGen/AIE/aie2p/cnvf2f.ll
@@ -11,9 +11,9 @@ define dso_local noundef float @test_fix2float(i32 noundef %n) {
 ; CHECK-LABEL: test_fix2float:
 ; CHECK:       // %bb.0: // %entry
 ; CHECK-NEXT:    nopa ; nopb ; nops ; ret lr; nopm ; nopv
-; CHECK-NEXT:    nopx // Delay Slot 5
-; CHECK-NEXT:    nop // Delay Slot 4
-; CHECK-NEXT:    mov s2, #0 // Delay Slot 3
+; CHECK-NEXT:    nop // Delay Slot 5
+; CHECK-NEXT:    mova r0, #0 // Delay Slot 4
+; CHECK-NEXT:    mov s2, r0 // Delay Slot 3
 ; CHECK-NEXT:    mov r0, r1.fx2flt, s2 // Delay Slot 2
 ; CHECK-NEXT:    nop // Delay Slot 1
 entry:
@@ -25,9 +25,9 @@ define dso_local noundef i32 @test_float2fix(float noundef %n) {
 ; CHECK-LABEL: test_float2fix:
 ; CHECK:       // %bb.0: // %entry
 ; CHECK-NEXT:    nopa ; nopb ; nops ; ret lr; nopm ; nopv
-; CHECK-NEXT:    nopx // Delay Slot 5
-; CHECK-NEXT:    nop // Delay Slot 4
-; CHECK-NEXT:    mov s3, #0 // Delay Slot 3
+; CHECK-NEXT:    nop // Delay Slot 5
+; CHECK-NEXT:    mova r0, #0 // Delay Slot 4
+; CHECK-NEXT:    mov s3, r0 // Delay Slot 3
 ; CHECK-NEXT:    mov r0, r1.flt2fx, s3 // Delay Slot 2
 ; CHECK-NEXT:    nop // Delay Slot 1
 entry:

--- a/llvm/test/CodeGen/AIE/aie2ps/constant-folding.ll
+++ b/llvm/test/CodeGen/AIE/aie2ps/constant-folding.ll
@@ -9,9 +9,9 @@ define dso_local noundef float @test_fix2float(i32 noundef %n) {
 ; CHECK-LABEL: test_fix2float:
 ; CHECK:       // %bb.0: // %entry
 ; CHECK-NEXT:    nopa ; nopb ; nops ; ret lr; nopm ; nopv
-; CHECK-NEXT:    nopx // Delay Slot 5
-; CHECK-NEXT:    nop // Delay Slot 4
-; CHECK-NEXT:    mov s2, #0 // Delay Slot 3
+; CHECK-NEXT:    nop // Delay Slot 5
+; CHECK-NEXT:    mova r3, #0 // Delay Slot 4
+; CHECK-NEXT:    mov s2, r3 // Delay Slot 3
 ; CHECK-NEXT:    mov r0, r1.fx2flt, s2 // Delay Slot 2
 ; CHECK-NEXT:    nop // Delay Slot 1
 entry:

--- a/llvm/test/CodeGen/AIE/aie2ps/constant-folding.mir
+++ b/llvm/test/CodeGen/AIE/aie2ps/constant-folding.mir
@@ -6,7 +6,12 @@
 #
 # (c) Copyright 2026 Advanced Micro Devices, Inc. or its affiliates
 #
-# RUN: llc -mtriple=aie2ps -run-pass=peephole-opt %s -verify-machineinstrs -o - | FileCheck %s
+# Test the AIE foldImmediate peephole (MOVA reg, #imm / COPY dst, reg → MOVA dst, #imm).
+#
+# Default run: folding is OFF (aie-enable-fold-imm defaults to false); the COPY survives.
+# RUN: llc -mtriple=aie2ps -run-pass=peephole-opt %s -verify-machineinstrs -o - | FileCheck %s --check-prefix=CHECK --check-prefix=NOFOLD
+# Opt-in run: folding is ON; the COPY is replaced by a new MOVA at the consumer site.
+# RUN: llc -mtriple=aie2ps -run-pass=peephole-opt -aie-enable-fold-imm %s -verify-machineinstrs -o - | FileCheck %s --check-prefix=CHECK --check-prefix=FOLD
 
 
 ---
@@ -25,8 +30,10 @@ body: |
     ; CHECK-NEXT: [[COPY2:%[0-9]+]]:mbmm = COPY $bmhh0
     ; CHECK-NEXT: [[COPY3:%[0-9]+]]:mcmm = COPY $cml0
     ; CHECK-NEXT: [[COPY4:%[0-9]+]]:edm = COPY $dm0
-    ; CHECK-NEXT: [[MOV_S_imm11_pseudo:%[0-9]+]]:es = MOV_S_imm11_pseudo 0
-    ; CHECK-NEXT: $cml0, $p2, $dc1 = VLDA_2D_UPS_4x_dmw_lda_ups_w2c_upsSign0 [[MOV_S_imm11_pseudo]], $p2, $d1, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0
+    ; NOFOLD-NEXT: [[COPY5:%[0-9]+]]:es = COPY [[MOV_RLC_imm11_pseudo]]
+    ; NOFOLD-NEXT: $cml0, $p2, $dc1 = VLDA_2D_UPS_4x_dmw_lda_ups_w2c_upsSign0 [[COPY5]], $p2, $d1, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0
+    ; FOLD-NEXT: [[MOV_S_imm11_pseudo:%[0-9]+]]:es = MOV_S_imm11_pseudo 0
+    ; FOLD-NEXT: $cml0, $p2, $dc1 = VLDA_2D_UPS_4x_dmw_lda_ups_w2c_upsSign0 [[MOV_S_imm11_pseudo]], $p2, $d1, implicit-def $srups_of, implicit $crsat, implicit $crupsmode, implicit $upssign0
     ; CHECK-NEXT: PseudoRET implicit $lr, implicit $cml0
     %21:er = MOV_RLC_imm11_pseudo 0
     %20:ep = COPY $p0
@@ -55,8 +62,10 @@ body: |
     ; CHECK-NEXT: [[COPY2:%[0-9]+]]:mbmm = COPY $bmhh0
     ; CHECK-NEXT: [[COPY3:%[0-9]+]]:mcmm = COPY $cml0
     ; CHECK-NEXT: [[COPY4:%[0-9]+]]:edm = COPY $dm0
-    ; CHECK-NEXT: [[MOVXM_lng_cg1:%[0-9]+]]:mr27_select = MOVXM_lng_cg 544654748
-    ; CHECK-NEXT: $r15 = SEL_EQZ $r23, $r22, [[MOVXM_lng_cg1]]
+    ; NOFOLD-NEXT: [[COPY5:%[0-9]+]]:mr27_select = COPY [[MOVXM_lng_cg]]
+    ; NOFOLD-NEXT: $r15 = SEL_EQZ $r23, $r22, [[COPY5]]
+    ; FOLD-NEXT: [[MOVXM_lng_cg1:%[0-9]+]]:mr27_select = MOVXM_lng_cg 544654748
+    ; FOLD-NEXT: $r15 = SEL_EQZ $r23, $r22, [[MOVXM_lng_cg1]]
     ; CHECK-NEXT: PseudoRET implicit $lr, implicit $r15
     %21:er = MOVXM_lng_cg 544654748
     %20:ep = COPY $p0
@@ -75,6 +84,8 @@ legalized: true
 tracksRegLiveness: true
 body: |
   bb.1.entry:
+    ; Folding into a control register class (mcrsat) is rejected even with FOLD
+    ; because getConstantMovOpcode returns nullopt for control regs.
     ; CHECK-LABEL: name: test_imm_control_reg
     ; CHECK: [[MOV_RLC_imm11_pseudo:%[0-9]+]]:er = MOV_RLC_imm11_pseudo 5
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:mcrsat = COPY [[MOV_RLC_imm11_pseudo]]
@@ -92,9 +103,15 @@ legalized: true
 tracksRegLiveness: true
 body: |
   bb.1.entry:
+    ; Without folding: the COPY remains.
+    ; With folding: constrainRegClass widens the dst to ep_as_32bit (which is
+    ; a superclass of ep), so the fold succeeds and produces a second MOVXM.
     ; CHECK-LABEL: name: test_imm_constant_fold_large_imm_into_ptr
-    ; CHECK: [[MOVXM_lng_cg:%[0-9]+]]:ep_as_32bit = MOVXM_lng_cg 70000
-    ; CHECK-NEXT: $p0 = COPY [[MOVXM_lng_cg]]
+    ; CHECK: [[MOVXM_lng_cg:%[0-9]+]]:er = MOVXM_lng_cg 70000
+    ; NOFOLD-NEXT: [[COPY:%[0-9]+]]:ep = COPY [[MOVXM_lng_cg]]
+    ; NOFOLD-NEXT: $p0 = COPY [[COPY]]
+    ; FOLD-NEXT: [[MOVXM_lng_cg1:%[0-9]+]]:ep_as_32bit = MOVXM_lng_cg 70000
+    ; FOLD-NEXT: $p0 = COPY [[MOVXM_lng_cg1]]
     ; CHECK-NEXT: PseudoRET implicit $lr, implicit $p0
     %0:er = MOVXM_lng_cg 70000
     %1:ep = COPY %0:er


### PR DESCRIPTION
## Problem

The `foldImmediate` peephole added in e9815c34 collapses `MOVA reg, #imm` / `COPY dst, reg` pairs into a single `MOVA dst, #imm` at the consumer site. This caused a correctness failure on AIE2 (NPU1) hardware, surfaced as a wrong-output failure in the `vector_exp` programming example in mlir-air CI ([run 27560527882](https://github.com/Xilinx/mlir-air/actions/runs/27560527882)).

### Root cause

The peephole removes a pre-RA data edge (the `COPY`) that the post-RA scheduler was using to keep a `VBCST.16` write separated from downstream vector-register readers. Without that edge, the scheduler places the `VBCST.16` (which fills a full 512-bit x-register) immediately adjacent to a `VMOV_mv_w` that reads only the **lower wl sub-register** (`wl2`) of the same x-register:

```
; Failing schedule produced after foldImmediate:
mova r0, #24;  vbcst.16 x2, r1   ← x2 written (cycle 0)
vshuffle x4, x8, x4, r0          ← gap (cycle 1)
vmov wh4, wl2                     ← wl2 read (cycle 2) — RAW hazard
```

The `wl` forwarding bypass encoded in the AIE2 itinerary for `II_VMOV_W_WMH_WML` consumers (shared `MOV_Bypass` with `VBAND`/`VMOV` outputs) **does not extend to `VBCST` producers**: `VBCST` writes both halves through a broadcast path that lacks the wl-specific forwarding, so the 2-cycle output latency is insufficient and the hardware reads a stale value.

### Why the itinerary is hard to fix directly

`VBAND` (II_VBLOG) and `VBCST` both emit `MOV_Bypass` for their x-register output. `VBAND→wl` has a real hardware bypass; `VBCST→wl` does not. LLVM's itinerary system allows only one bypass class per operand, so we cannot distinguish them without a new bypass type (which would require touching many itinerary entries) or increasing `VBCST` output latency (which would break the validated `VBCST→VEXTRACT` bypass). This is left as a follow-up.

## Fix

Disable `foldImmediate` by default and rename the controlling flag from `-aie-disable-fold-imm` (double-negative, `cl::init(false)`) to `-aie-enable-fold-imm` (`cl::init(false)`, opt-in), consistent with other AIE feature flags (`aie-tail-call-optimization`, `aie-subreg-renaming`, etc.).

## Testing

- All 7 affected codegen tests updated via `update_llc_test_checks.py` / `update_mir_test_checks.py`
- `constant-folding.mir` gains a second `RUN` line with `-aie-enable-fold-imm` that preserves the positive test for the folding logic (using `NOFOLD`/`FOLD` FileCheck prefixes)
- Verified on local NPU1 (Phoenix / amd8845hs):
  - `mlir-air check-air-e2e-peano`: identical pass/fail count before and after (19 pre-existing failures, none new)
  - `mlir-air check-programming-examples-peano`: `vector_exp` goes from FAIL → PASS; no other changes
  - LLVM `check-llvm`: 18 failures (all pre-existing; 3 fewer than before this fix)

## Follow-up

Correct the AIE2 itinerary to accurately model the VBCST→wl latency (either a new bypass class separating VBCST output from VBLOG/VMOV output, or per-consumer output latency for VBCST wl readers), then re-enable the optimisation by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)