### PR TITLE
[ArithToEmitC] Add lowering for arith.{min,max}{s,u}i

### DIFF
--- a/mlir/lib/Conversion/ArithToEmitC/ArithToEmitC.cpp
+++ b/mlir/lib/Conversion/ArithToEmitC/ArithToEmitC.cpp
@@ -666,6 +666,41 @@ class UnsignedShiftOpConversion final
   using ShiftOpConversion<ArithOp, EmitCOp, true>::ShiftOpConversion;
 };
 
+// Lowers arith.{min,max}{s,u}i as a compare-and-select, e.g. `min(a, b)`
+// becomes `a < b ? a : b`. Unlike ShiftOpConversion, there's no UB to guard
+// against, so the comparison can be materialized as an ordinary statement
+// rather than nested inside an emitc::ExpressionOp.
+template <typename ArithOp, emitc::CmpPredicate predicate, bool isUnsignedOp>
+class MinMaxOpConversion final : public OpConversionPattern<ArithOp> {
+public:
+  using OpConversionPattern<ArithOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(ArithOp op, typename ArithOp::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+
+    Type type = this->getTypeConverter()->convertType(op.getType());
+    if (!type || !(emitc::isIntegerOrOpaqueType(type) ||
+                   emitc::isPointerWideType(type))) {
+      return rewriter.notifyMatchFailure(
+          op, "expected integer or size_t/ssize_t/ptrdiff_t type");
+    }
+
+    // Compare using the correctly-signed view of the operands; the ternary
+    // still yields the original (unmodified) lhs/rhs values.
+    Type cmpType = adaptIntegralTypeSignedness(type, isUnsignedOp);
+    Value lhsForCmp = adaptValueType(adaptor.getLhs(), rewriter, cmpType);
+    Value rhsForCmp = adaptValueType(adaptor.getRhs(), rewriter, cmpType);
+
+    Value cmp =
+        emitc::CmpOp::create(rewriter, op.getLoc(), rewriter.getI1Type(),
+                             predicate, lhsForCmp, rhsForCmp);
+    rewriter.replaceOpWithNewOp<emitc::ConditionalOp>(
+        op, type, cmp, adaptor.getLhs(), adaptor.getRhs());
+    return success();
+  }
+};
+
 class SelectOpConversion : public OpConversionPattern<arith::SelectOp> {
 public:
   using OpConversionPattern<arith::SelectOp>::OpConversionPattern;
@@ -856,6 +891,10 @@ void mlir::populateArithToEmitCPatterns(TypeConverter &typeConverter,
     UnsignedShiftOpConversion<arith::ShLIOp, emitc::BitwiseLeftShiftOp>,
     SignedShiftOpConversion<arith::ShRSIOp, emitc::BitwiseRightShiftOp>,
     UnsignedShiftOpConversion<arith::ShRUIOp, emitc::BitwiseRightShiftOp>,
+    MinMaxOpConversion<arith::MinSIOp, emitc::CmpPredicate::lt, false>,
+    MinMaxOpConversion<arith::MaxSIOp, emitc::CmpPredicate::gt, false>,
+    MinMaxOpConversion<arith::MinUIOp, emitc::CmpPredicate::lt, true>,
+    MinMaxOpConversion<arith::MaxUIOp, emitc::CmpPredicate::gt, true>,
     CmpFOpConversion,
     CmpIOpConversion,
     NegFOpConversion,

--- a/mlir/test/Conversion/ArithToEmitC/arith-to-emitc.mlir
+++ b/mlir/test/Conversion/ArithToEmitC/arith-to-emitc.mlir
@@ -263,6 +263,58 @@ func.func @arith_shift_right_index(%amount: i32) {
 
 // -----
 
+// COMMON-LABEL: arith_minsi
+// COMMON-SAME: ([[Arg0:[^ ]*]]: i32, [[Arg1:[^ ]*]]: i32)
+func.func @arith_minsi(%arg0: i32, %arg1: i32) -> i32 {
+  // COMMON: [[Cmp:[^ ]*]] = emitc.cmp lt, [[Arg0]], [[Arg1]] : (i32, i32) -> i1
+  // COMMON: [[Cond:[^ ]*]] = emitc.conditional [[Cmp]], [[Arg0]], [[Arg1]] : i32
+  %0 = arith.minsi %arg0, %arg1 : i32
+  // COMMON: return [[Cond]]
+  return %0 : i32
+}
+
+// -----
+
+// COMMON-LABEL: arith_maxsi
+// COMMON-SAME: ([[Arg0:[^ ]*]]: i32, [[Arg1:[^ ]*]]: i32)
+func.func @arith_maxsi(%arg0: i32, %arg1: i32) -> i32 {
+  // COMMON: [[Cmp:[^ ]*]] = emitc.cmp gt, [[Arg0]], [[Arg1]] : (i32, i32) -> i1
+  // COMMON: [[Cond:[^ ]*]] = emitc.conditional [[Cmp]], [[Arg0]], [[Arg1]] : i32
+  %0 = arith.maxsi %arg0, %arg1 : i32
+  // COMMON: return [[Cond]]
+  return %0 : i32
+}
+
+// -----
+
+// COMMON-LABEL: arith_minui
+// COMMON-SAME: ([[Arg0:[^ ]*]]: i32, [[Arg1:[^ ]*]]: i32)
+func.func @arith_minui(%arg0: i32, %arg1: i32) -> i32 {
+  // COMMON-DAG: [[CastArg0:[^ ]*]] = emitc.cast [[Arg0]] : i32 to ui32
+  // COMMON-DAG: [[CastArg1:[^ ]*]] = emitc.cast [[Arg1]] : i32 to ui32
+  // COMMON: [[Cmp:[^ ]*]] = emitc.cmp lt, [[CastArg0]], [[CastArg1]] : (ui32, ui32) -> i1
+  // COMMON: [[Cond:[^ ]*]] = emitc.conditional [[Cmp]], [[Arg0]], [[Arg1]] : i32
+  %0 = arith.minui %arg0, %arg1 : i32
+  // COMMON: return [[Cond]]
+  return %0 : i32
+}
+
+// -----
+
+// COMMON-LABEL: arith_maxui
+// COMMON-SAME: ([[Arg0:[^ ]*]]: i32, [[Arg1:[^ ]*]]: i32)
+func.func @arith_maxui(%arg0: i32, %arg1: i32) -> i32 {
+  // COMMON-DAG: [[CastArg0:[^ ]*]] = emitc.cast [[Arg0]] : i32 to ui32
+  // COMMON-DAG: [[CastArg1:[^ ]*]] = emitc.cast [[Arg1]] : i32 to ui32
+  // COMMON: [[Cmp:[^ ]*]] = emitc.cmp gt, [[CastArg0]], [[CastArg1]] : (ui32, ui32) -> i1
+  // COMMON: [[Cond:[^ ]*]] = emitc.conditional [[Cmp]], [[Arg0]], [[Arg1]] : i32
+  %0 = arith.maxui %arg0, %arg1 : i32
+  // COMMON: return [[Cond]]
+  return %0 : i32
+}
+
+// -----
+
 func.func @arith_select(%arg0: i1, %arg1: tensor<8xi32>, %arg2: tensor<8xi32>) -> () {
   // COMMON: [[V0:[^ ]*]] = emitc.conditional %arg0, %arg1, %arg2 : tensor<8xi32>
   %0 = arith.select %arg0, %arg1, %arg2 : i1, tensor<8xi32>


### PR DESCRIPTION
ArithToEmitC already lowers arith.select directly to emitc.conditional, and ShiftOpConversion emits a compare-and-select ternary to guard against UB on out-of-range shift amounts. Despite proving it can emit emitc.conditional, the pass had no pattern at all for arith.minsi/ maxsi/minui/maxui, even though min/max is exactly the same shape (`a < b ? a : b`) without any UB to guard against.

Add MinMaxOpConversion, modeled on CmpIOpConversion's signed/unsigned handling, and register it for all four integer min/max ops. Floating point min/max (minimumf/maximumf/minnumf/maxnumf) are intentionally left out of scope due to NaN-propagation semantics.