### PR TITLE
feat: Add canonicalization for Slice(Pad(X)) in TOSA

### DIFF
--- a/mlir/lib/Dialect/Tosa/IR/TosaCanonicalizations.cpp
+++ b/mlir/lib/Dialect/Tosa/IR/TosaCanonicalizations.cpp
@@ -1113,8 +1113,18 @@ struct PadSliceOptimization : public OpRewritePattern<tosa::SliceOp> {
            "pad padding must have 2 * rank elements");
 
     // For each axis, split the slice window into the leading padding, the
-    // unpadded input, and the trailing padding it reads, expressing the result
-    // as pad(slice(input)).
+    // unpadded input, and the trailing padding it reads, and rewrite the slice
+    // as pad(slice(input)). Example with lowPad=3, inDim=10, highPad=3 and a
+    // slice of sliceStart=1, sliceSize=14 (so windowEnd=15):
+    //
+    //   padded idx:   0  1  2   3  4  5  6  7  8  9 10 11 12  13 14 15
+    //               [ P  P  P][ I  I  I  I  I  I  I  I  I  I][ P  P  P]
+    //                <-low=3->|<--------- inDim=10 -------->|<-high=3->
+    //   slice:          [<------------ sliceSize=14 ------------>)
+    //                   sliceStart=1                         windowEnd=15
+    //
+    //               newLow=2 |<------ inSize=10 ------>| newHigh=2
+    //               (idx 1,2)  (inStart=0 .. inEnd=10)   (idx 13,14)
     SmallVector<int64_t> newInStart(rank);
     SmallVector<int64_t> newInSize(rank);
     SmallVector<int64_t> newPadding(2 * rank, 0);

--- a/mlir/lib/Dialect/Tosa/IR/TosaCanonicalizations.cpp
+++ b/mlir/lib/Dialect/Tosa/IR/TosaCanonicalizations.cpp
@@ -1077,10 +1077,117 @@ struct TileSliceOptimization : public OpRewritePattern<tosa::SliceOp> {
   }
 };
 
