### PR TITLE
[TableGen] Error on sub-register indices that overflow their register

### DIFF
--- a/llvm/lib/Target/AIE/aie2p/AIE2PRegisterInfo.td
+++ b/llvm/lib/Target/AIE/aie2p/AIE2PRegisterInfo.td
@@ -60,7 +60,7 @@ def sub_hi_exp : SubRegIndex<32, 32>;
 def sub_bfp_exp : SubRegIndex<32,   0>;
 def sub_bfp_vec : SubRegIndex<256, 32>;
 
-def sub_bfp16_e : SubRegIndex<576,   512>;
+def sub_bfp16_e : SubRegIndex<64,   512>;
 def sub_bfp16_x : SubRegIndex<512, 0>;
 
 def sub_bfp576_lo : SubRegIndex<576,   0>;

--- a/llvm/test/TableGen/subreg-index-overflow-allowed.td
+++ b/llvm/test/TableGen/subreg-index-overflow-allowed.td
@@ -1,0 +1,37 @@
+// RUN: llvm-tblgen -gen-register-info -I %p/../../include %s -o - | FileCheck %s
+// Companion to subreg-index-overflow.td: patterns that look like an overflow
+// but are legitimate and must NOT be diagnosed by the size check.
+include "llvm/Target/Target.td"
+
+class MyReg<string n, list<Register> subs = []> : Register<n> {
+  let Namespace = "Test";
+  let SubRegs = subs;
+  let CoveredBySubRegs = 1;
+}
+class MyClass<int sz, list<ValueType> types, dag regs>
+  : RegisterClass<"Test", types, sz, regs> { let Size = sz; }
+
+def lo : SubRegIndex<32, 0>;
+def hi_gap : SubRegIndex<32, 64>; // leaves a [32,64) gap -> non-contiguous
+def lo2 : SubRegIndex<32, 0>;
+def hi2 : SubRegIndex<32, 32>;
+
+foreach i = 0-7 in { def R#i : MyReg<"r"#i>; }
+def GPR : MyClass<32, [i32], (sequence "R%u", 0, 7)>;
+
+// (1) Strided/spaced tuple: sub-registers at [0,32) and [64,96) extend past the
+// 64-bit class size, but are non-contiguous, so this is allowed.
+def StridedPair : RegisterTuples<[lo, hi_gap], [(add R0, R2), (add R1, R3)]>;
+def StridedRC : MyClass<64, [untyped], (add StridedPair)>;
+
+// (2) Untyped class: its size is a placeholder, not a bit width, so a 64-bit
+// pair living in it must not be diagnosed as overflowing.
+def DensePair : RegisterTuples<[lo2, hi2], [(add R4, R6), (add R5, R7)]>;
+def UntypedRC : MyClass<8, [untyped], (add DensePair)>;
+
+def TestTarget : Target;
+
+// Both synthesized tuples must be emitted, i.e. neither was rejected by the
+// sub-register overflow check.
+// CHECK-DAG: R0_R1 =
+// CHECK-DAG: R4_R5 =

--- a/llvm/test/TableGen/subreg-index-overflow.td
+++ b/llvm/test/TableGen/subreg-index-overflow.td
@@ -1,0 +1,29 @@
+// RUN: not llvm-tblgen -gen-register-info -I %p/../../include %s -o /dev/null 2>&1 | FileCheck %s
+include "llvm/Target/Target.td"
+
+class MyReg<string n> : Register<n> { let Namespace = "Test"; }
+class MyClass<int size, list<ValueType> types, dag registers>
+  : RegisterClass<"Test", types, size, registers> { let Size = size; }
+
+def sub_lo : SubRegIndex<32, 0>;
+// Erroneous: the high half is declared 64 bits at offset 32, so the pair's
+// sub-registers cover [0, 96) bits, past the end of the 64-bit register.
+def sub_hi : SubRegIndex<64, 32>;
+
+def L0 : MyReg<"l0">;
+def H0 : MyReg<"h0">;
+def L1 : MyReg<"l1">;
+def H1 : MyReg<"h1">;
+
+def LoRegs : MyClass<32, [i32], (add L0, L1)>;
+def HiRegs : MyClass<32, [i32], (add H0, H1)>;
+
+let SubRegIndices = [sub_lo, sub_hi], CoveredBySubRegs = 1 in {
+  def P0 : MyReg<"p0"> { let SubRegs = [L0, H0]; }
+  def P1 : MyReg<"p1"> { let SubRegs = [L1, H1]; }
+}
+def PairRegs : MyClass<64, [i64], (add P0, P1)>;
+
+def TestTarget : Target;
+
+// CHECK: error: register 'P0' has size 64 but its explicit sub-registers cover 96 bits; a SubRegIndex 'Size' is larger than the sub-register it describes

--- a/llvm/utils/TableGen/Common/CodeGenRegisters.cpp
+++ b/llvm/utils/TableGen/Common/CodeGenRegisters.cpp
@@ -469,6 +469,67 @@ CodeGenRegister::computeSubRegs(CodeGenRegBank &RegBank) {
   return SubRegs;
 }
 
+// Verify that a register's explicit sub-registers fit within it. A SubRegIndex
+// whose offset+size runs past the register's own size gives that sub-register
+// an oversized lane mask, which silently corrupts sub-register liveness and
+// spilling and is not otherwise diagnosed. (This was found via a real
+// wrong-code bug in a downstream target, where a 64-bit exponent sub-register
+// index was mistakenly declared with size 576.) The check is limited to
+// registers whose explicit sub-registers tile a contiguous bit range:
+// strided/spaced register tuples (e.g. ARM's Tuples3DSpc,
+// [dsub_0, dsub_2, dsub_4]) deliberately place sub-registers at non-adjacent
+// offsets that extend past the nominal size, and are not bugs.
+void CodeGenRegister::checkSubRegIndexSizes(CodeGenRegBank &RegBank) const {
+  // This register's own bit size is the largest register class containing it.
+  unsigned ParentSize = 0;
+  for (const auto &RC : RegBank.getRegClasses()) {
+    if (!RC.contains(this) || !RC.RSI.hasDefault())
+      continue;
+    // Only trust a register-class size that is backed by a real value type.
+    // An 'untyped' class carries a placeholder size, not the register's bit
+    // width, so its size cannot be compared against sub-register extents.
+    ArrayRef<ValueTypeByHwMode> VTs = RC.getValueTypes();
+    if (VTs.empty() || !VTs[0].isSimple() || VTs[0].getSimple() == MVT::Untyped)
+      continue;
+    ParentSize = std::max(ParentSize, RC.RSI.get(DefaultMode).RegSize);
+  }
+  if (!ParentSize)
+    return;
+
+  // Collect the explicit sub-register (offset, size) ranges. Bail on any
+  // register with incomplete or non-contiguous range info.
+  SmallVector<std::pair<unsigned, unsigned>, 8> Ranges;
+  for (const CodeGenSubRegIndex *Idx : ExplicitSubRegIndices) {
+    if (!Idx->Range.hasDefault())
+      return;
+    const SubRegRange &R = Idx->Range.get(DefaultMode);
+    if (R.Size == static_cast<uint16_t>(-1) ||
+        R.Offset == static_cast<uint16_t>(-1))
+      return; // non-contiguous tuple sub-index
+    Ranges.emplace_back(R.Offset, R.Size);
+  }
+  if (Ranges.empty())
+    return;
+
+  // Only contiguously-tiled registers are dense bit containers; anything with a
+  // gap or overlap is a strided/spaced tuple, which is allowed to exceed size.
+  llvm::sort(Ranges);
+  unsigned Pos = 0;
+  for (auto [Off, Sz] : Ranges) {
+    if (Off != Pos)
+      return; // gap or overlap -> strided/sparse, skip
+    Pos += Sz;
+  }
+
+  if (Pos > ParentSize)
+    PrintFatalError(TheDef->getLoc(),
+                    Twine("register '") + getName() + "' has size " +
+                        Twine(ParentSize) +
+                        " but its explicit sub-registers cover " + Twine(Pos) +
+                        " bits; a SubRegIndex 'Size' is larger than the "
+                        "sub-register it describes");
+}
+
 // In a register that is covered by its sub-registers, try to find redundant
 // sub-registers. For example:
 //
@@ -1325,6 +1386,11 @@ CodeGenRegBank::CodeGenRegBank(const RecordKeeper &Records,
   // Read in the register category definitions.
   for (const Record *R : Records.getAllDerivedDefinitions("RegisterCategory"))
     RegCategories.emplace_back(*this, R);
+
+  // Now that register classes (and their sizes) are built, check that no
+  // explicit SubRegIndex makes a sub-register overflow its register (#847).
+  for (const auto &Reg : Registers)
+    Reg.checkSubRegIndexSizes(*this);
 }
 
 // Create a synthetic CodeGenSubRegIndex without a corresponding Record.

--- a/llvm/utils/TableGen/Common/CodeGenRegisters.h
+++ b/llvm/utils/TableGen/Common/CodeGenRegisters.h
@@ -205,6 +205,11 @@ public:
   // graph has been built.
   void computeSuperRegs(CodeGenRegBank &);
 
+  // Diagnose an explicit SubRegIndex whose declared size makes a sub-register
+  // extend past the register that contains it (issue #847): an oversized lane
+  // mask that silently corrupts sub-register liveness and spilling.
+  void checkSubRegIndexSizes(CodeGenRegBank &) const;
+
   const SubRegMap &getSubRegs() const {
     assert(SubRegsComplete && "Must precompute sub-registers");
     return SubRegs;


### PR DESCRIPTION
Depends on #1059. This is the TableGen check that would have caught #1059's bug
at build time, so the two go together: this branch includes #1059's one-line
`sub_bfp16_e` fix as its first commit (the verifier is a hard error and would
otherwise reject the unfixed AIE2P register info). Once #1059 lands, I will
rebase this down to just the verifier commit. I also intend to propose the
verifier upstream to llvm-project.

## What

A register defined with `CoveredBySubRegs` derives its sub-register lane masks
from the declared `Size`/`Offset` of its explicit `SubRegIndex`es. If a
`SubRegIndex` `Size` is wrong such that `offset + size` runs past the
register's own size, that sub-register gets an oversized lane mask. Nothing
diagnoses this today, so it surfaces as silently wrong sub-register liveness
and spilling: a wrong-code bug with no ICE and no machine-verifier error.

This adds a check, run when the register bank is built, that a register's
explicit sub-registers tile a contiguous bit range that fits within the
register's size.

## Why (a real bug)

This is exactly the `-O1`/`-O2` miscompile from #847: `sub_bfp16_e` (the 64-bit
bfp16 block exponent) was declared with `Size` 576, so the exponent's lane mask
spanned 576 bits instead of 64. Once register pressure forced the bfp16 MAC
operands to spill, the reload was corrupted (the first element of every
8-element block, governed by the shared exponent). TableGen accepted it without
a word; this check turns it into a build error. With #1059 applied, AIE2P
builds clean.

## Scope and false-positive handling

The check only applies to registers whose explicit sub-registers tile a
*contiguous* bit range. Strided/spaced register tuples (e.g. ARM's
`Tuples3DSpc = [dsub_0, dsub_2, dsub_4]`) intentionally place sub-registers at
non-adjacent offsets that extend past the nominal size; those have
non-contiguous ranges and are skipped.

I ran `-gen-register-info` with the check over every in-tree target. It is
clean on all of them (including AIE2P with #1059), and it fires on a register
deliberately given an oversized sub-register index.

## Test

`llvm/test/TableGen/subreg-index-overflow.td` defines a 64-bit pair whose high
half is mis-sized so the sub-registers cover 96 bits, and checks for the error.
The TableGen lit suite passes (374/374).