### PR TITLE
[tosa] feat: improve reshape sinking through concat pattern

### DIFF
--- a/mlir/lib/Dialect/Tosa/Transforms/SinkInputOpsThroughConcat.cpp
+++ b/mlir/lib/Dialect/Tosa/Transforms/SinkInputOpsThroughConcat.cpp
@@ -46,6 +46,7 @@
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Tosa/IR/TosaOps.h"
 #include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/IR/PatternMatch.h"
@@ -57,7 +58,9 @@
 #include "llvm/Support/LogicalResult.h"
 #include "llvm/Support/raw_ostream.h"
 
-#include <variant>
+#include <numeric>
+#include <optional>
+
 namespace mlir {
 namespace tosa {
 #define GEN_PASS_DEF_SINKINPUTOPSTHROUGHCONCAT
@@ -349,37 +352,227 @@ bool areConcatInputsCompatible(ArrayRef<ShapedType> inputTypes,
   return true;
 }
 
+// Returns the product of all dimensions in `shape` (1 if empty).
+// Example: shapeProduct([2, 3, 4]) == 24; shapeProduct([]) == 1.
+int64_t shapeProduct(ArrayRef<int64_t> shape) {
+  return std::accumulate(shape.begin(), shape.end(), static_cast<int64_t>(1),
+                         std::multiplies<int64_t>());
+}
+
+// Decomposition of one reshape input around its pre-reshape concat axis `B`:
+//   - `prefix`:     input dims before `B`;
+//   - `innerGroup`: dims after `B` that collapse with `B` into the concat axis;
+//   - `suffix`:     dims after that group.
+// The concat group is the contiguous run of input axes starting at `B` whose
+// product equals the post-reshape concat dimension.
+//
+// Example: input tensor<2x3x4x5x6> reshaped to tensor<2x60x6>, concat on the
+// output axis of size 60. `B` is the input axis of size 3, and the run
+// 3*4*5 == 60 collapses into the concat axis, so:
+//   prefix = [2], innerGroup = [4, 5], suffix = [6].
+struct OperandAxisLayout {
+  SmallVector<int64_t> prefix;
+  SmallVector<int64_t> innerGroup;
+  SmallVector<int64_t> suffix;
+
+  // Decomposes one reshape input around the concat axis, or returns nullopt if
+  // no such decomposition exists. `boundary` is the product of the output dims
+  // before the concat axis (shared by all operands, as those dims are
+  // concat-invariant); `target` is this operand's post-reshape concat-axis
+  // size. `B` is the first non-unit input axis whose prefix product equals
+  // `boundary`, so unit dims at the boundary are never chosen as the concat
+  // axis.
+  //
+  // Example: inputType tensor<2x3x4x5x6>, boundary = 2, target = 60. The prefix
+  // product reaches 2 at input axis 1 (size 3, non-unit), so B = 1. Growing the
+  // group from there gives 3*4*5 == 60 == target, yielding
+  // prefix = [2], innerGroup = [4, 5], suffix = [6].
+  static std::optional<OperandAxisLayout>
+  compute(ShapedType inputType, int64_t boundary, int64_t target) {
+    ArrayRef<int64_t> inShape = inputType.getShape();
+
+    int64_t prefixProduct = 1;
+    size_t axisB = inShape.size();
+    for (size_t i = 0; i < inShape.size(); ++i) {
+      if (prefixProduct == boundary && inShape[i] != 1) {
+        axisB = i;
+        break;
+      }
+      prefixProduct *= inShape[i];
+    }
+    if (axisB == inShape.size())
+      return std::nullopt;
+
+    // Grow the concat group from `axisB` until its product reaches `target`.
+    int64_t groupProduct = 1;
+    size_t groupEnd = axisB;
+    for (; groupEnd < inShape.size(); ++groupEnd) {
+      groupProduct *= inShape[groupEnd];
+      if (groupProduct >= target)
+        break;
+    }
+    if (groupProduct != target)
+      return std::nullopt;
+    ++groupEnd;
+
+    OperandAxisLayout layout;
+    layout.prefix.assign(inShape.begin(), inShape.begin() + axisB);
+    layout.innerGroup.assign(inShape.begin() + axisB + 1,
+                             inShape.begin() + groupEnd);
+    layout.suffix.assign(inShape.begin() + groupEnd, inShape.end());
+    return layout;
+  }
+};
+
+// Plan to sink reshapes whose inputs decompose the concat axis differently (or
+// differ only in unit-dim placement). Each minority operand gets one adapter
+// reshape to a shared layout, after which a single concat plus one trailing
+// reshape is enough. `adaptedShapes[k]` is the input shape of operand `k` after
+// adaptation; `needsAdapter[k]` is set iff that operand requires the reshape.
+//
+// Example: three reshapes feeding a concat on output axis 1:
+//   op0, op1: tensor<2x3x4x5>  -> tensor<2x12x5>   (split 12 as 3x4)
+//   op2:      tensor<2x12x2x5> -> tensor<2x24x5>   (split 24 as 12x2)
+// The majority split (3x4, innerGroup [4]) is the reference, so only op2 needs
+// an adapter to tensor<2x6x4x5> (re-splitting 24 as 6x4), giving:
+//   concatAxis    = 1
+//   adaptedShapes = {2x3x4x5, 2x3x4x5, 2x6x4x5}
+//   needsAdapter  = {false, false, true}
+struct ReshapeSinkAdapterPlan {
+  size_t concatAxis;
+  SmallVector<SmallVector<int64_t>> adaptedShapes;
+  SmallVector<bool> needsAdapter;
+
+  // Builds an adapter plan, or returns nullopt when sinking is impossible or
+  // would not reduce the reshape count. Non-concat regions are matched by
+  // element count (so differing decompositions and unit-dim placements still
+  // qualify), and minority operands are reshaped to the majority's real layout.
+  //
+  // Example: four reshapes feeding a concat on output axis 1 (boundary = 4):
+  //   arg0: tensor<4x4x4x5> -> tensor<4x16x5>   (innerGroup [4])
+  //   arg1: tensor<4x2x8x5> -> tensor<4x16x5>   (innerGroup [8])
+  //   arg2: tensor<4x8x2x5> -> tensor<4x16x5>   (innerGroup [2])
+  //   arg3: tensor<4x8x4x5> -> tensor<4x32x5>   (innerGroup [4])
+  // The innerGroup [4] layout shared by arg0 and arg3 is the majority, so arg1
+  // and arg2 are adapted to tensor<4x4x4x5>, yielding concatAxis = 1 and
+  // needsAdapter = {false, true, true, false}. The 4 reshapes then collapse to
+  // 2 adapters + 1 concat + 1 trailing reshape.
+  static std::optional<ReshapeSinkAdapterPlan>
+  compute(ArrayRef<tosa::ReshapeOp> reshapes, ArrayRef<ShapedType> inputTypes,
+          size_t concatAxisAfter) {
+    const size_t numOperands = inputTypes.size();
+    if (numOperands == 0)
+      return std::nullopt;
+
+    // Dims before the concat axis are concat-invariant, so their product
+    // (`boundary`) is shared by all operands.
+    tosa::ReshapeOp firstReshape = reshapes.front();
+    auto firstOutput = cast<ShapedType>(firstReshape.getType());
+    const int64_t boundary =
+        shapeProduct(firstOutput.getShape().take_front(concatAxisAfter));
+
+    SmallVector<OperandAxisLayout> layouts;
+    layouts.reserve(numOperands);
+    for (size_t k = 0; k < numOperands; ++k) {
+      tosa::ReshapeOp reshape = reshapes[k];
+      const int64_t target =
+          cast<ShapedType>(reshape.getType()).getDimSize(concatAxisAfter);
+      std::optional<OperandAxisLayout> layout =
+          OperandAxisLayout::compute(inputTypes[k], boundary, target);
+      if (!layout)
+        return std::nullopt;
+      layouts.push_back(std::move(*layout));
+    }
+
+    // The concat is valid only if all operands agree on the element counts of
+    // the regions surrounding the concat axis. Their decompositions may differ:
+    // each minority operand is rewritten to the reference layout by an adapter
+    // reshape, which relinearizes its prefix/suffix regardless of how those
+    // dims were originally factored (e.g. a 40x2 suffix and an 80x1 suffix
+    // describe the same data and adapt to one another). Unit-dim placement
+    // differences are covered too. The products are guaranteed equal whenever
+    // the surrounding output dims match, but this stays defensive.
+    const int64_t refPrefixProduct = shapeProduct(layouts.front().prefix);
+    const int64_t refSuffixProduct = shapeProduct(layouts.front().suffix);
+    for (const OperandAxisLayout &layout : layouts)
+      if (shapeProduct(layout.prefix) != refPrefixProduct ||
+          shapeProduct(layout.suffix) != refSuffixProduct)
+        return std::nullopt;
+
+    // Pick the real layout shared by the most operands so the fewest adapters
+    // are needed; ties resolve to the first occurrence.
+    auto sameLayout = [](const OperandAxisLayout &a,
+                         const OperandAxisLayout &b) {
+      return a.prefix == b.prefix && a.innerGroup == b.innerGroup &&
+             a.suffix == b.suffix;
+    };
+    const OperandAxisLayout *reference = &layouts.front();
+    size_t bestCount = 0;
+    for (const OperandAxisLayout &candidate : layouts) {
+      const size_t count = llvm::count_if(layouts, [&](const auto &layout) {
+        return sameLayout(layout, candidate);
+      });
+      if (count > bestCount) {
+        bestCount = count;
+        reference = &candidate;
+      }
+    }
+
+    const int64_t referenceInnerProduct = shapeProduct(reference->innerGroup);
+    if (referenceInnerProduct == 0)
+      return std::nullopt;
+
+    // Reshape every minority operand to the reference layout, re-splitting its
+    // concat dim as <concatDim / innerProduct, innerGroup...>.
+    SmallVector<SmallVector<int64_t>> adaptedShapes(numOperands);
+    SmallVector<bool> needsAdapter(numOperands, false);
+    size_t numAdapters = 0;
+    for (size_t k = 0; k < numOperands; ++k) {
+      if (sameLayout(layouts[k], *reference)) {
+        adaptedShapes[k] = llvm::to_vector(inputTypes[k].getShape());
+        continue;
+      }
+
+      tosa::ReshapeOp reshape = reshapes[k];
+      const int64_t concatDim =
+          cast<ShapedType>(reshape.getType()).getDimSize(concatAxisAfter);
+      if (concatDim % referenceInnerProduct != 0)
+        return std::nullopt;
+
+      SmallVector<int64_t> &shape = adaptedShapes[k];
+      shape = reference->prefix;
+      shape.push_back(concatDim / referenceInnerProduct);
+      llvm::append_range(shape, reference->innerGroup);
+      llvm::append_range(shape, reference->suffix);
+      needsAdapter[k] = true;
+      ++numAdapters;
+    }
+
+    // Cost gate: the rewrite emits `numAdapters` reshapes plus one trailing
+    // reshape, so only fire when that is strictly fewer than the originals.
+    if (numAdapters + 1 >= numOperands)
+      return std::nullopt;
+
+    return ReshapeSinkAdapterPlan{reference->prefix.size(),
+                                  std::move(adaptedShapes),
+                                  std::move(needsAdapter)};
+  }
+};
+
 struct SinkReshapeOp : public OpRewritePattern<tosa::ConcatOp> {
   using OpRewritePattern<tosa::ConcatOp>::OpRewritePattern;
 
   LogicalResult matchAndRewrite(tosa::ConcatOp concatOp,
                                 PatternRewriter &rewriter) const override {
-    // High-level algorithm:
-    //   Before rewrite:
-    //     reshape(x0), reshape(x1), ... -> concat(axis = A)
-    //   After rewrite:
-    //     concat(x0, x1, ... , axis = B) -> reshape
-    //
-    // Each reshape operand may admit several possible pre-reshape concat axes
-    // because the reshape can fold or unfold groups of dimensions around the
-    // post-reshape concat axis A. For every operand we compute the candidate
-    // axes B whose prefix product before B matches the prefix product before A
-    // in the reshaped tensor. This aligns the concat boundary in the same
-    // linearized position, independent of whether the reshapes inserted or
-    // removed size-1 dimensions or spread the concatenated chunk across
-    // multiple input dimensions. For example:
-    //   6x1x6 --reshape--> 2x3x1x2x3 --concat(axis=2)--> 2x3x2x2x3
-    // can sink to:
-    //   6x1x6 --concat(axis=1)--> 6x2x6 --reshape--> 2x3x2x2x3
-    // because axis 1 is the input axis that preserves the same linearized
-    // concat boundary.
-    //
-    // We then intersect those candidate sets across all operands and choose the
-    // first common axis that also makes the raw reshape inputs valid operands
-    // of a concat, i.e. they have the same rank, element type, and identical
-    // dimensions on all non-concat axes. If such an axis exists, we build the
-    // concat on the reshape inputs and restore the original result shape with a
-    // single reshape after the concat.
+    // Sinks per-operand reshapes below the concat:
+    //   concat(reshape(x0), reshape(x1), ...) -> reshape(concat(x0', x1', ...))
+    // The pre-reshape concat axis is the input axis mapping to the same
+    // linearized position as the post-reshape concat axis. When operands split
+    // that axis differently (or place unit dims differently), minority operands
+    // are first adapted to a shared layout. For example:
+    //   6x1x6 -reshape-> 2x3x1x2x3 -concat(axis=2)-> 2x3x2x2x3
+    // sinks to:
+    //   6x1x6 -concat(axis=1)-> 6x2x6 -reshape-> 2x3x2x2x3
     const auto concatResultType = dyn_cast<ShapedType>(concatOp.getType());
     if (!concatResultType || !concatResultType.hasStaticShape())
       return rewriter.notifyMatchFailure(
@@ -387,56 +580,74 @@ struct SinkReshapeOp : public OpRewritePattern<tosa::ConcatOp> {
 
     const uint32_t concatAxisAfterReshape = concatOp.getAxis();
     SmallVector<ShapedType> inputTypes;
-    SmallVector<Value> concatOperands;
+    SmallVector<tosa::ReshapeOp> reshapes;
     SmallVector<size_t> commonAxes;
     SmallVector<Location> fusedLocs{concatOp.getLoc()};
 
     for (Value operand : concatOp.getOperands()) {
-      auto infoOrError = getReshapeOperandInfo(operand, concatAxisAfterReshape,
-                                               concatOp, rewriter);
-      if (failed(infoOrError))
+      FailureOr<ReshapeOperandInfo> info = getReshapeOperandInfo(
+          operand, concatAxisAfterReshape, concatOp, rewriter);
+      if (failed(info))
         return failure();
 
-      ReshapeOperandInfo &info = *infoOrError;
-
-      if (inputTypes.empty()) {
-        commonAxes = info.candidateAxes;
-      } else {
-        llvm::erase_if(commonAxes, [&info](size_t axis) {
-          return !llvm::is_contained(info.candidateAxes, axis);
+      if (inputTypes.empty())
+        commonAxes = info->candidateAxes;
+      else
+        llvm::erase_if(commonAxes, [&](size_t axis) {
+          return !llvm::is_contained(info->candidateAxes, axis);
         });
-      }
 
-      inputTypes.push_back(info.inputType);
-      concatOperands.push_back(info.reshape.getInput1());
-      fusedLocs.push_back(info.reshape.getLoc());
+      inputTypes.push_back(info->inputType);
+      reshapes.push_back(info->reshape);
+      fusedLocs.push_back(info->reshape.getLoc());
     }
 
-    if (commonAxes.empty())
-      return rewriter.notifyMatchFailure(
-          concatOp, "Sinking reshape not possible. No common compatible "
-                    "dimension for concat axis found.");
+    const Location fusedLoc = rewriter.getFusedLoc(fusedLocs);
+    SmallVector<Value> operands;
+    size_t concatAxisBeforeReshape = 0;
 
-    std::optional<size_t> concatAxisBeforeReshape;
+    // Fast path: a common pre-reshape axis whose raw inputs are directly
+    // concat-compatible needs no adapter. An empty `commonAxes` (e.g. unit dims
+    // shifted the axis indices apart) is not fatal; the adapter plan can still
+    // normalize the operands.
     for (size_t candidateAxis : commonAxes) {
       if (areConcatInputsCompatible(inputTypes, candidateAxis)) {
         concatAxisBeforeReshape = candidateAxis;
+        for (tosa::ReshapeOp reshape : reshapes)
+          operands.push_back(reshape.getInput1());
         break;
       }
     }
 
-    if (!concatAxisBeforeReshape)
-      return rewriter.notifyMatchFailure(
-          concatOp, "Sinking reshape not possible. Reshape inputs are not "
-                    "concat-compatible on a common pre-reshape axis.");
+    // Slow path: adapt minority operands to a shared decomposition, inserting
+    // an adapter reshape on each.
+    if (operands.empty()) {
+      std::optional<ReshapeSinkAdapterPlan> plan =
+          ReshapeSinkAdapterPlan::compute(reshapes, inputTypes,
+                                          concatAxisAfterReshape);
+      if (!plan)
+        return rewriter.notifyMatchFailure(
+            concatOp, "Reshape inputs are not concat-compatible on a common "
+                      "pre-reshape axis, even after adapting decompositions.");
 
-    Location fusedLoc = rewriter.getFusedLoc(fusedLocs);
-    auto concatNew = rewriter.create<tosa::ConcatOp>(fusedLoc, concatOperands,
-                                                     *concatAxisBeforeReshape);
-    auto reshapeNew = rewriter.create<tosa::ReshapeOp>(
-        fusedLoc, concatResultType, concatNew,
+      concatAxisBeforeReshape = plan->concatAxis;
+      for (size_t k = 0; k < reshapes.size(); ++k) {
+        Value input = reshapes[k].getInput1();
+        if (plan->needsAdapter[k])
+          input = rewriter.create<tosa::ReshapeOp>(
+              fusedLoc,
+              RankedTensorType::get(plan->adaptedShapes[k],
+                                    inputTypes[k].getElementType()),
+              input, rewriter.getDenseI64ArrayAttr(plan->adaptedShapes[k]));
+        operands.push_back(input);
+      }
+    }
+
+    auto concatNew = rewriter.create<tosa::ConcatOp>(fusedLoc, operands,
+                                                     concatAxisBeforeReshape);
+    rewriter.replaceOpWithNewOp<tosa::ReshapeOp>(
+        concatOp, concatResultType, concatNew,
         rewriter.getDenseI64ArrayAttr(concatResultType.getShape()));
-    rewriter.replaceOp(concatOp, reshapeNew.getResult());
     return success();
   }
 };

--- a/mlir/test/Dialect/Tosa/sink-input-ops-through-concat.mlir
+++ b/mlir/test/Dialect/Tosa/sink-input-ops-through-concat.mlir
@@ -496,6 +496,469 @@ func.func @reshape_complex_match(%arg0: tensor<1x42x1x1xbf16>, %arg1: tensor<1x4
 // CHECK:         }
 // -----
 
+// Operands reshape to the same concat shape but split the concat axis
+// differently: three split 256 as 16x16, one as 32x8. The odd operand is
+// adapted to the majority 16x16 split so a single high-rank concat plus one
+// trailing reshape can sink all four reshapes.
+func.func @reshape_differing_decomposition(%arg0: tensor<64x16x16x80x1xbf16>, %arg1: tensor<64x16x16x80x1xbf16>, %arg2: tensor<64x16x16x80x1xbf16>, %arg3: tensor<64x32x8x80x1xbf16>) -> tensor<64x1024x80x1xbf16> {
+  %0 = tosa.reshape %arg0 {new_shape = array<i64: 64, 256, 80, 1>} : (tensor<64x16x16x80x1xbf16>) -> tensor<64x256x80x1xbf16>
+  %1 = tosa.reshape %arg1 {new_shape = array<i64: 64, 256, 80, 1>} : (tensor<64x16x16x80x1xbf16>) -> tensor<64x256x80x1xbf16>
+  %2 = tosa.reshape %arg2 {new_shape = array<i64: 64, 256, 80, 1>} : (tensor<64x16x16x80x1xbf16>) -> tensor<64x256x80x1xbf16>
+  %3 = tosa.reshape %arg3 {new_shape = array<i64: 64, 256, 80, 1>} : (tensor<64x32x8x80x1xbf16>) -> tensor<64x256x80x1xbf16>
+  %4 = tosa.concat %0, %1, %2, %3 {axis = 1 : i32} : (tensor<64x256x80x1xbf16>, tensor<64x256x80x1xbf16>, tensor<64x256x80x1xbf16>, tensor<64x256x80x1xbf16>) -> tensor<64x1024x80x1xbf16>
+  return %4 : tensor<64x1024x80x1xbf16>
+}
+
+// CHECK-LABEL:  func.func @reshape_differing_decomposition
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<64x16x16x80x1xbf16>, [[PARAM_1_:%.+]]: tensor<64x16x16x80x1xbf16>, [[PARAM_2_:%.+]]: tensor<64x16x16x80x1xbf16>, [[PARAM_3_:%.+]]: tensor<64x32x8x80x1xbf16>) -> tensor<64x1024x80x1xbf16> {
+// CHECK:           [[VAR_0_:%.+]] = tosa.reshape [[PARAM_3_]] {new_shape = array<i64: 64, 16, 16, 80, 1>} : (tensor<64x32x8x80x1xbf16>) -> tensor<64x16x16x80x1xbf16>
+// CHECK:           [[VAR_1_:%.+]] = tosa.concat [[PARAM_0_]], [[PARAM_1_]], [[PARAM_2_]], [[VAR_0_]] {axis = 1 : i32} : (tensor<64x16x16x80x1xbf16>, tensor<64x16x16x80x1xbf16>, tensor<64x16x16x80x1xbf16>, tensor<64x16x16x80x1xbf16>) -> tensor<64x64x16x80x1xbf16>
+// CHECK:           [[VAR_2_:%.+]] = tosa.reshape [[VAR_1_]] {new_shape = array<i64: 64, 1024, 80, 1>} : (tensor<64x64x16x80x1xbf16>) -> tensor<64x1024x80x1xbf16>
+// CHECK:           return [[VAR_2_]] : tensor<64x1024x80x1xbf16>
+// CHECK:         }
+// -----
+
+// Two minority operands (32x8 and 8x32) are both adapted to the 16x16 majority.
+// 4 reshapes -> 2 adapters + 1 trailing reshape still reduces the count.
+func.func @reshape_two_minorities(%arg0: tensor<64x16x16x80x1xbf16>, %arg1: tensor<64x16x16x80x1xbf16>, %arg2: tensor<64x32x8x80x1xbf16>, %arg3: tensor<64x8x32x80x1xbf16>) -> tensor<64x1024x80x1xbf16> {
+  %0 = tosa.reshape %arg0 {new_shape = array<i64: 64, 256, 80, 1>} : (tensor<64x16x16x80x1xbf16>) -> tensor<64x256x80x1xbf16>
+  %1 = tosa.reshape %arg1 {new_shape = array<i64: 64, 256, 80, 1>} : (tensor<64x16x16x80x1xbf16>) -> tensor<64x256x80x1xbf16>
+  %2 = tosa.reshape %arg2 {new_shape = array<i64: 64, 256, 80, 1>} : (tensor<64x32x8x80x1xbf16>) -> tensor<64x256x80x1xbf16>
+  %3 = tosa.reshape %arg3 {new_shape = array<i64: 64, 256, 80, 1>} : (tensor<64x8x32x80x1xbf16>) -> tensor<64x256x80x1xbf16>
+  %4 = tosa.concat %0, %1, %2, %3 {axis = 1 : i32} : (tensor<64x256x80x1xbf16>, tensor<64x256x80x1xbf16>, tensor<64x256x80x1xbf16>, tensor<64x256x80x1xbf16>) -> tensor<64x1024x80x1xbf16>
+  return %4 : tensor<64x1024x80x1xbf16>
+}
+
+// CHECK-LABEL:  func.func @reshape_two_minorities
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<64x16x16x80x1xbf16>, [[PARAM_1_:%.+]]: tensor<64x16x16x80x1xbf16>, [[PARAM_2_:%.+]]: tensor<64x32x8x80x1xbf16>, [[PARAM_3_:%.+]]: tensor<64x8x32x80x1xbf16>) -> tensor<64x1024x80x1xbf16> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = tosa.reshape [[PARAM_2_]] {new_shape = array<i64: 64, 16, 16, 80, 1>} : (tensor<64x32x8x80x1xbf16>) -> tensor<64x16x16x80x1xbf16>
+// CHECK-DAG:       [[VAR_1_:%.+]] = tosa.reshape [[PARAM_3_]] {new_shape = array<i64: 64, 16, 16, 80, 1>} : (tensor<64x8x32x80x1xbf16>) -> tensor<64x16x16x80x1xbf16>
+// CHECK:           [[VAR_2_:%.+]] = tosa.concat [[PARAM_0_]], [[PARAM_1_]], [[VAR_0_]], [[VAR_1_]] {axis = 1 : i32} : (tensor<64x16x16x80x1xbf16>, tensor<64x16x16x80x1xbf16>, tensor<64x16x16x80x1xbf16>, tensor<64x16x16x80x1xbf16>) -> tensor<64x64x16x80x1xbf16>
+// CHECK:           [[VAR_3_:%.+]] = tosa.reshape [[VAR_2_]] {new_shape = array<i64: 64, 1024, 80, 1>} : (tensor<64x64x16x80x1xbf16>) -> tensor<64x1024x80x1xbf16>
+// CHECK:           return [[VAR_3_]] : tensor<64x1024x80x1xbf16>
+// CHECK:         }
+// -----
+
+// The majority operands keep the concat axis unsplit (single axis 16); the
+// minority 4x4 split is collapsed to match. The trailing identity reshape folds
+// away, leaving just the adapter reshape and the concat.
+func.func @reshape_collapse_minority(%arg0: tensor<4x16x5xbf16>, %arg1: tensor<4x16x5xbf16>, %arg2: tensor<4x4x4x5xbf16>) -> tensor<4x48x5xbf16> {
+  %0 = tosa.reshape %arg0 {new_shape = array<i64: 4, 16, 5>} : (tensor<4x16x5xbf16>) -> tensor<4x16x5xbf16>
+  %1 = tosa.reshape %arg1 {new_shape = array<i64: 4, 16, 5>} : (tensor<4x16x5xbf16>) -> tensor<4x16x5xbf16>
+  %2 = tosa.reshape %arg2 {new_shape = array<i64: 4, 16, 5>} : (tensor<4x4x4x5xbf16>) -> tensor<4x16x5xbf16>
+  %3 = tosa.concat %0, %1, %2 {axis = 1 : i32} : (tensor<4x16x5xbf16>, tensor<4x16x5xbf16>, tensor<4x16x5xbf16>) -> tensor<4x48x5xbf16>
+  return %3 : tensor<4x48x5xbf16>
+}
+
+// CHECK-LABEL:  func.func @reshape_collapse_minority
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<4x16x5xbf16>, [[PARAM_1_:%.+]]: tensor<4x16x5xbf16>, [[PARAM_2_:%.+]]: tensor<4x4x4x5xbf16>) -> tensor<4x48x5xbf16> {
+// CHECK:           [[VAR_0_:%.+]] = tosa.reshape [[PARAM_2_]] {new_shape = array<i64: 4, 16, 5>} : (tensor<4x4x4x5xbf16>) -> tensor<4x16x5xbf16>
+// CHECK:           [[VAR_1_:%.+]] = tosa.concat [[PARAM_0_]], [[PARAM_1_]], [[VAR_0_]] {axis = 1 : i32} : (tensor<4x16x5xbf16>, tensor<4x16x5xbf16>, tensor<4x16x5xbf16>) -> tensor<4x48x5xbf16>
+// CHECK:           return [[VAR_1_]] : tensor<4x48x5xbf16>
+// CHECK:         }
+// -----
+
+// No decomposition is shared by a majority (all three operands differ), so
+// adapting would not reduce the reshape count: the pass must not fire.
+func.func @reshape_no_majority(%arg0: tensor<4x4x4x5xbf16>, %arg1: tensor<4x2x8x5xbf16>, %arg2: tensor<4x8x2x5xbf16>) -> tensor<4x48x5xbf16> {
+  %0 = tosa.reshape %arg0 {new_shape = array<i64: 4, 16, 5>} : (tensor<4x4x4x5xbf16>) -> tensor<4x16x5xbf16>
+  %1 = tosa.reshape %arg1 {new_shape = array<i64: 4, 16, 5>} : (tensor<4x2x8x5xbf16>) -> tensor<4x16x5xbf16>
+  %2 = tosa.reshape %arg2 {new_shape = array<i64: 4, 16, 5>} : (tensor<4x8x2x5xbf16>) -> tensor<4x16x5xbf16>
+  %3 = tosa.concat %0, %1, %2 {axis = 1 : i32} : (tensor<4x16x5xbf16>, tensor<4x16x5xbf16>, tensor<4x16x5xbf16>) -> tensor<4x48x5xbf16>
+  return %3 : tensor<4x48x5xbf16>
+}
+
+// CHECK-LABEL:  func.func @reshape_no_majority
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<4x4x4x5xbf16>, [[PARAM_1_:%.+]]: tensor<4x2x8x5xbf16>, [[PARAM_2_:%.+]]: tensor<4x8x2x5xbf16>) -> tensor<4x48x5xbf16> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = tosa.reshape [[PARAM_0_]] {new_shape = array<i64: 4, 16, 5>} : (tensor<4x4x4x5xbf16>) -> tensor<4x16x5xbf16>
+// CHECK-DAG:       [[VAR_1_:%.+]] = tosa.reshape [[PARAM_1_]] {new_shape = array<i64: 4, 16, 5>} : (tensor<4x2x8x5xbf16>) -> tensor<4x16x5xbf16>
+// CHECK-DAG:       [[VAR_2_:%.+]] = tosa.reshape [[PARAM_2_]] {new_shape = array<i64: 4, 16, 5>} : (tensor<4x8x2x5xbf16>) -> tensor<4x16x5xbf16>
+// CHECK:           [[VAR_3_:%.+]] = tosa.concat [[VAR_0_]], [[VAR_1_]], [[VAR_2_]] {axis = 1 : i32} : (tensor<4x16x5xbf16>, tensor<4x16x5xbf16>, tensor<4x16x5xbf16>) -> tensor<4x48x5xbf16>
+// CHECK:           return [[VAR_3_]] : tensor<4x48x5xbf16>
+// CHECK:         }
+// -----
+
+// Two distinct minorities (2x8 and 8x2) are adapted to the 4x4 majority layout
+// shared by arg0 and arg3 (arg3 reaches it with a differing 8x4 split of a
+// larger concat dim). 4 reshapes -> 2 adapters + 1 trailing reshape.
+func.func @reshape_with_majority(%arg0: tensor<4x4x4x5xbf16>, %arg1: tensor<4x2x8x5xbf16>, %arg2: tensor<4x8x2x5xbf16>, %arg3: tensor<4x8x4x5xbf16>) -> tensor<4x80x5xbf16> {
+  %0 = tosa.reshape %arg0 {new_shape = array<i64: 4, 16, 5>} : (tensor<4x4x4x5xbf16>) -> tensor<4x16x5xbf16>
+  %1 = tosa.reshape %arg1 {new_shape = array<i64: 4, 16, 5>} : (tensor<4x2x8x5xbf16>) -> tensor<4x16x5xbf16>
+  %2 = tosa.reshape %arg2 {new_shape = array<i64: 4, 16, 5>} : (tensor<4x8x2x5xbf16>) -> tensor<4x16x5xbf16>
+  %4 = tosa.reshape %arg3 {new_shape = array<i64: 4, 32, 5>} : (tensor<4x8x4x5xbf16>) -> tensor<4x32x5xbf16>
+  %3 = tosa.concat %0, %1, %2, %4 {axis = 1 : i32} : (tensor<4x16x5xbf16>, tensor<4x16x5xbf16>, tensor<4x16x5xbf16>, tensor<4x32x5xbf16>) -> tensor<4x80x5xbf16>
+  return %3 : tensor<4x80x5xbf16>
+}
+
+// CHECK-LABEL:  func.func @reshape_with_majority
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<4x4x4x5xbf16>, [[PARAM_1_:%.+]]: tensor<4x2x8x5xbf16>, [[PARAM_2_:%.+]]: tensor<4x8x2x5xbf16>, [[PARAM_3_:%.+]]: tensor<4x8x4x5xbf16>) -> tensor<4x80x5xbf16> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = tosa.reshape [[PARAM_1_]] {new_shape = array<i64: 4, 4, 4, 5>} : (tensor<4x2x8x5xbf16>) -> tensor<4x4x4x5xbf16>
+// CHECK-DAG:       [[VAR_1_:%.+]] = tosa.reshape [[PARAM_2_]] {new_shape = array<i64: 4, 4, 4, 5>} : (tensor<4x8x2x5xbf16>) -> tensor<4x4x4x5xbf16>
+// CHECK:           [[VAR_2_:%.+]] = tosa.concat [[PARAM_0_]], [[VAR_0_]], [[VAR_1_]], [[PARAM_3_]] {axis = 1 : i32} : (tensor<4x4x4x5xbf16>, tensor<4x4x4x5xbf16>, tensor<4x4x4x5xbf16>, tensor<4x8x4x5xbf16>) -> tensor<4x20x4x5xbf16>
+// CHECK:           [[VAR_3_:%.+]] = tosa.reshape [[VAR_2_]] {new_shape = array<i64: 4, 80, 5>} : (tensor<4x20x4x5xbf16>) -> tensor<4x80x5xbf16>
+// CHECK:           return [[VAR_3_]] : tensor<4x80x5xbf16>
+// CHECK:         }
+
+// -----
+
+// The minority operand splits the concat axis differently (16x8 vs 16x16) *and*
+// carries a differing suffix decomposition (40x2 vs 80x1). The suffixes hold
+// the same number of elements (80) and the minority reshape is a pure collapse,
+// so it can still be adapted to the majority 16x16 / 80x1 layout: a single
+// adapter reshape relinearizes it, then one concat plus one trailing reshape
+// sinks all four reshapes.
+func.func @reshape_suffix_mismatch(%arg0: tensor<64x16x16x80x1xbf16>, %arg1: tensor<64x4x16x80x1xbf16>, %arg2: tensor<64x2x16x80x1xbf16>, %arg3: tensor<64x16x8x40x2xbf16>) -> tensor<64x480x80x1xbf16> {
+  %0 = tosa.reshape %arg0 {new_shape = array<i64: 64, 256, 80, 1>} : (tensor<64x16x16x80x1xbf16>) -> tensor<64x256x80x1xbf16>
+  %1 = tosa.reshape %arg1 {new_shape = array<i64: 64, 64, 80, 1>} : (tensor<64x4x16x80x1xbf16>) -> tensor<64x64x80x1xbf16>
+  %2 = tosa.reshape %arg2 {new_shape = array<i64: 64, 32, 80, 1>} : (tensor<64x2x16x80x1xbf16>) -> tensor<64x32x80x1xbf16>
+  %3 = tosa.reshape %arg3 {new_shape = array<i64: 64, 128, 80, 1>} : (tensor<64x16x8x40x2xbf16>) -> tensor<64x128x80x1xbf16>
+  %4 = tosa.concat %0, %1, %2, %3 {axis = 1 : i32} : (tensor<64x256x80x1xbf16>, tensor<64x64x80x1xbf16>, tensor<64x32x80x1xbf16>, tensor<64x128x80x1xbf16>) -> tensor<64x480x80x1xbf16>
+  return %4 : tensor<64x480x80x1xbf16>
+}
+
+// CHECK-LABEL:  func.func @reshape_suffix_mismatch
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<64x16x16x80x1xbf16>, [[PARAM_1_:%.+]]: tensor<64x4x16x80x1xbf16>, [[PARAM_2_:%.+]]: tensor<64x2x16x80x1xbf16>, [[PARAM_3_:%.+]]: tensor<64x16x8x40x2xbf16>) -> tensor<64x480x80x1xbf16> {
+// CHECK:           [[VAR_0_:%.+]] = tosa.reshape [[PARAM_3_]] {new_shape = array<i64: 64, 8, 16, 80, 1>} : (tensor<64x16x8x40x2xbf16>) -> tensor<64x8x16x80x1xbf16>
+// CHECK:           [[VAR_1_:%.+]] = tosa.concat [[PARAM_0_]], [[PARAM_1_]], [[PARAM_2_]], [[VAR_0_]] {axis = 1 : i32} : (tensor<64x16x16x80x1xbf16>, tensor<64x4x16x80x1xbf16>, tensor<64x2x16x80x1xbf16>, tensor<64x8x16x80x1xbf16>) -> tensor<64x30x16x80x1xbf16>
+// CHECK:           [[VAR_2_:%.+]] = tosa.reshape [[VAR_1_]] {new_shape = array<i64: 64, 480, 80, 1>} : (tensor<64x30x16x80x1xbf16>) -> tensor<64x480x80x1xbf16>
+// CHECK:           return [[VAR_2_]] : tensor<64x480x80x1xbf16>
+// CHECK:         }
+// -----
+
+// Operands describe the same layout but place their unit dimensions
+// differently (arg2 leads with a unit dim, the others trail with one). Unit
+// dims are ignored when matching, so the majority real layout (2x4x8x1) is
+// chosen and the minority operand is adapted to it. 3 reshapes -> 1 adapter +
+// 1 trailing reshape.
+func.func @reshape_unit_dim_placement(%arg0: tensor<2x4x8x1xf32>, %arg1: tensor<2x4x8x1xf32>, %arg2: tensor<1x2x4x8xf32>) -> tensor<2x96x1xf32> {
+  %0 = tosa.reshape %arg0 {new_shape = array<i64: 2, 32, 1>} : (tensor<2x4x8x1xf32>) -> tensor<2x32x1xf32>
+  %1 = tosa.reshape %arg1 {new_shape = array<i64: 2, 32, 1>} : (tensor<2x4x8x1xf32>) -> tensor<2x32x1xf32>
+  %2 = tosa.reshape %arg2 {new_shape = array<i64: 2, 32, 1>} : (tensor<1x2x4x8xf32>) -> tensor<2x32x1xf32>
+  %3 = tosa.concat %0, %1, %2 {axis = 1 : i32} : (tensor<2x32x1xf32>, tensor<2x32x1xf32>, tensor<2x32x1xf32>) -> tensor<2x96x1xf32>
+  return %3 : tensor<2x96x1xf32>
+}
+
+// CHECK-LABEL:  func.func @reshape_unit_dim_placement
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<2x4x8x1xf32>, [[PARAM_1_:%.+]]: tensor<2x4x8x1xf32>, [[PARAM_2_:%.+]]: tensor<1x2x4x8xf32>) -> tensor<2x96x1xf32> {
+// CHECK:           [[VAR_0_:%.+]] = tosa.reshape [[PARAM_2_]] {new_shape = array<i64: 2, 4, 8, 1>} : (tensor<1x2x4x8xf32>) -> tensor<2x4x8x1xf32>
+// CHECK:           [[VAR_1_:%.+]] = tosa.concat [[PARAM_0_]], [[PARAM_1_]], [[VAR_0_]] {axis = 1 : i32} : (tensor<2x4x8x1xf32>, tensor<2x4x8x1xf32>, tensor<2x4x8x1xf32>) -> tensor<2x12x8x1xf32>
+// CHECK:           [[VAR_2_:%.+]] = tosa.reshape [[VAR_1_]] {new_shape = array<i64: 2, 96, 1>} : (tensor<2x12x8x1xf32>) -> tensor<2x96x1xf32>
+// CHECK:           return [[VAR_2_]] : tensor<2x96x1xf32>
+// CHECK:         }
+// -----
+
+// Same differing-decomposition adaptation, but the minority operand (32x8) is
+// the *first* concat operand. The adapter is still placed on it and the concat
+// preserves operand order.
+func.func @reshape_minority_first(%arg0: tensor<64x32x8x80x1xbf16>, %arg1: tensor<64x16x16x80x1xbf16>, %arg2: tensor<64x16x16x80x1xbf16>) -> tensor<64x768x80x1xbf16> {
+  %0 = tosa.reshape %arg0 {new_shape = array<i64: 64, 256, 80, 1>} : (tensor<64x32x8x80x1xbf16>) -> tensor<64x256x80x1xbf16>
+  %1 = tosa.reshape %arg1 {new_shape = array<i64: 64, 256, 80, 1>} : (tensor<64x16x16x80x1xbf16>) -> tensor<64x256x80x1xbf16>
+  %2 = tosa.reshape %arg2 {new_shape = array<i64: 64, 256, 80, 1>} : (tensor<64x16x16x80x1xbf16>) -> tensor<64x256x80x1xbf16>
+  %3 = tosa.concat %0, %1, %2 {axis = 1 : i32} : (tensor<64x256x80x1xbf16>, tensor<64x256x80x1xbf16>, tensor<64x256x80x1xbf16>) -> tensor<64x768x80x1xbf16>
+  return %3 : tensor<64x768x80x1xbf16>
+}
+
+// CHECK-LABEL:  func.func @reshape_minority_first
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<64x32x8x80x1xbf16>, [[PARAM_1_:%.+]]: tensor<64x16x16x80x1xbf16>, [[PARAM_2_:%.+]]: tensor<64x16x16x80x1xbf16>) -> tensor<64x768x80x1xbf16> {
+// CHECK:           [[VAR_0_:%.+]] = tosa.reshape [[PARAM_0_]] {new_shape = array<i64: 64, 16, 16, 80, 1>} : (tensor<64x32x8x80x1xbf16>) -> tensor<64x16x16x80x1xbf16>
+// CHECK:           [[VAR_1_:%.+]] = tosa.concat [[VAR_0_]], [[PARAM_1_]], [[PARAM_2_]] {axis = 1 : i32} : (tensor<64x16x16x80x1xbf16>, tensor<64x16x16x80x1xbf16>, tensor<64x16x16x80x1xbf16>) -> tensor<64x48x16x80x1xbf16>
+// CHECK:           [[VAR_2_:%.+]] = tosa.reshape [[VAR_1_]] {new_shape = array<i64: 64, 768, 80, 1>} : (tensor<64x48x16x80x1xbf16>) -> tensor<64x768x80x1xbf16>
+// CHECK:           return [[VAR_2_]] : tensor<64x768x80x1xbf16>
+// CHECK:         }
+// -----
+
+// The minority operand (32x8) sits in the *middle* of the concat operands.
+func.func @reshape_minority_middle(%arg0: tensor<64x16x16x80x1xbf16>, %arg1: tensor<64x32x8x80x1xbf16>, %arg2: tensor<64x16x16x80x1xbf16>) -> tensor<64x768x80x1xbf16> {
+  %0 = tosa.reshape %arg0 {new_shape = array<i64: 64, 256, 80, 1>} : (tensor<64x16x16x80x1xbf16>) -> tensor<64x256x80x1xbf16>
+  %1 = tosa.reshape %arg1 {new_shape = array<i64: 64, 256, 80, 1>} : (tensor<64x32x8x80x1xbf16>) -> tensor<64x256x80x1xbf16>
+  %2 = tosa.reshape %arg2 {new_shape = array<i64: 64, 256, 80, 1>} : (tensor<64x16x16x80x1xbf16>) -> tensor<64x256x80x1xbf16>
+  %3 = tosa.concat %0, %1, %2 {axis = 1 : i32} : (tensor<64x256x80x1xbf16>, tensor<64x256x80x1xbf16>, tensor<64x256x80x1xbf16>) -> tensor<64x768x80x1xbf16>
+  return %3 : tensor<64x768x80x1xbf16>
+}
+
+// CHECK-LABEL:  func.func @reshape_minority_middle
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<64x16x16x80x1xbf16>, [[PARAM_1_:%.+]]: tensor<64x32x8x80x1xbf16>, [[PARAM_2_:%.+]]: tensor<64x16x16x80x1xbf16>) -> tensor<64x768x80x1xbf16> {
+// CHECK:           [[VAR_0_:%.+]] = tosa.reshape [[PARAM_1_]] {new_shape = array<i64: 64, 16, 16, 80, 1>} : (tensor<64x32x8x80x1xbf16>) -> tensor<64x16x16x80x1xbf16>
+// CHECK:           [[VAR_1_:%.+]] = tosa.concat [[PARAM_0_]], [[VAR_0_]], [[PARAM_2_]] {axis = 1 : i32} : (tensor<64x16x16x80x1xbf16>, tensor<64x16x16x80x1xbf16>, tensor<64x16x16x80x1xbf16>) -> tensor<64x48x16x80x1xbf16>
+// CHECK:           [[VAR_2_:%.+]] = tosa.reshape [[VAR_1_]] {new_shape = array<i64: 64, 768, 80, 1>} : (tensor<64x48x16x80x1xbf16>) -> tensor<64x768x80x1xbf16>
+// CHECK:           return [[VAR_2_]] : tensor<64x768x80x1xbf16>
+// CHECK:         }
+// -----
+
+// Rank-reducing reshapes (3D -> 1D) that fully collapse the tensor. The single
+// shared pre-reshape axis 0 lets the concat sink with no adapter.
+func.func @reshape_merge_to_1d(%arg0: tensor<2x3x4xf32>, %arg1: tensor<2x3x4xf32>) -> tensor<48xf32> {
+  %0 = tosa.reshape %arg0 {new_shape = array<i64: 24>} : (tensor<2x3x4xf32>) -> tensor<24xf32>
+  %1 = tosa.reshape %arg1 {new_shape = array<i64: 24>} : (tensor<2x3x4xf32>) -> tensor<24xf32>
+  %2 = tosa.concat %0, %1 {axis = 0 : i32} : (tensor<24xf32>, tensor<24xf32>) -> tensor<48xf32>
+  return %2 : tensor<48xf32>
+}
+
+// CHECK-LABEL:  func.func @reshape_merge_to_1d
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<2x3x4xf32>, [[PARAM_1_:%.+]]: tensor<2x3x4xf32>) -> tensor<48xf32> {
+// CHECK:           [[VAR_0_:%.+]] = tosa.concat [[PARAM_0_]], [[PARAM_1_]] {axis = 0 : i32} : (tensor<2x3x4xf32>, tensor<2x3x4xf32>) -> tensor<4x3x4xf32>
+// CHECK:           [[VAR_1_:%.+]] = tosa.reshape [[VAR_0_]] {new_shape = array<i64: 48>} : (tensor<4x3x4xf32>) -> tensor<48xf32>
+// CHECK:           return [[VAR_1_]] : tensor<48xf32>
+// CHECK:         }
+// -----
+
+// Rank-increasing reshapes (2D -> 4D) that split a dimension. The concat axis 0
+// maps to input axis 0 and sinks with no adapter.
+func.func @reshape_split_higher_rank(%arg0: tensor<3x24xf32>, %arg1: tensor<3x24xf32>) -> tensor<6x2x3x4xf32> {
+  %0 = tosa.reshape %arg0 {new_shape = array<i64: 3, 2, 3, 4>} : (tensor<3x24xf32>) -> tensor<3x2x3x4xf32>
+  %1 = tosa.reshape %arg1 {new_shape = array<i64: 3, 2, 3, 4>} : (tensor<3x24xf32>) -> tensor<3x2x3x4xf32>
+  %2 = tosa.concat %0, %1 {axis = 0 : i32} : (tensor<3x2x3x4xf32>, tensor<3x2x3x4xf32>) -> tensor<6x2x3x4xf32>
+  return %2 : tensor<6x2x3x4xf32>
+}
+
+// CHECK-LABEL:  func.func @reshape_split_higher_rank
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<3x24xf32>, [[PARAM_1_:%.+]]: tensor<3x24xf32>) -> tensor<6x2x3x4xf32> {
+// CHECK:           [[VAR_0_:%.+]] = tosa.concat [[PARAM_0_]], [[PARAM_1_]] {axis = 0 : i32} : (tensor<3x24xf32>, tensor<3x24xf32>) -> tensor<6x24xf32>
+// CHECK:           [[VAR_1_:%.+]] = tosa.reshape [[VAR_0_]] {new_shape = array<i64: 6, 2, 3, 4>} : (tensor<6x24xf32>) -> tensor<6x2x3x4xf32>
+// CHECK:           return [[VAR_1_]] : tensor<6x2x3x4xf32>
+// CHECK:         }
+// -----
+
+// Complex reshape: the minority operand both drops a unit dimension (implicit
+// squeeze of the leading-group 1) *and* keeps the concat axis unsplit (12)
+// while the majority splits it (3x4). It is adapted to the majority 3x4 layout.
+func.func @reshape_squeeze_and_split(%arg0: tensor<2x3x4x5xf32>, %arg1: tensor<2x3x4x5xf32>, %arg2: tensor<2x1x12x5xf32>) -> tensor<2x36x5xf32> {
+  %0 = tosa.reshape %arg0 {new_shape = array<i64: 2, 12, 5>} : (tensor<2x3x4x5xf32>) -> tensor<2x12x5xf32>
+  %1 = tosa.reshape %arg1 {new_shape = array<i64: 2, 12, 5>} : (tensor<2x3x4x5xf32>) -> tensor<2x12x5xf32>
+  %2 = tosa.reshape %arg2 {new_shape = array<i64: 2, 12, 5>} : (tensor<2x1x12x5xf32>) -> tensor<2x12x5xf32>
+  %3 = tosa.concat %0, %1, %2 {axis = 1 : i32} : (tensor<2x12x5xf32>, tensor<2x12x5xf32>, tensor<2x12x5xf32>) -> tensor<2x36x5xf32>
+  return %3 : tensor<2x36x5xf32>
+}
+
+// CHECK-LABEL:  func.func @reshape_squeeze_and_split
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<2x3x4x5xf32>, [[PARAM_1_:%.+]]: tensor<2x3x4x5xf32>, [[PARAM_2_:%.+]]: tensor<2x1x12x5xf32>) -> tensor<2x36x5xf32> {
+// CHECK:           [[VAR_0_:%.+]] = tosa.reshape [[PARAM_2_]] {new_shape = array<i64: 2, 3, 4, 5>} : (tensor<2x1x12x5xf32>) -> tensor<2x3x4x5xf32>
+// CHECK:           [[VAR_1_:%.+]] = tosa.concat [[PARAM_0_]], [[PARAM_1_]], [[VAR_0_]] {axis = 1 : i32} : (tensor<2x3x4x5xf32>, tensor<2x3x4x5xf32>, tensor<2x3x4x5xf32>) -> tensor<2x9x4x5xf32>
+// CHECK:           [[VAR_2_:%.+]] = tosa.reshape [[VAR_1_]] {new_shape = array<i64: 2, 36, 5>} : (tensor<2x9x4x5xf32>) -> tensor<2x36x5xf32>
+// CHECK:           return [[VAR_2_]] : tensor<2x36x5xf32>
+// CHECK:         }
+// -----
+
+// Complex reshape: the majority carries a trailing unit dim (2x6x1x8) while the
+// minority carries a leading one (1x2x6x8). Unit dims are ignored when matching,
+// so the minority is reshaped to the majority real layout before the concat.
+func.func @reshape_mixed_unit_dims(%arg0: tensor<2x6x1x8xf32>, %arg1: tensor<2x6x1x8xf32>, %arg2: tensor<1x2x6x8xf32>) -> tensor<2x18x8xf32> {
+  %0 = tosa.reshape %arg0 {new_shape = array<i64: 2, 6, 8>} : (tensor<2x6x1x8xf32>) -> tensor<2x6x8xf32>
+  %1 = tosa.reshape %arg1 {new_shape = array<i64: 2, 6, 8>} : (tensor<2x6x1x8xf32>) -> tensor<2x6x8xf32>
+  %2 = tosa.reshape %arg2 {new_shape = array<i64: 2, 6, 8>} : (tensor<1x2x6x8xf32>) -> tensor<2x6x8xf32>
+  %3 = tosa.concat %0, %1, %2 {axis = 1 : i32} : (tensor<2x6x8xf32>, tensor<2x6x8xf32>, tensor<2x6x8xf32>) -> tensor<2x18x8xf32>
+  return %3 : tensor<2x18x8xf32>
+}
+
+// CHECK-LABEL:  func.func @reshape_mixed_unit_dims
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<2x6x1x8xf32>, [[PARAM_1_:%.+]]: tensor<2x6x1x8xf32>, [[PARAM_2_:%.+]]: tensor<1x2x6x8xf32>) -> tensor<2x18x8xf32> {
+// CHECK:           [[VAR_0_:%.+]] = tosa.reshape [[PARAM_2_]] {new_shape = array<i64: 2, 6, 1, 8>} : (tensor<1x2x6x8xf32>) -> tensor<2x6x1x8xf32>
+// CHECK:           [[VAR_1_:%.+]] = tosa.concat [[PARAM_0_]], [[PARAM_1_]], [[VAR_0_]] {axis = 1 : i32} : (tensor<2x6x1x8xf32>, tensor<2x6x1x8xf32>, tensor<2x6x1x8xf32>) -> tensor<2x18x1x8xf32>
+// CHECK:           [[VAR_2_:%.+]] = tosa.reshape [[VAR_1_]] {new_shape = array<i64: 2, 18, 8>} : (tensor<2x18x1x8xf32>) -> tensor<2x18x8xf32>
+// CHECK:           return [[VAR_2_]] : tensor<2x18x8xf32>
+// CHECK:         }
+// -----
+
+// Five operands: three share the unsplit majority layout (6) and two distinct
+// minorities (2x3 and 3x2) are each adapted. 5 reshapes -> 2 adapters and the
+// trailing reshape folds away (concat already yields the result shape).
+func.func @reshape_five_operands(%arg0: tensor<8x6x10xf32>, %arg1: tensor<8x6x10xf32>, %arg2: tensor<8x6x10xf32>, %arg3: tensor<8x2x3x10xf32>, %arg4: tensor<8x3x2x10xf32>) -> tensor<8x30x10xf32> {
+  %0 = tosa.reshape %arg0 {new_shape = array<i64: 8, 6, 10>} : (tensor<8x6x10xf32>) -> tensor<8x6x10xf32>
+  %1 = tosa.reshape %arg1 {new_shape = array<i64: 8, 6, 10>} : (tensor<8x6x10xf32>) -> tensor<8x6x10xf32>
+  %2 = tosa.reshape %arg2 {new_shape = array<i64: 8, 6, 10>} : (tensor<8x6x10xf32>) -> tensor<8x6x10xf32>
+  %3 = tosa.reshape %arg3 {new_shape = array<i64: 8, 6, 10>} : (tensor<8x2x3x10xf32>) -> tensor<8x6x10xf32>
+  %4 = tosa.reshape %arg4 {new_shape = array<i64: 8, 6, 10>} : (tensor<8x3x2x10xf32>) -> tensor<8x6x10xf32>
+  %5 = tosa.concat %0, %1, %2, %3, %4 {axis = 1 : i32} : (tensor<8x6x10xf32>, tensor<8x6x10xf32>, tensor<8x6x10xf32>, tensor<8x6x10xf32>, tensor<8x6x10xf32>) -> tensor<8x30x10xf32>
+  return %5 : tensor<8x30x10xf32>
+}
+
+// CHECK-LABEL:  func.func @reshape_five_operands
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<8x6x10xf32>, [[PARAM_1_:%.+]]: tensor<8x6x10xf32>, [[PARAM_2_:%.+]]: tensor<8x6x10xf32>, [[PARAM_3_:%.+]]: tensor<8x2x3x10xf32>, [[PARAM_4_:%.+]]: tensor<8x3x2x10xf32>) -> tensor<8x30x10xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = tosa.reshape [[PARAM_3_]] {new_shape = array<i64: 8, 6, 10>} : (tensor<8x2x3x10xf32>) -> tensor<8x6x10xf32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = tosa.reshape [[PARAM_4_]] {new_shape = array<i64: 8, 6, 10>} : (tensor<8x3x2x10xf32>) -> tensor<8x6x10xf32>
+// CHECK:           [[VAR_2_:%.+]] = tosa.concat [[PARAM_0_]], [[PARAM_1_]], [[PARAM_2_]], [[VAR_0_]], [[VAR_1_]] {axis = 1 : i32} : (tensor<8x6x10xf32>, tensor<8x6x10xf32>, tensor<8x6x10xf32>, tensor<8x6x10xf32>, tensor<8x6x10xf32>) -> tensor<8x30x10xf32>
+// CHECK:           return [[VAR_2_]] : tensor<8x30x10xf32>
+// CHECK:         }
+// -----
+
+// A reshape result feeding both the concat and another consumer is not
+// single-use, so the pattern must not fire.
+func.func @reshape_multiple_uses(%arg0: tensor<2x3x4xf32>, %arg1: tensor<2x3x4xf32>) -> (tensor<48xf32>, tensor<24xf32>) {
+  %0 = tosa.reshape %arg0 {new_shape = array<i64: 24>} : (tensor<2x3x4xf32>) -> tensor<24xf32>
+  %1 = tosa.reshape %arg1 {new_shape = array<i64: 24>} : (tensor<2x3x4xf32>) -> tensor<24xf32>
+  %2 = tosa.concat %0, %1 {axis = 0 : i32} : (tensor<24xf32>, tensor<24xf32>) -> tensor<48xf32>
+  return %2, %0 : tensor<48xf32>, tensor<24xf32>
+}
+
+// CHECK-LABEL:  func.func @reshape_multiple_uses
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<2x3x4xf32>, [[PARAM_1_:%.+]]: tensor<2x3x4xf32>) -> (tensor<48xf32>, tensor<24xf32>) {
+// CHECK-DAG:       [[VAR_0_:%.+]] = tosa.reshape [[PARAM_0_]] {new_shape = array<i64: 24>} : (tensor<2x3x4xf32>) -> tensor<24xf32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = tosa.reshape [[PARAM_1_]] {new_shape = array<i64: 24>} : (tensor<2x3x4xf32>) -> tensor<24xf32>
+// CHECK:           [[VAR_2_:%.+]] = tosa.concat [[VAR_0_]], [[VAR_1_]] {axis = 0 : i32} : (tensor<24xf32>, tensor<24xf32>) -> tensor<48xf32>
+// CHECK:           return [[VAR_2_]], [[VAR_0_]] : tensor<48xf32>, tensor<24xf32>
+// CHECK:         }
+// -----
+
+// Dynamic reshape input shapes are unsupported, so the pattern must not fire.
+func.func @reshape_dynamic_shape(%arg0: tensor<?x4xf32>, %arg1: tensor<?x4xf32>) -> tensor<?x2x2xf32> {
+  %0 = tosa.reshape %arg0 {new_shape = array<i64: -1, 2, 2>} : (tensor<?x4xf32>) -> tensor<?x2x2xf32>
+  %1 = tosa.reshape %arg1 {new_shape = array<i64: -1, 2, 2>} : (tensor<?x4xf32>) -> tensor<?x2x2xf32>
+  %2 = tosa.concat %0, %1 {axis = 0 : i32} : (tensor<?x2x2xf32>, tensor<?x2x2xf32>) -> tensor<?x2x2xf32>
+  return %2 : tensor<?x2x2xf32>
+}
+
+// CHECK-LABEL:  func.func @reshape_dynamic_shape
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<?x4xf32>, [[PARAM_1_:%.+]]: tensor<?x4xf32>) -> tensor<?x2x2xf32> {
+// CHECK-DAG:       [[VAR_0_:%.+]] = tosa.reshape [[PARAM_0_]] {new_shape = array<i64: -1, 2, 2>} : (tensor<?x4xf32>) -> tensor<?x2x2xf32>
+// CHECK-DAG:       [[VAR_1_:%.+]] = tosa.reshape [[PARAM_1_]] {new_shape = array<i64: -1, 2, 2>} : (tensor<?x4xf32>) -> tensor<?x2x2xf32>
+// CHECK:           [[VAR_2_:%.+]] = tosa.concat [[VAR_0_]], [[VAR_1_]] {axis = 0 : i32} : (tensor<?x2x2xf32>, tensor<?x2x2xf32>) -> tensor<?x2x2xf32>
+// CHECK:           return [[VAR_2_]] : tensor<?x2x2xf32>
+// CHECK:         }
+// -----
+
+// Concat on the innermost axis: the reshape merges the trailing 2x3 into 6, so
+// the concat sinks onto input axis 1 (the start of that merged group).
+func.func @reshape_innermost_axis(%arg0: tensor<4x2x3xf32>, %arg1: tensor<4x2x3xf32>) -> tensor<4x12xf32> {
+  %0 = tosa.reshape %arg0 {new_shape = array<i64: 4, 6>} : (tensor<4x2x3xf32>) -> tensor<4x6xf32>
+  %1 = tosa.reshape %arg1 {new_shape = array<i64: 4, 6>} : (tensor<4x2x3xf32>) -> tensor<4x6xf32>
+  %2 = tosa.concat %0, %1 {axis = 1 : i32} : (tensor<4x6xf32>, tensor<4x6xf32>) -> tensor<4x12xf32>
+  return %2 : tensor<4x12xf32>
+}
+
+// CHECK-LABEL:  func.func @reshape_innermost_axis
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<4x2x3xf32>, [[PARAM_1_:%.+]]: tensor<4x2x3xf32>) -> tensor<4x12xf32> {
+// CHECK:           [[VAR_0_:%.+]] = tosa.concat [[PARAM_0_]], [[PARAM_1_]] {axis = 1 : i32} : (tensor<4x2x3xf32>, tensor<4x2x3xf32>) -> tensor<4x4x3xf32>
+// CHECK:           [[VAR_1_:%.+]] = tosa.reshape [[VAR_0_]] {new_shape = array<i64: 4, 12>} : (tensor<4x4x3xf32>) -> tensor<4x12xf32>
+// CHECK:           return [[VAR_1_]] : tensor<4x12xf32>
+// CHECK:         }
+// -----
+
+// Concat on the innermost axis of a 3D result produced from a 4D input: the
+// concat sinks onto the input's innermost axis 3.
+func.func @reshape_innermost_high_rank(%arg0: tensor<2x3x4x5xf32>, %arg1: tensor<2x3x4x5xf32>) -> tensor<2x12x10xf32> {
+  %0 = tosa.reshape %arg0 {new_shape = array<i64: 2, 12, 5>} : (tensor<2x3x4x5xf32>) -> tensor<2x12x5xf32>
+  %1 = tosa.reshape %arg1 {new_shape = array<i64: 2, 12, 5>} : (tensor<2x3x4x5xf32>) -> tensor<2x12x5xf32>
+  %2 = tosa.concat %0, %1 {axis = 2 : i32} : (tensor<2x12x5xf32>, tensor<2x12x5xf32>) -> tensor<2x12x10xf32>
+  return %2 : tensor<2x12x10xf32>
+}
+
+// CHECK-LABEL:  func.func @reshape_innermost_high_rank
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<2x3x4x5xf32>, [[PARAM_1_:%.+]]: tensor<2x3x4x5xf32>) -> tensor<2x12x10xf32> {
+// CHECK:           [[VAR_0_:%.+]] = tosa.concat [[PARAM_0_]], [[PARAM_1_]] {axis = 3 : i32} : (tensor<2x3x4x5xf32>, tensor<2x3x4x5xf32>) -> tensor<2x3x4x10xf32>
+// CHECK:           [[VAR_1_:%.+]] = tosa.reshape [[VAR_0_]] {new_shape = array<i64: 2, 12, 10>} : (tensor<2x3x4x10xf32>) -> tensor<2x12x10xf32>
+// CHECK:           return [[VAR_1_]] : tensor<2x12x10xf32>
+// CHECK:         }
+// -----
+
+// Concat on a middle axis (2) of a 4D result produced from a 5D input: the
+// 4x5 group merged into 20 sinks the concat onto input axis 2.
+func.func @reshape_mid_axis_high_rank(%arg0: tensor<2x3x4x5x6xf32>, %arg1: tensor<2x3x4x5x6xf32>) -> tensor<2x3x40x6xf32> {
+  %0 = tosa.reshape %arg0 {new_shape = array<i64: 2, 3, 20, 6>} : (tensor<2x3x4x5x6xf32>) -> tensor<2x3x20x6xf32>
+  %1 = tosa.reshape %arg1 {new_shape = array<i64: 2, 3, 20, 6>} : (tensor<2x3x4x5x6xf32>) -> tensor<2x3x20x6xf32>
+  %2 = tosa.concat %0, %1 {axis = 2 : i32} : (tensor<2x3x20x6xf32>, tensor<2x3x20x6xf32>) -> tensor<2x3x40x6xf32>
+  return %2 : tensor<2x3x40x6xf32>
+}
+
+// CHECK-LABEL:  func.func @reshape_mid_axis_high_rank
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<2x3x4x5x6xf32>, [[PARAM_1_:%.+]]: tensor<2x3x4x5x6xf32>) -> tensor<2x3x40x6xf32> {
+// CHECK:           [[VAR_0_:%.+]] = tosa.concat [[PARAM_0_]], [[PARAM_1_]] {axis = 2 : i32} : (tensor<2x3x4x5x6xf32>, tensor<2x3x4x5x6xf32>) -> tensor<2x3x8x5x6xf32>
+// CHECK:           [[VAR_1_:%.+]] = tosa.reshape [[VAR_0_]] {new_shape = array<i64: 2, 3, 40, 6>} : (tensor<2x3x8x5x6xf32>) -> tensor<2x3x40x6xf32>
+// CHECK:           return [[VAR_1_]] : tensor<2x3x40x6xf32>
+// CHECK:         }
+// -----
+
+// Concat on the innermost axis (3) of a 4D result produced from a 5D input:
+// the trailing 5x6 merged into 30 sinks the concat onto input axis 3.
+func.func @reshape_axis3_merge(%arg0: tensor<2x3x4x5x6xf32>, %arg1: tensor<2x3x4x5x6xf32>) -> tensor<2x3x4x60xf32> {
+  %0 = tosa.reshape %arg0 {new_shape = array<i64: 2, 3, 4, 30>} : (tensor<2x3x4x5x6xf32>) -> tensor<2x3x4x30xf32>
+  %1 = tosa.reshape %arg1 {new_shape = array<i64: 2, 3, 4, 30>} : (tensor<2x3x4x5x6xf32>) -> tensor<2x3x4x30xf32>
+  %2 = tosa.concat %0, %1 {axis = 3 : i32} : (tensor<2x3x4x30xf32>, tensor<2x3x4x30xf32>) -> tensor<2x3x4x60xf32>
+  return %2 : tensor<2x3x4x60xf32>
+}
+
+// CHECK-LABEL:  func.func @reshape_axis3_merge
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<2x3x4x5x6xf32>, [[PARAM_1_:%.+]]: tensor<2x3x4x5x6xf32>) -> tensor<2x3x4x60xf32> {
+// CHECK:           [[VAR_0_:%.+]] = tosa.concat [[PARAM_0_]], [[PARAM_1_]] {axis = 3 : i32} : (tensor<2x3x4x5x6xf32>, tensor<2x3x4x5x6xf32>) -> tensor<2x3x4x10x6xf32>
+// CHECK:           [[VAR_1_:%.+]] = tosa.reshape [[VAR_0_]] {new_shape = array<i64: 2, 3, 4, 60>} : (tensor<2x3x4x10x6xf32>) -> tensor<2x3x4x60xf32>
+// CHECK:           return [[VAR_1_]] : tensor<2x3x4x60xf32>
+// CHECK:         }
+// -----
+
+// Rank-increasing reshape (3D->4D, inserts a leading unit dim into the result)
+// with concat on axis 2: the concat sinks onto input axis 1.
+func.func @reshape_unsqueeze_mid_axis(%arg0: tensor<2x3x4xf32>, %arg1: tensor<2x3x4xf32>) -> tensor<2x1x6x4xf32> {
+  %0 = tosa.reshape %arg0 {new_shape = array<i64: 2, 1, 3, 4>} : (tensor<2x3x4xf32>) -> tensor<2x1x3x4xf32>
+  %1 = tosa.reshape %arg1 {new_shape = array<i64: 2, 1, 3, 4>} : (tensor<2x3x4xf32>) -> tensor<2x1x3x4xf32>
+  %2 = tosa.concat %0, %1 {axis = 2 : i32} : (tensor<2x1x3x4xf32>, tensor<2x1x3x4xf32>) -> tensor<2x1x6x4xf32>
+  return %2 : tensor<2x1x6x4xf32>
+}
+
+// CHECK-LABEL:  func.func @reshape_unsqueeze_mid_axis
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<2x3x4xf32>, [[PARAM_1_:%.+]]: tensor<2x3x4xf32>) -> tensor<2x1x6x4xf32> {
+// CHECK:           [[VAR_0_:%.+]] = tosa.concat [[PARAM_0_]], [[PARAM_1_]] {axis = 1 : i32} : (tensor<2x3x4xf32>, tensor<2x3x4xf32>) -> tensor<2x6x4xf32>
+// CHECK:           [[VAR_1_:%.+]] = tosa.reshape [[VAR_0_]] {new_shape = array<i64: 2, 1, 6, 4>} : (tensor<2x6x4xf32>) -> tensor<2x1x6x4xf32>
+// CHECK:           return [[VAR_1_]] : tensor<2x1x6x4xf32>
+// CHECK:         }
+// -----
+
+// Adapter path on the innermost axis (2): two majority operands split 256 as
+// 16x16, the minority splits 32x8 and is reshaped to the majority layout
+// before a single high-rank concat plus one trailing reshape.
+func.func @reshape_adapter_innermost(%arg0: tensor<2x64x16x16xf32>, %arg1: tensor<2x64x16x16xf32>, %arg2: tensor<2x64x32x8xf32>) -> tensor<2x64x768xf32> {
+  %0 = tosa.reshape %arg0 {new_shape = array<i64: 2, 64, 256>} : (tensor<2x64x16x16xf32>) -> tensor<2x64x256xf32>
+  %1 = tosa.reshape %arg1 {new_shape = array<i64: 2, 64, 256>} : (tensor<2x64x16x16xf32>) -> tensor<2x64x256xf32>
+  %2 = tosa.reshape %arg2 {new_shape = array<i64: 2, 64, 256>} : (tensor<2x64x32x8xf32>) -> tensor<2x64x256xf32>
+  %3 = tosa.concat %0, %1, %2 {axis = 2 : i32} : (tensor<2x64x256xf32>, tensor<2x64x256xf32>, tensor<2x64x256xf32>) -> tensor<2x64x768xf32>
+  return %3 : tensor<2x64x768xf32>
+}
+
+// CHECK-LABEL:  func.func @reshape_adapter_innermost
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<2x64x16x16xf32>, [[PARAM_1_:%.+]]: tensor<2x64x16x16xf32>, [[PARAM_2_:%.+]]: tensor<2x64x32x8xf32>) -> tensor<2x64x768xf32> {
+// CHECK:           [[VAR_0_:%.+]] = tosa.reshape [[PARAM_2_]] {new_shape = array<i64: 2, 64, 16, 16>} : (tensor<2x64x32x8xf32>) -> tensor<2x64x16x16xf32>
+// CHECK:           [[VAR_1_:%.+]] = tosa.concat [[PARAM_0_]], [[PARAM_1_]], [[VAR_0_]] {axis = 2 : i32} : (tensor<2x64x16x16xf32>, tensor<2x64x16x16xf32>, tensor<2x64x16x16xf32>) -> tensor<2x64x48x16xf32>
+// CHECK:           [[VAR_2_:%.+]] = tosa.reshape [[VAR_1_]] {new_shape = array<i64: 2, 64, 768>} : (tensor<2x64x48x16xf32>) -> tensor<2x64x768xf32>
+// CHECK:           return [[VAR_2_]] : tensor<2x64x768xf32>
+// CHECK:         }
+// -----
+
+// Adapter path on a middle axis (2) with a trailing suffix (5D inputs): only
+// the minority 32x8 operand is reshaped.
+func.func @reshape_adapter_mid_axis(%arg0: tensor<2x64x16x16x5xf32>, %arg1: tensor<2x64x16x16x5xf32>, %arg2: tensor<2x64x32x8x5xf32>) -> tensor<2x64x768x5xf32> {
+  %0 = tosa.reshape %arg0 {new_shape = array<i64: 2, 64, 256, 5>} : (tensor<2x64x16x16x5xf32>) -> tensor<2x64x256x5xf32>
+  %1 = tosa.reshape %arg1 {new_shape = array<i64: 2, 64, 256, 5>} : (tensor<2x64x16x16x5xf32>) -> tensor<2x64x256x5xf32>
+  %2 = tosa.reshape %arg2 {new_shape = array<i64: 2, 64, 256, 5>} : (tensor<2x64x32x8x5xf32>) -> tensor<2x64x256x5xf32>
+  %3 = tosa.concat %0, %1, %2 {axis = 2 : i32} : (tensor<2x64x256x5xf32>, tensor<2x64x256x5xf32>, tensor<2x64x256x5xf32>) -> tensor<2x64x768x5xf32>
+  return %3 : tensor<2x64x768x5xf32>
+}
+
+// CHECK-LABEL:  func.func @reshape_adapter_mid_axis
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<2x64x16x16x5xf32>, [[PARAM_1_:%.+]]: tensor<2x64x16x16x5xf32>, [[PARAM_2_:%.+]]: tensor<2x64x32x8x5xf32>) -> tensor<2x64x768x5xf32> {
+// CHECK:           [[VAR_0_:%.+]] = tosa.reshape [[PARAM_2_]] {new_shape = array<i64: 2, 64, 16, 16, 5>} : (tensor<2x64x32x8x5xf32>) -> tensor<2x64x16x16x5xf32>
+// CHECK:           [[VAR_1_:%.+]] = tosa.concat [[PARAM_0_]], [[PARAM_1_]], [[VAR_0_]] {axis = 2 : i32} : (tensor<2x64x16x16x5xf32>, tensor<2x64x16x16x5xf32>, tensor<2x64x16x16x5xf32>) -> tensor<2x64x48x16x5xf32>
+// CHECK:           [[VAR_2_:%.+]] = tosa.reshape [[VAR_1_]] {new_shape = array<i64: 2, 64, 768, 5>} : (tensor<2x64x48x16x5xf32>) -> tensor<2x64x768x5xf32>
+// CHECK:           return [[VAR_2_]] : tensor<2x64x768x5xf32>
+// CHECK:         }
+// -----
+
+// Adapter path on the innermost axis (3) of a 4D result (5D inputs): the
+// minority 32x8 operand is reshaped to the 16x16 majority layout.
+func.func @reshape_adapter_axis3(%arg0: tensor<2x4x8x16x16xf32>, %arg1: tensor<2x4x8x16x16xf32>, %arg2: tensor<2x4x8x32x8xf32>) -> tensor<2x4x8x768xf32> {
+  %0 = tosa.reshape %arg0 {new_shape = array<i64: 2, 4, 8, 256>} : (tensor<2x4x8x16x16xf32>) -> tensor<2x4x8x256xf32>
+  %1 = tosa.reshape %arg1 {new_shape = array<i64: 2, 4, 8, 256>} : (tensor<2x4x8x16x16xf32>) -> tensor<2x4x8x256xf32>
+  %2 = tosa.reshape %arg2 {new_shape = array<i64: 2, 4, 8, 256>} : (tensor<2x4x8x32x8xf32>) -> tensor<2x4x8x256xf32>
+  %3 = tosa.concat %0, %1, %2 {axis = 3 : i32} : (tensor<2x4x8x256xf32>, tensor<2x4x8x256xf32>, tensor<2x4x8x256xf32>) -> tensor<2x4x8x768xf32>
+  return %3 : tensor<2x4x8x768xf32>
+}
+
+// CHECK-LABEL:  func.func @reshape_adapter_axis3
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<2x4x8x16x16xf32>, [[PARAM_1_:%.+]]: tensor<2x4x8x16x16xf32>, [[PARAM_2_:%.+]]: tensor<2x4x8x32x8xf32>) -> tensor<2x4x8x768xf32> {
+// CHECK:           [[VAR_0_:%.+]] = tosa.reshape [[PARAM_2_]] {new_shape = array<i64: 2, 4, 8, 16, 16>} : (tensor<2x4x8x32x8xf32>) -> tensor<2x4x8x16x16xf32>
+// CHECK:           [[VAR_1_:%.+]] = tosa.concat [[PARAM_0_]], [[PARAM_1_]], [[VAR_0_]] {axis = 3 : i32} : (tensor<2x4x8x16x16xf32>, tensor<2x4x8x16x16xf32>, tensor<2x4x8x16x16xf32>) -> tensor<2x4x8x48x16xf32>
+// CHECK:           [[VAR_2_:%.+]] = tosa.reshape [[VAR_1_]] {new_shape = array<i64: 2, 4, 8, 768>} : (tensor<2x4x8x48x16xf32>) -> tensor<2x4x8x768xf32>
+// CHECK:           return [[VAR_2_]] : tensor<2x4x8x768xf32>
+// CHECK:         }
+// -----
+
 // valid tests for all supported operations
 
 !in_type = tensor<1x8x8xf32>


### PR DESCRIPTION
```
// Complex reshape: the minority operand both drops a unit dimension (implicit
// squeeze of the leading-group 1) *and* keeps the concat axis unsplit (12)
// while the majority splits it (3x4). It is adapted to the majority 3x4 layout.
func.func @reshape_squeeze_and_split(%arg0: tensor<2x3x4x5xf32>, %arg1: tensor<2x3x4x5xf32>, %arg2: tensor<2x1x12x5xf32>) -> tensor<2x36x5xf32> {
  %0 = tosa.reshape %arg0 {new_shape = array<i64: 2, 12, 5>} : (tensor<2x3x4x5xf32>) -> tensor<2x12x5xf32>
  %1 = tosa.reshape %arg1 {new_shape = array<i64: 2, 12, 5>} : (tensor<2x3x4x5xf32>) -> tensor<2x12x5xf32>
  %2 = tosa.reshape %arg2 {new_shape = array<i64: 2, 12, 5>} : (tensor<2x1x12x5xf32>) -> tensor<2x12x5xf32>
  %3 = tosa.concat %0, %1, %2 {axis = 1 : i32} : (tensor<2x12x5xf32>, tensor<2x12x5xf32>, tensor<2x12x5xf32>) -> tensor<2x36x5xf32>
  return %3 : tensor<2x36x5xf32>
}

// CHECK-LABEL:  func.func @reshape_squeeze_and_split
// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<2x3x4x5xf32>, [[PARAM_1_:%.+]]: tensor<2x3x4x5xf32>, [[PARAM_2_:%.+]]: tensor<2x1x12x5xf32>) -> tensor<2x36x5xf32> {
// CHECK:           [[VAR_0_:%.+]] = tosa.reshape [[PARAM_2_]] {new_shape = array<i64: 2, 3, 4, 5>} : (tensor<2x1x12x5xf32>) -> tensor<2x3x4x5xf32>
// CHECK:           [[VAR_1_:%.+]] = tosa.concat [[PARAM_0_]], [[PARAM_1_]], [[VAR_0_]] {axis = 1 : i32} : (tensor<2x3x4x5xf32>, tensor<2x3x4x5xf32>, tensor<2x3x4x5xf32>) -> tensor<2x9x4x5xf32>
// CHECK:           [[VAR_2_:%.+]] = tosa.reshape [[VAR_1_]] {new_shape = array<i64: 2, 36, 5>} : (tensor<2x9x4x5xf32>) -> tensor<2x36x5xf32>
// CHECK:           return [[VAR_2_]] : tensor<2x36x5xf32>
// CHECK:         }
// -----
```


```
// Two distinct minorities (2x8 and 8x2) are adapted to the 4x4 majority layout
// shared by arg0 and arg3 (arg3 reaches it with a differing 8x4 split of a
// larger concat dim). 4 reshapes -> 2 adapters + 1 trailing reshape.
func.func @reshape_with_majority(%arg0: tensor<4x4x4x5xbf16>, %arg1: tensor<4x2x8x5xbf16>, %arg2: tensor<4x8x2x5xbf16>, %arg3: tensor<4x8x4x5xbf16>) -> tensor<4x80x5xbf16> {
  %0 = tosa.reshape %arg0 {new_shape = array<i64: 4, 16, 5>} : (tensor<4x4x4x5xbf16>) -> tensor<4x16x5xbf16>
  %1 = tosa.reshape %arg1 {new_shape = array<i64: 4, 16, 5>} : (tensor<4x2x8x5xbf16>) -> tensor<4x16x5xbf16>
  %2 = tosa.reshape %arg2 {new_shape = array<i64: 4, 16, 5>} : (tensor<4x8x2x5xbf16>) -> tensor<4x16x5xbf16>
  %4 = tosa.reshape %arg3 {new_shape = array<i64: 4, 32, 5>} : (tensor<4x8x4x5xbf16>) -> tensor<4x32x5xbf16>
  %3 = tosa.concat %0, %1, %2, %4 {axis = 1 : i32} : (tensor<4x16x5xbf16>, tensor<4x16x5xbf16>, tensor<4x16x5xbf16>, tensor<4x32x5xbf16>) -> tensor<4x80x5xbf16>
  return %3 : tensor<4x80x5xbf16>
}

// CHECK-LABEL:  func.func @reshape_with_majority
// CHECK-SAME:   ([[PARAM_0_:%.+]]: tensor<4x4x4x5xbf16>, [[PARAM_1_:%.+]]: tensor<4x2x8x5xbf16>, [[PARAM_2_:%.+]]: tensor<4x8x2x5xbf16>, [[PARAM_3_:%.+]]: tensor<4x8x4x5xbf16>) -> tensor<4x80x5xbf16> {
// CHECK-DAG:       [[VAR_0_:%.+]] = tosa.reshape [[PARAM_1_]] {new_shape = array<i64: 4, 4, 4, 5>} : (tensor<4x2x8x5xbf16>) -> tensor<4x4x4x5xbf16>
// CHECK-DAG:       [[VAR_1_:%.+]] = tosa.reshape [[PARAM_2_]] {new_shape = array<i64: 4, 4, 4, 5>} : (tensor<4x8x2x5xbf16>) -> tensor<4x4x4x5xbf16>
// CHECK:           [[VAR_2_:%.+]] = tosa.concat [[PARAM_0_]], [[VAR_0_]], [[VAR_1_]], [[PARAM_3_]] {axis = 1 : i32} : (tensor<4x4x4x5xbf16>, tensor<4x4x4x5xbf16>, tensor<4x4x4x5xbf16>, tensor<4x8x4x5xbf16>) -> tensor<4x20x4x5xbf16>
// CHECK:           [[VAR_3_:%.+]] = tosa.reshape [[VAR_2_]] {new_shape = array<i64: 4, 80, 5>} : (tensor<4x20x4x5xbf16>) -> tensor<4x80x5xbf16>
// CHECK:           return [[VAR_3_]] : tensor<4x80x5xbf16>
// CHECK:         }
```