+/// Fold a tosa.pad consumed by a tosa.slice so the slice reads directly from
+/// the pad's input, re-padding only the region the slice still covers. When the
+/// slice window lies entirely within the unpadded input, the pad is dropped.
+struct PadSliceOptimization : public OpRewritePattern<tosa::SliceOp> {
+  using OpRewritePattern<tosa::SliceOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(tosa::SliceOp sliceOp,
+                                PatternRewriter &rewriter) const override {
+    Value sliceInput = sliceOp.getInput1();
+    auto padOp = sliceInput.getDefiningOp<tosa::PadOp>();
+    if (!padOp)
+      return rewriter.notifyMatchFailure(sliceOp,
+                                         "slice input must be pad operation");
+    if (!padOp->hasOneUse())
+      return rewriter.notifyMatchFailure(
+          sliceOp, "preceding pad must have a single use");
+
+    auto padInputType = dyn_cast<RankedTensorType>(padOp.getInput1().getType());
+    if (!padInputType || !padInputType.hasStaticShape())
+      return rewriter.notifyMatchFailure(
+          sliceOp, "input to preceding pad op must be a static ranked tensor");
+
+    ElementsAttr paddingElems;
+    if (!matchPattern(padOp.getPadding(), m_Constant(&paddingElems)))
+      return rewriter.notifyMatchFailure(
+          sliceOp, "preceding pad must have constant padding");
+
+    const int64_t rank = padInputType.getRank();
+    SmallVector<int64_t> paddings;
+    paddings.reserve(2 * rank);
+    for (const APInt &padVal : paddingElems.getValues<APInt>())
+      paddings.push_back(padVal.getZExtValue());
+    assert(static_cast<int64_t>(paddings.size()) == 2 * rank &&
+           "pad padding must have 2 * rank elements");
+
+    // For each axis, split the slice window into the leading padding, the
+    // unpadded input, and the trailing padding it reads, expressing the result
+    // as pad(slice(input)).
+    SmallVector<int64_t> newInStart(rank);
+    SmallVector<int64_t> newInSize(rank);
+    SmallVector<int64_t> newPadding(2 * rank, 0);
+    bool needsInputSlice = false;
+    bool changed = false;
+    for (auto [axis, sliceStart, sliceSize] :
+         llvm::enumerate(sliceOp.getStart(), sliceOp.getSize())) {
+      if (sliceSize <= 0)
+        return rewriter.notifyMatchFailure(
+            sliceOp, "degenerate slice with zero sized dim");
+
+      const int64_t lowPad = paddings[2 * axis];
+      const int64_t highPad = paddings[2 * axis + 1];
+      const int64_t inDim = padInputType.getDimSize(axis);
+      const int64_t windowEnd = sliceStart + sliceSize;
+
+      // Portion of the leading/trailing padding that the slice still reads.
+      const int64_t newLow =
+          std::clamp(lowPad - sliceStart, int64_t(0), sliceSize);
+      const int64_t newHigh = std::max(
+          int64_t(0), windowEnd - std::max(sliceStart, lowPad + inDim));
+
+      // Sub-region of the (unpadded) input that the slice reads.
+      const int64_t inStart = std::max(sliceStart - lowPad, int64_t(0));
+      const int64_t inEnd = std::min(windowEnd - lowPad, inDim);
+      const int64_t inSize = inEnd - inStart;
+      if (inSize <= 0)
+        return rewriter.notifyMatchFailure(
+            sliceOp, "slice reads only padding; left to constant folding");
+
+      newInStart[axis] = inStart;
+      newInSize[axis] = inSize;
+      newPadding[2 * axis] = newLow;
+      newPadding[2 * axis + 1] = newHigh;
+
+      needsInputSlice |= inStart != 0 || inSize != inDim;
+      changed |= needsInputSlice || newLow != lowPad || newHigh != highPad;
+    }
+    if (!changed)
+      return rewriter.notifyMatchFailure(sliceOp,
+                                         "could not reduce preceding pad");
+
+    // Slice the pad's input down to the region the slice actually reads.
+    Value newInput = padOp.getInput1();
+    if (needsInputSlice)
+      newInput = rewriter.create<tosa::SliceOp>(
+          sliceOp.getLoc(), padInputType.clone(newInSize), newInput,
+          rewriter.getDenseI64ArrayAttr(newInStart),
+          rewriter.getDenseI64ArrayAttr(newInSize));
+
+    // Re-pad only with the padding the slice still reads. If nothing is left,
+    // the slice reads the input region directly.
+    if (llvm::all_of(newPadding, [](int64_t pad) { return pad == 0; })) {
+      rewriter.replaceOp(sliceOp, newInput);
+      return success();
+    }
+
+    Value newPaddingShape =
+        getTosaConstShape(rewriter, padOp.getPadding().getLoc(), newPadding);
+    auto newPad = rewriter.create<tosa::PadOp>(
+        padOp.getLoc(), sliceOp.getType(),
+        ValueRange{newInput, newPaddingShape, padOp.getPadConst()},
+        padOp->getAttrs());
+    rewriter.replaceOp(sliceOp, newPad.getResult());
+    return success();
+  }
+};
+
 void SliceOp::getCanonicalizationPatterns(RewritePatternSet &results,
                                           MLIRContext *context) {
   results.add<ConcatSliceOptimization>(context);
   results.add<TileSliceOptimization>(context);
+  results.add<PadSliceOptimization>(context);
 }
 
 struct MinToClampOptimization : public OpRewritePattern<tosa::MinimumOp> {

--- a/mlir/test/Dialect/Tosa/canonicalize.mlir
+++ b/mlir/test/Dialect/Tosa/canonicalize.mlir
@@ -1266,7 +1266,9 @@ func.func @pad_slice_reduce_low_pad(%arg0: tensor<10xf32>) -> tensor<11xf32> {
 
 // CHECK-LABEL: func.func @pad_slice_drop_low_pad_exact(
 // CHECK-SAME:   [[X:%.+]]: tensor<10xf32>
-// CHECK-NEXT:   return [[X]] : tensor<10xf32>
+// CHECK-NOT:    tosa.pad
+// CHECK-NOT:    tosa.slice
+// CHECK:        return [[X]] : tensor<10xf32>
 func.func @pad_slice_drop_low_pad_exact(%arg0: tensor<10xf32>) -> tensor<10xf32> {
   %p = tosa.const_shape {value = dense<[4, 0]> : tensor<2xindex>} : () -> !tosa.shape<2>
   %c = "tosa.const"() <{value = dense<0.0> : tensor<f32>}> : () -> tensor<f32>
@@ -1310,7 +1312,9 @@ func.func @pad_slice_reduce_high_pad(%arg0: tensor<10xf32>) -> tensor<11xf32> {
 
 // CHECK-LABEL: func.func @pad_slice_drop_high_pad_exact(
 // CHECK-SAME:   [[X:%.+]]: tensor<10xf32>
-// CHECK-NEXT:   return [[X]] : tensor<10xf32>
+// CHECK-NOT:    tosa.pad
+// CHECK-NOT:    tosa.slice
+// CHECK:        return [[X]] : tensor<10xf32>
 func.func @pad_slice_drop_high_pad_exact(%arg0: tensor<10xf32>) -> tensor<10xf32> {
   %p = tosa.const_shape {value = dense<[0, 4]> : tensor<2xindex>} : () -> !tosa.shape<2>
   %c = "tosa.const"() <{value = dense<0.0> : tensor<f32>}> : () -> tensor<f32>
@@ -1378,6 +1382,22 @@ func.func @pad_slice_low_retained_high_dropped(%arg0: tensor<10xf32>) -> tensor<
   %c = "tosa.const"() <{value = dense<0.0> : tensor<f32>}> : () -> tensor<f32>
   %0 = tosa.pad %arg0, %p, %c : (tensor<10xf32>, !tosa.shape<2>, tensor<f32>) -> tensor<18xf32>
   %1 = tosa.slice %0 {size = array<i64: 10>, start = array<i64: 2>} : (tensor<18xf32>) -> tensor<10xf32>
+  return %1 : tensor<10xf32>
+}
+
+// -----
+
+// CHECK-LABEL: func.func @pad_slice_start_in_input_end_in_high_pad(
+// CHECK-SAME:   [[X:%.+]]: tensor<10xf32>
+// CHECK-DAG:    [[P:%.+]] = tosa.const_shape {{.*}}dense<[0, 2]> : tensor<2xindex>
+// CHECK-DAG:    [[C:%.+]] = "tosa.const"{{.*}}dense<0.000000e+00> : tensor<f32>
+// CHECK:        [[S:%.+]] = tosa.slice [[X]] {size = array<i64: 8>, start = array<i64: 2>} : (tensor<10xf32>) -> tensor<8xf32>
+// CHECK:        tosa.pad [[S]], [[P]], [[C]] : (tensor<8xf32>, !tosa.shape<2>, tensor<f32>) -> tensor<10xf32>
+func.func @pad_slice_start_in_input_end_in_high_pad(%arg0: tensor<10xf32>) -> tensor<10xf32> {
+  %p = tosa.const_shape {value = dense<[3, 3]> : tensor<2xindex>} : () -> !tosa.shape<2>
+  %c = "tosa.const"() <{value = dense<0.0> : tensor<f32>}> : () -> tensor<f32>
+  %0 = tosa.pad %arg0, %p, %c : (tensor<10xf32>, !tosa.shape<2>, tensor<f32>) -> tensor<16xf32>
+  %1 = tosa.slice %0 {size = array<i64: 10>, start = array<i64: 5>} : (tensor<16xf32>) -> tensor<10xf32>
   return %1 : tensor<10xf32>
 }
 

--- a/mlir/test/Dialect/Tosa/canonicalize.mlir
+++ b/mlir/test/Dialect/Tosa/canonicalize.mlir
@@ -1248,6 +1248,228 @@ func.func @canonicalize_tile_slice_multi_output(%arg0 : tensor<1x12x12x10x10xf32
 
 // -----
 
+// CHECK-LABEL: func.func @pad_slice_reduce_low_pad(
+// CHECK-SAME:   [[X:%.+]]: tensor<10xf32>
+// CHECK-DAG:    [[P:%.+]] = tosa.const_shape {{.*}}dense<[3, 0]> : tensor<2xindex>
+// CHECK-DAG:    [[C:%.+]] = "tosa.const"{{.*}}dense<0.000000e+00> : tensor<f32>
+// CHECK:        [[S:%.+]] = tosa.slice [[X]] {size = array<i64: 8>, start = array<i64: 0>} : (tensor<10xf32>) -> tensor<8xf32>
+// CHECK:        tosa.pad [[S]], [[P]], [[C]] : (tensor<8xf32>, !tosa.shape<2>, tensor<f32>) -> tensor<11xf32>
+func.func @pad_slice_reduce_low_pad(%arg0: tensor<10xf32>) -> tensor<11xf32> {
+  %p = tosa.const_shape {value = dense<[4, 0]> : tensor<2xindex>} : () -> !tosa.shape<2>
+  %c = "tosa.const"() <{value = dense<0.0> : tensor<f32>}> : () -> tensor<f32>
+  %0 = tosa.pad %arg0, %p, %c : (tensor<10xf32>, !tosa.shape<2>, tensor<f32>) -> tensor<14xf32>
+  %1 = tosa.slice %0 {size = array<i64: 11>, start = array<i64: 1>} : (tensor<14xf32>) -> tensor<11xf32>
+  return %1 : tensor<11xf32>
+}
+
+// -----
+
+// CHECK-LABEL: func.func @pad_slice_drop_low_pad_exact(
+// CHECK-SAME:   [[X:%.+]]: tensor<10xf32>
+// CHECK-NEXT:   return [[X]] : tensor<10xf32>
+func.func @pad_slice_drop_low_pad_exact(%arg0: tensor<10xf32>) -> tensor<10xf32> {
+  %p = tosa.const_shape {value = dense<[4, 0]> : tensor<2xindex>} : () -> !tosa.shape<2>
+  %c = "tosa.const"() <{value = dense<0.0> : tensor<f32>}> : () -> tensor<f32>
+  %0 = tosa.pad %arg0, %p, %c : (tensor<10xf32>, !tosa.shape<2>, tensor<f32>) -> tensor<14xf32>
+  %1 = tosa.slice %0 {size = array<i64: 10>, start = array<i64: 4>} : (tensor<14xf32>) -> tensor<10xf32>
+  return %1 : tensor<10xf32>
+}
+
+// -----
+
+// CHECK-LABEL: func.func @pad_slice_drop_low_pad_into_input(
+// CHECK-SAME:   [[X:%.+]]: tensor<10xf32>
+// CHECK-NOT:    tosa.pad
+// CHECK:        [[S:%.+]] = tosa.slice [[X]] {size = array<i64: 8>, start = array<i64: 2>} : (tensor<10xf32>) -> tensor<8xf32>
+// CHECK:        return [[S]] : tensor<8xf32>
+func.func @pad_slice_drop_low_pad_into_input(%arg0: tensor<10xf32>) -> tensor<8xf32> {
+  %p = tosa.const_shape {value = dense<[4, 0]> : tensor<2xindex>} : () -> !tosa.shape<2>
+  %c = "tosa.const"() <{value = dense<0.0> : tensor<f32>}> : () -> tensor<f32>
+  %0 = tosa.pad %arg0, %p, %c : (tensor<10xf32>, !tosa.shape<2>, tensor<f32>) -> tensor<14xf32>
+  %1 = tosa.slice %0 {size = array<i64: 8>, start = array<i64: 6>} : (tensor<14xf32>) -> tensor<8xf32>
+  return %1 : tensor<8xf32>
+}
+
+// -----
+
+// CHECK-LABEL: func.func @pad_slice_reduce_high_pad(
+// CHECK-SAME:   [[X:%.+]]: tensor<10xf32>
+// CHECK-DAG:    [[C:%.+]] = "tosa.const"{{.*}}dense<0.000000e+00> : tensor<f32>
+// CHECK-DAG:    [[P:%.+]] = tosa.const_shape {{.*}}dense<[0, 1]> : tensor<2xindex>
+// CHECK-NOT:    tosa.slice
+// CHECK:        tosa.pad [[X]], [[P]], [[C]] : (tensor<10xf32>, !tosa.shape<2>, tensor<f32>) -> tensor<11xf32>
+func.func @pad_slice_reduce_high_pad(%arg0: tensor<10xf32>) -> tensor<11xf32> {
+  %p = tosa.const_shape {value = dense<[0, 4]> : tensor<2xindex>} : () -> !tosa.shape<2>
+  %c = "tosa.const"() <{value = dense<0.0> : tensor<f32>}> : () -> tensor<f32>
+  %0 = tosa.pad %arg0, %p, %c : (tensor<10xf32>, !tosa.shape<2>, tensor<f32>) -> tensor<14xf32>
+  %1 = tosa.slice %0 {size = array<i64: 11>, start = array<i64: 0>} : (tensor<14xf32>) -> tensor<11xf32>
+  return %1 : tensor<11xf32>
+}
+
+// -----
+
+// CHECK-LABEL: func.func @pad_slice_drop_high_pad_exact(
+// CHECK-SAME:   [[X:%.+]]: tensor<10xf32>
+// CHECK-NEXT:   return [[X]] : tensor<10xf32>
+func.func @pad_slice_drop_high_pad_exact(%arg0: tensor<10xf32>) -> tensor<10xf32> {
+  %p = tosa.const_shape {value = dense<[0, 4]> : tensor<2xindex>} : () -> !tosa.shape<2>
+  %c = "tosa.const"() <{value = dense<0.0> : tensor<f32>}> : () -> tensor<f32>
+  %0 = tosa.pad %arg0, %p, %c : (tensor<10xf32>, !tosa.shape<2>, tensor<f32>) -> tensor<14xf32>
+  %1 = tosa.slice %0 {size = array<i64: 10>, start = array<i64: 0>} : (tensor<14xf32>) -> tensor<10xf32>
+  return %1 : tensor<10xf32>
+}
+
+// -----
+
+// CHECK-LABEL: func.func @pad_slice_drop_high_pad_into_input(
+// CHECK-SAME:   [[X:%.+]]: tensor<10xf32>
+// CHECK-NOT:    tosa.pad
+// CHECK:        [[S:%.+]] = tosa.slice [[X]] {size = array<i64: 8>, start = array<i64: 0>} : (tensor<10xf32>) -> tensor<8xf32>
+// CHECK:        return [[S]] : tensor<8xf32>
+func.func @pad_slice_drop_high_pad_into_input(%arg0: tensor<10xf32>) -> tensor<8xf32> {
+  %p = tosa.const_shape {value = dense<[0, 4]> : tensor<2xindex>} : () -> !tosa.shape<2>
+  %c = "tosa.const"() <{value = dense<0.0> : tensor<f32>}> : () -> tensor<f32>
+  %0 = tosa.pad %arg0, %p, %c : (tensor<10xf32>, !tosa.shape<2>, tensor<f32>) -> tensor<14xf32>
+  %1 = tosa.slice %0 {size = array<i64: 8>, start = array<i64: 0>} : (tensor<14xf32>) -> tensor<8xf32>
+  return %1 : tensor<8xf32>
+}
+
+// -----
+
+// CHECK-LABEL: func.func @pad_slice_reduce_both_pads(
+// CHECK-SAME:   [[X:%.+]]: tensor<10xf32>
+// CHECK-DAG:    [[C:%.+]] = "tosa.const"{{.*}}dense<0.000000e+00> : tensor<f32>
+// CHECK-DAG:    [[P:%.+]] = tosa.const_shape {{.*}}dense<2> : tensor<2xindex>
+// CHECK-NOT:    tosa.slice
+// CHECK:        tosa.pad [[X]], [[P]], [[C]] : (tensor<10xf32>, !tosa.shape<2>, tensor<f32>) -> tensor<14xf32>
+func.func @pad_slice_reduce_both_pads(%arg0: tensor<10xf32>) -> tensor<14xf32> {
+  %p = tosa.const_shape {value = dense<[3, 3]> : tensor<2xindex>} : () -> !tosa.shape<2>
+  %c = "tosa.const"() <{value = dense<0.0> : tensor<f32>}> : () -> tensor<f32>
+  %0 = tosa.pad %arg0, %p, %c : (tensor<10xf32>, !tosa.shape<2>, tensor<f32>) -> tensor<16xf32>
+  %1 = tosa.slice %0 {size = array<i64: 14>, start = array<i64: 1>} : (tensor<16xf32>) -> tensor<14xf32>
+  return %1 : tensor<14xf32>
+}
+
+// -----
+
+// CHECK-LABEL: func.func @pad_slice_drop_both_into_input(
+// CHECK-SAME:   [[X:%.+]]: tensor<10xf32>
+// CHECK-NOT:    tosa.pad
+// CHECK:        [[S:%.+]] = tosa.slice [[X]] {size = array<i64: 6>, start = array<i64: 2>} : (tensor<10xf32>) -> tensor<6xf32>
+// CHECK:        return [[S]] : tensor<6xf32>
+func.func @pad_slice_drop_both_into_input(%arg0: tensor<10xf32>) -> tensor<6xf32> {
+  %p = tosa.const_shape {value = dense<[3, 3]> : tensor<2xindex>} : () -> !tosa.shape<2>
+  %c = "tosa.const"() <{value = dense<0.0> : tensor<f32>}> : () -> tensor<f32>
+  %0 = tosa.pad %arg0, %p, %c : (tensor<10xf32>, !tosa.shape<2>, tensor<f32>) -> tensor<16xf32>
+  %1 = tosa.slice %0 {size = array<i64: 6>, start = array<i64: 5>} : (tensor<16xf32>) -> tensor<6xf32>
+  return %1 : tensor<6xf32>
+}
+
+// -----
+
+// CHECK-LABEL: func.func @pad_slice_low_retained_high_dropped(
+// CHECK-SAME:   [[X:%.+]]: tensor<10xf32>
+// CHECK-DAG:    [[P:%.+]] = tosa.const_shape {{.*}}dense<[2, 0]> : tensor<2xindex>
+// CHECK-DAG:    [[C:%.+]] = "tosa.const"{{.*}}dense<0.000000e+00> : tensor<f32>
+// CHECK:        [[S:%.+]] = tosa.slice [[X]] {size = array<i64: 8>, start = array<i64: 0>} : (tensor<10xf32>) -> tensor<8xf32>
+// CHECK:        tosa.pad [[S]], [[P]], [[C]] : (tensor<8xf32>, !tosa.shape<2>, tensor<f32>) -> tensor<10xf32>
+func.func @pad_slice_low_retained_high_dropped(%arg0: tensor<10xf32>) -> tensor<10xf32> {
+  %p = tosa.const_shape {value = dense<[4, 4]> : tensor<2xindex>} : () -> !tosa.shape<2>
+  %c = "tosa.const"() <{value = dense<0.0> : tensor<f32>}> : () -> tensor<f32>
+  %0 = tosa.pad %arg0, %p, %c : (tensor<10xf32>, !tosa.shape<2>, tensor<f32>) -> tensor<18xf32>
+  %1 = tosa.slice %0 {size = array<i64: 10>, start = array<i64: 2>} : (tensor<18xf32>) -> tensor<10xf32>
+  return %1 : tensor<10xf32>
+}
+
+// -----
+
+// CHECK-LABEL: func.func @pad_slice_reduce_low_pad_i8(
+// CHECK-SAME:   [[X:%.+]]: tensor<10xi8>
+// CHECK-DAG:    [[P:%.+]] = tosa.const_shape {{.*}}dense<[3, 0]> : tensor<2xindex>
+// CHECK-DAG:    [[C:%.+]] = "tosa.const"{{.*}}dense<0> : tensor<i8>
+// CHECK:        [[S:%.+]] = tosa.slice [[X]] {size = array<i64: 8>, start = array<i64: 0>} : (tensor<10xi8>) -> tensor<8xi8>
+// CHECK:        tosa.pad [[S]], [[P]], [[C]] : (tensor<8xi8>, !tosa.shape<2>, tensor<i8>) -> tensor<11xi8>
+func.func @pad_slice_reduce_low_pad_i8(%arg0: tensor<10xi8>) -> tensor<11xi8> {
+  %p = tosa.const_shape {value = dense<[4, 0]> : tensor<2xindex>} : () -> !tosa.shape<2>
+  %c = "tosa.const"() <{value = dense<0> : tensor<i8>}> : () -> tensor<i8>
+  %0 = tosa.pad %arg0, %p, %c : (tensor<10xi8>, !tosa.shape<2>, tensor<i8>) -> tensor<14xi8>
+  %1 = tosa.slice %0 {size = array<i64: 11>, start = array<i64: 1>} : (tensor<14xi8>) -> tensor<11xi8>
+  return %1 : tensor<11xi8>
+}
+
+// -----
+
+// CHECK-LABEL: func.func @pad_slice_multi_axis_reduce_pads(
+// CHECK-SAME:   [[X:%.+]]: tensor<10x10xf32>
+// CHECK-DAG:    [[C:%.+]] = "tosa.const"{{.*}}dense<0.000000e+00> : tensor<f32>
+// CHECK-DAG:    [[P:%.+]] = tosa.const_shape {{.*}}dense<[1, 1, 2, 0]> : tensor<4xindex>
+// CHECK-NOT:    tosa.slice
+// CHECK:        tosa.pad [[X]], [[P]], [[C]] : (tensor<10x10xf32>, !tosa.shape<4>, tensor<f32>) -> tensor<12x12xf32>
+func.func @pad_slice_multi_axis_reduce_pads(%arg0: tensor<10x10xf32>) -> tensor<12x12xf32> {
+  %p = tosa.const_shape {value = dense<[2, 2, 3, 3]> : tensor<4xindex>} : () -> !tosa.shape<4>
+  %c = "tosa.const"() <{value = dense<0.0> : tensor<f32>}> : () -> tensor<f32>
+  %0 = tosa.pad %arg0, %p, %c : (tensor<10x10xf32>, !tosa.shape<4>, tensor<f32>) -> tensor<14x16xf32>
+  %1 = tosa.slice %0 {size = array<i64: 12, 12>, start = array<i64: 1, 1>} : (tensor<14x16xf32>) -> tensor<12x12xf32>
+  return %1 : tensor<12x12xf32>
+}
+
+// -----
+
+// CHECK-LABEL: func.func @pad_slice_multi_axis_mixed(
+// CHECK-SAME:   [[X:%.+]]: tensor<8x8xf32>
+// CHECK-DAG:    [[P:%.+]] = tosa.const_shape {{.*}}dense<[0, 0, 0, 1]> : tensor<4xindex>
+// CHECK-DAG:    [[C:%.+]] = "tosa.const"{{.*}}dense<0.000000e+00> : tensor<f32>
+// CHECK:        [[S:%.+]] = tosa.slice [[X]] {size = array<i64: 5, 8>, start = array<i64: 1, 0>} : (tensor<8x8xf32>) -> tensor<5x8xf32>
+// CHECK:        tosa.pad [[S]], [[P]], [[C]] : (tensor<5x8xf32>, !tosa.shape<4>, tensor<f32>) -> tensor<5x9xf32>
+func.func @pad_slice_multi_axis_mixed(%arg0: tensor<8x8xf32>) -> tensor<5x9xf32> {
+  %p = tosa.const_shape {value = dense<[2, 0, 0, 2]> : tensor<4xindex>} : () -> !tosa.shape<4>
+  %c = "tosa.const"() <{value = dense<0.0> : tensor<f32>}> : () -> tensor<f32>
+  %0 = tosa.pad %arg0, %p, %c : (tensor<8x8xf32>, !tosa.shape<4>, tensor<f32>) -> tensor<10x10xf32>
+  %1 = tosa.slice %0 {size = array<i64: 5, 9>, start = array<i64: 3, 0>} : (tensor<10x10xf32>) -> tensor<5x9xf32>
+  return %1 : tensor<5x9xf32>
+}
+
+// -----
+
+// CHECK-LABEL: func.func @pad_slice_unsupported_slice_in_low_pad(
+// CHECK:        tosa.pad
+// CHECK:        tosa.slice
+func.func @pad_slice_unsupported_slice_in_low_pad(%arg0: tensor<10xf32>) -> tensor<3xf32> {
+  %p = tosa.const_shape {value = dense<[4, 0]> : tensor<2xindex>} : () -> !tosa.shape<2>
+  %c = "tosa.const"() <{value = dense<0.0> : tensor<f32>}> : () -> tensor<f32>
+  %0 = tosa.pad %arg0, %p, %c : (tensor<10xf32>, !tosa.shape<2>, tensor<f32>) -> tensor<14xf32>
+  %1 = tosa.slice %0 {size = array<i64: 3>, start = array<i64: 0>} : (tensor<14xf32>) -> tensor<3xf32>
+  return %1 : tensor<3xf32>
+}
+
+// -----
+
+// CHECK-LABEL: func.func @pad_slice_unsupported_slice_in_high_pad(
+// CHECK:        tosa.pad
+// CHECK:        tosa.slice
+func.func @pad_slice_unsupported_slice_in_high_pad(%arg0: tensor<10xf32>) -> tensor<3xf32> {
+  %p = tosa.const_shape {value = dense<[0, 4]> : tensor<2xindex>} : () -> !tosa.shape<2>
+  %c = "tosa.const"() <{value = dense<0.0> : tensor<f32>}> : () -> tensor<f32>
+  %0 = tosa.pad %arg0, %p, %c : (tensor<10xf32>, !tosa.shape<2>, tensor<f32>) -> tensor<14xf32>
+  %1 = tosa.slice %0 {size = array<i64: 3>, start = array<i64: 11>} : (tensor<14xf32>) -> tensor<3xf32>
+  return %1 : tensor<3xf32>
+}
+
+// -----
+
+// CHECK-LABEL: func.func @pad_slice_multi_use_pad(
+// CHECK:        tosa.pad
+// CHECK:        tosa.slice
+func.func @pad_slice_multi_use_pad(%arg0: tensor<10xf32>) -> (tensor<14xf32>, tensor<8xf32>) {
+  %p = tosa.const_shape {value = dense<[4, 0]> : tensor<2xindex>} : () -> !tosa.shape<2>
+  %c = "tosa.const"() <{value = dense<0.0> : tensor<f32>}> : () -> tensor<f32>
+  %0 = tosa.pad %arg0, %p, %c : (tensor<10xf32>, !tosa.shape<2>, tensor<f32>) -> tensor<14xf32>
+  %1 = tosa.slice %0 {size = array<i64: 8>, start = array<i64: 6>} : (tensor<14xf32>) -> tensor<8xf32>
+  return %0, %1 : tensor<14xf32>, tensor<8xf32>
+}
+
+// -----
+
 // CHECK-LABEL: @canonicalize_optimize_sqrt_reciprocal
 func.func @canonicalize_optimize_sqrt_reciprocal(%arg0: tensor<1x5x1x1xf32>) -> tensor<1x5x1x1xf32> {
   // CHECK: %[[RSQRT:.*]] = tosa.rsqrt %arg{{.*}} : (tensor<1x5x1x1xf32>) -> tensor<1x5x1x1xf32>


### PR DESCRIPTION
Fold a tosa.pad consumed by a tosa.slice so the slice reads directly from the pad's input, re-padding only the region the slice still covers. When the slice window lies entirely within the unpadded input, the pad is dropped.