### PR TITLE
[AIEX] Skip update_ore_test_checks on Windows when llc-binary is absent

### DIFF
--- a/llvm/test/tools/UpdateTestChecks/update_ore_test_checks/lit.local.cfg
+++ b/llvm/test/tools/UpdateTestChecks/update_ore_test_checks/lit.local.cfg
@@ -1,0 +1,3 @@
+# These tests require llc.
+if "llc-binary" not in config.available_features:
+    config.unsupported = True


### PR DESCRIPTION
skip optimisation remark tests under windows