### PR TITLE
[NFC][AIEX] Add IR verifier RUN line to outer-loop-pipelining tests

### DIFF
--- a/llvm/test/CodeGen/AIE/aie2p/outer-loop-pipelining-gep.ll
+++ b/llvm/test/CodeGen/AIE/aie2p/outer-loop-pipelining-gep.ll
@@ -8,6 +8,11 @@
 ; RUN:     -stop-after=aie-outer-loop-pipeliner \
 ; RUN:     -o - %s 2>&1 | FileCheck %s
 
+
+; RUN: llc -mtriple=aie2p -O2 -aie-enable-outer-loop-pipelining \
+; RUN:     -stop-after=aie-outer-loop-pipeliner -o - %s \
+; RUN:   | llc -mtriple=aie2p -x mir -run-pass=none -o /dev/null
+
 ; Test for the AIE Outer Loop Pipelining pass with GEP instructions.
 ;
 ; This tests that address computation instructions (GEPs) between PHI pointers

--- a/llvm/test/CodeGen/AIE/aie2p/outer-loop-pipelining-metadata.ll
+++ b/llvm/test/CodeGen/AIE/aie2p/outer-loop-pipelining-metadata.ll
@@ -7,6 +7,10 @@
 ; RUN: llc -mtriple=aie2p -O2 -stop-after=aie-outer-loop-pipeliner \
 ; RUN:     -o - %s 2>&1 | FileCheck %s
 
+
+; RUN: llc -mtriple=aie2p -O2 -stop-after=aie-outer-loop-pipeliner -o - %s \
+; RUN:   | llc -mtriple=aie2p -x mir -run-pass=none -o /dev/null
+
 ; Tests for per-loop metadata control of the AIE Outer Loop Pipelining pass
 ; via !llvm.loop.hint.aie-enable-outer-loop-pipelining.
 ;

--- a/llvm/test/CodeGen/AIE/aie2p/outer-loop-pipelining-nested.ll
+++ b/llvm/test/CodeGen/AIE/aie2p/outer-loop-pipelining-nested.ll
@@ -7,6 +7,10 @@
 ; RUN: llc -mtriple=aie2p -O2 -stop-after=aie-outer-loop-pipeliner \
 ; RUN:     -o - %s 2>&1 | FileCheck %s
 
+
+; RUN: llc -mtriple=aie2p -O2 -stop-after=aie-outer-loop-pipeliner -o - %s \
+; RUN:   | llc -mtriple=aie2p -x mir -run-pass=none -o /dev/null
+
 ; Test for the AIE Outer Loop Pipelining pass with nested loop structures.
 ;
 ; This test verifies that the pass correctly handles triple-nested loops

--- a/llvm/test/CodeGen/AIE/aie2p/outer-loop-pipelining-ptr-lifting.ll
+++ b/llvm/test/CodeGen/AIE/aie2p/outer-loop-pipelining-ptr-lifting.ll
@@ -8,6 +8,11 @@
 ; RUN:     -stop-after=aie-outer-loop-pipeliner \
 ; RUN:     -o - %s 2>&1 | FileCheck %s
 
+
+; RUN: llc -mtriple=aie2p -O2 -aie-enable-outer-loop-pipelining \
+; RUN:     -stop-after=aie-outer-loop-pipeliner -o - %s \
+; RUN:   | llc -mtriple=aie2p -x mir -run-pass=none -o /dev/null
+
 ; Test for pointer update lifting in the AIE Outer Loop Pipeliner pass.
 ;
 ; When pointer update instructions (GEPs, addrspacecasts, add.2d, add.3d, etc.)

--- a/llvm/test/CodeGen/AIE/aie2p/outer-loop-pipelining-step.ll
+++ b/llvm/test/CodeGen/AIE/aie2p/outer-loop-pipelining-step.ll
@@ -8,6 +8,11 @@
 ; RUN:     -stop-after=aie-outer-loop-pipeliner \
 ; RUN:     -o - %s 2>&1 | FileCheck %s
 
+
+; RUN: llc -mtriple=aie2p -O2 -aie-enable-outer-loop-pipelining \
+; RUN:     -stop-after=aie-outer-loop-pipeliner -o - %s \
+; RUN:   | llc -mtriple=aie2p -x mir -run-pass=none -o /dev/null
+
 ; Tests for correct handling of arbitrary constant induction steps in the
 ; AIE Outer Loop Pipeliner pass.
 ;

--- a/llvm/test/CodeGen/AIE/aie2p/outer-loop-pipelining.ll
+++ b/llvm/test/CodeGen/AIE/aie2p/outer-loop-pipelining.ll
@@ -8,6 +8,11 @@
 ; RUN:     -stop-after=aie-outer-loop-pipeliner \
 ; RUN:     -o - %s 2>&1 | FileCheck %s
 
+
+; RUN: llc -mtriple=aie2p -O2 -aie-enable-outer-loop-pipelining \
+; RUN:     -stop-after=aie-outer-loop-pipeliner -o - %s \
+; RUN:   | llc -mtriple=aie2p -x mir -run-pass=none -o /dev/null
+
 ; Test for the AIE Outer Loop Pipelining pass.
 ;
 ; The pass rotates the outer loop body so that the prologue loads of iteration


### PR DESCRIPTION
The outer-loop-pipelining unit tests run the pass via `llc -stop-after=aie-outer-loop-pipeliner`, which halts the codegen pipeline immediately after the pass and prints the IR. The codegen IR verifier only runs on the pass *input*, so malformed output (e.g. a PHI whose incoming block is not a predecessor) slips through as a silent FileCheck mismatch rather than an error.

Add a second RUN line that feeds the emitted MIR back through `llc -x mir -run-pass=none`, so the MIR parser re-runs the IR verifier on the pass output and the tests fail loudly on broken IR. Each verifier line mirrors its test's own pipeliner flags (the metadata/nested tests opt in via loop metadata rather than -aie-enable-outer-loop-pipelining).

The end-to-end tests under aie2ps/end-to-end already exercise the full pipeline (and thus the module verifier), so they are left unchanged.