### PR TITLE
[AIE] Register symbols referenced from a bundle slot

### DIFF
--- a/llvm/lib/Target/AIE/AIEBaseAsmPrinter.cpp
+++ b/llvm/lib/Target/AIE/AIEBaseAsmPrinter.cpp
@@ -37,22 +37,6 @@ using namespace llvm;
 
 #define DEBUG_TYPE "asm-printer"
 
-void AIEBaseAsmPrinter::EmitToStreamer(MCStreamer &S, const MCInst &Inst) {
-  // This searches for SymbolRefs in sub-instruction operands to register them
-  // as used symbols. This mimics the base MCStreamer::emitInstruction
-  for (const auto &MO : Inst) {
-    if (MO.isInst()) {
-      const MCInst &SI = *MO.getInst();
-      for (const auto &SMO : SI) {
-        if (SMO.isExpr()) {
-          S.visitUsedExpr(*SMO.getExpr());
-        }
-      }
-    }
-  }
-  AsmPrinter::EmitToStreamer(S, Inst);
-}
-
 void AIEBaseAsmPrinter::emitFunctionBodyStart() {
   // AIEBaseAsmPrinter lives for the whole Module, clear out data from the
   // previous function.

--- a/llvm/lib/Target/AIE/AIEBaseAsmPrinter.h
+++ b/llvm/lib/Target/AIE/AIEBaseAsmPrinter.h
@@ -39,8 +39,6 @@ public:
   bool isBlockOnlyReachableByFallthrough(
       const MachineBasicBlock *MBB) const override;
 
-  void EmitToStreamer(MCStreamer &S, const MCInst &Inst);
-
   virtual bool lowerPseudoInstExpansion(const MachineInstr *MI, MCInst &Inst) = 0;
   void emitXXStructorList(const DataLayout &DL, const Constant *List,
                           bool IsCtor) override;

--- a/llvm/lib/Target/AIE/MCTargetDesc/AIEMCELFStreamer.cpp
+++ b/llvm/lib/Target/AIE/MCTargetDesc/AIEMCELFStreamer.cpp
@@ -1,0 +1,44 @@
+//===- AIEMCELFStreamer.cpp - AIE subclass of MCELFStreamer ---------------===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2026 Advanced Micro Devices, Inc. or its affiliates
+//
+//===----------------------------------------------------------------------===//
+
+#include "AIEMCELFStreamer.h"
+#include "llvm/MC/MCAsmBackend.h"
+#include "llvm/MC/MCCodeEmitter.h"
+#include "llvm/MC/MCInst.h"
+#include "llvm/MC/MCObjectWriter.h"
+
+using namespace llvm;
+
+void AIEMCELFStreamer::visitInstOperands(const MCInst &Inst) {
+  for (unsigned I = Inst.getNumOperands(); I--;) {
+    const MCOperand &Op = Inst.getOperand(I);
+    if (Op.isExpr())
+      visitUsedExpr(*Op.getExpr());
+    else if (Op.isInst())
+      visitInstOperands(*Op.getInst());
+  }
+}
+
+void AIEMCELFStreamer::emitInstruction(const MCInst &Inst,
+                                       const MCSubtargetInfo &STI) {
+  // Before emitting, so the symbols exist by the time relocations are recorded.
+  // Recursing rather than calling emitInstruction per slot, which would emit
+  // every sub-instruction again.
+  visitInstOperands(Inst);
+  MCObjectStreamer::emitInstruction(Inst, STI);
+}
+
+MCStreamer *llvm::createAIEELFStreamer(const Triple &TT, MCContext &Context,
+                                       std::unique_ptr<MCAsmBackend> &&MAB,
+                                       std::unique_ptr<MCObjectWriter> &&OW,
+                                       std::unique_ptr<MCCodeEmitter> &&CE) {
+  return new AIEMCELFStreamer(Context, std::move(MAB), std::move(OW),
+                              std::move(CE));
+}

--- a/llvm/lib/Target/AIE/MCTargetDesc/AIEMCELFStreamer.h
+++ b/llvm/lib/Target/AIE/MCTargetDesc/AIEMCELFStreamer.h
@@ -1,0 +1,45 @@
+//===- AIEMCELFStreamer.h - AIE subclass of MCELFStreamer -------*- C++ -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2026 Advanced Micro Devices, Inc. or its affiliates
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIB_TARGET_AIE_MCTARGETDESC_AIEMCELFSTREAMER_H
+#define LLVM_LIB_TARGET_AIE_MCTARGETDESC_AIEMCELFSTREAMER_H
+
+#include "llvm/MC/MCELFStreamer.h"
+
+namespace llvm {
+
+/// Registers the symbols an AIE bundle references from its slots.
+///
+/// A bundle is one MCInst whose operands are its slot instructions, so a symbol
+/// referenced from a slot sits one level below MCStreamer::emitInstruction's
+/// operand scan. Hexagon subclasses the ELF streamer for the same reason.
+class AIEMCELFStreamer : public MCELFStreamer {
+public:
+  AIEMCELFStreamer(MCContext &Context, std::unique_ptr<MCAsmBackend> TAB,
+                   std::unique_ptr<MCObjectWriter> OW,
+                   std::unique_ptr<MCCodeEmitter> Emitter)
+      : MCELFStreamer(Context, std::move(TAB), std::move(OW),
+                      std::move(Emitter)) {}
+
+  void emitInstruction(const MCInst &Inst, const MCSubtargetInfo &STI) override;
+
+private:
+  /// Visit every expression in \p Inst, descending into slot sub-instructions.
+  void visitInstOperands(const MCInst &Inst);
+};
+
+MCStreamer *createAIEELFStreamer(const Triple &TT, MCContext &Context,
+                                 std::unique_ptr<MCAsmBackend> &&MAB,
+                                 std::unique_ptr<MCObjectWriter> &&OW,
+                                 std::unique_ptr<MCCodeEmitter> &&CE);
+
+} // end namespace llvm
+
+#endif // LLVM_LIB_TARGET_AIE_MCTARGETDESC_AIEMCELFSTREAMER_H

--- a/llvm/lib/Target/AIE/MCTargetDesc/AIEMCTargetDesc.cpp
+++ b/llvm/lib/Target/AIE/MCTargetDesc/AIEMCTargetDesc.cpp
@@ -17,6 +17,7 @@
 #include "AIE2AsmBackend.h"
 #include "AIE2MCTargetDesc.h"
 #include "AIEMCAsmInfo.h"
+#include "AIEMCELFStreamer.h"
 #include "AIETargetAsmStreamer.h"
 #include "AIETargetELFStreamer.h"
 #include "InstPrinter/AIE2InstPrinter.h"
@@ -27,6 +28,7 @@
 #include "aie2p/AIE2PMCTargetDesc.h"
 #include "aie2ps/AIE2PSAsmBackend.h"
 #include "aie2ps/AIE2PSMCTargetDesc.h"
+#include "llvm/MC/MCCodeEmitter.h"
 #include "llvm/MC/MCDwarf.h"
 #include "llvm/MC/MCELFObjectWriter.h"
 #include "llvm/MC/MCInstrInfo.h"
@@ -184,6 +186,8 @@ extern "C" LLVM_EXTERNAL_VISIBILITY void LLVMInitializeAIETargetMC() {
 
     TargetRegistry::RegisterObjectTargetStreamer(*T,
                                                  createAIEObjectTargetStreamer);
+    // Registers symbols referenced from a bundle's slots; see AIEMCELFStreamer.
+    TargetRegistry::RegisterELFStreamer(*T, createAIEELFStreamer);
     // Support for ASM output files
     TargetRegistry::RegisterAsmTargetStreamer(*T, createTargetAsmStreamer);
   }

--- a/llvm/lib/Target/AIE/MCTargetDesc/CMakeLists.txt
+++ b/llvm/lib/Target/AIE/MCTargetDesc/CMakeLists.txt
@@ -20,6 +20,7 @@ add_llvm_component_library(LLVMAIEDesc
   AIEMCInstrInfo.cpp
   AIEMCTargetDesc.cpp
   AIETargetAsmStreamer.cpp
+  AIEMCELFStreamer.cpp
   AIETargetELFStreamer.cpp
   AIE2MCFixupKinds.cpp
   AIE2MCFormats.cpp

--- a/llvm/test/MC/AIE/bundle-slot-symbol-reloc.s
+++ b/llvm/test/MC/AIE/bundle-slot-symbol-reloc.s
@@ -1,0 +1,32 @@
+//===- bundle-slot-symbol-reloc.s --------------------------------*- C++ -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2026 Advanced Micro Devices, Inc. or its affiliates
+//
+//===----------------------------------------------------------------------===//
+//
+// A symbol referenced from a bundle slot must be named by its relocation; an
+// index of 0 links the call to address 0 and hangs with no diagnostic.
+
+// RUN: llvm-mc -triple aie2 -filetype=obj %s -o %t2.o
+// RUN: llvm-readobj -r --symbols %t2.o | FileCheck %s
+// RUN: llvm-mc -triple aie2p -filetype=obj %s -o %t2p.o
+// RUN: llvm-readobj -r --symbols %t2p.o | FileCheck %s
+// RUN: llvm-mc -triple aie2ps -filetype=obj %s -o %t2ps.o
+// RUN: llvm-readobj -r --symbols %t2ps.o | FileCheck %s
+
+	.text
+	.globl _start
+_start:
+	jl	#undeclared_callee
+	nop
+
+// CHECK: Relocations [
+// CHECK: R_AIE_{{[0-9]+}} undeclared_callee
+
+// CHECK: Symbols [
+// CHECK: Name: undeclared_callee
+// CHECK: Section: Undefined


### PR DESCRIPTION
## Problem

`MCStreamer::emitInstruction` scans an MCInst's own operands for expressions, and
a bundle's operands are its slot instructions, so a symbol referenced from a slot
never reached the symbol table. The relocation went out against index 0 and the
linker resolved the call to address 0 -- a silent hang.

## Fix

Register them in an ELF streamer subclass, as Hexagon does. This is the layer
both object-emitting paths pass through, so `AIEBaseAsmPrinter::EmitToStreamer`'s
slot walk goes with it.

## Test

New `MC/AIE/bundle-slot-symbol-reloc.s`, on aie2, aie2p and aie2ps. `MC/AIE` +
`CodeGen/AIE`: 2260 pass, 2 fail; both failures are pre-existing, identical with
the walk restored. aie1 registers the same streamer but its asm parser cannot
assemble a call.
