### PR TITLE
[AIEX][OLP] Establish LCSSA form before loop pipelining

### DIFF
--- a/llvm/lib/Target/AIE/AIEOuterLoopPipeliner.cpp
+++ b/llvm/lib/Target/AIE/AIEOuterLoopPipeliner.cpp
@@ -336,8 +336,6 @@ class OrigLoopStructure : public LoopStructure {
 
   explicit OrigLoopStructure(Loop *L) : OuterLoop(L) {}
 
-  Loop *getOuterLoop() const { return OuterLoop; }
-
   // Populate the inner-loop fields and top/bottom regions from
   // OuterLoop; returns false unless the loop is a supported pipelining
   // candidate.
@@ -395,6 +393,8 @@ class OrigLoopStructure : public LoopStructure {
 public:
   // Build and validate the LS for L; nullptr if L is not a supported candidate.
   static std::unique_ptr<OrigLoopStructure> tryBuildFrom(Loop *L);
+
+  Loop *getOuterLoop() const { return OuterLoop; }
 
   Loop *getInnerLoop() const { return InnerLoop; }
 
@@ -1789,6 +1789,10 @@ bool AIEOuterLoopPipeliner::liftBottomPointerUpdatesToTop(
 
 bool AIEOuterLoopPipeliner::performTransformation(OrigLoopStructure &OrigLS,
                                                   const OLPOpts &Opts) {
+
+  /// Restore LCSSA if this property was invalidated.
+  formLCSSARecursively(*OrigLS.getOuterLoop(), *DT, LI, SE);
+
   liftBottomPointerUpdatesToTop(OrigLS);
 
   const auto IsSplitPoint = [&Opts](const Instruction *I) {

--- a/llvm/lib/Target/AIE/AIEOuterLoopPipeliner.cpp
+++ b/llvm/lib/Target/AIE/AIEOuterLoopPipeliner.cpp
@@ -1397,24 +1397,6 @@ void AIEOuterLoopPipeliner::remapExitForReplacement(
   reroutePhiIncomings(OrigExit, OrigLS.getBottom(), ReplacementLS.getBottom(),
                       PhiEdge::Repoint,
                       [&](Value *V) { return ReplacementLS.cloneOf(V); });
-
-  // Non-phi exit live-outs: when the latch dominates the exit there is no LCSSA
-  // phi, so LCSSA rematerializes the live-out as a plain instruction in the
-  // exit whose operands reference loop-internal values (e.g. the outer-header
-  // PHI and an inner-loop def). removeFromCFG deletes those originals, which
-  // would leave the exit reading poison. Remap each such operand to a live
-  // clone so the exit reads a defined value.
-  for (Instruction &I :
-       make_range(OrigExit->getFirstNonPHIIt(), OrigExit->end())) {
-    for (Use &Op : I.operands()) {
-      Value *V = Op.get();
-      // CFG successors are basic-block operands; only remap data values.
-      if (isa<BasicBlock>(V))
-        continue;
-      if (Value *Mapped = ReplacementLS.cloneOf(V); Mapped != V)
-        Op.set(Mapped);
-    }
-  }
 }
 
 bool BlockRegion::isSingleEntrySingleExit() const {

--- a/llvm/test/CodeGen/AIE/aie2p/outer-loop-pipeliner/outer-loop-pipelining-exit-no-phi.ll
+++ b/llvm/test/CodeGen/AIE/aie2p/outer-loop-pipeliner/outer-loop-pipelining-exit-no-phi.ll
@@ -41,15 +41,15 @@ define i32 @exit_uses_latch_def(ptr noalias %a, ptr noalias %c, i32 %N, i32 %M) 
   ; CHECK-NEXT: bb.3.steady.stage1.top:
   ; CHECK-NEXT:   successors: %bb.4(0x80000000)
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT:   [[PHI:%[0-9]+]]:_(s32) = G_PHI [[C1]](s32), %bb.2, %20(s32), %bb.5
+  ; CHECK-NEXT:   [[PHI:%[0-9]+]]:_(s32) = G_PHI [[C1]](s32), %bb.2, %21(s32), %bb.5
   ; CHECK-NEXT:   [[PHI1:%[0-9]+]]:_(p0) = G_PHI [[COPY]](p0), %bb.2, %14(p0), %bb.5
   ; CHECK-NEXT:   [[PHI2:%[0-9]+]]:_(p0) = G_PHI [[COPY1]](p0), %bb.2, %15(p0), %bb.5
-  ; CHECK-NEXT:   [[PHI3:%[0-9]+]]:_(s32) = G_PHI [[C1]](s32), %bb.2, %19(s32), %bb.5
-  ; CHECK-NEXT:   [[PHI4:%[0-9]+]]:_(s32) = G_PHI [[LOAD]](s32), %bb.2, %22(s32), %bb.5
+  ; CHECK-NEXT:   [[PHI3:%[0-9]+]]:_(s32) = G_PHI [[C1]](s32), %bb.2, %20(s32), %bb.5
+  ; CHECK-NEXT:   [[PHI4:%[0-9]+]]:_(s32) = G_PHI [[LOAD]](s32), %bb.2, %23(s32), %bb.5
   ; CHECK-NEXT:   G_INTRINSIC_W_SIDE_EFFECTS intrinsic(@llvm.set.loop.iterations), [[COPY3]](s32)
   ; CHECK-NEXT:   [[C2:%[0-9]+]]:_(s20) = G_CONSTANT i20 4
-  ; CHECK-NEXT:   %14:_(p0) = nuw nusw G_PTR_ADD [[PHI1]], [[C2]](s20)
-  ; CHECK-NEXT:   %15:_(p0) = nuw nusw G_PTR_ADD [[PHI2]], [[C2]](s20)
+  ; CHECK-NEXT:   [[PTR_ADD:%[0-9]+]]:_(p0) = nuw nusw G_PTR_ADD [[PHI1]], [[C2]](s20)
+  ; CHECK-NEXT:   [[PTR_ADD1:%[0-9]+]]:_(p0) = nuw nusw G_PTR_ADD [[PHI2]], [[C2]](s20)
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT: bb.4.steady.stage1.inner.inner.header:
   ; CHECK-NEXT:   successors: %bb.4(0x7c000000), %bb.5(0x04000000)
@@ -63,11 +63,12 @@ define i32 @exit_uses_latch_def(ptr noalias %a, ptr noalias %c, i32 %N, i32 %M) 
   ; CHECK-NEXT: bb.5.steady.stage1.bottom.and.stage0.top:
   ; CHECK-NEXT:   successors: %bb.3(0x7c000000), %bb.6(0x04000000)
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT:   G_STORE [[ADD]](s32), [[PHI2]](p0) :: (store (s32) into %ir.c.ptr.steady)
-  ; CHECK-NEXT:   [[ADD1:%[0-9]+]]:_(s32) = G_ADD [[PHI3]], [[ADD]]
+  ; CHECK-NEXT:   [[PHI6:%[0-9]+]]:_(s32) = G_PHI [[ADD]](s32), %bb.4
+  ; CHECK-NEXT:   G_STORE [[PHI6]](s32), [[PHI2]](p0) :: (store (s32) into %ir.c.ptr.steady)
+  ; CHECK-NEXT:   [[ADD1:%[0-9]+]]:_(s32) = G_ADD [[PHI3]], [[PHI6]]
   ; CHECK-NEXT:   [[ADD2:%[0-9]+]]:_(s32) = G_ADD [[PHI]], [[C]]
   ; CHECK-NEXT:   [[ICMP:%[0-9]+]]:_(s1) = G_ICMP intpred(slt), [[ADD2]](s32), [[SUB]]
-  ; CHECK-NEXT:   [[LOAD1:%[0-9]+]]:_(s32) = G_LOAD %14(p0) :: (load (s32) from %ir.a.ptr.next.steady)
+  ; CHECK-NEXT:   [[LOAD1:%[0-9]+]]:_(s32) = G_LOAD [[PTR_ADD]](p0) :: (load (s32) from %ir.a.ptr.next.steady)
   ; CHECK-NEXT:   G_BRCOND [[ICMP]](s1), %bb.3
   ; CHECK-NEXT:   G_BR %bb.6
   ; CHECK-NEXT: {{  $}}
@@ -79,8 +80,8 @@ define i32 @exit_uses_latch_def(ptr noalias %a, ptr noalias %c, i32 %N, i32 %M) 
   ; CHECK-NEXT: bb.7.lastiter.stage1.inner.inner.header:
   ; CHECK-NEXT:   successors: %bb.7(0x7c000000), %bb.8(0x04000000)
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT:   [[PHI6:%[0-9]+]]:_(s32) = G_PHI [[C1]](s32), %bb.6, %24(s32), %bb.7
-  ; CHECK-NEXT:   [[ADD3:%[0-9]+]]:_(s32) = G_ADD [[PHI6]], [[LOAD1]]
+  ; CHECK-NEXT:   [[PHI7:%[0-9]+]]:_(s32) = G_PHI [[C1]](s32), %bb.6, %25(s32), %bb.7
+  ; CHECK-NEXT:   [[ADD3:%[0-9]+]]:_(s32) = G_ADD [[PHI7]], [[LOAD1]]
   ; CHECK-NEXT:   [[INT1:%[0-9]+]]:_(s1) = G_INTRINSIC_W_SIDE_EFFECTS intrinsic(@llvm.loop.decrement), [[C]](s32)
   ; CHECK-NEXT:   G_BRCOND [[INT1]](s1), %bb.7
   ; CHECK-NEXT:   G_BR %bb.8
@@ -88,11 +89,14 @@ define i32 @exit_uses_latch_def(ptr noalias %a, ptr noalias %c, i32 %N, i32 %M) 
   ; CHECK-NEXT: bb.8.lastiter.stage1.bottom:
   ; CHECK-NEXT:   successors: %bb.9(0x80000000)
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT:   G_STORE [[ADD3]](s32), %15(p0) :: (store (s32) into %ir.c.ptr.next.steady)
-  ; CHECK-NEXT:   [[ADD4:%[0-9]+]]:_(s32) = G_ADD [[ADD1]], [[ADD3]]
+  ; CHECK-NEXT:   [[PHI8:%[0-9]+]]:_(s32) = G_PHI [[ADD3]](s32), %bb.7
+  ; CHECK-NEXT:   G_STORE [[PHI8]](s32), [[PTR_ADD1]](p0) :: (store (s32) into %ir.c.ptr.next.steady)
+  ; CHECK-NEXT:   [[ADD4:%[0-9]+]]:_(s32) = G_ADD [[ADD1]], [[PHI8]]
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT: bb.9.exit:
-  ; CHECK-NEXT:   [[ADD5:%[0-9]+]]:_(s32) = G_ADD [[ADD1]], [[ADD3]]
+  ; CHECK-NEXT:   [[PHI9:%[0-9]+]]:_(s32) = G_PHI [[ADD1]](s32), %bb.8
+  ; CHECK-NEXT:   [[PHI10:%[0-9]+]]:_(s32) = G_PHI [[PHI8]](s32), %bb.8
+  ; CHECK-NEXT:   [[ADD5:%[0-9]+]]:_(s32) = G_ADD [[PHI9]], [[PHI10]]
   ; CHECK-NEXT:   [[ADD6:%[0-9]+]]:_(s32) = G_ADD [[ADD5]], [[C]]
   ; CHECK-NEXT:   $r0 = COPY [[ADD6]](s32)
   ; CHECK-NEXT:   PseudoRET implicit $lr, implicit $r0

--- a/llvm/test/CodeGen/AIE/aie2p/outer-loop-pipeliner/outer-loop-pipelining-latch-accumulate.ll
+++ b/llvm/test/CodeGen/AIE/aie2p/outer-loop-pipeliner/outer-loop-pipelining-latch-accumulate.ll
@@ -44,15 +44,15 @@ define i32 @latch_accumulate_return(ptr noalias %a, ptr noalias %c, i32 %N, i32 
   ; CHECK-NEXT: bb.4.steady.stage1.top:
   ; CHECK-NEXT:   successors: %bb.5(0x80000000)
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT:   [[PHI:%[0-9]+]]:_(s32) = G_PHI %21(s32), %bb.6, [[C1]](s32), %bb.3
+  ; CHECK-NEXT:   [[PHI:%[0-9]+]]:_(s32) = G_PHI %22(s32), %bb.6, [[C1]](s32), %bb.3
   ; CHECK-NEXT:   [[PHI1:%[0-9]+]]:_(p0) = G_PHI %15(p0), %bb.6, [[COPY]](p0), %bb.3
   ; CHECK-NEXT:   [[PHI2:%[0-9]+]]:_(p0) = G_PHI %16(p0), %bb.6, [[COPY1]](p0), %bb.3
-  ; CHECK-NEXT:   [[PHI3:%[0-9]+]]:_(s32) = G_PHI %20(s32), %bb.6, [[C1]](s32), %bb.3
-  ; CHECK-NEXT:   [[PHI4:%[0-9]+]]:_(s32) = G_PHI [[LOAD]](s32), %bb.3, %23(s32), %bb.6
+  ; CHECK-NEXT:   [[PHI3:%[0-9]+]]:_(s32) = G_PHI %21(s32), %bb.6, [[C1]](s32), %bb.3
+  ; CHECK-NEXT:   [[PHI4:%[0-9]+]]:_(s32) = G_PHI [[LOAD]](s32), %bb.3, %24(s32), %bb.6
   ; CHECK-NEXT:   G_INTRINSIC_W_SIDE_EFFECTS intrinsic(@llvm.set.loop.iterations), [[COPY3]](s32)
   ; CHECK-NEXT:   [[C2:%[0-9]+]]:_(s20) = G_CONSTANT i20 4
-  ; CHECK-NEXT:   %15:_(p0) = nuw nusw G_PTR_ADD [[PHI1]], [[C2]](s20)
-  ; CHECK-NEXT:   %16:_(p0) = nuw nusw G_PTR_ADD [[PHI2]], [[C2]](s20)
+  ; CHECK-NEXT:   [[PTR_ADD:%[0-9]+]]:_(p0) = nuw nusw G_PTR_ADD [[PHI1]], [[C2]](s20)
+  ; CHECK-NEXT:   [[PTR_ADD1:%[0-9]+]]:_(p0) = nuw nusw G_PTR_ADD [[PHI2]], [[C2]](s20)
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT: bb.5.steady.stage1.inner.inner.header:
   ; CHECK-NEXT:   successors: %bb.5(0x7c000000), %bb.6(0x04000000)
@@ -66,11 +66,12 @@ define i32 @latch_accumulate_return(ptr noalias %a, ptr noalias %c, i32 %N, i32 
   ; CHECK-NEXT: bb.6.steady.stage1.bottom.and.stage0.top:
   ; CHECK-NEXT:   successors: %bb.4(0x7c000000), %bb.7(0x04000000)
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT:   G_STORE [[ADD]](s32), [[PHI2]](p0) :: (store (s32) into %ir.c.ptr.steady)
-  ; CHECK-NEXT:   [[ADD1:%[0-9]+]]:_(s32) = G_ADD [[PHI3]], [[ADD]]
+  ; CHECK-NEXT:   [[PHI6:%[0-9]+]]:_(s32) = G_PHI [[ADD]](s32), %bb.5
+  ; CHECK-NEXT:   G_STORE [[PHI6]](s32), [[PHI2]](p0) :: (store (s32) into %ir.c.ptr.steady)
+  ; CHECK-NEXT:   [[ADD1:%[0-9]+]]:_(s32) = G_ADD [[PHI3]], [[PHI6]]
   ; CHECK-NEXT:   [[ADD2:%[0-9]+]]:_(s32) = G_ADD [[PHI]], [[C]]
   ; CHECK-NEXT:   [[ICMP1:%[0-9]+]]:_(s1) = G_ICMP intpred(slt), [[ADD2]](s32), [[SUB]]
-  ; CHECK-NEXT:   [[LOAD1:%[0-9]+]]:_(s32) = G_LOAD %15(p0) :: (load (s32) from %ir.a.ptr.next.steady)
+  ; CHECK-NEXT:   [[LOAD1:%[0-9]+]]:_(s32) = G_LOAD [[PTR_ADD]](p0) :: (load (s32) from %ir.a.ptr.next.steady)
   ; CHECK-NEXT:   G_BRCOND [[ICMP1]](s1), %bb.4
   ; CHECK-NEXT:   G_BR %bb.7
   ; CHECK-NEXT: {{  $}}
@@ -82,8 +83,8 @@ define i32 @latch_accumulate_return(ptr noalias %a, ptr noalias %c, i32 %N, i32 
   ; CHECK-NEXT: bb.8.lastiter.stage1.inner.inner.header:
   ; CHECK-NEXT:   successors: %bb.8(0x7c000000), %bb.9(0x04000000)
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT:   [[PHI6:%[0-9]+]]:_(s32) = G_PHI [[C1]](s32), %bb.7, %25(s32), %bb.8
-  ; CHECK-NEXT:   [[ADD3:%[0-9]+]]:_(s32) = G_ADD [[PHI6]], [[LOAD1]]
+  ; CHECK-NEXT:   [[PHI7:%[0-9]+]]:_(s32) = G_PHI [[C1]](s32), %bb.7, %26(s32), %bb.8
+  ; CHECK-NEXT:   [[ADD3:%[0-9]+]]:_(s32) = G_ADD [[PHI7]], [[LOAD1]]
   ; CHECK-NEXT:   [[INT1:%[0-9]+]]:_(s1) = G_INTRINSIC_W_SIDE_EFFECTS intrinsic(@llvm.loop.decrement), [[C]](s32)
   ; CHECK-NEXT:   G_BRCOND [[INT1]](s1), %bb.8
   ; CHECK-NEXT:   G_BR %bb.9
@@ -91,17 +92,20 @@ define i32 @latch_accumulate_return(ptr noalias %a, ptr noalias %c, i32 %N, i32 
   ; CHECK-NEXT: bb.9.lastiter.stage1.bottom:
   ; CHECK-NEXT:   successors: %bb.10(0x80000000)
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT:   G_STORE [[ADD3]](s32), %16(p0) :: (store (s32) into %ir.c.ptr.next.steady)
-  ; CHECK-NEXT:   [[ADD4:%[0-9]+]]:_(s32) = G_ADD [[ADD1]], [[ADD3]]
+  ; CHECK-NEXT:   [[PHI8:%[0-9]+]]:_(s32) = G_PHI [[ADD3]](s32), %bb.8
+  ; CHECK-NEXT:   G_STORE [[PHI8]](s32), [[PTR_ADD1]](p0) :: (store (s32) into %ir.c.ptr.next.steady)
+  ; CHECK-NEXT:   [[ADD4:%[0-9]+]]:_(s32) = G_ADD [[ADD1]], [[PHI8]]
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT: bb.10.exit.loopexit:
   ; CHECK-NEXT:   successors: %bb.11(0x80000000)
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT:   [[ADD5:%[0-9]+]]:_(s32) = G_ADD [[ADD1]], [[ADD3]]
+  ; CHECK-NEXT:   [[PHI9:%[0-9]+]]:_(s32) = G_PHI [[ADD1]](s32), %bb.9
+  ; CHECK-NEXT:   [[PHI10:%[0-9]+]]:_(s32) = G_PHI [[PHI8]](s32), %bb.9
+  ; CHECK-NEXT:   [[ADD5:%[0-9]+]]:_(s32) = G_ADD [[PHI9]], [[PHI10]]
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT: bb.11.exit:
-  ; CHECK-NEXT:   [[PHI7:%[0-9]+]]:_(s32) = G_PHI [[C1]](s32), %bb.1, [[ADD5]](s32), %bb.10
-  ; CHECK-NEXT:   $r0 = COPY [[PHI7]](s32)
+  ; CHECK-NEXT:   [[PHI11:%[0-9]+]]:_(s32) = G_PHI [[C1]](s32), %bb.1, [[ADD5]](s32), %bb.10
+  ; CHECK-NEXT:   $r0 = COPY [[PHI11]](s32)
   ; CHECK-NEXT:   PseudoRET implicit $lr, implicit $r0
 entry:
   %cmp.outer = icmp sgt i32 %N, 1

--- a/llvm/test/CodeGen/AIE/aie2p/outer-loop-pipeliner/outer-loop-pipelining-ptr-lifting.ll
+++ b/llvm/test/CodeGen/AIE/aie2p/outer-loop-pipeliner/outer-loop-pipelining-ptr-lifting.ll
@@ -132,7 +132,8 @@ declare i1 @llvm.loop.decrement.i32(i32)
 
 ; Steady-state bottom: a.ptr.next stays here (inner loop dependency)
 ; CHECK: steady.stage1.bottom.and.stage0.top:
-; CHECK:   %offset.steady = sext i32 %acc.next.steady to i64
+; An LCSSA phi may be inserted for acc.next before the sext
+; CHECK:   %offset.steady = sext i32 %{{[a-z0-9.]+}} to i64
 ; CHECK:   %a.ptr.next.steady = getelementptr inbounds i8, ptr %a.ptr.steady, i64 %offset.steady
 
 define void @ptr_lifting_inner_dep(ptr noalias %a, ptr noalias %b, ptr noalias %c,

--- a/llvm/test/CodeGen/AIE/aie2p/outer-loop-pipeliner/outer-loop-pipelining-shared-exit.ll
+++ b/llvm/test/CodeGen/AIE/aie2p/outer-loop-pipeliner/outer-loop-pipelining-shared-exit.ll
@@ -47,14 +47,14 @@ define i32 @shared_exit(ptr noalias %a, ptr noalias %c, i32 %N, i32 %M) {
   ; CHECK-NEXT: bb.4.steady.stage1.top:
   ; CHECK-NEXT:   successors: %bb.5(0x80000000)
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT:   [[PHI:%[0-9]+]]:_(s32) = G_PHI %19(s32), %bb.6, [[C1]](s32), %bb.3
+  ; CHECK-NEXT:   [[PHI:%[0-9]+]]:_(s32) = G_PHI %20(s32), %bb.6, [[C1]](s32), %bb.3
   ; CHECK-NEXT:   [[PHI1:%[0-9]+]]:_(p0) = G_PHI %14(p0), %bb.6, [[COPY]](p0), %bb.3
   ; CHECK-NEXT:   [[PHI2:%[0-9]+]]:_(p0) = G_PHI %15(p0), %bb.6, [[COPY1]](p0), %bb.3
-  ; CHECK-NEXT:   [[PHI3:%[0-9]+]]:_(s32) = G_PHI [[LOAD]](s32), %bb.3, %21(s32), %bb.6
+  ; CHECK-NEXT:   [[PHI3:%[0-9]+]]:_(s32) = G_PHI [[LOAD]](s32), %bb.3, %22(s32), %bb.6
   ; CHECK-NEXT:   G_INTRINSIC_W_SIDE_EFFECTS intrinsic(@llvm.set.loop.iterations), [[COPY3]](s32)
   ; CHECK-NEXT:   [[C2:%[0-9]+]]:_(s20) = G_CONSTANT i20 4
-  ; CHECK-NEXT:   %14:_(p0) = nuw nusw G_PTR_ADD [[PHI1]], [[C2]](s20)
-  ; CHECK-NEXT:   %15:_(p0) = nuw nusw G_PTR_ADD [[PHI2]], [[C2]](s20)
+  ; CHECK-NEXT:   [[PTR_ADD:%[0-9]+]]:_(p0) = nuw nusw G_PTR_ADD [[PHI1]], [[C2]](s20)
+  ; CHECK-NEXT:   [[PTR_ADD1:%[0-9]+]]:_(p0) = nuw nusw G_PTR_ADD [[PHI2]], [[C2]](s20)
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT: bb.5.steady.stage1.inner.inner.header:
   ; CHECK-NEXT:   successors: %bb.5(0x7c000000), %bb.6(0x04000000)
@@ -68,10 +68,11 @@ define i32 @shared_exit(ptr noalias %a, ptr noalias %c, i32 %N, i32 %M) {
   ; CHECK-NEXT: bb.6.steady.stage1.bottom.and.stage0.top:
   ; CHECK-NEXT:   successors: %bb.4(0x7c000000), %bb.7(0x04000000)
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT:   G_STORE [[ADD]](s32), [[PHI2]](p0) :: (store (s32) into %ir.c.ptr.steady)
+  ; CHECK-NEXT:   [[PHI5:%[0-9]+]]:_(s32) = G_PHI [[ADD]](s32), %bb.5
+  ; CHECK-NEXT:   G_STORE [[PHI5]](s32), [[PHI2]](p0) :: (store (s32) into %ir.c.ptr.steady)
   ; CHECK-NEXT:   [[ADD1:%[0-9]+]]:_(s32) = G_ADD [[PHI]], [[C]]
   ; CHECK-NEXT:   [[ICMP1:%[0-9]+]]:_(s1) = G_ICMP intpred(slt), [[ADD1]](s32), [[SUB]]
-  ; CHECK-NEXT:   [[LOAD1:%[0-9]+]]:_(s32) = G_LOAD %14(p0) :: (load (s32) from %ir.a.ptr.next.steady)
+  ; CHECK-NEXT:   [[LOAD1:%[0-9]+]]:_(s32) = G_LOAD [[PTR_ADD]](p0) :: (load (s32) from %ir.a.ptr.next.steady)
   ; CHECK-NEXT:   G_BRCOND [[ICMP1]](s1), %bb.4
   ; CHECK-NEXT:   G_BR %bb.7
   ; CHECK-NEXT: {{  $}}
@@ -83,8 +84,8 @@ define i32 @shared_exit(ptr noalias %a, ptr noalias %c, i32 %N, i32 %M) {
   ; CHECK-NEXT: bb.8.lastiter.stage1.inner.inner.header:
   ; CHECK-NEXT:   successors: %bb.8(0x7c000000), %bb.9(0x04000000)
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT:   [[PHI5:%[0-9]+]]:_(s32) = G_PHI [[C1]](s32), %bb.7, %23(s32), %bb.8
-  ; CHECK-NEXT:   [[ADD2:%[0-9]+]]:_(s32) = G_ADD [[PHI5]], [[LOAD1]]
+  ; CHECK-NEXT:   [[PHI6:%[0-9]+]]:_(s32) = G_PHI [[C1]](s32), %bb.7, %24(s32), %bb.8
+  ; CHECK-NEXT:   [[ADD2:%[0-9]+]]:_(s32) = G_ADD [[PHI6]], [[LOAD1]]
   ; CHECK-NEXT:   [[INT1:%[0-9]+]]:_(s1) = G_INTRINSIC_W_SIDE_EFFECTS intrinsic(@llvm.loop.decrement), [[C]](s32)
   ; CHECK-NEXT:   G_BRCOND [[INT1]](s1), %bb.8
   ; CHECK-NEXT:   G_BR %bb.9
@@ -92,11 +93,12 @@ define i32 @shared_exit(ptr noalias %a, ptr noalias %c, i32 %N, i32 %M) {
   ; CHECK-NEXT: bb.9.lastiter.stage1.bottom:
   ; CHECK-NEXT:   successors: %bb.10(0x80000000)
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT:   G_STORE [[ADD2]](s32), %15(p0) :: (store (s32) into %ir.c.ptr.next.steady)
+  ; CHECK-NEXT:   [[PHI7:%[0-9]+]]:_(s32) = G_PHI [[ADD2]](s32), %bb.8
+  ; CHECK-NEXT:   G_STORE [[PHI7]](s32), [[PTR_ADD1]](p0) :: (store (s32) into %ir.c.ptr.next.steady)
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT: bb.10.exit:
-  ; CHECK-NEXT:   [[PHI6:%[0-9]+]]:_(s32) = G_PHI [[C1]](s32), %bb.1, [[ADD2]](s32), %bb.9
-  ; CHECK-NEXT:   $r0 = COPY [[PHI6]](s32)
+  ; CHECK-NEXT:   [[PHI8:%[0-9]+]]:_(s32) = G_PHI [[C1]](s32), %bb.1, [[PHI7]](s32), %bb.9
+  ; CHECK-NEXT:   $r0 = COPY [[PHI8]](s32)
   ; CHECK-NEXT:   PseudoRET implicit $lr, implicit $r0
 entry:
   %cmp.outer = icmp sgt i32 %N, 1

--- a/llvm/test/CodeGen/AIE/aie2p/outer-loop-pipeliner/outer-loop-pipelining-speculative-no-anchor.ll
+++ b/llvm/test/CodeGen/AIE/aie2p/outer-loop-pipeliner/outer-loop-pipelining-speculative-no-anchor.ll
@@ -47,12 +47,12 @@ define void @speculative_no_anchor(ptr %a, ptr %c, i32 %n, i32 %m) {
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   [[PHI:%[0-9]+]]:_(p0) = G_PHI %15(p0), %bb.6, [[COPY]](p0), %bb.3
   ; CHECK-NEXT:   [[PHI1:%[0-9]+]]:_(p0) = G_PHI %16(p0), %bb.6, [[COPY1]](p0), %bb.3
-  ; CHECK-NEXT:   [[PHI2:%[0-9]+]]:_(s32) = G_PHI [[LOAD]](s32), %bb.3, %20(s32), %bb.6
-  ; CHECK-NEXT:   [[PHI3:%[0-9]+]]:_(s32) = G_PHI [[INT]](s32), %bb.3, %21(s32), %bb.6
+  ; CHECK-NEXT:   [[PHI2:%[0-9]+]]:_(s32) = G_PHI [[LOAD]](s32), %bb.3, %21(s32), %bb.6
+  ; CHECK-NEXT:   [[PHI3:%[0-9]+]]:_(s32) = G_PHI [[INT]](s32), %bb.3, %22(s32), %bb.6
   ; CHECK-NEXT:   G_INTRINSIC_W_SIDE_EFFECTS intrinsic(@llvm.set.loop.iterations), [[COPY3]](s32)
   ; CHECK-NEXT:   [[C2:%[0-9]+]]:_(s20) = G_CONSTANT i20 4
-  ; CHECK-NEXT:   %15:_(p0) = nuw nusw G_PTR_ADD [[PHI]], [[C2]](s20)
-  ; CHECK-NEXT:   %16:_(p0) = nuw nusw G_PTR_ADD [[PHI1]], [[C2]](s20)
+  ; CHECK-NEXT:   [[PTR_ADD:%[0-9]+]]:_(p0) = nuw nusw G_PTR_ADD [[PHI]], [[C2]](s20)
+  ; CHECK-NEXT:   [[PTR_ADD1:%[0-9]+]]:_(p0) = nuw nusw G_PTR_ADD [[PHI1]], [[C2]](s20)
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT: bb.5.steady.stage1.inner.inner.header:
   ; CHECK-NEXT:   successors: %bb.5(0x7c000000), %bb.6(0x04000000)
@@ -66,8 +66,9 @@ define void @speculative_no_anchor(ptr %a, ptr %c, i32 %n, i32 %m) {
   ; CHECK-NEXT: bb.6.steady.stage1.bottom.and.stage0.top:
   ; CHECK-NEXT:   successors: %bb.4(0x7c000000), %bb.7(0x04000000)
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT:   G_STORE [[ADD]](s32), [[PHI1]](p0) :: (store (s32) into %ir.c.ptr.steady)
-  ; CHECK-NEXT:   [[LOAD1:%[0-9]+]]:_(s32) = G_LOAD %15(p0) :: (load (s32) from %ir.a.ptr.next.steady)
+  ; CHECK-NEXT:   [[PHI5:%[0-9]+]]:_(s32) = G_PHI [[ADD]](s32), %bb.5
+  ; CHECK-NEXT:   G_STORE [[PHI5]](s32), [[PHI1]](p0) :: (store (s32) into %ir.c.ptr.steady)
+  ; CHECK-NEXT:   [[LOAD1:%[0-9]+]]:_(s32) = G_LOAD [[PTR_ADD]](p0) :: (load (s32) from %ir.a.ptr.next.steady)
   ; CHECK-NEXT:   [[INT2:%[0-9]+]]:_(s32) = G_INTRINSIC_W_SIDE_EFFECTS intrinsic(@llvm.loop.decrement.reg), [[PHI3]](s32), [[C]](s32)
   ; CHECK-NEXT:   [[ICMP1:%[0-9]+]]:_(s1) = G_ICMP intpred(ne), [[INT2]](s32), [[C1]]
   ; CHECK-NEXT:   G_BRCOND [[ICMP1]](s1), %bb.4

--- a/llvm/test/CodeGen/AIE/aie2p/outer-loop-pipeliner/outer-loop-pipelining.ll
+++ b/llvm/test/CodeGen/AIE/aie2p/outer-loop-pipeliner/outer-loop-pipelining.ll
@@ -202,7 +202,7 @@ declare i1 @llvm.loop.decrement.i32(i32)
 ; CHECK:   br i1 %inner.cond.lastiter, label %lastiter.stage1.inner.inner.header, label %lastiter.stage1.bottom
 
 ; CHECK: lastiter.stage1.bottom:
-; CHECK:   store i32 %acc.next.lastiter
+; CHECK:   store i32 %{{[a-z0-9.]+}}
 ; CHECK:   br label %exit
 
 define void @outer_to_inner_phi(ptr noalias %a, ptr noalias %b, ptr noalias %c,
@@ -327,3 +327,4 @@ exit:
 !10 = !{!"llvm.loop.mustprogress"}
 !11 = !{!"llvm.loop.itercount.range", i32 2}
 !12 = !{!"llvm.loop.itercount.range", i32 8}
+

--- a/llvm/test/CodeGen/AIE/aie2ps/end-to-end/gemm_mx6_loop_for_body_1.ll
+++ b/llvm/test/CodeGen/AIE/aie2ps/end-to-end/gemm_mx6_loop_for_body_1.ll
@@ -122,7 +122,7 @@ define dso_local void @gemm.if.then5(ptr %add.ptr, ptr %tdm1, i32 %cond3) #5 {
 ; ASM-NEXT:    lda dc0, [p1], #4; vmov bmlh0, bmll0
 ; ASM-NEXT:    lda dc4, [p1], #24; or r16, r10, r10; vmov cmh1, cml1
 ; ASM-NEXT:    lda dc1, [p1], #4; movs m7, dj3; movx r5, #0; vmov cmh0, cml0
-; ASM-NEXT:    lda dn0, [p2, #0]; movs m6, dj3; or r25, r5, r5; mov r7, p1
+; ASM-NEXT:    lda dn0, [p2, #0]; movs m6, dj3; or r25, r5, r5; mov r17, p1
 ; ASM-NEXT:    lda dc5, [p1, #0]; movs p1, p0; or r24, r5, r5; mov p0, p3
 ; ASM-NEXT:  .LBB0_1: // %steady.stage1.top
 ; ASM-NEXT:    // =>This Loop Header: Depth=1
@@ -164,7 +164,7 @@ define dso_local void @gemm.if.then5(ptr %add.ptr, ptr %tdm1, i32 %cond3) #5 {
 ; ASM-NEXT:    mov r5, p3; vmac.f dm7, dm7, fex4, fey0, r10
 ; ASM-NEXT:    vmov fewl2, fewh2; vmac.f dm6, dm6, fex4, fey0, r10
 ; ASM-NEXT:    vmov fewl0, fewh10; vmac.f dm5, dm5, fex2, fey0, r10
-; ASM-NEXT:    mov r17, p2; vmac.f dm1, dm1, fex2, fey0, r10
+; ASM-NEXT:    mov r7, p2; vmac.f dm1, dm1, fex2, fey0, r10
 ; ASM-NEXT:    vmov fewl0, fewh8; vmac.f dm4, dm4, fex10, fey3, r10
 ; ASM-NEXT:    movxm p2, #.LBB0_1; vmac.f dm3, dm3, fex0, fey3, r10
 ; ASM-NEXT:    vst.conv.bf16.fp32 cml7, [p5], #64; vmac.f dm0, dm0, fex0, fey3, r10
@@ -202,7 +202,7 @@ define dso_local void @gemm.if.then5(ptr %add.ptr, ptr %tdm1, i32 %cond3) #5 {
 ; ASM-NEXT:    vlda.fill [p0, lf0, r24]; vldb.fill [p1, lf1, r25]; vmov fewl2, fewh2; vmac.f dm6, dm6, fex4, fey0, r8
 ; ASM-NEXT:    vlda.pop fex6, [p0, lf0, r24]; vldb.pop fex10, [p1, lf1, r25]; vmov fewl0, fewh10; vmac.f dm5, dm5, fex2, fey0, r8
 ; ASM-NEXT:    vlda.pop.3d fex7, [p0, lf0, r24, d1]; vldb.pop.3d fex8, [p1, lf1, r25, d0]; vmov cmh4, cmh0; vmac.f dm1, dm1, fex2, fey0, r8
-; ASM-NEXT:    movs p2, r17; vmov fewl0, fewh8; vmac.f dm4, dm4, fex10, fey3, r8
+; ASM-NEXT:    movs p2, r7; vmov fewl0, fewh8; vmac.f dm4, dm4, fex10, fey3, r8
 ; ASM-NEXT:    nopa ; nopb ; movs p4, r5; add.nc lc, r1, #-2; vmov cmh3, cmh0; vmac.f dm3, dm3, fex0, fey3, r8
 ; ASM-NEXT:  .LBB0_5: // %lastiter.stage1.inner.for.body18.i
 ; ASM-NEXT:    // =>This Inner Loop Header: Depth=1
@@ -216,14 +216,14 @@ define dso_local void @gemm.if.then5(ptr %add.ptr, ptr %tdm1, i32 %cond3) #5 {
 ; ASM-NEXT:  .L_LEnd0:
 ; ASM-NEXT:    nopa ; nopb ; nops ; nopxm ; vmac.f dm3, dm3, fex0, fey3, r8
 ; ASM-NEXT:  // %bb.6: // %lastiter.stage1.bottom
-; ASM-NEXT:    padda [p5], #128; paddb [p3], #128; movs p0, r7; nopx ; mov m0, #-32; vmac.f dm0, dm0, fex0, fey3, r8
-; ASM-NEXT:    lda p7, [sp, #-60]; paddb [p0], m0; nops ; movx r8, #772; vmov fewl4, fewh4; vmac.f dm2, dm2, fex8, fey3, r8 // 4-byte Folded Reload
-; ASM-NEXT:    lda p6, [sp, #-64]; nopb ; st dc0, [p0], #4; nopx ; mov r10, r16; vmac.f dm7, dm7, fex4, fey0, r8 // 4-byte Folded Reload
-; ASM-NEXT:    paddxm [sp], #-64; st dc4, [p0], #24; vmov fewl2, fewh2; vmac.f dm6, dm6, fex4, fey0, r8
-; ASM-NEXT:    st dc1, [p0, #0]; vmov fewl0, fewh10; vmac.f dm5, dm5, fex2, fey0, r8
-; ASM-NEXT:    st dc5, [p0, #4]; vmac.f dm1, dm1, fex2, fey0, r8
-; ASM-NEXT:    vmov fewl0, fewh8; vmac.f dm4, dm4, fex10, fey3, r8
-; ASM-NEXT:    vmac.f dm3, dm3, fex0, fey3, r8
+; ASM-NEXT:    padda [p5], #128; paddb [p3], #128; movs p0, r17; nopx ; mov m0, #32; vmac.f dm0, dm0, fex0, fey3, r8
+; ASM-NEXT:    lda p7, [sp, #-60]; paddb [p0], m0; movx r8, #772; vmov fewl4, fewh4; vmac.f dm2, dm2, fex8, fey3, r8 // 4-byte Folded Reload
+; ASM-NEXT:    lda p6, [sp, #-64]; or r10, r16, r16; mov m0, #-64; vmac.f dm7, dm7, fex4, fey0, r8 // 4-byte Folded Reload
+; ASM-NEXT:    paddxm [sp], #-64; st r1, [p0], m0; vmov fewl2, fewh2; vmac.f dm6, dm6, fex4, fey0, r8
+; ASM-NEXT:    st dc0, [p0], #4; vmov fewl0, fewh10; vmac.f dm5, dm5, fex2, fey0, r8
+; ASM-NEXT:    st dc4, [p0], #24; vmac.f dm1, dm1, fex2, fey0, r8
+; ASM-NEXT:    st dc1, [p0, #0]; vmov fewl0, fewh8; vmac.f dm4, dm4, fex10, fey3, r8
+; ASM-NEXT:    st dc5, [p0, #4]; vmac.f dm3, dm3, fex0, fey3, r8
 ; ASM-NEXT:    vst.conv.bf16.fp32 cmh7, [p5], #64; vmac.f dm0, dm0, fex0, fey3, r8
 ; ASM-NEXT:    vst.conv.bf16.fp32 cml6, [p5], #64; movx r8, #772; vmac.f dm2, dm2, fex8, fey3, r8
 ; ASM-NEXT:    vst.conv.bf16.fp32 cmh6, [p5], #64; mov r8, r6

--- a/llvm/test/CodeGen/AIE/aie2ps/outer-loop-pipeliner/outer-loop-pipelining-two-loops-lcssa.ll
+++ b/llvm/test/CodeGen/AIE/aie2ps/outer-loop-pipeliner/outer-loop-pipelining-two-loops-lcssa.ll
@@ -10,19 +10,14 @@
 
 ; Test: Two mutually exclusive pipelined outer loops with a common exit block.
 ;
-; This test documents a BUG in the Outer Loop Pipeliner where LCSSA form is
-; not properly maintained when a function has two independent outer loops
-; (selected by a condition) that both branch to a common exit block with phi nodes.
+; This test verifies that LCSSA form is properly maintained when pipelining
+; loops that exit through intermediate blocks to a common exit with phi nodes.
 ;
-; Bug scenario:
+; Structure:
 ;   - Function has two mutually exclusive outer loops (loop1 when cond, loop2 when !cond)
 ;   - Both loops compute values that flow to a common exit block via phi nodes
-;   - After pipelining loop1, the exit phi nodes should use values from loop1's
-;     transformed blocks, but the pipeliner fails to update them
-;   - Result: phi nodes get poison values from loop1's exit edge
-;
-; This test verifies the current (buggy) behavior. When the bug is fixed,
-; the CHECK-POISON lines should be changed to CHECK-NOT: poison.
+;   - Each loop exits through an intermediate block (loop1.exit, loop2.exit)
+;   - After pipelining, the exit phi nodes must use the correct LCSSA phi values
 
 ; CHECK-LABEL: define void @two_loops_shared_exit
 
@@ -34,11 +29,10 @@
 ; CHECK: stage0.top{{[0-9]+}}:
 ; CHECK:   load i32
 
-; BUG: The exit phi has poison values because the outer loop pipeliner doesn't
-; update LCSSA phis when the loop exits through an intermediate block.
-; The phi should have the last-iteration accumulator values, but instead gets poison.
+; The exit phi must have correct LCSSA values (not poison) after pipelining.
 ; CHECK: exit:
-; CHECK:   %final.acc = phi i32 [ 0, %entry ], [ poison, %loop1.exit ], [ poison, %loop2.exit ]
+; CHECK:   %final.acc = phi i32 [ 0, %entry ], [ %{{[a-z0-9.]+}}, %loop1.exit ], [ %{{[a-z0-9.]+}}, %loop2.exit ]
+; CHECK-NOT: poison
 
 define void @two_loops_shared_exit(ptr noalias %a, ptr noalias %b, ptr noalias %c,
                                     i32 %N, i32 %M, i1 %cond) {
@@ -136,11 +130,8 @@ loop2.exit:
 
 ; ========== Common exit ==========
 exit:
-  ; This phi must have valid values from BOTH loops after pipelining
-  ; BUG: After pipelining, this phi gets poison from one loop's exit edge
-  ; because the pipeliner doesn't update LCSSA phis for values defined
-  ; in the loop latch when the exit block is shared with another loop via
-  ; an intermediate exit block.
+  ; This phi must have valid LCSSA values from BOTH loops after pipelining.
+  ; The formLCSSARecursively call ensures proper LCSSA phis are created.
   %final.acc = phi i32 [ 0, %entry ], [ %acc1.next, %loop1.exit ], [ %acc2.next, %loop2.exit ]
   store i32 %final.acc, ptr %c, align 4
   ret void

--- a/llvm/test/CodeGen/AIE/aie2ps/outer-loop-pipeliner/outer-loop-pipelining-two-loops-lcssa.ll
+++ b/llvm/test/CodeGen/AIE/aie2ps/outer-loop-pipeliner/outer-loop-pipelining-two-loops-lcssa.ll
@@ -1,0 +1,163 @@
+; This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+; See https://llvm.org/LICENSE.txt for license information.
+; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+;
+; (c) Copyright 2026 Advanced Micro Devices, Inc. or its affiliates
+;
+; RUN: llc -mtriple=aie2ps -O2 -aie-enable-outer-loop-pipelining \
+; RUN:     -stop-after=aie-outer-loop-pipeliner \
+; RUN:     -o - %s 2>&1 | FileCheck %s
+
+; Test: Two mutually exclusive pipelined outer loops with a common exit block.
+;
+; This test documents a BUG in the Outer Loop Pipeliner where LCSSA form is
+; not properly maintained when a function has two independent outer loops
+; (selected by a condition) that both branch to a common exit block with phi nodes.
+;
+; Bug scenario:
+;   - Function has two mutually exclusive outer loops (loop1 when cond, loop2 when !cond)
+;   - Both loops compute values that flow to a common exit block via phi nodes
+;   - After pipelining loop1, the exit phi nodes should use values from loop1's
+;     transformed blocks, but the pipeliner fails to update them
+;   - Result: phi nodes get poison values from loop1's exit edge
+;
+; This test verifies the current (buggy) behavior. When the bug is fixed,
+; the CHECK-POISON lines should be changed to CHECK-NOT: poison.
+
+; CHECK-LABEL: define void @two_loops_shared_exit
+
+; Verify loop1 is pipelined
+; CHECK: stage0.top:
+; CHECK:   load i32
+
+; Verify loop2 is pipelined  
+; CHECK: stage0.top{{[0-9]+}}:
+; CHECK:   load i32
+
+; BUG: The exit phi has poison values because the outer loop pipeliner doesn't
+; update LCSSA phis when the loop exits through an intermediate block.
+; The phi should have the last-iteration accumulator values, but instead gets poison.
+; CHECK: exit:
+; CHECK:   %final.acc = phi i32 [ 0, %entry ], [ poison, %loop1.exit ], [ poison, %loop2.exit ]
+
+define void @two_loops_shared_exit(ptr noalias %a, ptr noalias %b, ptr noalias %c,
+                                    i32 %N, i32 %M, i1 %cond) {
+entry:
+  %cmp = icmp sgt i32 %N, 1
+  br i1 %cmp, label %choose.loop, label %exit
+
+choose.loop:
+  br i1 %cond, label %outer1.preheader, label %outer2.preheader
+
+; ========== Loop 1 (when cond is true) ==========
+; Structure matches working test: preheader -> outer.header -> inner.header -> outer.latch
+outer1.preheader:
+  br label %outer1.header
+
+outer1.header:
+  %i1 = phi i32 [ 0, %outer1.preheader ], [ %i1.next, %outer1.latch ]
+  %a.ptr1 = phi ptr [ %a, %outer1.preheader ], [ %a.ptr1.next, %outer1.latch ]
+  %b.ptr1 = phi ptr [ %b, %outer1.preheader ], [ %b.ptr1.next, %outer1.latch ]
+  %c.ptr1 = phi ptr [ %c, %outer1.preheader ], [ %c.ptr1.next, %outer1.latch ]
+  ; Prologue: loads for the inner loop
+  %v0.1 = load i32, ptr %a.ptr1, align 4
+  %v1.1 = load i32, ptr %b.ptr1, align 4
+  ; Set up hardware loop counter
+  call void @llvm.set.loop.iterations.i32(i32 %M)
+  br label %inner1.header
+
+inner1.header:
+  %acc1 = phi i32 [ 0, %outer1.header ], [ %acc1.next, %inner1.header ]
+  %prod1 = mul i32 %v0.1, %v1.1
+  %acc1.next = add i32 %acc1, %prod1
+  ; Hardware loop decrement
+  %inner1.cond = call i1 @llvm.loop.decrement.i32(i32 1)
+  br i1 %inner1.cond, label %inner1.header, label %outer1.latch, !llvm.loop !1
+
+outer1.latch:
+  ; Epilogue: store result + compute live-out values
+  store i32 %acc1.next, ptr %c.ptr1, align 4
+  ; Advance pointers
+  %a.ptr1.next = getelementptr inbounds i32, ptr %a.ptr1, i32 1
+  %b.ptr1.next = getelementptr inbounds i32, ptr %b.ptr1, i32 1
+  %c.ptr1.next = getelementptr inbounds i32, ptr %c.ptr1, i32 1
+  %i1.next = add i32 %i1, 1
+  %outer1.cond = icmp slt i32 %i1.next, %N
+  br i1 %outer1.cond, label %outer1.header, label %loop1.exit, !llvm.loop !0
+
+; Intermediate exit block for loop 1
+loop1.exit:
+  ; Store something specific to loop 1
+  store i32 42, ptr %a, align 4
+  br label %exit
+
+; ========== Loop 2 (when cond is false) ==========
+; Structure matches working test: preheader -> outer.header -> inner.header -> outer.latch
+outer2.preheader:
+  br label %outer2.header
+
+outer2.header:
+  %i2 = phi i32 [ 0, %outer2.preheader ], [ %i2.next, %outer2.latch ]
+  %a.ptr2 = phi ptr [ %a, %outer2.preheader ], [ %a.ptr2.next, %outer2.latch ]
+  %b.ptr2 = phi ptr [ %b, %outer2.preheader ], [ %b.ptr2.next, %outer2.latch ]
+  %c.ptr2 = phi ptr [ %c, %outer2.preheader ], [ %c.ptr2.next, %outer2.latch ]
+  ; Prologue: loads + a computation
+  %v0.2 = load i32, ptr %a.ptr2, align 4
+  %v1.2 = load i32, ptr %b.ptr2, align 4
+  %init2 = add i32 %v0.2, %v1.2
+  ; Set up hardware loop counter
+  call void @llvm.set.loop.iterations.i32(i32 %M)
+  br label %inner2.header
+
+inner2.header:
+  %acc2 = phi i32 [ %init2, %outer2.header ], [ %acc2.next, %inner2.header ]
+  %prod2 = mul i32 %v0.2, %v1.2
+  %acc2.next = add i32 %acc2, %prod2
+  ; Hardware loop decrement
+  %inner2.cond = call i1 @llvm.loop.decrement.i32(i32 1)
+  br i1 %inner2.cond, label %inner2.header, label %outer2.latch, !llvm.loop !3
+
+outer2.latch:
+  ; Epilogue: store result + compute live-out values
+  store i32 %acc2.next, ptr %c.ptr2, align 4
+  ; Advance pointers
+  %a.ptr2.next = getelementptr inbounds i32, ptr %a.ptr2, i32 1
+  %b.ptr2.next = getelementptr inbounds i32, ptr %b.ptr2, i32 1
+  %c.ptr2.next = getelementptr inbounds i32, ptr %c.ptr2, i32 1
+  %i2.next = add i32 %i2, 1
+  %outer2.cond = icmp slt i32 %i2.next, %N
+  br i1 %outer2.cond, label %outer2.header, label %loop2.exit, !llvm.loop !2
+
+; Intermediate exit block for loop 2
+loop2.exit:
+  ; Store something specific to loop 2
+  store i32 24, ptr %b, align 4
+  br label %exit
+
+; ========== Common exit ==========
+exit:
+  ; This phi must have valid values from BOTH loops after pipelining
+  ; BUG: After pipelining, this phi gets poison from one loop's exit edge
+  ; because the pipeliner doesn't update LCSSA phis for values defined
+  ; in the loop latch when the exit block is shared with another loop via
+  ; an intermediate exit block.
+  %final.acc = phi i32 [ 0, %entry ], [ %acc1.next, %loop1.exit ], [ %acc2.next, %loop2.exit ]
+  store i32 %final.acc, ptr %c, align 4
+  ret void
+}
+
+declare void @llvm.set.loop.iterations.i32(i32)
+declare i1 @llvm.loop.decrement.i32(i32)
+
+; Loop 1 outer loop metadata
+!0 = distinct !{!0, !4, !5}
+; Loop 1 inner loop metadata
+!1 = distinct !{!1, !4}
+
+; Loop 2 outer loop metadata
+!2 = distinct !{!2, !4, !5}
+; Loop 2 inner loop metadata
+!3 = distinct !{!3, !4}
+
+!4 = !{!"llvm.loop.mustprogress"}
+!5 = !{!"llvm.loop.itercount.range", i32 2}


### PR DESCRIPTION
### Problem

The Outer Loop Pipeliner produces __poison values__ in exit phi nodes when:

- A function contains multiple loops that share a common exit block
- Loops exit through intermediate exit blocks (not directly to the shared exit)
- Values computed in the loop need to flow to the shared exit via phi nodes

This occurred because the pipeliner's transformation (cloning and remapping) did not properly maintain LCSSA form. When the original loop blocks were removed, references in exit phi nodes became dangling and resolved to poison.

### Root Cause

LCSSA (Loop Closed Static Single Assignment) form requires that all values used outside a loop are captured by phi nodes at the loop's exit. Without proper LCSSA form before the transformation:

1. Values exiting through intermediate blocks had no LCSSA phi
2. The pipeliner's remap logic couldn't connect exit live-outs to cloned definitions
3. After `removeFromCFG` deleted original blocks, exit phis referenced deleted values → poison

### Solution
__Add a single line at the start of `performTransformation`:__

```cpp
formLCSSARecursively(*OrigLS.getOuterLoop(), *DT, LI, SE);
```

This ensures proper LCSSA form is established before any transformation, creating the necessary phi nodes for all exit live-outs.

### Cleanup (Follow-up NFC)

The "non-phi exit live-out" workaround code (manual operand remapping in the exit block) is now dead and can be removed. This workaround was handling cases where no LCSSA phi existed - a situation that can no longer occur with LCSSA form guaranteed upfront.
