### PR TITLE
[MLIR] Hide ParallelDiagnosticHandlerImpl symbols

### DIFF
--- a/mlir/lib/IR/Diagnostics.cpp
+++ b/mlir/lib/IR/Diagnostics.cpp
@@ -4,6 +4,9 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+// Modifications (c) Copyright 2026 Advanced Micro Devices, Inc. or its
+// affiliates
+//
 //===----------------------------------------------------------------------===//
 
 #include "mlir/IR/Diagnostics.h"
@@ -929,7 +932,8 @@ void SourceMgrDiagnosticVerifierHandler::process(LocationAttr loc,
 
 namespace mlir {
 namespace detail {
-struct ParallelDiagnosticHandlerImpl : public llvm::PrettyStackTraceEntry {
+struct LLVM_LIBRARY_VISIBILITY ParallelDiagnosticHandlerImpl
+    : public llvm::PrettyStackTraceEntry {
   struct ThreadDiagnostic {
     ThreadDiagnostic(size_t id, Diagnostic diag)
         : id(id), diag(std::move(diag)) {}


### PR DESCRIPTION
ParallelDiagnosticHandlerImpl is an internal implementation type, but its vtable and RTTI can be emitted with default visibility because it derives from the LLVM_ABI-annotated PrettyStackTraceEntry.

This causes symbol interposition when a process contains multiple statically linked copies of LLVM/MLIR. For example, an MLIR shared library may construct the handler using its local PrettyStackTraceEntry state while the dynamic linker selects the implementation vtable from the executable. Destruction then uses a different thread-local PrettyStackTraceHead and fails with:

"Pretty stack trace entry destruction is out of order"

Mark ParallelDiagnosticHandlerImpl with LLVM_LIBRARY_VISIBILITY. The type is only used behind ParallelDiagnosticHandler's private unique_ptr and is not part of MLIR's public ABI, so its vtable and RTTI should not be externally visible.


Triaged + assisted by gpt 🤖 