### PR TITLE
[AIE] Disable libc null checks for the AIE runtimes

### DIFF
--- a/clang/cmake/caches/Peano-AIE-runtime-libraries.cmake
+++ b/clang/cmake/caches/Peano-AIE-runtime-libraries.cmake
@@ -72,6 +72,10 @@ foreach(target ${LLVM_BUILTIN_TARGETS})
   set(RUNTIMES_${target}_CMAKE_CXX_FLAGS "-mno-vitis-headers" CACHE STRING "")
   set(RUNTIMES_${target}_CMAKE_ASM_FLAGS "-mno-vitis-headers" CACHE STRING "")
 
+  # libc's null checks expand to __builtin_trap(), which no AIE subtarget can
+  # select. Passing NULL to these entrypoints is UB anyway, so drop the checks
+  # rather than trap.
+  set(RUNTIMES_${target}_LIBC_ADD_NULL_CHECKS OFF CACHE BOOL "")
   set(RUNTIMES_${target}_LIBC_ENABLE_USE_BY_CLANG ON CACHE STRING "")
   # LIBC includes C++ sources which by default trigger inclusion of standard libc++ headers
   # However these are not available while building libc, thus disable the include explicitly


### PR DESCRIPTION
Upstream ff844df719d7 ("[libc] Expand usage of libc null checks") added LIBC_CRASH_ON_NULLPTR to memccpy, memchr, mempcpy, memrchr, stpncpy, strcat and strcpy. That macro expands to __builtin_trap(), and no AIE subtarget can select G_TRAP, so the AIE libc builds failed with "cannot select: G_TRAP". Turn the null checks off for the AIE runtimes: passing NULL to these entrypoints is undefined behavior anyway, and these functions carried no such check before this bump.