### PR TITLE
Revert "[AIE] Tighten top-fixed -> ExitSU latency with cross-BB MaxLatencyFinder"

### DIFF
--- a/llvm/lib/Target/AIE/AIEBaseSubtarget.cpp
+++ b/llvm/lib/Target/AIE/AIEBaseSubtarget.cpp
@@ -608,27 +608,15 @@ private:
     auto IsTopFixedSU = [Scheduler](const SUnit &SU) {
       return Scheduler->isFixedSU(SU, true);
     };
-    // Establish dependencies to ExitSU for each top-fixed sched. unit.
-    //
-    // When MaxLatencyFinder cannot use successor information (unknown
-    // successors, non-bottom region, or an abstract block) it returns the
-    // conservative AIE::maxLatency(). Otherwise it returns the effective
-    // latency: the part of the latency that is not already absorbed by the
-    // successor's leading cycles, computed from the cross-boundary edges of the
-    // instruction's pre-boundary node in the inter-block DDG. This tightens the
-    // region length and avoids padding the epilogue with unnecessary NOPs.
-    //
-    // Only the canonical (last-iteration) copy of each epilogue instruction is
-    // registered as a pre-boundary producer (see TopInsertSemanticOrder).
-    // Earlier-iteration copies have no pre-boundary node, so they get an
-    // effective latency of 0 here: their value is overwritten before the
-    // boundary, so the last copy's edge to ExitSU dominates and the earlier
-    // copies need no constraint of their own.
-    AIE::MaxLatencyFinder MaxLatency(DAG);
+    // TODO: this is pessimistic, we can handle this in RegionEndEdges after
+    // a mutation reordering.
+    // Establish dependencies to ExitSU for each top-fixed sched. unit by taking
+    // into account MaxLatency.
     for (SUnit &FixedSU : make_filter_range(DAG->SUnits, IsTopFixedSU)) {
-      MachineInstr &MI = *FixedSU.getInstr();
+      const MachineInstr &MI = *FixedSU.getInstr();
       SDep Dep(&FixedSU, SDep::Artificial);
-      Dep.setLatency(MaxLatency(MI));
+      Dep.setLatency(
+          AIE::maxLatency(&MI, *TII, *ItinData, /*IncludeStages=*/true));
       DAG->ExitSU.addPred(Dep, /*Required=*/true);
     }
   }

