### PR TITLE
[AIE][OLP] Simplify trivial LCSSA PHIs to avoid register copies

### DIFF
--- a/llvm/lib/Target/AIE/AIEOuterLoopPipeliner.cpp
+++ b/llvm/lib/Target/AIE/AIEOuterLoopPipeliner.cpp
@@ -649,6 +649,18 @@ void AIEOuterLoopPipeliner::getAnalysisUsage(AnalysisUsage &AU) const {
   FunctionPass::getAnalysisUsage(AU);
 }
 
+/// Simplify trivial PHI nodes in all blocks of a function.
+static void simplifyTrivialPHIsInFunction(Function &F) {
+  for (BasicBlock &BB : F) {
+    for (PHINode &PN : make_early_inc_range(BB.phis())) {
+      if (Value *V = PN.hasConstantValue()) {
+        PN.replaceAllUsesWith(V);
+        PN.eraseFromParent();
+      }
+    }
+  }
+}
+
 bool AIEOuterLoopPipeliner::runOnFunction(Function &F) {
   if (skipFunction(F))
     return false;
@@ -667,6 +679,11 @@ bool AIEOuterLoopPipeliner::runOnFunction(Function &F) {
   SmallVector<Loop *, 4> TopLevelLoops(LI->begin(), LI->end());
   for (Loop *L : TopLevelLoops)
     Changed |= runOnLoop(L);
+
+  // Simplify all trivial PHIs in the function
+  if (Changed)
+    simplifyTrivialPHIsInFunction(F);
+
   return Changed;
 }
 

--- a/llvm/test/CodeGen/AIE/aie2p/outer-loop-pipeliner/outer-loop-pipelining-exit-no-phi.ll
+++ b/llvm/test/CodeGen/AIE/aie2p/outer-loop-pipeliner/outer-loop-pipelining-exit-no-phi.ll
@@ -41,11 +41,11 @@ define i32 @exit_uses_latch_def(ptr noalias %a, ptr noalias %c, i32 %N, i32 %M) 
   ; CHECK-NEXT: bb.3.steady.stage1.top:
   ; CHECK-NEXT:   successors: %bb.4(0x80000000)
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT:   [[PHI:%[0-9]+]]:_(s32) = G_PHI [[C1]](s32), %bb.2, %21(s32), %bb.5
+  ; CHECK-NEXT:   [[PHI:%[0-9]+]]:_(s32) = G_PHI [[C1]](s32), %bb.2, %20(s32), %bb.5
   ; CHECK-NEXT:   [[PHI1:%[0-9]+]]:_(p0) = G_PHI [[COPY]](p0), %bb.2, %14(p0), %bb.5
   ; CHECK-NEXT:   [[PHI2:%[0-9]+]]:_(p0) = G_PHI [[COPY1]](p0), %bb.2, %15(p0), %bb.5
-  ; CHECK-NEXT:   [[PHI3:%[0-9]+]]:_(s32) = G_PHI [[C1]](s32), %bb.2, %20(s32), %bb.5
-  ; CHECK-NEXT:   [[PHI4:%[0-9]+]]:_(s32) = G_PHI [[LOAD]](s32), %bb.2, %23(s32), %bb.5
+  ; CHECK-NEXT:   [[PHI3:%[0-9]+]]:_(s32) = G_PHI [[C1]](s32), %bb.2, %19(s32), %bb.5
+  ; CHECK-NEXT:   [[PHI4:%[0-9]+]]:_(s32) = G_PHI [[LOAD]](s32), %bb.2, %22(s32), %bb.5
   ; CHECK-NEXT:   G_INTRINSIC_W_SIDE_EFFECTS intrinsic(@llvm.set.loop.iterations), [[COPY3]](s32)
   ; CHECK-NEXT:   [[C2:%[0-9]+]]:_(s20) = G_CONSTANT i20 4
   ; CHECK-NEXT:   [[PTR_ADD:%[0-9]+]]:_(p0) = nuw nusw G_PTR_ADD [[PHI1]], [[C2]](s20)
@@ -63,9 +63,8 @@ define i32 @exit_uses_latch_def(ptr noalias %a, ptr noalias %c, i32 %N, i32 %M) 
   ; CHECK-NEXT: bb.5.steady.stage1.bottom.and.stage0.top:
   ; CHECK-NEXT:   successors: %bb.3(0x7c000000), %bb.6(0x04000000)
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT:   [[PHI6:%[0-9]+]]:_(s32) = G_PHI [[ADD]](s32), %bb.4
-  ; CHECK-NEXT:   G_STORE [[PHI6]](s32), [[PHI2]](p0) :: (store (s32) into %ir.c.ptr.steady)
-  ; CHECK-NEXT:   [[ADD1:%[0-9]+]]:_(s32) = G_ADD [[PHI3]], [[PHI6]]
+  ; CHECK-NEXT:   G_STORE [[ADD]](s32), [[PHI2]](p0) :: (store (s32) into %ir.c.ptr.steady)
+  ; CHECK-NEXT:   [[ADD1:%[0-9]+]]:_(s32) = G_ADD [[PHI3]], [[ADD]]
   ; CHECK-NEXT:   [[ADD2:%[0-9]+]]:_(s32) = G_ADD [[PHI]], [[C]]
   ; CHECK-NEXT:   [[ICMP:%[0-9]+]]:_(s1) = G_ICMP intpred(slt), [[ADD2]](s32), [[SUB]]
   ; CHECK-NEXT:   [[LOAD1:%[0-9]+]]:_(s32) = G_LOAD [[PTR_ADD]](p0) :: (load (s32) from %ir.a.ptr.next.steady)
@@ -80,8 +79,8 @@ define i32 @exit_uses_latch_def(ptr noalias %a, ptr noalias %c, i32 %N, i32 %M) 
   ; CHECK-NEXT: bb.7.lastiter.stage1.inner.inner.header:
   ; CHECK-NEXT:   successors: %bb.7(0x7c000000), %bb.8(0x04000000)
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT:   [[PHI7:%[0-9]+]]:_(s32) = G_PHI [[C1]](s32), %bb.6, %25(s32), %bb.7
-  ; CHECK-NEXT:   [[ADD3:%[0-9]+]]:_(s32) = G_ADD [[PHI7]], [[LOAD1]]
+  ; CHECK-NEXT:   [[PHI6:%[0-9]+]]:_(s32) = G_PHI [[C1]](s32), %bb.6, %24(s32), %bb.7
+  ; CHECK-NEXT:   [[ADD3:%[0-9]+]]:_(s32) = G_ADD [[PHI6]], [[LOAD1]]
   ; CHECK-NEXT:   [[INT1:%[0-9]+]]:_(s1) = G_INTRINSIC_W_SIDE_EFFECTS intrinsic(@llvm.loop.decrement), [[C]](s32)
   ; CHECK-NEXT:   G_BRCOND [[INT1]](s1), %bb.7
   ; CHECK-NEXT:   G_BR %bb.8
@@ -89,14 +88,11 @@ define i32 @exit_uses_latch_def(ptr noalias %a, ptr noalias %c, i32 %N, i32 %M) 
   ; CHECK-NEXT: bb.8.lastiter.stage1.bottom:
   ; CHECK-NEXT:   successors: %bb.9(0x80000000)
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT:   [[PHI8:%[0-9]+]]:_(s32) = G_PHI [[ADD3]](s32), %bb.7
-  ; CHECK-NEXT:   G_STORE [[PHI8]](s32), [[PTR_ADD1]](p0) :: (store (s32) into %ir.c.ptr.next.steady)
-  ; CHECK-NEXT:   [[ADD4:%[0-9]+]]:_(s32) = G_ADD [[ADD1]], [[PHI8]]
+  ; CHECK-NEXT:   G_STORE [[ADD3]](s32), [[PTR_ADD1]](p0) :: (store (s32) into %ir.c.ptr.next.steady)
+  ; CHECK-NEXT:   [[ADD4:%[0-9]+]]:_(s32) = G_ADD [[ADD1]], [[ADD3]]
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT: bb.9.exit:
-  ; CHECK-NEXT:   [[PHI9:%[0-9]+]]:_(s32) = G_PHI [[ADD1]](s32), %bb.8
-  ; CHECK-NEXT:   [[PHI10:%[0-9]+]]:_(s32) = G_PHI [[PHI8]](s32), %bb.8
-  ; CHECK-NEXT:   [[ADD5:%[0-9]+]]:_(s32) = G_ADD [[PHI9]], [[PHI10]]
+  ; CHECK-NEXT:   [[ADD5:%[0-9]+]]:_(s32) = G_ADD [[ADD1]], [[ADD3]]
   ; CHECK-NEXT:   [[ADD6:%[0-9]+]]:_(s32) = G_ADD [[ADD5]], [[C]]
   ; CHECK-NEXT:   $r0 = COPY [[ADD6]](s32)
   ; CHECK-NEXT:   PseudoRET implicit $lr, implicit $r0

--- a/llvm/test/CodeGen/AIE/aie2p/outer-loop-pipeliner/outer-loop-pipelining-latch-accumulate.ll
+++ b/llvm/test/CodeGen/AIE/aie2p/outer-loop-pipeliner/outer-loop-pipelining-latch-accumulate.ll
@@ -44,11 +44,11 @@ define i32 @latch_accumulate_return(ptr noalias %a, ptr noalias %c, i32 %N, i32 
   ; CHECK-NEXT: bb.4.steady.stage1.top:
   ; CHECK-NEXT:   successors: %bb.5(0x80000000)
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT:   [[PHI:%[0-9]+]]:_(s32) = G_PHI %22(s32), %bb.6, [[C1]](s32), %bb.3
+  ; CHECK-NEXT:   [[PHI:%[0-9]+]]:_(s32) = G_PHI %21(s32), %bb.6, [[C1]](s32), %bb.3
   ; CHECK-NEXT:   [[PHI1:%[0-9]+]]:_(p0) = G_PHI %15(p0), %bb.6, [[COPY]](p0), %bb.3
   ; CHECK-NEXT:   [[PHI2:%[0-9]+]]:_(p0) = G_PHI %16(p0), %bb.6, [[COPY1]](p0), %bb.3
-  ; CHECK-NEXT:   [[PHI3:%[0-9]+]]:_(s32) = G_PHI %21(s32), %bb.6, [[C1]](s32), %bb.3
-  ; CHECK-NEXT:   [[PHI4:%[0-9]+]]:_(s32) = G_PHI [[LOAD]](s32), %bb.3, %24(s32), %bb.6
+  ; CHECK-NEXT:   [[PHI3:%[0-9]+]]:_(s32) = G_PHI %20(s32), %bb.6, [[C1]](s32), %bb.3
+  ; CHECK-NEXT:   [[PHI4:%[0-9]+]]:_(s32) = G_PHI [[LOAD]](s32), %bb.3, %23(s32), %bb.6
   ; CHECK-NEXT:   G_INTRINSIC_W_SIDE_EFFECTS intrinsic(@llvm.set.loop.iterations), [[COPY3]](s32)
   ; CHECK-NEXT:   [[C2:%[0-9]+]]:_(s20) = G_CONSTANT i20 4
   ; CHECK-NEXT:   [[PTR_ADD:%[0-9]+]]:_(p0) = nuw nusw G_PTR_ADD [[PHI1]], [[C2]](s20)
@@ -66,9 +66,8 @@ define i32 @latch_accumulate_return(ptr noalias %a, ptr noalias %c, i32 %N, i32 
   ; CHECK-NEXT: bb.6.steady.stage1.bottom.and.stage0.top:
   ; CHECK-NEXT:   successors: %bb.4(0x7c000000), %bb.7(0x04000000)
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT:   [[PHI6:%[0-9]+]]:_(s32) = G_PHI [[ADD]](s32), %bb.5
-  ; CHECK-NEXT:   G_STORE [[PHI6]](s32), [[PHI2]](p0) :: (store (s32) into %ir.c.ptr.steady)
-  ; CHECK-NEXT:   [[ADD1:%[0-9]+]]:_(s32) = G_ADD [[PHI3]], [[PHI6]]
+  ; CHECK-NEXT:   G_STORE [[ADD]](s32), [[PHI2]](p0) :: (store (s32) into %ir.c.ptr.steady)
+  ; CHECK-NEXT:   [[ADD1:%[0-9]+]]:_(s32) = G_ADD [[PHI3]], [[ADD]]
   ; CHECK-NEXT:   [[ADD2:%[0-9]+]]:_(s32) = G_ADD [[PHI]], [[C]]
   ; CHECK-NEXT:   [[ICMP1:%[0-9]+]]:_(s1) = G_ICMP intpred(slt), [[ADD2]](s32), [[SUB]]
   ; CHECK-NEXT:   [[LOAD1:%[0-9]+]]:_(s32) = G_LOAD [[PTR_ADD]](p0) :: (load (s32) from %ir.a.ptr.next.steady)
@@ -83,8 +82,8 @@ define i32 @latch_accumulate_return(ptr noalias %a, ptr noalias %c, i32 %N, i32 
   ; CHECK-NEXT: bb.8.lastiter.stage1.inner.inner.header:
   ; CHECK-NEXT:   successors: %bb.8(0x7c000000), %bb.9(0x04000000)
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT:   [[PHI7:%[0-9]+]]:_(s32) = G_PHI [[C1]](s32), %bb.7, %26(s32), %bb.8
-  ; CHECK-NEXT:   [[ADD3:%[0-9]+]]:_(s32) = G_ADD [[PHI7]], [[LOAD1]]
+  ; CHECK-NEXT:   [[PHI6:%[0-9]+]]:_(s32) = G_PHI [[C1]](s32), %bb.7, %25(s32), %bb.8
+  ; CHECK-NEXT:   [[ADD3:%[0-9]+]]:_(s32) = G_ADD [[PHI6]], [[LOAD1]]
   ; CHECK-NEXT:   [[INT1:%[0-9]+]]:_(s1) = G_INTRINSIC_W_SIDE_EFFECTS intrinsic(@llvm.loop.decrement), [[C]](s32)
   ; CHECK-NEXT:   G_BRCOND [[INT1]](s1), %bb.8
   ; CHECK-NEXT:   G_BR %bb.9
@@ -92,20 +91,17 @@ define i32 @latch_accumulate_return(ptr noalias %a, ptr noalias %c, i32 %N, i32 
   ; CHECK-NEXT: bb.9.lastiter.stage1.bottom:
   ; CHECK-NEXT:   successors: %bb.10(0x80000000)
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT:   [[PHI8:%[0-9]+]]:_(s32) = G_PHI [[ADD3]](s32), %bb.8
-  ; CHECK-NEXT:   G_STORE [[PHI8]](s32), [[PTR_ADD1]](p0) :: (store (s32) into %ir.c.ptr.next.steady)
-  ; CHECK-NEXT:   [[ADD4:%[0-9]+]]:_(s32) = G_ADD [[ADD1]], [[PHI8]]
+  ; CHECK-NEXT:   G_STORE [[ADD3]](s32), [[PTR_ADD1]](p0) :: (store (s32) into %ir.c.ptr.next.steady)
+  ; CHECK-NEXT:   [[ADD4:%[0-9]+]]:_(s32) = G_ADD [[ADD1]], [[ADD3]]
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT: bb.10.exit.loopexit:
   ; CHECK-NEXT:   successors: %bb.11(0x80000000)
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT:   [[PHI9:%[0-9]+]]:_(s32) = G_PHI [[ADD1]](s32), %bb.9
-  ; CHECK-NEXT:   [[PHI10:%[0-9]+]]:_(s32) = G_PHI [[PHI8]](s32), %bb.9
-  ; CHECK-NEXT:   [[ADD5:%[0-9]+]]:_(s32) = G_ADD [[PHI9]], [[PHI10]]
+  ; CHECK-NEXT:   [[ADD5:%[0-9]+]]:_(s32) = G_ADD [[ADD1]], [[ADD3]]
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT: bb.11.exit:
-  ; CHECK-NEXT:   [[PHI11:%[0-9]+]]:_(s32) = G_PHI [[C1]](s32), %bb.1, [[ADD5]](s32), %bb.10
-  ; CHECK-NEXT:   $r0 = COPY [[PHI11]](s32)
+  ; CHECK-NEXT:   [[PHI7:%[0-9]+]]:_(s32) = G_PHI [[C1]](s32), %bb.1, [[ADD5]](s32), %bb.10
+  ; CHECK-NEXT:   $r0 = COPY [[PHI7]](s32)
   ; CHECK-NEXT:   PseudoRET implicit $lr, implicit $r0
 entry:
   %cmp.outer = icmp sgt i32 %N, 1

--- a/llvm/test/CodeGen/AIE/aie2p/outer-loop-pipeliner/outer-loop-pipelining-shared-exit.ll
+++ b/llvm/test/CodeGen/AIE/aie2p/outer-loop-pipeliner/outer-loop-pipelining-shared-exit.ll
@@ -47,10 +47,10 @@ define i32 @shared_exit(ptr noalias %a, ptr noalias %c, i32 %N, i32 %M) {
   ; CHECK-NEXT: bb.4.steady.stage1.top:
   ; CHECK-NEXT:   successors: %bb.5(0x80000000)
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT:   [[PHI:%[0-9]+]]:_(s32) = G_PHI %20(s32), %bb.6, [[C1]](s32), %bb.3
+  ; CHECK-NEXT:   [[PHI:%[0-9]+]]:_(s32) = G_PHI %19(s32), %bb.6, [[C1]](s32), %bb.3
   ; CHECK-NEXT:   [[PHI1:%[0-9]+]]:_(p0) = G_PHI %14(p0), %bb.6, [[COPY]](p0), %bb.3
   ; CHECK-NEXT:   [[PHI2:%[0-9]+]]:_(p0) = G_PHI %15(p0), %bb.6, [[COPY1]](p0), %bb.3
-  ; CHECK-NEXT:   [[PHI3:%[0-9]+]]:_(s32) = G_PHI [[LOAD]](s32), %bb.3, %22(s32), %bb.6
+  ; CHECK-NEXT:   [[PHI3:%[0-9]+]]:_(s32) = G_PHI [[LOAD]](s32), %bb.3, %21(s32), %bb.6
   ; CHECK-NEXT:   G_INTRINSIC_W_SIDE_EFFECTS intrinsic(@llvm.set.loop.iterations), [[COPY3]](s32)
   ; CHECK-NEXT:   [[C2:%[0-9]+]]:_(s20) = G_CONSTANT i20 4
   ; CHECK-NEXT:   [[PTR_ADD:%[0-9]+]]:_(p0) = nuw nusw G_PTR_ADD [[PHI1]], [[C2]](s20)
@@ -68,8 +68,7 @@ define i32 @shared_exit(ptr noalias %a, ptr noalias %c, i32 %N, i32 %M) {
   ; CHECK-NEXT: bb.6.steady.stage1.bottom.and.stage0.top:
   ; CHECK-NEXT:   successors: %bb.4(0x7c000000), %bb.7(0x04000000)
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT:   [[PHI5:%[0-9]+]]:_(s32) = G_PHI [[ADD]](s32), %bb.5
-  ; CHECK-NEXT:   G_STORE [[PHI5]](s32), [[PHI2]](p0) :: (store (s32) into %ir.c.ptr.steady)
+  ; CHECK-NEXT:   G_STORE [[ADD]](s32), [[PHI2]](p0) :: (store (s32) into %ir.c.ptr.steady)
   ; CHECK-NEXT:   [[ADD1:%[0-9]+]]:_(s32) = G_ADD [[PHI]], [[C]]
   ; CHECK-NEXT:   [[ICMP1:%[0-9]+]]:_(s1) = G_ICMP intpred(slt), [[ADD1]](s32), [[SUB]]
   ; CHECK-NEXT:   [[LOAD1:%[0-9]+]]:_(s32) = G_LOAD [[PTR_ADD]](p0) :: (load (s32) from %ir.a.ptr.next.steady)
@@ -84,8 +83,8 @@ define i32 @shared_exit(ptr noalias %a, ptr noalias %c, i32 %N, i32 %M) {
   ; CHECK-NEXT: bb.8.lastiter.stage1.inner.inner.header:
   ; CHECK-NEXT:   successors: %bb.8(0x7c000000), %bb.9(0x04000000)
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT:   [[PHI6:%[0-9]+]]:_(s32) = G_PHI [[C1]](s32), %bb.7, %24(s32), %bb.8
-  ; CHECK-NEXT:   [[ADD2:%[0-9]+]]:_(s32) = G_ADD [[PHI6]], [[LOAD1]]
+  ; CHECK-NEXT:   [[PHI5:%[0-9]+]]:_(s32) = G_PHI [[C1]](s32), %bb.7, %23(s32), %bb.8
+  ; CHECK-NEXT:   [[ADD2:%[0-9]+]]:_(s32) = G_ADD [[PHI5]], [[LOAD1]]
   ; CHECK-NEXT:   [[INT1:%[0-9]+]]:_(s1) = G_INTRINSIC_W_SIDE_EFFECTS intrinsic(@llvm.loop.decrement), [[C]](s32)
   ; CHECK-NEXT:   G_BRCOND [[INT1]](s1), %bb.8
   ; CHECK-NEXT:   G_BR %bb.9
@@ -93,12 +92,11 @@ define i32 @shared_exit(ptr noalias %a, ptr noalias %c, i32 %N, i32 %M) {
   ; CHECK-NEXT: bb.9.lastiter.stage1.bottom:
   ; CHECK-NEXT:   successors: %bb.10(0x80000000)
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT:   [[PHI7:%[0-9]+]]:_(s32) = G_PHI [[ADD2]](s32), %bb.8
-  ; CHECK-NEXT:   G_STORE [[PHI7]](s32), [[PTR_ADD1]](p0) :: (store (s32) into %ir.c.ptr.next.steady)
+  ; CHECK-NEXT:   G_STORE [[ADD2]](s32), [[PTR_ADD1]](p0) :: (store (s32) into %ir.c.ptr.next.steady)
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT: bb.10.exit:
-  ; CHECK-NEXT:   [[PHI8:%[0-9]+]]:_(s32) = G_PHI [[C1]](s32), %bb.1, [[PHI7]](s32), %bb.9
-  ; CHECK-NEXT:   $r0 = COPY [[PHI8]](s32)
+  ; CHECK-NEXT:   [[PHI6:%[0-9]+]]:_(s32) = G_PHI [[C1]](s32), %bb.1, [[ADD2]](s32), %bb.9
+  ; CHECK-NEXT:   $r0 = COPY [[PHI6]](s32)
   ; CHECK-NEXT:   PseudoRET implicit $lr, implicit $r0
 entry:
   %cmp.outer = icmp sgt i32 %N, 1

--- a/llvm/test/CodeGen/AIE/aie2p/outer-loop-pipeliner/outer-loop-pipelining-speculative-no-anchor.ll
+++ b/llvm/test/CodeGen/AIE/aie2p/outer-loop-pipeliner/outer-loop-pipelining-speculative-no-anchor.ll
@@ -47,8 +47,8 @@ define void @speculative_no_anchor(ptr %a, ptr %c, i32 %n, i32 %m) {
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   [[PHI:%[0-9]+]]:_(p0) = G_PHI %15(p0), %bb.6, [[COPY]](p0), %bb.3
   ; CHECK-NEXT:   [[PHI1:%[0-9]+]]:_(p0) = G_PHI %16(p0), %bb.6, [[COPY1]](p0), %bb.3
-  ; CHECK-NEXT:   [[PHI2:%[0-9]+]]:_(s32) = G_PHI [[LOAD]](s32), %bb.3, %21(s32), %bb.6
-  ; CHECK-NEXT:   [[PHI3:%[0-9]+]]:_(s32) = G_PHI [[INT]](s32), %bb.3, %22(s32), %bb.6
+  ; CHECK-NEXT:   [[PHI2:%[0-9]+]]:_(s32) = G_PHI [[LOAD]](s32), %bb.3, %20(s32), %bb.6
+  ; CHECK-NEXT:   [[PHI3:%[0-9]+]]:_(s32) = G_PHI [[INT]](s32), %bb.3, %21(s32), %bb.6
   ; CHECK-NEXT:   G_INTRINSIC_W_SIDE_EFFECTS intrinsic(@llvm.set.loop.iterations), [[COPY3]](s32)
   ; CHECK-NEXT:   [[C2:%[0-9]+]]:_(s20) = G_CONSTANT i20 4
   ; CHECK-NEXT:   [[PTR_ADD:%[0-9]+]]:_(p0) = nuw nusw G_PTR_ADD [[PHI]], [[C2]](s20)
@@ -66,8 +66,7 @@ define void @speculative_no_anchor(ptr %a, ptr %c, i32 %n, i32 %m) {
   ; CHECK-NEXT: bb.6.steady.stage1.bottom.and.stage0.top:
   ; CHECK-NEXT:   successors: %bb.4(0x7c000000), %bb.7(0x04000000)
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT:   [[PHI5:%[0-9]+]]:_(s32) = G_PHI [[ADD]](s32), %bb.5
-  ; CHECK-NEXT:   G_STORE [[PHI5]](s32), [[PHI1]](p0) :: (store (s32) into %ir.c.ptr.steady)
+  ; CHECK-NEXT:   G_STORE [[ADD]](s32), [[PHI1]](p0) :: (store (s32) into %ir.c.ptr.steady)
   ; CHECK-NEXT:   [[LOAD1:%[0-9]+]]:_(s32) = G_LOAD [[PTR_ADD]](p0) :: (load (s32) from %ir.a.ptr.next.steady)
   ; CHECK-NEXT:   [[INT2:%[0-9]+]]:_(s32) = G_INTRINSIC_W_SIDE_EFFECTS intrinsic(@llvm.loop.decrement.reg), [[PHI3]](s32), [[C]](s32)
   ; CHECK-NEXT:   [[ICMP1:%[0-9]+]]:_(s1) = G_ICMP intpred(ne), [[INT2]](s32), [[C1]]

--- a/llvm/test/CodeGen/AIE/aie2ps/end-to-end/gemm_mx6_loop_for_body_1.ll
+++ b/llvm/test/CodeGen/AIE/aie2ps/end-to-end/gemm_mx6_loop_for_body_1.ll
@@ -122,7 +122,7 @@ define dso_local void @gemm.if.then5(ptr %add.ptr, ptr %tdm1, i32 %cond3) #5 {
 ; ASM-NEXT:    lda dc0, [p1], #4; vmov bmlh0, bmll0
 ; ASM-NEXT:    lda dc4, [p1], #24; or r16, r10, r10; vmov cmh1, cml1
 ; ASM-NEXT:    lda dc1, [p1], #4; movs m7, dj3; movx r5, #0; vmov cmh0, cml0
-; ASM-NEXT:    lda dc5, [p1, #0]; movs m6, dj3; or r25, r5, r5; mov r17, p1
+; ASM-NEXT:    lda dc5, [p1, #0]; movs m6, dj3; or r25, r5, r5; mov r7, p1
 ; ASM-NEXT:    movs p1, p0; or r24, r5, r5; mov p0, p3
 ; ASM-NEXT:  .LBB0_1: // %steady.stage1.top
 ; ASM-NEXT:    // =>This Loop Header: Depth=1
@@ -162,7 +162,7 @@ define dso_local void @gemm.if.then5(ptr %add.ptr, ptr %tdm1, i32 %cond3) #5 {
 ; ASM-NEXT:    mov r5, p3; vmac.f dm7, dm7, fex4, fey0, r10
 ; ASM-NEXT:    vmov fewl2, fewh2; vmac.f dm6, dm6, fex4, fey0, r10
 ; ASM-NEXT:    vmov fewl0, fewh10; vmac.f dm5, dm5, fex2, fey0, r10
-; ASM-NEXT:    mov r7, p2; vmac.f dm1, dm1, fex2, fey0, r10
+; ASM-NEXT:    mov r17, p2; vmac.f dm1, dm1, fex2, fey0, r10
 ; ASM-NEXT:    vmov fewl0, fewh8; vmac.f dm4, dm4, fex10, fey3, r10
 ; ASM-NEXT:    movxm p2, #.LBB0_1; vmac.f dm3, dm3, fex0, fey3, r10
 ; ASM-NEXT:    vst.conv.bf16.fp32 cml7, [p5], #64; vmac.f dm0, dm0, fex0, fey3, r10
@@ -198,7 +198,7 @@ define dso_local void @gemm.if.then5(ptr %add.ptr, ptr %tdm1, i32 %cond3) #5 {
 ; ASM-NEXT:    vlda.fill [p0, lf0, r24]; vldb.fill [p1, lf1, r25]; vmov fewl2, fewh2; vmac.f dm6, dm6, fex4, fey0, r8
 ; ASM-NEXT:    vlda.pop fex6, [p0, lf0, r24]; vldb.pop fex10, [p1, lf1, r25]; vmov fewl0, fewh10; vmac.f dm5, dm5, fex2, fey0, r8
 ; ASM-NEXT:    vlda.pop.3d fex7, [p0, lf0, r24, d1]; vldb.pop.3d fex8, [p1, lf1, r25, d0]; movxm ls, #.LBB0_5; vmac.f dm1, dm1, fex2, fey0, r8
-; ASM-NEXT:    movs p2, r7; add.nc lc, r1, #-2; vmov fewl0, fewh8; vmac.f dm4, dm4, fex10, fey3, r8
+; ASM-NEXT:    movs p2, r17; add.nc lc, r1, #-2; vmov fewl0, fewh8; vmac.f dm4, dm4, fex10, fey3, r8
 ; ASM-NEXT:    nopa ; nopb ; movs p4, r5; movxm le, #.L_LEnd0; vmac.f dm3, dm3, fex0, fey3, r8
 ; ASM-NEXT:  .LBB0_5: // %lastiter.stage1.inner.for.body18.i
 ; ASM-NEXT:    // =>This Inner Loop Header: Depth=1
@@ -212,14 +212,14 @@ define dso_local void @gemm.if.then5(ptr %add.ptr, ptr %tdm1, i32 %cond3) #5 {
 ; ASM-NEXT:  .L_LEnd0:
 ; ASM-NEXT:    nopa ; nopb ; nops ; nopxm ; vmac.f dm3, dm3, fex0, fey3, r8
 ; ASM-NEXT:  // %bb.6: // %lastiter.stage1.bottom
-; ASM-NEXT:    padda [p5], #128; paddb [p3], #128; movs p0, r17; nopx ; mov m0, #32; vmac.f dm0, dm0, fex0, fey3, r8
-; ASM-NEXT:    lda p7, [sp, #-60]; paddb [p0], m0; movx r8, #772; vmov fewl4, fewh4; vmac.f dm2, dm2, fex8, fey3, r8 // 4-byte Folded Reload
-; ASM-NEXT:    lda p6, [sp, #-64]; or r10, r16, r16; mov m0, #-64; vmac.f dm7, dm7, fex4, fey0, r8 // 4-byte Folded Reload
-; ASM-NEXT:    paddxm [sp], #-64; st r1, [p0], m0; vmov fewl2, fewh2; vmac.f dm6, dm6, fex4, fey0, r8
-; ASM-NEXT:    st dc0, [p0], #4; vmov fewl0, fewh10; vmac.f dm5, dm5, fex2, fey0, r8
-; ASM-NEXT:    st dc4, [p0], #24; vmac.f dm1, dm1, fex2, fey0, r8
-; ASM-NEXT:    st dc1, [p0, #0]; vmov fewl0, fewh8; vmac.f dm4, dm4, fex10, fey3, r8
-; ASM-NEXT:    st dc5, [p0, #4]; vmac.f dm3, dm3, fex0, fey3, r8
+; ASM-NEXT:    padda [p5], #128; paddb [p3], #128; movs p0, r7; nopx ; mov m0, #-32; vmac.f dm0, dm0, fex0, fey3, r8
+; ASM-NEXT:    lda p7, [sp, #-60]; paddb [p0], m0; nops ; movx r8, #772; vmov fewl4, fewh4; vmac.f dm2, dm2, fex8, fey3, r8 // 4-byte Folded Reload
+; ASM-NEXT:    lda p6, [sp, #-64]; nopb ; st dc0, [p0], #4; nopx ; mov r10, r16; vmac.f dm7, dm7, fex4, fey0, r8 // 4-byte Folded Reload
+; ASM-NEXT:    paddxm [sp], #-64; st dc4, [p0], #24; vmov fewl2, fewh2; vmac.f dm6, dm6, fex4, fey0, r8
+; ASM-NEXT:    st dc1, [p0, #0]; vmov fewl0, fewh10; vmac.f dm5, dm5, fex2, fey0, r8
+; ASM-NEXT:    st dc5, [p0, #4]; vmac.f dm1, dm1, fex2, fey0, r8
+; ASM-NEXT:    vmov fewl0, fewh8; vmac.f dm4, dm4, fex10, fey3, r8
+; ASM-NEXT:    vmac.f dm3, dm3, fex0, fey3, r8
 ; ASM-NEXT:    vst.conv.bf16.fp32 cmh7, [p5], #64; vmac.f dm0, dm0, fex0, fey3, r8
 ; ASM-NEXT:    vst.conv.bf16.fp32 cml6, [p5], #64; movx r8, #772; vmac.f dm2, dm2, fex8, fey3, r8
 ; ASM-NEXT:    vst.conv.bf16.fp32 cmh6, [p5], #64; mov r8, r6


### PR DESCRIPTION
After restoring LCSSA form, simplify trivial PHI nodes at loop exits to prevent unnecessary register moves during code generation.