### PR TITLE
[AIE2P] Fix sub_bfp16_e subregister size (576 -> 64)

### DIFF
--- a/llvm/lib/Target/AIE/aie2p/AIE2PRegisterInfo.td
+++ b/llvm/lib/Target/AIE/aie2p/AIE2PRegisterInfo.td
@@ -60,7 +60,7 @@ def sub_hi_exp : SubRegIndex<32, 32>;
 def sub_bfp_exp : SubRegIndex<32,   0>;
 def sub_bfp_vec : SubRegIndex<256, 32>;
 
-def sub_bfp16_e : SubRegIndex<576,   512>;
+def sub_bfp16_e : SubRegIndex<64,   512>;
 def sub_bfp16_x : SubRegIndex<512, 0>;
 
 def sub_bfp576_lo : SubRegIndex<576,   0>;


### PR DESCRIPTION
Addresses the **-O1/-O2 miscompile** reported in #847. (The -O0 ICE in the same
issue is a separate root cause, fixed in #1058.)

## Root cause

The bfp16 vector-exponent register `ex# = [x#, e#]` (defined in
`aie2p/AIE2PRegisterInfo.td`) is a 576-bit pair: a 512-bit mantissa
(`sub_bfp16_x`) plus a 64-bit exponent register `e#`, whose register class is
`EXPVEC64` (64 bits). The exponent subregister index was declared with the
wrong size:

```
def sub_bfp16_e : SubRegIndex<576, 512>;   // size 576, offset 512  -> spans [512, 1088)
def sub_bfp16_x : SubRegIndex<512, 0>;
```

`512 + 64 = 576`, so the exponent at offset 512 must be size **64**, not 576.
As written it extends to bit 1088, well past the end of the 576-bit register.
The 288-bit analogue is sized correctly (`sub_bfp_exp = 32`, `sub_bfp_vec =
256`, total 288), which makes the 576 here stand out as a copy of the register
class size.

Because the register is `CoveredBySubRegs`, the oversized range gives the
exponent subregister an oversized lane mask. That is harmless until register
pressure forces the bfp16 MAC operands to spill: the wrong lane mask corrupts
subregister liveness and the spill/reload, silently. There is no ICE and the
machine verifier is happy, so it slips through as wrong code at `-O1`/`-O2`.

This matches the report exactly: the bug only appears once there are enough
live bfp16 values to spill (2 accumulators with emulation, 4 with native
bfp16), and the corruption lands on the first element of every 8-element block,
which is the element governed by the shared block exponent.

## Fix

```
def sub_bfp16_e : SubRegIndex<64, 512>;
```

The generated `SubRegIdxRanges` entry changes from `{512, 576}` to `{512, 64}`.

## Validation

On Strix Point / XDNA2 (NPU2), using the reporter's harness from #847 (a 3x3
conv built on `aie::mmul<8,8,8,bfloat16>` with `-DAIE_API_EMULATE_BFLOAT16_MMUL_WITH_BFP16`,
identity weights, all-ones input, expected output 9.0):

```
                     before fix          after fix
kernel_1acc (1 acc):   0/3968  PASS        0/3968  PASS
kernel_2acc (2 acc): 682/3968  FAIL        0/3968  PASS
```

The 2-accumulator kernel (the spilling case) goes from 682 wrong elements to
zero; the single-accumulator kernel is unaffected. Compiler: Peano clang 21.

No change to the `llvm/test/CodeGen/AIE/aie2p/GlobalIsel` suite (170/170 pass).

## Note

Running an audit of all `SubRegIndex` definitions across the AIE backends found
this to be the only size-vs-overflow inconsistency. A TableGen check that flags
a `SubRegIndex` whose `offset + size` overflows the register it covers would
have caught this at build time; I can follow up with that separately.
