### PR TITLE
[NFC][AIE][INTERBLOCK] Don't overload BS.Fixpoint.II as pipelining indicator

### DIFF
--- a/llvm/lib/Target/AIE/AIEInterBlockScheduling.cpp
+++ b/llvm/lib/Target/AIE/AIEInterBlockScheduling.cpp
@@ -62,7 +62,7 @@ static cl::opt<bool>
                        "iterative loop scheduling"));
 
 static cl::opt<int> PostPipelinerMaxII(
-    "aie-postpipeliner-maxii", cl::init(40),
+    "aie-postpipeliner-maxii", cl::init(60),
     cl::desc("[AIE] Maximum II to be tried in the post-ra pipeliner"));
 
 static cl::opt<bool> EnableMultiSlotInstrMaterialization(
@@ -825,9 +825,12 @@ SchedulingStage InterBlockScheduling::updateScheduling(BlockState &BS) {
   if (BS.getRegions().size() == 1) {
     auto &PostSWP = BS.getPostSWP();
     if (PostSWP.isPostPipelineCandidate(*BS.TheBlock)) {
-      BS.FixPoint.II = PostSWP.getResMII(*BS.TheBlock);
-      BS.FixPoint.IITries = 1;
-      return SchedulingStage::Pipelining;
+      const int ResMII = PostSWP.getResMII(*BS.TheBlock);
+      if (ResMII <= PostPipelinerMaxII) {
+        BS.FixPoint.II = ResMII;
+        BS.FixPoint.IITries = 1;
+        return SchedulingStage::Pipelining;
+      }
     }
   }
   return SchedulingStage::SchedulingDone;

--- a/llvm/lib/Target/AIE/AIEMachineScheduler.cpp
+++ b/llvm/lib/Target/AIE/AIEMachineScheduler.cpp
@@ -1762,7 +1762,7 @@ void llvm::AIEPostRASchedStrategy::buildGraph(ScheduleDAGMI &DAG, AAResults *AA,
   auto &BS = InterBlock.getBlockState(CurMBB);
   const auto &Region = BS.getCurrentRegion();
   int NCopies = 1;
-  if (BS.FixPoint.II) {
+  if (BS.FixPoint.Stage == SchedulingStage::Pipelining) {
     assert(BS.Kind == BlockType::Loop);
     assert(BS.getRegions().size() == 1);
     assert(Region.getBotFixedBundles().empty());


### PR DESCRIPTION

These are some final relics from an earlier series

Additionally, we don't try pipelining if we exceed the maximum II upfront. This save a bit of time and a lot of logging if you are debugging a specific pipeliner mode.

The maximum absolute II was set comfortably high, since time control is better done with the number of II tries.