### PR TITLE
[mlir] Resolve CodeQL high/critical alerts in MLIR sources

### DIFF
--- a/mlir/include/mlir/IR/Operation.h
+++ b/mlir/include/mlir/IR/Operation.h
@@ -4,6 +4,9 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// Modifications (c) Copyright 2026 Advanced Micro Devices, Inc. or its
+// affiliates
+//
 //===----------------------------------------------------------------------===//
 //
 // This file defines the Operation class.
@@ -993,6 +996,9 @@ private:
   detail::OutOfLineOpResult *getOutOfLineOpResult(unsigned resultNumber) {
     // Out-of-line results are stored in reverse order after (before in memory)
     // the inline results.
+    // codeql[cpp/suspicious-pointer-scaling] Intentional: out-of-line results
+    // are co-allocated and addressed in reverse; scaling by OutOfLineOpResult
+    // is deliberate.
     return reinterpret_cast<detail::OutOfLineOpResult *>(getInlineOpResult(
                detail::OpResultImpl::getMaxInlineResults() - 1)) -
            ++resultNumber;
@@ -1002,6 +1008,9 @@ private:
   detail::InlineOpResult *getInlineOpResult(unsigned resultNumber) {
     // Inline results are stored in reverse order before the operation in
     // memory.
+    // codeql[cpp/suspicious-pointer-scaling] Intentional: inline results are
+    // co-allocated before the Operation; scaling by InlineOpResult is
+    // deliberate.
     return reinterpret_cast<detail::InlineOpResult *>(this) - ++resultNumber;
   }
 

--- a/mlir/lib/Analysis/Presburger/Matrix.cpp
+++ b/mlir/lib/Analysis/Presburger/Matrix.cpp
@@ -4,6 +4,9 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// Modifications (c) Copyright 2026 Advanced Micro Devices, Inc. or its
+// affiliates
+//
 //===----------------------------------------------------------------------===//
 
 #include "mlir/Analysis/Presburger/Matrix.h"
@@ -23,8 +26,9 @@ Matrix<T>::Matrix(unsigned rows, unsigned columns, unsigned reservedRows,
                   unsigned reservedColumns)
     : nRows(rows), nColumns(columns),
       nReservedColumns(std::max(nColumns, reservedColumns)),
-      data(nRows * nReservedColumns) {
-  data.reserve(std::max(nRows, reservedRows) * nReservedColumns);
+      data(static_cast<size_t>(nRows) * nReservedColumns) {
+  data.reserve(static_cast<size_t>(std::max(nRows, reservedRows)) *
+               nReservedColumns);
 }
 
 /// We cannot use the default implementation of operator== as it compares
@@ -128,12 +132,12 @@ void Matrix<T>::swapColumns(unsigned column, unsigned otherColumn) {
 
 template <typename T>
 MutableArrayRef<T> Matrix<T>::getRow(unsigned row) {
-  return {&data[row * nReservedColumns], nColumns};
+  return {&data[static_cast<size_t>(row) * nReservedColumns], nColumns};
 }
 
 template <typename T>
 ArrayRef<T> Matrix<T>::getRow(unsigned row) const {
-  return {&data[row * nReservedColumns], nColumns};
+  return {&data[static_cast<size_t>(row) * nReservedColumns], nColumns};
 }
 
 template <typename T>

--- a/mlir/lib/Dialect/GPU/Transforms/SubgroupReduceLowering.cpp
+++ b/mlir/lib/Dialect/GPU/Transforms/SubgroupReduceLowering.cpp
@@ -4,6 +4,9 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// Modifications (c) Copyright 2026 Advanced Micro Devices, Inc. or its
+// affiliates
+//
 //===----------------------------------------------------------------------===//
 //
 // Implements gradual lowering of `gpu.subgroup_reduce` ops.
@@ -83,7 +86,7 @@ struct BreakDownSubgroupReduce final : OpRewritePattern<gpu::SubgroupReduceOp> {
         rewriter.create<arith::ConstantOp>(loc, rewriter.getZeroAttr(vecTy));
 
     for (unsigned i = 0; i != numNewReductions; ++i) {
-      int64_t startIdx = i * elementsPerShuffle;
+      int64_t startIdx = static_cast<int64_t>(i) * elementsPerShuffle;
       int64_t endIdx =
           std::min(startIdx + elementsPerShuffle, vecTy.getNumElements());
       int64_t numElems = endIdx - startIdx;

--- a/mlir/lib/Dialect/Linalg/Transforms/ConvertConv2DToImg2Col.cpp
+++ b/mlir/lib/Dialect/Linalg/Transforms/ConvertConv2DToImg2Col.cpp
@@ -4,6 +4,9 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// Modifications (c) Copyright 2026 Advanced Micro Devices, Inc. or its
+// affiliates
+//
 //===----------------------------------------------------------------------===//
 
 #include "mlir/Dialect/Affine/Utils.h"
@@ -278,12 +281,12 @@ rewriteInIm2Col(RewriterBase &rewriter,
       cast<RankedTensorType>(filterT.getType()).getShape();
   ArrayRef<int64_t> outputShape = outputType.getShape();
 
-  int n = outputShape[0];
-  int oh = outputShape[1];
-  int ow = outputShape[2];
-  int c = outputShape[3];
-  int fh = filterTShape[1];
-  int fw = filterTShape[2];
+  int64_t n = outputShape[0];
+  int64_t oh = outputShape[1];
+  int64_t ow = outputShape[2];
+  int64_t c = outputShape[3];
+  int64_t fh = filterTShape[1];
+  int64_t fw = filterTShape[2];
 
   SmallVector<int64_t> colTensorShape = {n, c, oh, ow, fh, fw};
   Value transposedOutputTensor = transposeOperand(output, {0, 3, 1, 2});

--- a/mlir/lib/Dialect/Vector/Transforms/LowerVectorTranspose.cpp
+++ b/mlir/lib/Dialect/Vector/Transforms/LowerVectorTranspose.cpp
@@ -4,6 +4,9 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// Modifications (c) Copyright 2026 Advanced Micro Devices, Inc. or its
+// affiliates
+//
 //===----------------------------------------------------------------------===//
 //
 // This file implements target-independent rewrites and utilities to lower the
@@ -188,7 +191,7 @@ static Value create4x128BitSuffle(ImplicitLocOpBuilder &b, Value v1, Value v2,
 /// 1-D vector and have `m`x`n` elements.
 static Value transposeToShuffle1D(OpBuilder &b, Value source, int m, int n) {
   SmallVector<int64_t> mask;
-  mask.reserve(m * n);
+  mask.reserve(static_cast<size_t>(m) * n);
   for (int64_t j = 0; j < n; ++j)
     for (int64_t i = 0; i < m; ++i)
       mask.push_back(i * n + j);

--- a/mlir/lib/Dialect/Vector/Transforms/VectorEmulateNarrowType.cpp
+++ b/mlir/lib/Dialect/Vector/Transforms/VectorEmulateNarrowType.cpp
@@ -4,6 +4,9 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// Modifications (c) Copyright 2026 Advanced Micro Devices, Inc. or its
+// affiliates
+//
 //===----------------------------------------------------------------------===//
 //
 // This file implements target-independent rewrites and utilities to emulate
@@ -170,7 +173,8 @@ static FailureOr<Operation *> getCompressedMaskOp(OpBuilder &rewriter,
             SmallVector<bool> paddedMaskValues(numFrontPadElems, false);
             paddedMaskValues.append(originalMask.template value_begin<bool>(),
                                     originalMask.template value_end<bool>());
-            paddedMaskValues.resize(numDestElems * numSrcElemsPerDest, false);
+            paddedMaskValues.resize(
+                static_cast<size_t>(numDestElems) * numSrcElemsPerDest, false);
 
             // Compressing by combining every `numSrcElemsPerDest` elements:
             SmallVector<bool> compressedMaskValues;

--- a/mlir/lib/IR/Value.cpp
+++ b/mlir/lib/IR/Value.cpp
@@ -4,6 +4,9 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// Modifications (c) Copyright 2026 Advanced Micro Devices, Inc. or its
+// affiliates
+//
 //===----------------------------------------------------------------------===//
 
 #include "mlir/IR/Value.h"
@@ -177,6 +180,9 @@ OpResultImpl *OpResultImpl::getNextResultAtOffset(intptr_t offset) {
 
   // If we land here, the current result is an out-of-line result and we can
   // offset directly.
+  // codeql[cpp/suspicious-pointer-scaling] Intentional: out-of-line results are
+  // co-allocated and addressed by index; scaling by OutOfLineOpResult is
+  // deliberate.
   return reinterpret_cast<OutOfLineOpResult *>(result) - offset;
 }
 

--- a/mlir/tools/mlir-tblgen/OpGenHelpers.cpp
+++ b/mlir/tools/mlir-tblgen/OpGenHelpers.cpp
@@ -4,6 +4,9 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// Modifications (c) Copyright 2026 Advanced Micro Devices, Inc. or its
+// affiliates
+//
 //===----------------------------------------------------------------------===//
 //
 // This file defines helpers used in the op generators.
@@ -95,7 +98,8 @@ void mlir::tblgen::shardOpDefinitions(
   }
 
   unsigned minShardSize = defs.size() / opShardCount;
-  unsigned numMissing = defs.size() - minShardSize * opShardCount;
+  unsigned numMissing =
+      defs.size() - static_cast<size_t>(minShardSize) * opShardCount;
   shardedDefs.reserve(opShardCount);
   for (unsigned i = 0, start = 0; i < opShardCount; ++i) {
     unsigned size = minShardSize + (i < numMissing);


### PR DESCRIPTION
cpp/integer-multiplication-cast-to-long (15) — widen operands to 64-bit before the assignment/index so the multiply no longer overflows in 32-bit:
  - mlir/lib/Analysis/Presburger/Matrix.cpp                         (4)
  - mlir/lib/Dialect/Linalg/Transforms/ConvertConv2DToImg2Col.cpp   (6; declare tensor dims int64_t, matching the file's other conversions)
  - mlir/lib/Dialect/GPU/Transforms/SubgroupReduceLowering.cpp      (1)
  - mlir/lib/Dialect/Vector/Transforms/LowerVectorTranspose.cpp     (1)
  - mlir/lib/Dialect/Vector/Transforms/VectorEmulateNarrowType.cpp  (1 at resize(); the store-path alert was already 64-bit)
  - mlir/tools/mlir-tblgen/OpGenHelpers.cpp                         (1)
cpp/suspicious-pointer-scaling (3) — false positives on MLIR's intentional
reverse-order co-allocated result storage; annotated with
// codeql[cpp/suspicious-pointer-scaling] + justification instead of
rewriting core pointer arithmetic:
  - mlir/include/mlir/IR/Operation.h                                (2)
  - mlir/lib/IR/Value.cpp                                           (1)