### PR TITLE
Martien.maxlatencyfinder fixcrash

### DIFF
--- a/llvm/lib/Target/AIE/AIEInterBlockScheduling.cpp
+++ b/llvm/lib/Target/AIE/AIEInterBlockScheduling.cpp
@@ -978,7 +978,10 @@ BlockState &InterBlockScheduling::getBlockState(MachineBasicBlock *BB) {
 }
 
 void InterBlockScheduling::buildGraph(InterBlockEdges &DAG) {
-  const BlockState &BS = getBlockState(DAG.getPred());
+
+  MachineBasicBlock *PredBB = DAG.getPred();
+
+  const BlockState &BS = getBlockState(PredBB);
   const Region &Bot = BS.getBottom();
 
   // Pre-boundary: free instructions of the current region.
@@ -989,17 +992,27 @@ void InterBlockScheduling::buildGraph(InterBlockEdges &DAG) {
 
   // Post-boundary: free instructions. Empty regions signify empty basic
   // blocks; in that case no post-boundary nodes are added.
-  const BlockState &SBS = getBlockState(DAG.getSucc());
-  if (!SBS.getRegions().empty()) {
-    for (MachineInstr *MI : SBS.getTop().getFreeInstructions())
+  MachineBasicBlock *SuccBB = DAG.getSucc();
+  const BlockState &SuccBS = getBlockState(SuccBB);
+  if (!SuccBS.getRegions().empty()) {
+    for (MachineInstr *MI : SuccBS.getTop().getFreeInstructions())
       DAG.addNode(MI);
   }
 
   // Post-boundary: BotFixed first-iteration copies (SWP prologue clones),
   // in the semantic order of the original loop instructions. This vector is
   // empty for non-pipelined blocks.
-  for (MachineInstr *MI : SBS.BottomInsertSemanticOrder)
+  for (MachineInstr *MI : SuccBS.BottomInsertSemanticOrder) {
     DAG.addNode(MI);
+    // Some queries in edge building require a parent to get to SubTarget.
+    // We push them in the corresponding block. edge building uses the
+    // insertion order in the DAG, not the block, so position within the block
+    // is irrelevant. The instructions will be removed again before the regular
+    // reinsertion that is part of scheduling Fixed regions.
+    if (!MI->getParent()) {
+      SuccBB->push_back(MI);
+    }
+  }
 
   DAG.buildEdges();
 }
@@ -1018,6 +1031,7 @@ void InterBlockScheduling::buildPerSuccEdges(MachineBasicBlock *BB) {
   for (MachineBasicBlock *SuccBB : BB->successors()) {
     DEBUG_BLOCKS(dbgs() << "Building InterBlockEdge: Pred=" << BB->getNumber()
                         << " Succ=" << SuccBB->getNumber() << "\n");
+
     InterBlockEdges &SE = *PerSuccEdges.emplace_back(
         std::make_unique<InterBlockEdges>(C, SafeToIgnoreMemDeps, BB, SuccBB));
     buildGraph(SE);
@@ -1283,6 +1297,13 @@ void InterBlockScheduling::emitInterBlockBottom(const BlockState &BS) const {
   MachineBasicBlock *PreHeader = BS.TheBlock;
   assert(PreHeader->end() == PreHeader->getFirstTerminator() &&
          "PreHeader is not fall-through");
+  // BottomInsertSemanticOrder instructions may have been temporarily placed in
+  // the block by buildPerSuccEdges to enable dependency analysis. Remove them
+  // before emitBundles re-inserts all BottomInsert instructions properly.
+  for (MachineInstr *MI : BS.BottomInsertSemanticOrder) {
+    if (MI->getParent() == PreHeader)
+      PreHeader->remove_instr(MI);
+  }
   emitBundles(BS.BottomInsert, PreHeader, PreHeader->end(), /*Move=*/false,
               /*EmitNops=*/false);
 }

--- a/llvm/test/CodeGen/AIE/aie2ps/schedule/postpipeliner/crash-bottom-insert-register-dep.mir
+++ b/llvm/test/CodeGen/AIE/aie2ps/schedule/postpipeliner/crash-bottom-insert-register-dep.mir
@@ -4,7 +4,6 @@
 #
 # (c) Copyright 2026 Advanced Micro Devices, Inc. or its affiliates
 
-# XFAIL: *
 # RUN: llc -mtriple=aie2ps -O2 --start-before=postmisched %s -o /dev/null
 
 # Variant of crash-bottom-insert-semantic-order.mir that exercises a crash that

--- a/llvm/test/CodeGen/AIE/aie2ps/schedule/postpipeliner/crash-bottom-insert-register-dep.mir
+++ b/llvm/test/CodeGen/AIE/aie2ps/schedule/postpipeliner/crash-bottom-insert-register-dep.mir
@@ -1,0 +1,141 @@
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# (c) Copyright 2026 Advanced Micro Devices, Inc. or its affiliates
+
+# XFAIL: *
+# RUN: llc -mtriple=aie2ps -O2 --start-before=postmisched %s -o /dev/null
+
+# Variant of crash-bottom-insert-semantic-order.mir that exercises a crash that
+# does not involve isDereferenceableInvariantLoad().
+# Please refer to the original test for an expose of the basic block structure.
+# This one differs only in the sense that the second loop does not contain a
+# Load, which cause a second failure path to be shortcircuited.
+ 
+--- |
+  target triple = "aie2ps"
+
+  define void @test(ptr addrspace(5) noalias %p0, ptr addrspace(6) noalias %p1,
+                    i32 %n0, i32 %n1) {
+  entry:
+    %skip = icmp eq i32 %n0, 0
+    br i1 %skip, label %between_loops, label %preheader_a
+
+  preheader_a:
+    call void @llvm.set.loop.iterations.i32(i32 %n0)
+    br label %loop_a
+
+  loop_a:
+    %pa = phi ptr addrspace(5) [ %p0, %preheader_a ], [ %pa.next, %loop_a ]
+    %pb = phi ptr addrspace(6) [ %p1, %preheader_a ], [ %pb.next, %loop_a ]
+    %da = load <8 x i32>, ptr addrspace(5) %pa, align 64
+    %pa.next = getelementptr inbounds i8, ptr addrspace(5) %pa, i32 64
+    store <8 x i32> %da, ptr addrspace(6) %pb, align 64
+    %pb.next = getelementptr inbounds i8, ptr addrspace(6) %pb, i32 64
+    %deca = call i1 @llvm.loop.decrement.i32(i32 1)
+    br i1 %deca, label %loop_a, label %between_loops, !llvm.loop !0
+
+  between_loops:
+    call void @llvm.set.loop.iterations.i32(i32 %n1)
+    br label %loop_b
+
+  loop_b:
+    %pc = phi ptr addrspace(5) [ %p0, %between_loops ], [ %pc.next, %loop_b ]
+    %pd = phi ptr addrspace(6) [ %p1, %between_loops ], [ %pd.next, %loop_b ]
+    %db = load <8 x i32>, ptr addrspace(5) %pc, align 64
+    %pc.next = getelementptr inbounds i8, ptr addrspace(5) %pc, i32 64
+    store <8 x i32> %db, ptr addrspace(6) %pd, align 64
+    %pd.next = getelementptr inbounds i8, ptr addrspace(6) %pd, i32 64
+    %decb = call i1 @llvm.loop.decrement.i32(i32 1)
+    br i1 %decb, label %loop_b, label %exit, !llvm.loop !2
+
+  exit:
+    ret void
+  }
+
+  declare void @llvm.set.loop.iterations.i32(i32)
+  declare i1 @llvm.loop.decrement.i32(i32)
+
+  !0 = distinct !{!0, !1}
+  !1 = !{!"llvm.loop.itercount.range", i64 4}
+  !2 = distinct !{!2, !3}
+  !3 = !{!"llvm.loop.itercount.range", i64 16}
+
+...
+---
+name:            test
+tracksRegLiveness: true
+body:             |
+  ; bb.0 has two successors: bb.1 (fallthrough when r0==0) and bb.3 (jump
+  ; when r0!=0, skipping Loop A entirely). This gives bb.3 two predecessors
+  ; (bb.0 and bb.2), which is the condition that triggers makeDedicatedLoopExit
+  ; to split the bb.2->bb.3 edge when scheduling bb.3 as Loop A's epilogue.
+  bb.0.entry:
+    successors: %bb.1(0x40000000), %bb.3(0x40000000)
+    liveins: $r0, $r1, $p0, $p1
+
+    JNZ $r0, %bb.3
+    DelayedSchedBarrier
+
+  ; bb.1 is the dedicated fallthrough preheader of bb.2 (Loop A).
+  ; succ_size==1 satisfies getDedicatedFallThroughPreheader, making bb.2
+  ; a post-pipeline candidate.
+  bb.1.preheader_a:
+    successors: %bb.2
+    liveins: $r0, $p0, $p1
+
+    $lc = ADD_NC_add_lc_ri $r0, 0
+    MOVXM_lng_cg_ls_abs %bb.2, implicit-def $ls
+    MOVXM_lng_cg_le_abs <mcsymbol .L_LEnd0>, implicit-def $le
+
+  ; bb.2 is Loop A: a single-block ZOL with a VLDA and a VST.
+  ; After scheduling, the PostPipeliner pipelines it, creating prologue
+  ; clones stored in bb.1.BottomInsertSemanticOrder.
+  bb.2.loop_a:
+    successors: %bb.2(0x7c000000), %bb.3(0x04000000)
+    liveins: $p0, $p1
+
+    $x0, $p0 = VLDA_dmx_lda_x_ld_pstm_nrm_imm $p0, 64 :: (load (<8 x s32>) from %ir.pa, addrspace 5)
+    $p1 = VST_dmx_sts_x_st_pstm_nrm_imm $x0, $p1, 64 :: (store (<8 x s32>) into %ir.pb, addrspace 6)
+    PseudoLoopEnd <mcsymbol .L_LEnd0>, %bb.2
+
+  ; bb.3 is simultaneously:
+  ;   (a) The epilogue of Loop A (bb.2 -> bb.3 exit edge), classified
+  ;       as BlockType::Epilogue because bb.2 is a Loop predecessor.
+  ;   (b) The dedicated fallthrough preheader of Loop B (bb.4):
+  ;       succ_size==1, no terminator, layout-adjacent to bb.4.
+  ; After Loop B (bb.4) is pipelined, bb.3.BottomInsertSemanticOrder
+  ; holds Loop B prologue clones created by CloneMachineInstr but not
+  ; yet inserted into any MachineBasicBlock.
+  bb.3.between_loops:
+    successors: %bb.4
+    liveins: $r1, $p0, $p1, $x0
+
+    $lc = ADD_NC_add_lc_ri $r1, 0
+    MOVXM_lng_cg_ls_abs %bb.4, implicit-def $ls
+    MOVXM_lng_cg_le_abs <mcsymbol .L_LEnd1>, implicit-def $le
+    ; Store $x0 (live-in from loop_a) before entering Loop B. This creates a
+    ; register dependence with the VBCST_32 prologue clone of Loop B, triggering
+    ; the getSignedOperandLatency crash path.
+    $p0 = VST_dmx_sts_x_st_pstm_nrm_imm $x0, $p0, 64 :: (store (<8 x s32>) into %ir.pb, addrspace 6)
+
+  ; bb.4 is Loop B: VBCST_32 (mv slot) + VST (st slot), no loads.
+  ; With itercount=16 and II=1, the PostPipeliner creates a prologue whose
+  ; first-iteration VBCST_32 clone lands in bb.3.BottomInsertSemanticOrder.
+  bb.4.loop_b:
+    successors: %bb.4(0x7c000000), %bb.5(0x04000000)
+    liveins: $r1, $p1
+
+    ; VBCST_32 (mv slot) broadcasts scalar $r1 into vector $x0. This is not a
+    ; memory load so isDereferenceableInvariantLoad() returns false immediately.
+    ; After pipelining (II=1), the first-iteration clone of VBCST_32 goes into
+    ; bb.3.BottomInsertSemanticOrder without a parent MachineBasicBlock.
+    $x0 = VBCST_32 $r1
+    $p1 = VST_dmx_sts_x_st_pstm_nrm_imm $x0, $p1, 64 :: (store (<8 x s32>) into %ir.pd, addrspace 6)
+    PseudoLoopEnd <mcsymbol .L_LEnd1>, %bb.4
+
+  bb.5.exit:
+    RET implicit $lr
+    DelayedSchedBarrier
+...

--- a/llvm/test/CodeGen/AIE/aie2ps/schedule/postpipeliner/crash-bottom-insert-semantic-order.mir
+++ b/llvm/test/CodeGen/AIE/aie2ps/schedule/postpipeliner/crash-bottom-insert-semantic-order.mir
@@ -1,0 +1,171 @@
+# This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# (c) Copyright 2026 Advanced Micro Devices, Inc. or its affiliates
+
+# XFAIL: *
+# RUN: llc -mtriple=aie2ps -O2 --start-before=postmisched %s -o /dev/null
+
+# This test reproduces a crash triggered by
+# InterBlockScheduling::buildGraph accessing BottomInsertSemanticOrder
+# instructions that are not yet embedded in a MachineBasicBlock.
+#
+# The crash occurs via the call chain:
+#   emitInterBlockTop(bb.3)
+#     -> makeDedicatedLoopExit(bb.2, bb.3)   [bb.3.pred_size == 2]
+#       -> buildPerSuccEdges(DedicatedExit)
+#         -> buildGraph(DedicatedExit -> bb.3)
+#           -> DAG.addNode(MI) for each MI in bb.3.BottomInsertSemanticOrder
+#             -> DAG.buildEdges()
+#               -> isDereferenceableInvariantLoad()
+#                 -> getParent()->getParent()  NULL DEREFERENCE
+#
+# The root cause is that bb.3 is simultaneously:
+#   - The epilogue of Loop A (bb.2), causing makeDedicatedLoopExit to
+#     rebuild edges touching bb.3 before emitInterBlockBottom(bb.3) runs.
+#   - The dedicated fallthrough preheader of Loop B (bb.4), so after
+#     Loop B is pipelined, bb.3.BottomInsertSemanticOrder holds Loop B
+#     prologue clones that were created by CloneMachineInstr but have
+#     not yet been inserted into any MachineBasicBlock.
+#
+# CFG:
+#   bb.0.entry --JNZ $r0--> bb.3.between_loops
+#       |                         ^
+#       v (fallthrough)           |
+#   bb.1.preheader_a          bb.2.loop_a <-\
+#       |                         |          |
+#       v (fallthrough)           \----------/
+#   bb.2.loop_a
+#       |
+#       v
+#   bb.3.between_loops -> bb.4.loop_b <-\
+#                             |          |
+#                             \----------/
+#                             |
+#                             v
+#                         bb.5.exit
+#
+# bb.3 has pred_size == 2 (bb.0 and bb.2), causing makeDedicatedLoopExit
+# to split the bb.2->bb.3 edge. When buildPerSuccEdges rebuilds edges for
+# the new DedicatedExit->bb.3, it finds bb.3.BottomInsertSemanticOrder
+# populated with Loop B prologue clones that lack a parent MBB.
+
+--- |
+  target triple = "aie2ps"
+
+  define void @test(ptr addrspace(5) noalias %p0, ptr addrspace(6) noalias %p1,
+                    i32 %n0, i32 %n1) {
+  entry:
+    %skip = icmp eq i32 %n0, 0
+    br i1 %skip, label %between_loops, label %preheader_a
+
+  preheader_a:
+    call void @llvm.set.loop.iterations.i32(i32 %n0)
+    br label %loop_a
+
+  loop_a:
+    %pa = phi ptr addrspace(5) [ %p0, %preheader_a ], [ %pa.next, %loop_a ]
+    %pb = phi ptr addrspace(6) [ %p1, %preheader_a ], [ %pb.next, %loop_a ]
+    %da = load <8 x i32>, ptr addrspace(5) %pa, align 64
+    %pa.next = getelementptr inbounds i8, ptr addrspace(5) %pa, i32 64
+    store <8 x i32> %da, ptr addrspace(6) %pb, align 64
+    %pb.next = getelementptr inbounds i8, ptr addrspace(6) %pb, i32 64
+    %deca = call i1 @llvm.loop.decrement.i32(i32 1)
+    br i1 %deca, label %loop_a, label %between_loops, !llvm.loop !0
+
+  between_loops:
+    call void @llvm.set.loop.iterations.i32(i32 %n1)
+    br label %loop_b
+
+  loop_b:
+    %pc = phi ptr addrspace(5) [ %p0, %between_loops ], [ %pc.next, %loop_b ]
+    %pd = phi ptr addrspace(6) [ %p1, %between_loops ], [ %pd.next, %loop_b ]
+    %db = load <8 x i32>, ptr addrspace(5) %pc, align 64
+    %pc.next = getelementptr inbounds i8, ptr addrspace(5) %pc, i32 64
+    store <8 x i32> %db, ptr addrspace(6) %pd, align 64
+    %pd.next = getelementptr inbounds i8, ptr addrspace(6) %pd, i32 64
+    %decb = call i1 @llvm.loop.decrement.i32(i32 1)
+    br i1 %decb, label %loop_b, label %exit, !llvm.loop !2
+
+  exit:
+    ret void
+  }
+
+  declare void @llvm.set.loop.iterations.i32(i32)
+  declare i1 @llvm.loop.decrement.i32(i32)
+
+  !0 = distinct !{!0, !1}
+  !1 = !{!"llvm.loop.itercount.range", i64 4}
+  !2 = distinct !{!2, !3}
+  !3 = !{!"llvm.loop.itercount.range", i64 4}
+
+...
+---
+name:            test
+tracksRegLiveness: true
+body:             |
+  ; bb.0 has two successors: bb.1 (fallthrough when r0==0) and bb.3 (jump
+  ; when r0!=0, skipping Loop A entirely). This gives bb.3 two predecessors
+  ; (bb.0 and bb.2), which is the condition that triggers makeDedicatedLoopExit
+  ; to split the bb.2->bb.3 edge when scheduling bb.3 as Loop A's epilogue.
+  bb.0.entry:
+    successors: %bb.1(0x40000000), %bb.3(0x40000000)
+    liveins: $r0, $r1, $p0, $p1
+
+    JNZ $r0, %bb.3
+    DelayedSchedBarrier
+
+  ; bb.1 is the dedicated fallthrough preheader of bb.2 (Loop A).
+  ; succ_size==1 satisfies getDedicatedFallThroughPreheader, making bb.2
+  ; a post-pipeline candidate.
+  bb.1.preheader_a:
+    successors: %bb.2
+    liveins: $r0, $p0, $p1
+
+    $lc = ADD_NC_add_lc_ri $r0, 0
+    MOVXM_lng_cg_ls_abs %bb.2, implicit-def $ls
+    MOVXM_lng_cg_le_abs <mcsymbol .L_LEnd0>, implicit-def $le
+
+  ; bb.2 is Loop A: a single-block ZOL with a VLDA and a VST.
+  ; After scheduling, the PostPipeliner pipelines it, creating prologue
+  ; clones stored in bb.1.BottomInsertSemanticOrder.
+  bb.2.loop_a:
+    successors: %bb.2(0x7c000000), %bb.3(0x04000000)
+    liveins: $p0, $p1
+
+    $x0, $p0 = VLDA_dmx_lda_x_ld_pstm_nrm_imm $p0, 64 :: (load (<8 x s32>) from %ir.pa, addrspace 5)
+    $p1 = VST_dmx_sts_x_st_pstm_nrm_imm $x0, $p1, 64 :: (store (<8 x s32>) into %ir.pb, addrspace 6)
+    PseudoLoopEnd <mcsymbol .L_LEnd0>, %bb.2
+
+  ; bb.3 is simultaneously:
+  ;   (a) The epilogue of Loop A (bb.2 -> bb.3 exit edge), classified
+  ;       as BlockType::Epilogue because bb.2 is a Loop predecessor.
+  ;   (b) The dedicated fallthrough preheader of Loop B (bb.4):
+  ;       succ_size==1, no terminator, layout-adjacent to bb.4.
+  ; After Loop B (bb.4) is pipelined, bb.3.BottomInsertSemanticOrder
+  ; holds Loop B prologue clones created by CloneMachineInstr but not
+  ; yet inserted into any MachineBasicBlock.
+  bb.3.between_loops:
+    successors: %bb.4
+    liveins: $r1, $p0, $p1
+
+    $lc = ADD_NC_add_lc_ri $r1, 0
+    MOVXM_lng_cg_ls_abs %bb.4, implicit-def $ls
+    MOVXM_lng_cg_le_abs <mcsymbol .L_LEnd1>, implicit-def $le
+
+  ; bb.4 is Loop B: same structure as Loop A but with separate labels.
+  ; Pipelined during Phase 1 of scheduling, before bb.3 is entered as
+  ; Loop A's epilogue.
+  bb.4.loop_b:
+    successors: %bb.4(0x7c000000), %bb.5(0x04000000)
+    liveins: $p0, $p1
+
+    $x0, $p0 = VLDA_dmx_lda_x_ld_pstm_nrm_imm $p0, 64 :: (load (<8 x s32>) from %ir.pc, addrspace 5)
+    $p1 = VST_dmx_sts_x_st_pstm_nrm_imm $x0, $p1, 64 :: (store (<8 x s32>) into %ir.pd, addrspace 6)
+    PseudoLoopEnd <mcsymbol .L_LEnd1>, %bb.4
+
+  bb.5.exit:
+    RET implicit $lr
+    DelayedSchedBarrier
+...

--- a/llvm/test/CodeGen/AIE/aie2ps/schedule/postpipeliner/crash-bottom-insert-semantic-order.mir
+++ b/llvm/test/CodeGen/AIE/aie2ps/schedule/postpipeliner/crash-bottom-insert-semantic-order.mir
@@ -4,7 +4,6 @@
 #
 # (c) Copyright 2026 Advanced Micro Devices, Inc. or its affiliates
 
-# XFAIL: *
 # RUN: llc -mtriple=aie2ps -O2 --start-before=postmisched %s -o /dev/null
 
 # This test reproduces a crash triggered by


### PR DESCRIPTION
This fixes a crash that was observed in a consumer CI pipeline, The crash was dereferencing a nullptr parent basic block of a prologue instruction in and InterBlockEdges while building the edges.
It has been fixed by temporarily putting them the prologue instruction into the block where they should ultimately land, and removing them again before we definitely insert the bundles.