--- a/llvm/lib/Target/AIE/AIEInterBlockScheduling.cpp
+++ b/llvm/lib/Target/AIE/AIEInterBlockScheduling.cpp
@@ -443,14 +443,9 @@ class PipelineExtractor : public PipelineScheduleVisitor {
   bool InLoop = false;
   // True while visiting the prologue section.
   bool InPrologue = false;
-  // True while visiting the epilogue section.
-  bool InEpilogue = false;
   // Maps each original loop instruction to its first-iteration clone in the
   // prologue. Only the first occurrence of each original is recorded.
   DenseMap<const MachineInstr *, MachineInstr *> PrologueFirstIterClones;
-  // Maps each original loop instruction to its last-iteration clone in the
-  // epilogue. Only the last occurrence of each original is kept.
-  DenseMap<const MachineInstr *, MachineInstr *> EpilogueLastIterClones;
 
   void startPrologue() override { InPrologue = true; }
   void startLoop() override {
@@ -483,7 +478,21 @@ class PipelineExtractor : public PipelineScheduleVisitor {
     Loop.getTop().Bundles = TimedRegion;
     TimedRegion.clear();
     InLoop = false;
-    InEpilogue = true;
+  }
+  void finish() override {
+    auto &CopyTo = Epilogue->TopInsert;
+    assert(CopyTo.empty() && "Epilogue already has a timed region at Top.");
+
+    // Establish the number of bundles to copy. Note that std::distance on a
+    // vector is O(1)
+    int NonEmpty = std::distance(
+        find_if(reverse(TimedRegion), [](const auto &B) { return !B.empty(); }),
+        TimedRegion.rend());
+    // And copy them.
+    for (int I = 0; I < NonEmpty; I++) {
+      CopyTo.push_back(TimedRegion[I]);
+    }
+    TimedRegion.clear();
   }
   void startBundle() override { CurrentBundle.clear(); }
   void addToBundle(MachineInstr *MI) override {
@@ -498,50 +507,8 @@ class PipelineExtractor : public PipelineScheduleVisitor {
     // occurrence (i.e. the first-iteration copy) is kept.
     if (InPrologue)
       PrologueFirstIterClones.try_emplace(MI, ToBeEmitted);
-
-    // Record the last-iteration epilogue clone for each original instruction.
-    // Plain assignment overwrites, so the final occurrence (i.e. the
-    // last-iteration copy) is kept.
-    if (InEpilogue)
-      EpilogueLastIterClones[MI] = ToBeEmitted;
   }
   void endBundle() override { TimedRegion.emplace_back(CurrentBundle); }
-  void finish() override {
-    auto &CopyTo = Epilogue->TopInsert;
-    assert(CopyTo.empty() && "Epilogue already has a timed region at Top.");
-
-    // Establish the number of bundles to copy. Note that std::distance on a
-    // vector is O(1)
-    int NonEmpty = std::distance(
-        find_if(reverse(TimedRegion), [](const auto &B) { return !B.empty(); }),
-        TimedRegion.rend());
-    // And copy them.
-    for (int I = 0; I < NonEmpty; I++) {
-      CopyTo.push_back(TimedRegion[I]);
-    }
-
-    // Populate the epilogue semantic order, the exact mirror of the prologue's
-    // BottomInsertSemanticOrder. A software-pipelined epilogue contains several
-    // overlapping iterations, so the same loop instruction can be emitted more
-    // than once. We keep a single canonical copy per loop instruction: the
-    // last-iteration clone. Because the pipeliner never renames across
-    // iterations, that last copy is the final writer of the value, so its
-    // distance-to-ExitSU constraint dominates every earlier copy (an earlier
-    // copy is scheduled an integral number of IIs before it, with a dead def at
-    // the boundary). Earlier copies are therefore redundant as pre-boundary
-    // producers and are dropped here. We follow the original loop body order so
-    // the result is deterministic and parallel to the loop's SemanticOrder.
-    auto &TopOrder = Epilogue->TopInsertSemanticOrder;
-    assert(TopOrder.empty() && "Epilogue already has a top semantic order.");
-    for (MachineInstr *OrigMI : Loop.getTop().getFreeInstructions()) {
-      const auto It = EpilogueLastIterClones.find(OrigMI);
-      if (It != EpilogueLastIterClones.end())
-        TopOrder.push_back(It->second);
-    }
-
-    TimedRegion.clear();
-    InEpilogue = false;
-  }
 
 public:
   PipelineExtractor(InterBlockScheduling &InterBlock, BlockState &BS,
@@ -1018,21 +985,6 @@ void InterBlockScheduling::buildGraph(InterBlockEdges &DAG) {
   for (MachineInstr *MI : Bot.getFreeInstructions())
     DAG.addNode(MI);
 
-  // Pre-boundary: top-fixed instructions of the predecessor (a SWP epilogue).
-  // These are immovable producers whose results may be consumed in the
-  // successor block. Adding them lets computeEffectiveLatency() tighten the
-  // top-fixed -> ExitSU latency using successor depths. The vector is empty
-  // for blocks without a pipelined epilogue. Only instructions that are
-  // already physically emitted into a block are added: until emitInterBlockTop
-  // runs, the epilogue clones have no parent MBB and cannot participate in
-  // edge building. This may happen when a predecessor's edges are rebuilt
-  // (e.g. from the prologue path in leaveBlock) before the epilogue itself is
-  // entered for scheduling. In that case we simply fall back to the
-  // conservative latency for those producers.
-  for (MachineInstr *MI : BS.TopInsertSemanticOrder)
-    if (MI->getParent())
-      DAG.addNode(MI);
-
   DAG.markBoundary();
 
   // Post-boundary: free instructions. Empty regions signify empty basic
@@ -1313,15 +1265,6 @@ void InterBlockScheduling::emitInterBlockTop(BlockState &BS) {
     // If we are in the same BB, just emit.
     emitBundles(BS.TopInsert, DedicatedExit, DedicatedExit->begin(),
                 /*Move=*/false, /*EmitNops=*/false);
-
-    // The SWP epilogue instructions are now physically present at the top of
-    // this block and carry valid MF context. Rebuild this block's own
-    // inter-block DDG edges so that its top-fixed instructions appear as
-    // pre-boundary producer nodes (via TopInsertSemanticOrder). This lets
-    // MaxLatencyFinder tighten the top-fixed -> ExitSU latency using successor
-    // depths when this block is scheduled (which happens right after this).
-    if (!BS.TopInsertSemanticOrder.empty())
-      buildPerSuccEdges(DedicatedExit);
   } else {
     // If not, transfer the timed region to the new block state created
     // by makeDedicatedLoopExit. The Kind of both blocks was already updated
@@ -1330,10 +1273,6 @@ void InterBlockScheduling::emitInterBlockTop(BlockState &BS) {
     BlockState &NewBS = getBlockState(DedicatedExit);
     NewBS.TopInsert = BS.TopInsert;
     BS.TopInsert.clear();
-    // Transfer the top semantic order alongside the bundles. The dedicated
-    // exit will rebuild its own DDG edges when it is entered for scheduling.
-    NewBS.TopInsertSemanticOrder = std::move(BS.TopInsertSemanticOrder);
-    BS.TopInsertSemanticOrder.clear();
   }
 }
 

--- a/llvm/lib/Target/AIE/AIEInterBlockScheduling.h
+++ b/llvm/lib/Target/AIE/AIEInterBlockScheduling.h
@@ -199,19 +199,6 @@ public:
   /// during PipeliningDone.
   std::vector<MachineInstr *> BottomInsertSemanticOrder;
 
-  /// For pipelined loop epilogues: the mirror of BottomInsertSemanticOrder. A
-  /// software-pipelined epilogue overlaps several iterations, so the same loop
-  /// instruction can appear multiple times in TopInsert. This holds the single
-  /// canonical copy per loop instruction (the last-iteration clone), ordered by
-  /// the loop body's SemanticOrder. Because the pipeliner never renames across
-  /// iterations, the last copy is the final writer and its distance-to-ExitSU
-  /// constraint dominates the earlier copies, which are therefore omitted.
-  /// These instructions are added as pre-boundary producer nodes to the
-  /// inter-block DDG so that the top-fixed -> ExitSU latency can be tightened
-  /// using successor information. Populated by PipelineExtractor during
-  /// PipeliningDone.
-  std::vector<MachineInstr *> TopInsertSemanticOrder;
-
   void initInterBlock(const MachineSchedContext &Context,
                       const AIEHazardRecognizer &HR);
 

--- a/llvm/lib/Target/AIE/AIEMaxLatencyFinder.cpp
+++ b/llvm/lib/Target/AIE/AIEMaxLatencyFinder.cpp
@@ -13,18 +13,11 @@
 //===----------------------------------------------------------------------===//
 
 #include "AIEMaxLatencyFinder.h"
-#include "AIEHazardRecognizer.h"
-#include "llvm/ADT/SmallVector.h"
 
 #undef DEBUG_TYPE
 #define DEBUG_TYPE "sched-blocks"
 
 namespace llvm::AIE {
-
-// Typical number of instructions in a VLIW bundle. This is only the inline
-// capacity of the SmallVector below, not a hard limit, so larger bundles still
-// work without heap allocation in the common case.
-static constexpr unsigned MaxBundleSlots = 8;
 
 // Resetting aie-interblock-latency will use worst case instruction latencies
 // on ExitSU edges. This reverts to the 'classical' safety margin for
@@ -117,55 +110,40 @@ int MaxLatencyFinder::computeEffectiveLatency(MachineInstr &MI) {
                << (SE.getSucc() ? SE.getSucc()->getNumber() : -1) << "\n");
     LLVM_DEBUG(dbgs() << format("Successor %d PostRegionMaxDepth=%d\n", SuccNo,
                                 SE.getPostRegionMaxDepth()));
-    // A top-fixed instruction is represented as a BUNDLE root in the
-    // scheduling DAG, but the inter-block DDG holds the individual bundled
-    // instructions. Collect the pre-boundary nodes for every member so the
-    // bundle's effective latency is the max over its instructions.
-    SmallVector<const SUnit *, MaxBundleSlots> Preds;
-    if (MI.isBundle()) {
-      for (const MachineInstr &BundledMI : const_bundled_instrs(MI))
-        if (const SUnit *Pred =
-                SE.getPreBoundaryNode(const_cast<MachineInstr *>(&BundledMI)))
-          Preds.push_back(Pred);
-    } else if (const SUnit *Pred = SE.getPreBoundaryNode(&MI)) {
-      Preds.push_back(Pred);
-    }
-    if (Preds.empty()) {
+    const SUnit *Pred = SE.getPreBoundaryNode(&MI);
+    if (!Pred) {
       LLVM_DEBUG(
           dbgs() << "   No pre-boundary node for this successor, skip\n");
       continue;
     }
+    LLVM_DEBUG(dbgs() << "   Pre-boundary " << Pred->NodeNum << " has "
+                      << Pred->Succs.size() << " successor edge(s)\n");
 
-    for (const SUnit *Pred : Preds) {
-      LLVM_DEBUG(dbgs() << "   Pre-boundary " << Pred->NodeNum << " has "
-                        << Pred->Succs.size() << " successor edge(s)\n");
-      for (const SDep &Dep : Pred->Succs) {
-        SUnit *Succ = Dep.getSUnit();
-        if (!SE.isPostBoundaryNode(Succ)) {
-          LLVM_DEBUG(dbgs() << "   SU" << Succ->NodeNum
-                            << " is not a post-boundary node, skip\n");
-          continue;
-        }
-
-        // For ExitSU the depth is the full length of the successor block's
-        // top region (all its cycles have elapsed before reaching ExitSU).
-        // For a regular instruction node the depth is its scheduled cycle
-        // within the block.
-        const int Depth = Succ->isBoundaryNode()
-                              ? SE.getPostRegionMaxDepth() + 1
-                              : SE.getPostDepthOr(Succ, 0);
-        const int EdgeLat = Dep.getSignedLatency();
-        const int Remaining = EdgeLat - Depth;
-        LLVM_DEBUG(
-            dbgs() << "   " << (Succ->isBoundaryNode() ? "ExitSU" : "SU")
-                   << (Succ->isBoundaryNode() ? ""
-                                              : std::to_string(Succ->NodeNum))
-                   << ": latency=" << EdgeLat << ", depth=" << Depth
-                   << ", remaining=" << Remaining
-                   << ", updating EffectiveLatency " << EffectiveLatency
-                   << " -> " << std::max(EffectiveLatency, Remaining) << "\n");
-        EffectiveLatency = std::max(EffectiveLatency, Remaining);
+    for (const SDep &Dep : Pred->Succs) {
+      SUnit *Succ = Dep.getSUnit();
+      if (!SE.isPostBoundaryNode(Succ)) {
+        LLVM_DEBUG(dbgs() << "   SU" << Succ->NodeNum
+                          << " is not a post-boundary node, skip\n");
+        continue;
       }
+
+      // For ExitSU the depth is the full length of the successor block's
+      // top region (all its cycles have elapsed before reaching ExitSU).
+      // For a regular instruction node the depth is its scheduled cycle
+      // within the block.
+      const int Depth = Succ->isBoundaryNode() ? SE.getPostRegionMaxDepth() + 1
+                                               : SE.getPostDepthOr(Succ, 0);
+      const int EdgeLat = Dep.getSignedLatency();
+      const int Remaining = EdgeLat - Depth;
+      LLVM_DEBUG(
+          dbgs() << "   " << (Succ->isBoundaryNode() ? "ExitSU" : "SU")
+                 << (Succ->isBoundaryNode() ? ""
+                                            : std::to_string(Succ->NodeNum))
+                 << ": latency=" << EdgeLat << ", depth=" << Depth
+                 << ", remaining=" << Remaining
+                 << ", updating EffectiveLatency " << EffectiveLatency << " -> "
+                 << std::max(EffectiveLatency, Remaining) << "\n");
+      EffectiveLatency = std::max(EffectiveLatency, Remaining);
     }
     SuccNo++;
   }

--- a/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/add-store.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/add-store.mir
@@ -39,7 +39,8 @@
   ; CHECK-NEXT:  .L_LEnd0:
   ; CHECK-NEXT:    nopb ; nopa ; st r1, [p0], #4; add r1, r1, #1; nopm ; nopv
   ; CHECK-NEXT:  // %bb.3: // %for.cond.cleanup
-  ; CHECK-NEXT:    nopb ; nopa ; st r1, [p0], #4; nopxm ; nopv
+  ; CHECK-NEXT:    nopa ; nopb ; nopxm ; st r1, [p0], #4
+  ; CHECK-NEXT:    nop
   ; CHECK-NEXT:    .p2align 4
   ; CHECK-NEXT:  .LBB0_4: // %for.cond.cleanup
   ; CHECK-NEXT:    nopa ; ret lr

--- a/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/bitwisexor.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/bitwisexor.mir
@@ -85,7 +85,7 @@ body:             |
   ; CHECK-NEXT:   - Prologue:        bb.1.for.body.preheader
   ; CHECK-NEXT:   - PrologueBundles: '15'
   ; CHECK-NEXT:   - Epilogue:        bb.4.for.cond.cleanup
-  ; CHECK-NEXT:   - EpilogueBundles: '11'
+  ; CHECK-NEXT:   - EpilogueBundles: '12'
   ; CHECK-NEXT: ...
   bb.0.entry (align 16):
     successors: %bb.1(0x50000000), %bb.3(0x30000000)

--- a/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/conv2d_bf16-1.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/conv2d_bf16-1.mir
@@ -76,7 +76,7 @@ body:             |
   ; CHECK-NEXT:   - Prologue:        bb.1.for.body.preheader
   ; CHECK-NEXT:   - PrologueBundles: '20'
   ; CHECK-NEXT:   - Epilogue:        bb.4.for.cond.cleanup
-  ; CHECK-NEXT:   - EpilogueBundles: '14'
+  ; CHECK-NEXT:   - EpilogueBundles: '20'
   ; CHECK-NEXT: ...
   bb.0.entry (align 16):
     successors: %bb.1(0x50000000), %bb.3(0x30000000)

--- a/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/conv2d_bf16-2.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/conv2d_bf16-2.mir
@@ -77,7 +77,7 @@ body:             |
   ; CHECK-NEXT:   - Prologue:        bb.1.for.body.preheader
   ; CHECK-NEXT:   - PrologueBundles: '16'
   ; CHECK-NEXT:   - Epilogue:        bb.4.for.cond.cleanup
-  ; CHECK-NEXT:   - EpilogueBundles: '18'
+  ; CHECK-NEXT:   - EpilogueBundles: '24'
   ; CHECK-NEXT: ...
   bb.0.entry (align 16):
     successors: %bb.1(0x50000000), %bb.3(0x30000000)

--- a/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/conv2d_bf16-feasibleRA.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/conv2d_bf16-feasibleRA.mir
@@ -77,7 +77,7 @@ body:             |
   ; CHECK-NEXT:   - Prologue:        bb.1.for.body.preheader
   ; CHECK-NEXT:   - PrologueBundles: '18'
   ; CHECK-NEXT:   - Epilogue:        bb.4.for.cond.cleanup
-  ; CHECK-NEXT:   - EpilogueBundles: '16'
+  ; CHECK-NEXT:   - EpilogueBundles: '22'
   ; CHECK-NEXT: ...
   bb.0.entry (align 16):
     successors: %bb.1(0x50000000), %bb.3(0x30000000)

--- a/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/conv2d_bf16.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/conv2d_bf16.mir
@@ -76,7 +76,7 @@ body:             |
   ; CHECK-NEXT:   - Prologue:        bb.1.for.body.preheader
   ; CHECK-NEXT:   - PrologueBundles: '21'
   ; CHECK-NEXT:   - Epilogue:        bb.4.for.cond.cleanup
-  ; CHECK-NEXT:   - EpilogueBundles: '17'
+  ; CHECK-NEXT:   - EpilogueBundles: '23'
   ; CHECK-NEXT: ...
   bb.0.entry (align 16):
     successors: %bb.1(0x50000000), %bb.3(0x30000000)

--- a/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/gemm-1.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/gemm-1.mir
@@ -76,7 +76,7 @@ body:             |
   ; CHECK-NEXT:   - Prologue:        bb.1.for.body.preheader
   ; CHECK-NEXT:   - PrologueBundles: '21'
   ; CHECK-NEXT:   - Epilogue:        bb.4.for.cond.cleanup
-  ; CHECK-NEXT:   - EpilogueBundles: '17'
+  ; CHECK-NEXT:   - EpilogueBundles: '23'
   ; CHECK-NEXT: ...
   bb.0.entry (align 16):
     successors: %bb.1(0x50000000), %bb.3(0x30000000)

--- a/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/gemm-2.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/gemm-2.mir
@@ -76,7 +76,7 @@ body:             |
   ; CHECK-NEXT:   - Prologue:        bb.1.for.body.preheader
   ; CHECK-NEXT:   - PrologueBundles: '19'
   ; CHECK-NEXT:   - Epilogue:        bb.4.for.cond.cleanup
-  ; CHECK-NEXT:   - EpilogueBundles: '18'
+  ; CHECK-NEXT:   - EpilogueBundles: '24'
   ; CHECK-NEXT: ...
   bb.0.entry (align 16):
     successors: %bb.1(0x50000000), %bb.3(0x30000000)

--- a/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/gemm-3.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/gemm-3.mir
@@ -76,7 +76,7 @@ body:             |
   ; CHECK-NEXT:   - Prologue:        bb.1.for.body.preheader
   ; CHECK-NEXT:   - PrologueBundles: '19'
   ; CHECK-NEXT:   - Epilogue:        bb.4.for.cond.cleanup
-  ; CHECK-NEXT:   - EpilogueBundles: '18'
+  ; CHECK-NEXT:   - EpilogueBundles: '24'
   ; CHECK-NEXT: ...
   bb.0.entry (align 16):
     successors: %bb.1(0x50000000), %bb.3(0x30000000)

--- a/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/gemm-feasibleRA-nopstinc.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/gemm-feasibleRA-nopstinc.mir
@@ -77,7 +77,7 @@ body:             |
   ; CHECK-NEXT:   - Prologue:        bb.1.for.body.preheader
   ; CHECK-NEXT:   - PrologueBundles: '32'
   ; CHECK-NEXT:   - Epilogue:        bb.4.for.cond.cleanup
-  ; CHECK-NEXT:   - EpilogueBundles: '18'
+  ; CHECK-NEXT:   - EpilogueBundles: '24'
   ; CHECK-NEXT: ...
   bb.0.entry (align 16):
     successors: %bb.1(0x50000000), %bb.3(0x30000000)

--- a/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/gemm-feasibleRA.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/gemm-feasibleRA.mir
@@ -76,7 +76,7 @@ body:             |
   ; CHECK-NEXT:   - Prologue:        bb.1.for.body.preheader
   ; CHECK-NEXT:   - PrologueBundles: '32'
   ; CHECK-NEXT:   - Epilogue:        bb.4.for.cond.cleanup
-  ; CHECK-NEXT:   - EpilogueBundles: '19'
+  ; CHECK-NEXT:   - EpilogueBundles: '25'
   ; CHECK-NEXT: ...
   bb.0.entry (align 16):
     successors: %bb.1(0x50000000), %bb.3(0x30000000)

--- a/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/gemm-nooffset.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/gemm-nooffset.mir
@@ -76,7 +76,7 @@ body:             |
   ; CHECK-NEXT:   - Prologue:        bb.1.for.body.preheader
   ; CHECK-NEXT:   - PrologueBundles: '32'
   ; CHECK-NEXT:   - Epilogue:        bb.4.for.cond.cleanup
-  ; CHECK-NEXT:   - EpilogueBundles: '18'
+  ; CHECK-NEXT:   - EpilogueBundles: '24'
   ; CHECK-NEXT: ...
   bb.0.entry (align 16):
     successors: %bb.1(0x50000000), %bb.3(0x30000000)

--- a/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/gemm-nopresched-nobanks.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/gemm-nopresched-nobanks.mir
@@ -76,7 +76,7 @@ body:             |
   ; CHECK-NEXT:   - Prologue:        bb.1.for.body.preheader
   ; CHECK-NEXT:   - PrologueBundles: '34'
   ; CHECK-NEXT:   - Epilogue:        bb.4.for.cond.cleanup
-  ; CHECK-NEXT:   - EpilogueBundles: '19'
+  ; CHECK-NEXT:   - EpilogueBundles: '25'
   ; CHECK-NEXT: ...
   bb.0.entry (align 16):
     successors: %bb.1(0x50000000), %bb.3(0x30000000)

--- a/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/gemm-nopresched.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/gemm-nopresched.mir
@@ -76,7 +76,7 @@ body:             |
   ; CHECK-NEXT:   - Prologue:        bb.1.for.body.preheader
   ; CHECK-NEXT:   - PrologueBundles: '16'
   ; CHECK-NEXT:   - Epilogue:        bb.4.for.cond.cleanup
-  ; CHECK-NEXT:   - EpilogueBundles: '15'
+  ; CHECK-NEXT:   - EpilogueBundles: '21'
   ; CHECK-NEXT: ...
   bb.0.entry (align 16):
     successors: %bb.1(0x50000000), %bb.3(0x30000000)

--- a/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/gemm-waw.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/gemm-waw.mir
@@ -81,7 +81,7 @@ body:             |
   ; CHECK-NEXT:   - Prologue:        bb.1.for.body.preheader
   ; CHECK-NEXT:   - PrologueBundles: '21'
   ; CHECK-NEXT:   - Epilogue:        bb.3.loop.exit
-  ; CHECK-NEXT:   - EpilogueBundles: '17'
+  ; CHECK-NEXT:   - EpilogueBundles: '23'
   ; CHECK-NEXT: ...
   bb.0.entry (align 16):
     successors: %bb.1(0x50000000), %bb.4(0x30000000)

--- a/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/gemm.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/gemm.mir
@@ -76,7 +76,7 @@ body:             |
   ; CHECK-NEXT:   - Prologue:        bb.1.for.body.preheader
   ; CHECK-NEXT:   - PrologueBundles: '21'
   ; CHECK-NEXT:   - Epilogue:        bb.4.for.cond.cleanup
-  ; CHECK-NEXT:   - EpilogueBundles: '17'
+  ; CHECK-NEXT:   - EpilogueBundles: '23'
   ; CHECK-NEXT: ...
   bb.0.entry (align 16):
     successors: %bb.1(0x50000000), %bb.3(0x30000000)

--- a/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/large-II.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/large-II.mir
@@ -163,7 +163,7 @@ body:             |
   ; CHECK-NEXT:   - Prologue:        bb.1.for.body.preheader
   ; CHECK-NEXT:   - PrologueBundles: '8'
   ; CHECK-NEXT:   - Epilogue:        bb.4.for.cond.cleanup
-  ; CHECK-NEXT:   - EpilogueBundles: '7'
+  ; CHECK-NEXT:   - EpilogueBundles: '8'
   ; CHECK-NEXT: ...
   bb.0.entry (align 16):
     successors: %bb.1(0x50000000), %bb.3(0x30000000)

--- a/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/ld2-mv-mac2-st2.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/ld2-mv-mac2-st2.mir
@@ -75,7 +75,7 @@ body:             |
   ; CHECK-NEXT:   - Prologue:        bb.1.for.body.preheader
   ; CHECK-NEXT:   - PrologueBundles: '12'
   ; CHECK-NEXT:   - Epilogue:        bb.4.for.cond.cleanup
-  ; CHECK-NEXT:   - EpilogueBundles: '12'
+  ; CHECK-NEXT:   - EpilogueBundles: '15'
   ; CHECK-NEXT: ...
   bb.0.entry (align 16):
     successors: %bb.1, %bb.3

--- a/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/load-add-or-store.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/load-add-or-store.mir
@@ -40,7 +40,7 @@
   ; CHECK-NEXT:  .L_LEnd0:
   ; CHECK-NEXT:    nopb ; nopa ; st r2, [p0], #4; add r1, r0, #1; nopm ; nopv
   ; CHECK-NEXT:  // %bb.3: // %for.cond.cleanup
-  ; CHECK-NEXT:    nopa ; nopb ; or r2, r1, r1; nopm ; nops
+  ; CHECK-NEXT:    nopa ; nopb ; or r2, r1, r1; nopm
   ; CHECK-NEXT:    st r2, [p0], #4; add r1, r0, #1
   ; CHECK-NEXT:    or r2, r1, r1
   ; CHECK-NEXT:    st r2, [p0], #4; add r1, r0, #1
@@ -48,6 +48,7 @@
   ; CHECK-NEXT:    st r2, [p0], #4; add r1, r0, #1
   ; CHECK-NEXT:    or r2, r1, r1
   ; CHECK-NEXT:    st r2, [p0], #4
+  ; CHECK-NEXT:    nop
   ; CHECK-NEXT:    .p2align 4
   ; CHECK-NEXT:  .LBB0_4: // %for.cond.cleanup
   ; CHECK-NEXT:    nopa ; ret lr

--- a/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/load-add-store-renamed.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/load-add-store-renamed.mir
@@ -39,7 +39,7 @@
   ; CHECK-NEXT:  .L_LEnd0:
   ; CHECK-NEXT:    nopb ; lda r0, [p1], #4; st r1, [p0], #4; add r1, r0, #1; nopm ; nopv
   ; CHECK-NEXT:  // %bb.3: // %for.cond.cleanup
-  ; CHECK-NEXT:    st r1, [p0], #4; nopb ; add r1, r0, #1
+  ; CHECK-NEXT:    st r1, [p0], #4; add r1, r0, #1
   ; CHECK-NEXT:    st r1, [p0], #4; add r1, r0, #1
   ; CHECK-NEXT:    st r1, [p0], #4; add r1, r0, #1
   ; CHECK-NEXT:    st r1, [p0], #4; add r1, r0, #1
@@ -47,6 +47,7 @@
   ; CHECK-NEXT:    st r1, [p0], #4; add r1, r0, #1
   ; CHECK-NEXT:    st r1, [p0], #4; add r1, r0, #1
   ; CHECK-NEXT:    st r1, [p0], #4
+  ; CHECK-NEXT:    nop
   ; CHECK-NEXT:    .p2align 4
   ; CHECK-NEXT:  .LBB0_4: // %for.cond.cleanup
   ; CHECK-NEXT:    nopa ; ret lr

--- a/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/load-add-store.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/load-add-store.mir
@@ -40,13 +40,14 @@
   ; CHECK-NEXT:  .L_LEnd0:
   ; CHECK-NEXT:    nopb ; nopa ; nops ; add r0, r0, #1; nopm ; nopv
   ; CHECK-NEXT:  // %bb.3: // %for.cond.cleanup
-  ; CHECK-NEXT:    st r0, [p0], #4; nopb ; nopx
+  ; CHECK-NEXT:    st r0, [p0], #4; nopx
   ; CHECK-NEXT:    add r0, r0, #1
   ; CHECK-NEXT:    st r0, [p0], #4
   ; CHECK-NEXT:    add r0, r0, #1
   ; CHECK-NEXT:    st r0, [p0], #4
   ; CHECK-NEXT:    add r0, r0, #1
   ; CHECK-NEXT:    st r0, [p0], #4
+  ; CHECK-NEXT:    nop
   ; CHECK-NEXT:    .p2align 4
   ; CHECK-NEXT:  .LBB0_4: // %for.cond.cleanup
   ; CHECK-NEXT:    nopa ; ret lr

--- a/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/load-mac-store.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/load-mac-store.mir
@@ -40,13 +40,14 @@
   ; CHECK-NEXT:  .L_LEnd0:
   ; CHECK-NEXT:    nopb ; nopa ; nops ; add r0, r0, #1; nopm ; nopv
   ; CHECK-NEXT:  // %bb.3: // %for.cond.cleanup
-  ; CHECK-NEXT:    st r0, [p0], #4; nopb ; nopx
+  ; CHECK-NEXT:    st r0, [p0], #4; nopx
   ; CHECK-NEXT:    add r0, r0, #1
   ; CHECK-NEXT:    st r0, [p0], #4
   ; CHECK-NEXT:    add r0, r0, #1
   ; CHECK-NEXT:    st r0, [p0], #4
   ; CHECK-NEXT:    add r0, r0, #1
   ; CHECK-NEXT:    st r0, [p0], #4
+  ; CHECK-NEXT:    nop
   ; CHECK-NEXT:    .p2align 4
   ; CHECK-NEXT:  .LBB0_4: // %for.cond.cleanup
   ; CHECK-NEXT:    nopa ; ret lr

--- a/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/round-memdep.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/round-memdep.mir
@@ -51,8 +51,8 @@
   ; CHECK-NEXT:  .L_LEnd0:
   ; CHECK-NEXT:    nopb ; vlda.ups.s32.s8 cm0, s0, [p0], #32; vst.srs.d8.s32 cm2, s0, [p1], #32; nopx ; vups.s32.s8 cm3, wh2, s1; nopv
   ; CHECK-NEXT:  // %bb.3: // %loop.exit
-  ; CHECK-NEXT:    nopb ; vlda.ups.s32.s8 cm1, s0, [p0], #32; vsrs.s8.s32 wh0, cm0, s1; nopx ; vups.s32.s8 cm2, wh0, s1; nopv
-  ; CHECK-NEXT:    nopx
+  ; CHECK-NEXT:    vlda.ups.s32.s8 cm1, s0, [p0], #32; vsrs.s8.s32 wh0, cm0, s1; nopx ; vups.s32.s8 cm2, wh0, s1
+  ; CHECK-NEXT:    nop
   ; CHECK-NEXT:    vsrs.s8.s32 wh2, cm1, s1
   ; CHECK-NEXT:    vst.srs.d8.s32 cm2, s0, [p1], #32; vups.s32.s8 cm3, wh2, s1
   ; CHECK-NEXT:    vsrs.s8.s32 wh0, cm0, s1; vups.s32.s8 cm2, wh0, s1
@@ -67,6 +67,9 @@
   ; CHECK-NEXT:    nop
   ; CHECK-NEXT:    nop
   ; CHECK-NEXT:    vst.srs.d8.s32 cm2, s0, [p1], #32; vups.s32.s8 cm3, wh2, s1
+  ; CHECK-NEXT:    nop
+  ; CHECK-NEXT:    nop
+  ; CHECK-NEXT:    nop
   ; CHECK-NEXT:    .p2align 4
   ; CHECK-NEXT:  .LBB0_4: // %for.cond.cleanup
   ; CHECK-NEXT:    nopa ; ret lr

--- a/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/round-war.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/round-war.mir
@@ -53,7 +53,7 @@
   ; CHECK-NEXT:  .L_LEnd0:
   ; CHECK-NEXT:    nopb ; vlda.ups.s32.s8 cm1, s0, [p0], #32; vst.srs.d8.s32 cm3, s0, [p1], #32; nopx ; vups.s32.s8 cm2, wh0, s1; nopv
   ; CHECK-NEXT:  // %bb.3: // %loop.exit
-  ; CHECK-NEXT:    nopb ; nopa ; vsrs.s8.s32 wh2, cm1, s1; nopx ; vups.s32.s8 cm3, wh2, s1; nopv
+  ; CHECK-NEXT:    nopa ; vsrs.s8.s32 wh2, cm1, s1; nopx ; vups.s32.s8 cm3, wh2, s1
   ; CHECK-NEXT:    vsrs.s8.s32 wh0, cm0, s1
   ; CHECK-NEXT:    vst.srs.d8.s32 cm2, s0, [p1], #32
   ; CHECK-NEXT:    vst.srs.d8.s32 cm3, s0, [p1], #32; vups.s32.s8 cm2, wh0, s1
@@ -69,6 +69,8 @@
   ; CHECK-NEXT:    nop
   ; CHECK-NEXT:    vst.srs.d8.s32 cm2, s0, [p1], #32
   ; CHECK-NEXT:    vst.srs.d8.s32 cm3, s0, [p1], #32
+  ; CHECK-NEXT:    nop
+  ; CHECK-NEXT:    nop
   ; CHECK-NEXT:    mov crSRSSign, #0
   ; CHECK-NEXT:    .p2align 4
   ; CHECK-NEXT:  .LBB0_4: // %for.cond.cleanup

--- a/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/round.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/round.mir
@@ -93,7 +93,7 @@ body:             |
   ; CHECK-NEXT:   - Prologue:        bb.1.for.body.preheader
   ; CHECK-NEXT:   - PrologueBundles: '16'
   ; CHECK-NEXT:   - Epilogue:        bb.4.for.cond.cleanup
-  ; CHECK-NEXT:   - EpilogueBundles: '16'
+  ; CHECK-NEXT:   - EpilogueBundles: '19'
   ; CHECK-NEXT: ...
   bb.0.entry (align 16):
     successors: %bb.1(0x50000000), %bb.3(0x30000000)

--- a/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/small-II.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/small-II.mir
@@ -143,7 +143,7 @@ body:             |
   ; CHECK-NEXT:   - Prologue:        bb.1.for.body.preheader
   ; CHECK-NEXT:   - PrologueBundles: '8'
   ; CHECK-NEXT:   - Epilogue:        bb.4.for.cond.cleanup
-  ; CHECK-NEXT:   - EpilogueBundles: '7'
+  ; CHECK-NEXT:   - EpilogueBundles: '8'
   ; CHECK-NEXT: ...
   bb.0.entry (align 16):
     successors: %bb.1(0x50000000), %bb.3(0x30000000)

--- a/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/unpack-extract-block-cycles.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/unpack-extract-block-cycles.mir
@@ -78,7 +78,7 @@ body:             |
   ; CHECK-NEXT:   - Prologue:        bb.1.for.body.preheader
   ; CHECK-NEXT:   - PrologueBundles: '6'
   ; CHECK-NEXT:   - Epilogue:        bb.3.loop.exit
-  ; CHECK-NEXT:   - EpilogueBundles: '4'
+  ; CHECK-NEXT:   - EpilogueBundles: '5'
   ; CHECK-NEXT: ...
   bb.0.entry (align 16):
     successors: %bb.1(0x50000000), %bb.4(0x30000000)

--- a/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/Conv2D_bfp16_conv.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/Conv2D_bfp16_conv.mir
@@ -34,7 +34,7 @@ body:             |
   ; CONSERVATIVE-NEXT:   - Prologue:        bb.1
   ; CONSERVATIVE-NEXT:   - PrologueBundles: '22'
   ; CONSERVATIVE-NEXT:   - Epilogue:        bb.4
-  ; CONSERVATIVE-NEXT:   - EpilogueBundles: '11'
+  ; CONSERVATIVE-NEXT:   - EpilogueBundles: '15'
   ; CONSERVATIVE-NEXT: ...
   ; OPTIMISTIC: --- !Passed
   ; OPTIMISTIC-NEXT: Pass:            pipeliner
@@ -49,7 +49,7 @@ body:             |
   ; OPTIMISTIC-NEXT:   - Prologue:        bb.1
   ; OPTIMISTIC-NEXT:   - PrologueBundles: '22'
   ; OPTIMISTIC-NEXT:   - Epilogue:        bb.4
-  ; OPTIMISTIC-NEXT:   - EpilogueBundles: '11'
+  ; OPTIMISTIC-NEXT:   - EpilogueBundles: '15'
   ; OPTIMISTIC-NEXT: ...
   bb.0.entry (align 16):
     successors: %bb.3(0x30000000), %bb.1(0x50000000)

--- a/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/multiSlotAssignment/fill-stream-separation.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/multiSlotAssignment/fill-stream-separation.mir
@@ -19,9 +19,9 @@
 
 --- |
   define dso_local void @fill_stream_separation(ptr noalias %pA, ptr noalias %pB, ptr noalias %psum_ld, ptr noalias %psum_st, i32 %n) {
-  ; CHECK-LABEL: fill_stream_separation:
+  ; CHECK-LABEL: fill_stream_separation: // @fill_stream_separation
   ; CHECK:         .p2align 4
-  ; CHECK-NEXT:  // %bb.0:
+  ; CHECK-NEXT:    // %bb.0:
   ; CHECK-NEXT:    mova r1, #0; nopx
   ; CHECK-NEXT:    ge r1, r1, r0
   ; CHECK-NEXT:    jnz r1, #.LBB0_4
@@ -30,7 +30,7 @@
   ; CHECK-NEXT:    nop // Delay Slot 3
   ; CHECK-NEXT:    nop // Delay Slot 2
   ; CHECK-NEXT:    nop // Delay Slot 1
-  ; CHECK-NEXT:  // %bb.1:
+  ; CHECK-NEXT:    // %bb.1:
   ; CHECK-NEXT:    vlda.fill.512 [p1, lf1, r25]; vldb.fill.512 [p0, lf0, r24]
   ; CHECK-NEXT:    vldb.pop.576 ex3, [p1, lf1, r25]
   ; CHECK-NEXT:    vlda bmlh4, [p7, #64]; vldb.pop.576 ex11, [p0, lf0, r24]
@@ -67,7 +67,7 @@
   ; CHECK-NEXT:    vlda bmlh4, [p7, #64]; vldb.pop.576 ex2, [p1, lf1, r25]; movxm ls, #.LBB0_2; vst bmlh0, [p3, #64]
   ; CHECK-NEXT:    vlda bmhl4, [p7, #128]; vldb.pop.576 ex7, [p0, lf0, r24]; vst bmhl0, [p3, #128]; movxm le, #.L_LEnd0; vmac.f dm3, dm4, ex11, ex3, r2
   ; CHECK-NEXT:    .p2align 4
-  ; CHECK-NEXT:  .LBB0_2: // =>This Inner Loop Header: Depth=1
+  ; CHECK-NEXT:    .LBB0_2: // =>This Inner Loop Header: Depth=1
   ; CHECK-NEXT:    vlda.pop.576.2d ex0, [p1, lf1, r25, d3]; vldb.pop.576.2d ex5, [p0, lf0, r24, d1]; vst bmhh0, [p3, #192]; nopxm ; vmac.f dm0, dm1, ex5, ex8, r2
   ; CHECK-NEXT:    vlda.fill.512 [p1, lf1, r25]; vldb.fill.512 [p0, lf0, r24]; vst.2d bmll0, [p3], d0; nopxm ; vmac.f dm1, dm2, ex7, ex2, r2
   ; CHECK-NEXT:    vlda.2d bmll4, [p7], d2; vldb.pop.576 ex3, [p1, lf1, r25]
@@ -79,12 +79,12 @@
   ; CHECK-NEXT:    vlda.pop.576 ex4, [p1, lf1, r25]; vst bmhl0, [p3, #128]; vmac.f dm1, dm2, ex7, ex10, r2
   ; CHECK-NEXT:    vlda bmhh4, [p7, #192]; vldb.pop.576 ex9, [p0, lf0, r24]; vst.2d bmll0, [p3], d0; vmac.f dm2, dm3, ex9, ex4, r2
   ; CHECK-NEXT:    vlda bmlh4, [p7, #64]; vldb.pop.576 ex2, [p1, lf1, r25]; vst bmlh0, [p3, #64]
-  ; CHECK-NEXT:  .L_LEnd0:
+  ; CHECK-NEXT:    .L_LEnd0:
   ; CHECK-NEXT:    vlda bmhl4, [p7, #128]; vldb.pop.576 ex7, [p0, lf0, r24]; vst bmhl0, [p3, #128]; nopxm ; vmac.f dm3, dm4, ex11, ex3, r2
-  ; CHECK-NEXT:  // %bb.3:
-  ; CHECK-NEXT:    vlda.pop.576.2d ex0, [p1, lf1, r25, d3]; vldb.pop.576.2d ex5, [p0, lf0, r24, d1]; vst bmhh0, [p3, #192]; vmac.f dm0, dm1, ex5, ex8, r2
-  ; CHECK-NEXT:    vst.2d bmll0, [p3], d0; vmac.f dm1, dm2, ex7, ex2, r2
-  ; CHECK-NEXT:    vlda.2d bmll4, [p7], d2
+  ; CHECK-NEXT:    // %bb.3:
+  ; CHECK-NEXT:    vlda.pop.576.2d ex0, [p1, lf1, r25, d3]; vldb.pop.576.2d ex5, [p0, lf0, r24, d1]; vst bmhh0, [p3, #192]; nopxm ; vmac.f dm0, dm1, ex5, ex8, r2
+  ; CHECK-NEXT:    nopa ; nopb ; vst.2d bmll0, [p3], d0; nopxm ; vmac.f dm1, dm2, ex7, ex2, r2
+  ; CHECK-NEXT:    vlda.2d bmll4, [p7], d2; nopx
   ; CHECK-NEXT:    nop
   ; CHECK-NEXT:    vmac.f dm0, dm1, ex5, ex0, r2
   ; CHECK-NEXT:    vmac.f dm2, dm3, ex9, ex1, r2
@@ -108,14 +108,9 @@
   ; CHECK-NEXT:    vst bmhl0, [p3, #128]
   ; CHECK-NEXT:    vst bmhh0, [p3, #192]
   ; CHECK-NEXT:    vst.2d bmll0, [p3], d0
+  ; CHECK-NEXT:    nop
   ; CHECK-NEXT:    .p2align 4
-  ; CHECK-NEXT:  .LBB0_4:
-  ; CHECK-NEXT:    nopa ; ret lr
-  ; CHECK-NEXT:    nop // Delay Slot 5
-  ; CHECK-NEXT:    nop // Delay Slot 4
-  ; CHECK-NEXT:    nop // Delay Slot 3
-  ; CHECK-NEXT:    nop // Delay Slot 2
-  ; CHECK-NEXT:    nop // Delay Slot 1
+  ; CHECK-NEXT:    .LBB0_4:
   entry:
     %pA0 = getelementptr i8, ptr %pA, i32 0
     %pA1 = getelementptr i8, ptr %pA, i32 64

--- a/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/softmax-aa.mir
+++ b/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/softmax-aa.mir
@@ -280,7 +280,7 @@ body:             |
   ; CHECK-NEXT:   - Prologue:        bb.2.for.cond2.preheader
   ; CHECK-NEXT:   - PrologueBundles: '12'
   ; CHECK-NEXT:   - Epilogue:        bb.4.for.cond.cleanup4
-  ; CHECK-NEXT:   - EpilogueBundles: '10'
+  ; CHECK-NEXT:   - EpilogueBundles: '11'
   ; CHECK-NEXT: ...
   bb.0.entry (align 16):
     successors: %bb.1(0x50000000), %bb.5(0x30000000)
@@ -398,7 +398,7 @@ body:             |
   ; CHECK-NEXT:   - Prologue:        bb.2.for.cond2.preheader
   ; CHECK-NEXT:   - PrologueBundles: '13'
   ; CHECK-NEXT:   - Epilogue:        bb.4.for.cond.cleanup4
-  ; CHECK-NEXT:   - EpilogueBundles: '10'
+  ; CHECK-NEXT:   - EpilogueBundles: '11'
   ; CHECK-NEXT: ...
   bb.0.entry (align 16):
     successors: %bb.1(0x50000000), %bb.5(0x30000000)

--- a/llvm/test/CodeGen/AIE/aie2ps/end-to-end/conv2d_opt_outerloop_blocks.ll
+++ b/llvm/test/CodeGen/AIE/aie2ps/end-to-end/conv2d_opt_outerloop_blocks.ll
@@ -109,17 +109,17 @@ define dso_local void @conv2d(i32 %0, ptr %add.ptr3, ptr %ofm, ptr %psum_0_tdm, 
 ; CHECK-NEXT:  // %bb.3: // %for.cond.cleanup54.i
 ; CHECK-NEXT:    // in Loop: Header=BB0_1 Depth=1
 ; CHECK-NEXT:    vlda x4, [p7, #192]; paddb.3d [p1], d1; padds [p7], #128; nopxm ; vmac dm0, dm0, x2, x4, r8
-; CHECK-NEXT:    vlda x6, [p7, #128]; vldb.popx x10, [p1, lf1, r25]; movs dc4, dc7; nopx ; vshuffle x2, x10, x8, r2; vmac dm1, dm1, x2, x6, r8
-; CHECK-NEXT:    vlda x4, [p7, #192]; vldb.pop.3d x1, [p1, lf1, r25, d0]; padds [p7], #128; nopx ; mov srssign0, r6; vmac dm0, dm0, x2, x4, r8
-; CHECK-NEXT:    padda [p0], m4; nopb ; nops ; nopx ; vshuffle x2, x10, x8, r2; vmac dm1, dm1, x2, x6, r8
-; CHECK-NEXT:    paddb.3d [p0], d2; nopx ; vmac dm0, dm0, x2, x4, r8
-; CHECK-NEXT:    vldb x8, [p0, #0]; vshuffle x2, x10, x8, r2; vmac dm1, dm1, x2, x6, r8
-; CHECK-NEXT:    vldb x6, [p0, #64]; mov r0, dc6; vmac dm0, dm0, x2, x4, r8
-; CHECK-NEXT:    vlda.ups.2x cml1, s0, upssign1, [p2], #64; lshl r0, r0, r16; vshuffle x2, x10, x8, r2; vmac dm1, dm1, x2, x6, r8
-; CHECK-NEXT:    vlda.ups.2x cmh1, s0, upssign1, [p2], #64; or r20, r0, r18; mov dj7, r0; vmac dm0, dm0, x2, x4, r8
-; CHECK-NEXT:    vlda.ups.2x cml0, s0, upssign1, [p3], #64; vldb.128 wl2, [p5, dj7]; mov dj7, r20; vmac dm1, dm1, x2, x6, r8
-; CHECK-NEXT:    vlda.ups.2x cmh0, s0, upssign1, [p3], #64; vldb.128 wl4, [p5, dj7]; vshuffle x10, x10, x1, r2; vmac dm0, dm0, x2, x4, r8
-; CHECK-NEXT:    jnzd r1, r1, p4
+; CHECK-NEXT:    vlda x6, [p7, #128]; paddb [p0], m4; movs dc4, dc7; nopx ; vshuffle x2, x10, x8, r2; vmac dm1, dm1, x2, x6, r8
+; CHECK-NEXT:    vlda x4, [p7, #192]; vldb.popx x10, [p1, lf1, r25]; padds [p7], #128; nopx ; mov srssign0, r6; vmac dm0, dm0, x2, x4, r8
+; CHECK-NEXT:    vlda.pop.3d x1, [p1, lf1, r25, d0]; paddb.3d [p0], d2; nops ; nopx ; vshuffle x2, x10, x8, r2; vmac dm1, dm1, x2, x6, r8
+; CHECK-NEXT:    vldb x8, [p0, #0]; nopx ; mov r0, dc6; vmac dm0, dm0, x2, x4, r8
+; CHECK-NEXT:    vldb x6, [p0, #64]; lshl r0, r0, r16; vshuffle x2, x10, x8, r2; vmac dm1, dm1, x2, x6, r8
+; CHECK-NEXT:    or r20, r0, r18; mov dj7, r0; vmac dm0, dm0, x2, x4, r8
+; CHECK-NEXT:    movs dj7, r20; vldb.128 wl2, [p5, dj7]; vshuffle x2, x10, x8, r2; vmac dm1, dm1, x2, x6, r8
+; CHECK-NEXT:    vlda.ups.2x cml0, s0, upssign1, [p3], #64; vldb.128 wl4, [p5, dj7]; vmac dm0, dm0, x2, x4, r8
+; CHECK-NEXT:    vlda.ups.2x cml1, s0, upssign1, [p2], #64; vmac dm1, dm1, x2, x6, r8
+; CHECK-NEXT:    vlda.ups.2x cmh1, s0, upssign1, [p2], #64; vmac dm0, dm0, x2, x4, r8
+; CHECK-NEXT:    vlda.ups.2x cmh0, s0, upssign1, [p3], #64; jnzd r1, r1, p4; vshuffle x10, x10, x1, r2
 ; CHECK-NEXT:    nop // Delay Slot 5
 ; CHECK-NEXT:    nop // Delay Slot 4
 ; CHECK-NEXT:    nop // Delay Slot 3


### PR DESCRIPTION
Reverts Xilinx/llvm-aie#1050

There is a fundamental problem with using the cloned MIs for tracking cross-BB dependencies, because these clones are potentially not part of any BB yet. Discussed with @martien-de-jong: he'll address the problem for the PR that originally introduced the cross-BB DDG creation (https://github.com/Xilinx/llvm-aie/pull/1007) by using the MIs from the loop body instead. This will also clean up the implementation because we'll no longer require to create copies of the semantic order of the prologue and epilogue instructions created by the SWP. We can use the semantic order of the loop body instead.

I'll reapply this PR once the cross-BB DDG creation is fixed. Reverting for now.