### PR TITLE
Extend various workflows to run for PR's pointing to `bump_to_*` as well

### DIFF
--- a/.github/workflows/amd-aie-tests.yml
+++ b/.github/workflows/amd-aie-tests.yml
@@ -11,6 +11,7 @@ on:
   pull_request:
     branches:
       - 'aie-public'
+      - 'bump_to_*'
 
 concurrency:
   # A PR number if a pull request and otherwise the commit hash. This cancels

--- a/.github/workflows/amd-upstream-tests.yml
+++ b/.github/workflows/amd-upstream-tests.yml
@@ -11,6 +11,7 @@ on:
   pull_request:
     branches:
       - 'aie-public'
+      - 'bump_to_*'
 
 concurrency:
   # A PR number if a pull request and otherwise the commit hash. This cancels

--- a/.github/workflows/mlir-tests.yml
+++ b/.github/workflows/mlir-tests.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
   # Only builds on push populate the ccache that can be used by PRs
   push:
-    branches: [ main, feature/fused-ops, aie-public ]
+    branches: [ main, feature/fused-ops, aie-public, 'bump_to_*' ]
 
 concurrency:
   # Skip intermediate builds: always.

--- a/.github/workflows/pr-code-format.yml
+++ b/.github/workflows/pr-code-format.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - 'aie-public'
+      - 'bump_to_*'
 
 jobs:
   code_formatter:


### PR DESCRIPTION
**Description**: This change has been requested by the team to support workflow checks for chains of bump PRs, e.g., `aie-public <- bump_to_A <- bump_to_B`, so that the pull request`bump_to_A <- bump_to_B` is also executing testing. 

**Note**: Pull request workflows usually use the speculative merge between the base (e.g., `B`) and the head branch (e.g., `C`) to run the checks.

 In cases where the base branch `B` itself also wants to merge to another base branch `A` - forming a chain of PRs `A <- B <- C` - the speculative merge will not be created from the whole chain of PRs. This might be confusing as the pull request workflows for PR `B <- C` will never see the changes from `A` unless `B` is explicitly rebased on top of `A` which might render the workflow check results invalid. 

This concept needs to be understood to avoid confusion when the base branch for pull request `B <- C` changes once `A <- B` has been merged as the checks will not rerun for `(A+B) <- C`. 