### PR TITLE
[AIE] Build the AIE runtimes (libc) in the public AIE test job

### DIFF
--- a/.github/workflows/amd-aie-tests.yml
+++ b/.github/workflows/amd-aie-tests.yml
@@ -27,7 +27,7 @@ jobs:
     name: Test AIE llvm,clang,lld
     uses: ./.github/workflows/llvm-project-tests.yml
     with:
-      build_target: check-llvm-aie check-clang-aie check-lld-aie builtins
+      build_target: check-llvm-aie check-clang-aie check-lld-aie builtins runtimes-aie-none-unknown-elf runtimes-aie2p-none-unknown-elf
       projects: clang;lld
       cache-key: amd-aie
       extra_cmake_args: '-DLLVM_USE_LINKER=gold -C clang/cmake/caches/Peano-AIE.cmake'

--- a/.github/workflows/llvm-project-tests.yml
+++ b/.github/workflows/llvm-project-tests.yml
@@ -97,7 +97,6 @@ jobs:
         with:
           fetch-depth: 250
       - name: Install requirements.txt
-        if: inputs.projects == 'mlir'
         run: |
           sudo apt-get update
           sudo apt-get install -y python3-dev python3-pip


### PR DESCRIPTION
The test job builds an explicit target list, so the runtimes external projects configured by Peano-AIE.cmake (libc) were never compiled. And they are not covered by "builtins" which was recently added.