### PR TITLE
Martien.modulo scoreboard

### DIFF
--- a/llvm/include/llvm/CodeGen/ResourceScoreboard.h
+++ b/llvm/include/llvm/CodeGen/ResourceScoreboard.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// (c) Copyright 2023-2025 Advanced Micro Devices, Inc. or its affiliates
+// (c) Copyright 2023-2026 Advanced Micro Devices, Inc. or its affiliates
 //
 //===----------------------------------------------------------------------===//
 //
@@ -18,8 +18,10 @@
 #define LLVM_CODEGEN_RESOURCESCOREBOARD_H
 
 #include "llvm/Support/Debug.h"
+#include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/raw_ostream.h"
 #include <cassert>
+#include <climits>
 #include <vector>
 
 namespace llvm {
@@ -36,8 +38,14 @@ template <typename RC> class ResourceScoreboard {
   std::vector<RC> Cycles;
 
   /// The maximum number of cycles monitored by the Scoreboard.
-  /// For efficiency, it is rounded up to a power of two.
+  /// For the sliding-window mode, it is rounded up to a power of two.
   int Size = 0;
+
+  /// When non-zero, the scoreboard operates in modulo mode: operator[]
+  /// maps any cycle to ((Cycle + Period) % Period). There is no sliding
+  /// window; calling advance() or recede() is a contract violation.
+  /// Valid cycle indices are in [-Period, INT_MAX - Period].
+  int Period = 0;
 
   /// The scoreboard extends from Head - Lowest to Head + Highest
   /// When querying for conflicts, we have more liberty, with out-of-range
@@ -51,12 +59,20 @@ template <typename RC> class ResourceScoreboard {
 public:
   int getSize() const { return Size; }
 
-  /// Index operators. Size is checked to be a power of two. Masking it
-  /// will properly wrap around in the allocated space.
+  /// Index operators.
+  /// Sliding-window mode: Size is a power of two and masking wraps.
+  /// Modulo mode: Cycle must be in [-Period, INT_MAX - Period] so that
+  /// adding Period yields a non-negative value before the final reduction.
   const RC &operator[](int Cycle) const {
+    if (Period > 0)
+      return Cycles[(Cycle + Period) % Period];
     return Cycles[(Head + Cycle) & (Size - 1)];
   }
-  RC &operator[](int Cycle) { return Cycles[(Head + Cycle) & (Size - 1)]; }
+  RC &operator[](int Cycle) {
+    if (Period > 0)
+      return Cycles[(Cycle + Period) % Period];
+    return Cycles[(Head + Cycle) & (Size - 1)];
+  }
 
   void clear() {
     assert(Size);
@@ -86,15 +102,39 @@ public:
   }
 
   bool isInRange(int Index) const {
+    // In modulo mode the valid range is [-Period, INT_MAX - Period], which
+    // ensures that (Index + Period) neither underflows nor overflows before
+    // the final modulo reduction.
+    if (Period > 0)
+      return Index >= -Period && Index <= INT_MAX - Period;
     return Index >= LowestCycle && Index <= HighestCycle;
   }
 
+  // Configure a modulo scoreboard of size P.
+  // operator[] maps any cycle to (cycle % P), so pipeline residuals that
+  // cross the stage boundary wrap around automatically.
+  // Calling advance() or recede() on a modulo scoreboard is a contract
+  // violation and will trigger llvm_unreachable.
+  void configModulo(int P) {
+    assert(P > 0 && "Modulo period must be positive.");
+    Period = P;
+    Size = P;
+    LowestCycle = 0;
+    HighestCycle = P - 1;
+    Head = 0;
+    Cycles.assign(P, RC{});
+  }
+
   void advance() {
+    if (Period > 0)
+      llvm_unreachable("advance() is not valid in modulo mode.");
     (*this)[LowestCycle].clearResources();
     Head = (Head + 1) & (Size - 1);
   }
 
   void recede() {
+    if (Period > 0)
+      llvm_unreachable("recede() is not valid in modulo mode.");
     (*this)[HighestCycle].clearResources();
     Head = (Head - 1) & (Size - 1);
   }

--- a/llvm/lib/Target/AIE/AIEHazardRecognizer.cpp
+++ b/llvm/lib/Target/AIE/AIEHazardRecognizer.cpp
@@ -711,6 +711,35 @@ void AIEHazardRecognizer::enterResources(
   });
 }
 
+int AIEHazardRecognizer::computeInstrSelfMII(const MachineInstr &MI) const {
+  const MCInstrDesc &Desc = MI.getDesc();
+  const unsigned SchedClass =
+      TII->getSchedClass(Desc, MI.operands(), MI.getMF()->getRegInfo());
+  // Instructions without scheduling info cannot self-conflict.
+  if (SchedClass == 0 || PipelineDepth <= 0)
+    return 1;
+
+  // Scan all candidate II values. Self-conflict is not monotone: a
+  // non-conflicting II can be followed by a conflicting one (e.g. resource
+  // uses at cycles {0, 3, 7} conflict at II=7 because 7 mod 7 == 0 mod 7,
+  // even if II=5 is conflict-free). We therefore track the largest II that
+  // self-conflicts and return that value plus one.
+  int SelfMII = 1;
+  for (int II = 1; II <= PipelineDepth; ++II) {
+    std::vector<FuncUnitWrapper> SelfBoard(II);
+    if (anyStage(ItinData->getStages(SchedClass),
+                 [&](int Cycle, const FuncUnitWrapper &ThisCycle) {
+                   const int Mod = Cycle % II;
+                   if (ThisCycle.conflict(SelfBoard[Mod]))
+                     return true;
+                   SelfBoard[Mod] |= ThisCycle;
+                   return false;
+                 }))
+      SelfMII = II + 1;
+  }
+  return SelfMII;
+}
+
 unsigned AIEHazardRecognizer::getPipelineDepth() const { return PipelineDepth; }
 
 unsigned AIEHazardRecognizer::getMaxLatency() const { return MaxLatency; }

--- a/llvm/lib/Target/AIE/AIEHazardRecognizer.h
+++ b/llvm/lib/Target/AIE/AIEHazardRecognizer.h
@@ -245,6 +245,12 @@ public:
   /// stores. This is not for correctness, but for wait cycles avoidance.
   MemoryObjectPair getMemoryObjectsBits(const MachineInstr *MI) const;
 
+  /// Return the minimum II at which instruction \p MI does not conflict with
+  /// a copy of itself from the previous iteration (self-conflict). A single
+  /// instruction whose pipeline resources span more than one cycle can alias
+  /// with itself in the modulo schedule when II is too small.
+  int computeInstrSelfMII(const MachineInstr &MI) const;
+
   /// The pipeline depth is the depth of the deepest instruction.
   /// We compute that once from the itineraries.
   unsigned getPipelineDepth() const;

--- a/llvm/lib/Target/AIE/AIEPostPipeliner.cpp
+++ b/llvm/lib/Target/AIE/AIEPostPipeliner.cpp
@@ -239,6 +239,13 @@ int PostPipeliner::getResMII(MachineBasicBlock &LoopBlock) {
     Counts += getSlotCounts(MI.getOpcode(), TII);
   }
   int MII = Counts.max();
+
+  // A single instruction whose pipeline stages alias at a given II causes a
+  // resource conflict with itself in the next iteration.
+  for (auto &MI : LoopBlock) {
+    MII = std::max(MII, HR.computeInstrSelfMII(MI));
+  }
+
   LLVM_DEBUG(dbgs() << "PostPipeliner: ResMII=" << MII << "\n");
   return MII;
 }
@@ -857,8 +864,6 @@ void PostPipeliner::resetSchedule(bool FullReset) {
 }
 
 bool PostPipeliner::scheduleFirstIteration(PostPipelinerStrategy &Strategy) {
-  // Set up the basic schedule from the original instructions
-  const int PipelineDepth = HR.getPipelineDepth();
   for (int K = 0; K < NInstr; K++) {
     const int N = mostUrgent(Strategy);
     SUnit &SU = DAG->SUnits[N];
@@ -866,7 +871,7 @@ bool PostPipeliner::scheduleFirstIteration(PostPipelinerStrategy &Strategy) {
     const int Earliest = Strategy.earliest(SU);
     const int Latest = Strategy.latest(SU);
     LLVM_DEBUG(
-        dbgs() << format("  Trying %d in [%d, %d]\n", N, Earliest, Latest));
+        dbgs() << format("  Trying SU%d in [%d, %d]\n", N, Earliest, Latest));
     if (Earliest > Latest) {
       LLVM_DEBUG(dbgs() << "  Latency violation.\n");
       return false;
@@ -888,27 +893,12 @@ bool PostPipeliner::scheduleFirstIteration(PostPipelinerStrategy &Strategy) {
     const int ModCycle = Actual % II;
     const MemoryBankBits MemoryBanks = HR.getMemoryBanks(MI);
     const MemoryObjectPair ObjectBits = HR.getMemoryObjectsBits(MI);
-    int Cycle = ModCycle;
-    // We are scheduling the first iteration, checking for conflicts with other
-    // instructions that were scheduled earlier.
-    // Newly scheduled instruction have ModCycle < II,
-    // and have no conflict beyond
-    // ModCycle + PipelineDepth
-    const int Horizon =
-        std::min(II + PipelineDepth, ScoreboardSize - PipelineDepth);
-    LLVM_DEBUG(dbgs() << "  Emit in " << Cycle << "\n");
-    int Iter = 0;
-    while (Cycle < Horizon) {
-      if (HR.checkConflict(Scoreboard, *MI, Cycle)) {
-        LLVM_DEBUG(dbgs() << "Conflict in iteration N=" << Iter << "\n");
-        return false;
-      }
-
-      HR.emitInScoreboard(Scoreboard, MI->getDesc(), MemoryBanks, ObjectBits,
-                          MI->operands(), MI->getMF()->getRegInfo(), Cycle);
-      Cycle += II;
-      Iter++;
+    if (HR.checkConflict(Scoreboard, *MI, ModCycle)) {
+      LLVM_DEBUG(dbgs() << "Conflict at modulo cycle " << ModCycle << "\n");
+      return false;
     }
+    HR.emitInScoreboard(Scoreboard, MI->getDesc(), MemoryBanks, ObjectBits,
+                        MI->operands(), MI->getMF()->getRegInfo(), ModCycle);
 
     scheduleNode(SU, Actual, Strategy);
     Info.commitCycle(N);
@@ -1054,29 +1044,6 @@ bool PostPipeliner::scheduleOtherIterations(PostPipelinerStrategy &Strategy) {
     }
 
     scheduleNode(SU, Insert, Strategy);
-  }
-
-  // Make a final check on the resources. We bring a pristine scoreboard
-  // to steady state by checking and inserting NStages. Since the steady
-  // state is the busiest, we can shift the scoreboard by II after each stage.
-  // We repeat the resource schedule often enough to make the final one land
-  // after the conflict horizon of the first one.
-  const int PipelineDepth = HR.getPipelineDepth();
-  ResourceScoreboard<FuncUnitWrapper> Resources;
-  Resources.config(0, 2 * II + PipelineDepth);
-  for (int Start = 0; Start < II + PipelineDepth; Start += II) {
-    for (int I = 0; I < NInstr; I++) {
-      SUnit &SU = DAG->SUnits[I];
-      MachineInstr &MI = *SU.getInstr();
-      int ModCycle = Info[I].ModuloCycle;
-      if (HR.checkConflict(Resources, MI, ModCycle)) {
-        return false;
-      }
-      HR.emitInScoreboard(Resources, MI, MI.getDesc(), ModCycle);
-    }
-    for (int I = 0; I < II; I++) {
-      Resources.advance();
-    }
   }
 
   return true;
@@ -1602,15 +1569,10 @@ bool PostPipeliner::schedule(ScheduleDAGMI &TheDAG, int InitiationInterval) {
   II = InitiationInterval;
   DAG = &TheDAG;
 
-  // We need to set up a scoreboard that gives us some look-ahead.
-  // The look-ahead is used heuristically, to see conflicts with future
-  // iterations of nodes scheduled earlier.
-  // We will check conflicts in cycle [0, II) and we want to insert the future
-  // iterations that can conflict with it.
-  const int InsertRange = std::max(II, int(HR.getPipelineDepth()));
-
-  ScoreboardSize = InsertRange + HR.getPipelineDepth();
-  Scoreboard.config(0, ScoreboardSize - 1);
+  // Configure a modulo scoreboard of size II. Pipeline residuals that cross
+  // the stage boundary wrap around automatically via modulo indexing, so no
+  // extra slack for pipeline depth is needed.
+  Scoreboard.configModulo(II);
 
   Info.init(NInstr);
 

--- a/llvm/lib/Target/AIE/AIEPostPipeliner.cpp
+++ b/llvm/lib/Target/AIE/AIEPostPipeliner.cpp
@@ -45,6 +45,11 @@ static cl::opt<int>
     HeuristicRuns("aie-postpipeliner-heuristic-runs",
                   cl::desc("Number of runs for heuristics that converge"),
                   cl::init(20), cl::Hidden);
+static cl::opt<std::string>
+    DisabledStrategyPrefix("aie-postpipeliner-disable-strategy",
+                           cl::desc("Disable all post-pipeliner strategies"
+                                    " whose name starts with this prefix"),
+                           cl::init(""), cl::Hidden);
 
 static cl::opt<int> PresetII("aie-postpipeliner-target-ii",
                              cl::desc("II for which to allow the solver"),
@@ -1449,6 +1454,11 @@ static const ConfigStrategy::Configuration Heuristics[] = {
     {1, false, false, 1, {Prio::NodeNum}, {}}, // pure bottom up
 };
 
+bool PostPipelinerStrategy::isEnabled() {
+  return DisabledStrategyPrefix.empty() ||
+         !StringRef(name()).starts_with(DisabledStrategyPrefix);
+}
+
 bool PostPipeliner::tryApproaches() {
   DEBUG_SUMMARY(dbgs() << "-- MinLength=" << MinLength << "\n");
   int HeuristicIndex = 0;
@@ -1459,6 +1469,9 @@ bool PostPipeliner::tryApproaches() {
     const int StrategyLength = MinLength + Config.ExtraStages * II;
     ConfigStrategy S(*DAG, Info, StrategyLength, Config.TopDown,
                      Config.Alternate, Config.Components, Config.Modifiers);
+    if (!S.isEnabled()) {
+      continue;
+    }
     resetSchedule(/*FullReset=*/true);
     for (int Run = 0; Run < Config.Runs && Run < HeuristicRuns; Run++) {
       DEBUG_SUMMARY(dbgs() << "--- Strategy " << S.name() << " run=" << Run
@@ -1478,9 +1491,11 @@ bool PostPipeliner::tryApproaches() {
     DEBUG_SUMMARY(dbgs() << "    Strategy " << S.name() << " failed\n");
   }
   IterCountSlackStrategy Relaxed(*DAG, Info, MinLength + II);
-  resetSchedule(/*FullReset=*/true);
-  if (scheduleWithStrategy(Relaxed)) {
-    return true;
+  if (Relaxed.isEnabled()) {
+    resetSchedule(/*FullReset=*/true);
+    if (scheduleWithStrategy(Relaxed)) {
+      return true;
+    }
   }
 
   // TargetII is the OK from the user to spend some time reaching this II.

--- a/llvm/lib/Target/AIE/AIEPostPipeliner.h
+++ b/llvm/lib/Target/AIE/AIEPostPipeliner.h
@@ -186,6 +186,8 @@ public:
   virtual ~PostPipelinerStrategy() {};
   // Provide a name for logging purposes
   virtual std::string name() { return "PostPipelinerStrategy"; }
+  // Returns false if the strategy is disabled by a command line option.
+  bool isEnabled();
   // Choose among available alternatives
   virtual bool better(const SUnit &A, const SUnit &B) { return false; }
   // Define the earliest cycle in which to insert \p N

--- a/llvm/lib/Target/AIE/AIEPostPipeliner.h
+++ b/llvm/lib/Target/AIE/AIEPostPipeliner.h
@@ -266,7 +266,6 @@ class PostPipeliner {
 
   /// Basic modulo scheduling parameters.
   int NInstr;
-  int ScoreboardSize;
   int II = 1;
   int NStages = 0;
   int NPrologueStages = 0;

--- a/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/round-memdep.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/round-memdep.mir
@@ -20,7 +20,7 @@
   ; CHECK-LABEL: round:
   ; CHECK:         .p2align 4
   ; CHECK-NEXT:  // %bb.0: // %entry
-  ; CHECK-NEXT:    mova r1, #0; nopb ; nopx
+  ; CHECK-NEXT:    mova r1, #0; nopb ; nopxm
   ; CHECK-NEXT:    ge r1, r1, r0
   ; CHECK-NEXT:    jnz r1, #.LBB0_4
   ; CHECK-NEXT:    nop // Delay Slot 5
@@ -36,34 +36,34 @@
   ; CHECK-NEXT:    vlda.ups.s32.s8 cm0, s0, [p0], #32
   ; CHECK-NEXT:    vlda.ups.s32.s8 cm1, s0, [p0], #32
   ; CHECK-NEXT:    nop
-  ; CHECK-NEXT:    add.nc lc, r0, #-4
-  ; CHECK-NEXT:    vlda.ups.s32.s8 cm0, s0, [p0], #32; movxm ls, #.LBB0_2
-  ; CHECK-NEXT:    nopb ; vlda.ups.s32.s8 cm1, s0, [p0], #32; vsrs.s8.s32 wh0, cm0, s1; movxm le, #.L_LEnd0; nopv
-  ; CHECK-NEXT:    nopb ; nopa ; nops ; nopxm ; nopv
+  ; CHECK-NEXT:    nop
+  ; CHECK-NEXT:    vlda.ups.s32.s8 cm0, s0, [p0], #32
+  ; CHECK-NEXT:    vlda.ups.s32.s8 cm1, s0, [p0], #32; vsrs.s8.s32 wh0, cm0, s1
+  ; CHECK-NEXT:    vsrs.s8.s32 wh2, cm1, s1; add.nc lc, r0, #-4
+  ; CHECK-NEXT:    movxm ls, #.LBB0_2
+  ; CHECK-NEXT:    nopb ; vlda.ups.s32.s8 cm0, s0, [p0], #32; nops ; movxm le, #.L_LEnd0; nopv
+  ; CHECK-NEXT:    nopb ; vlda.ups.s32.s8 cm1, s0, [p0], #32; vsrs.s8.s32 wh0, cm0, s1; nopx ; vups.s32.s8 cm2, wh0, s1; nopv
   ; CHECK-NEXT:    nopb ; nopa ; vsrs.s8.s32 wh2, cm1, s1; nopxm ; nopv
-  ; CHECK-NEXT:    nopb ; vlda.ups.s32.s8 cm0, s0, [p0], #32; nops ; nopxm ; nopv
+  ; CHECK-NEXT:    nopb ; nopa ; nops ; nopxm ; nopv
   ; CHECK-NEXT:    .p2align 4
   ; CHECK-NEXT:  .LBB0_2: // %for.body
   ; CHECK-NEXT:    // =>This Inner Loop Header: Depth=1
+  ; CHECK-NEXT:    nopb ; vlda.ups.s32.s8 cm0, s0, [p0], #32; vst.srs.d8.s32 cm2, s0, [p1], #32; nopx ; vups.s32.s8 cm3, wh2, s1; nopv
   ; CHECK-NEXT:    nopb ; vlda.ups.s32.s8 cm1, s0, [p0], #32; vsrs.s8.s32 wh0, cm0, s1; nopx ; vups.s32.s8 cm2, wh0, s1; nopv
-  ; CHECK-NEXT:    nopb ; nopa ; nops ; nopxm ; nopv
   ; CHECK-NEXT:    nopb ; nopa ; vsrs.s8.s32 wh2, cm1, s1; nopxm ; nopv
   ; CHECK-NEXT:  .L_LEnd0:
-  ; CHECK-NEXT:    nopb ; vlda.ups.s32.s8 cm0, s0, [p0], #32; vst.srs.d8.s32 cm2, s0, [p1], #32; nopx ; vups.s32.s8 cm3, wh2, s1; nopv
+  ; CHECK-NEXT:    nopb ; nopa ; nops ; nopxm ; nopv
   ; CHECK-NEXT:  // %bb.3: // %loop.exit
-  ; CHECK-NEXT:    vlda.ups.s32.s8 cm1, s0, [p0], #32; vsrs.s8.s32 wh0, cm0, s1; nopx ; vups.s32.s8 cm2, wh0, s1
-  ; CHECK-NEXT:    nop
+  ; CHECK-NEXT:    nopa ; vst.srs.d8.s32 cm2, s0, [p1], #32; nopx ; vups.s32.s8 cm3, wh2, s1
+  ; CHECK-NEXT:    vsrs.s8.s32 wh0, cm0, s1; vups.s32.s8 cm2, wh0, s1
   ; CHECK-NEXT:    vsrs.s8.s32 wh2, cm1, s1
+  ; CHECK-NEXT:    vst wh6, [p0, #32]
   ; CHECK-NEXT:    vst.srs.d8.s32 cm2, s0, [p1], #32; vups.s32.s8 cm3, wh2, s1
   ; CHECK-NEXT:    vsrs.s8.s32 wh0, cm0, s1; vups.s32.s8 cm2, wh0, s1
-  ; CHECK-NEXT:    nop
   ; CHECK-NEXT:    vsrs.s8.s32 wh2, cm1, s1
-  ; CHECK-NEXT:    vst.srs.d8.s32 cm2, s0, [p1], #32; vups.s32.s8 cm3, wh2, s1
-  ; CHECK-NEXT:    vsrs.s8.s32 wh0, cm0, s1; vups.s32.s8 cm2, wh0, s1
   ; CHECK-NEXT:    nop
-  ; CHECK-NEXT:    vsrs.s8.s32 wh2, cm1, s1
   ; CHECK-NEXT:    vst.srs.d8.s32 cm2, s0, [p1], #32; vups.s32.s8 cm3, wh2, s1
-  ; CHECK-NEXT:    vst wh6, [p0, #32]; vups.s32.s8 cm2, wh0, s1
+  ; CHECK-NEXT:    vups.s32.s8 cm2, wh0, s1
   ; CHECK-NEXT:    nop
   ; CHECK-NEXT:    nop
   ; CHECK-NEXT:    vst.srs.d8.s32 cm2, s0, [p1], #32; vups.s32.s8 cm3, wh2, s1

--- a/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/round-war.mir
+++ b/llvm/test/CodeGen/AIE/aie2/schedule/postpipeliner/round-war.mir
@@ -19,7 +19,7 @@
   ; CHECK-LABEL: round:
   ; CHECK:         .p2align 4
   ; CHECK-NEXT:  // %bb.0: // %entry
-  ; CHECK-NEXT:    mova r1, #0; nopb ; nopxm ; nops
+  ; CHECK-NEXT:    mova r1, #0; nopb ; nopxm
   ; CHECK-NEXT:    ge r1, r1, r0
   ; CHECK-NEXT:    jnz r1, #.LBB0_4
   ; CHECK-NEXT:    nop // Delay Slot 5
@@ -29,45 +29,45 @@
   ; CHECK-NEXT:    nop // Delay Slot 1
   ; CHECK-NEXT:  // %bb.1: // %for.body.preheader
   ; CHECK-NEXT:    vlda.ups.s32.s8 cm0, s0, [p0], #32
-  ; CHECK-NEXT:    nop
-  ; CHECK-NEXT:    nop
   ; CHECK-NEXT:    vlda.ups.s32.s8 cm1, s0, [p0], #32
+  ; CHECK-NEXT:    nop
+  ; CHECK-NEXT:    nop
   ; CHECK-NEXT:    vlda.ups.s32.s8 cm0, s0, [p0], #32
-  ; CHECK-NEXT:    nop
-  ; CHECK-NEXT:    nop
   ; CHECK-NEXT:    vlda.ups.s32.s8 cm1, s0, [p0], #32
+  ; CHECK-NEXT:    nop
+  ; CHECK-NEXT:    nop
   ; CHECK-NEXT:    vlda.ups.s32.s8 cm0, s0, [p0], #32
-  ; CHECK-NEXT:    vsrs.s8.s32 wh0, cm0, s1
-  ; CHECK-NEXT:    add.nc lc, r0, #-4
-  ; CHECK-NEXT:    vlda.ups.s32.s8 cm1, s0, [p0], #32; movxm ls, #.LBB0_2
-  ; CHECK-NEXT:    nopb ; vlda.ups.s32.s8 cm0, s0, [p0], #32; vsrs.s8.s32 wh2, cm1, s1; movxm le, #.L_LEnd0; nopv
-  ; CHECK-NEXT:    nopb ; nopa ; vsrs.s8.s32 wh0, cm0, s1; nopxm ; nopv
+  ; CHECK-NEXT:    vlda.ups.s32.s8 cm1, s0, [p0], #32; vsrs.s8.s32 wh0, cm0, s1
+  ; CHECK-NEXT:    vsrs.s8.s32 wh2, cm1, s1; add.nc lc, r0, #-4
+  ; CHECK-NEXT:    movxm ls, #.LBB0_2
+  ; CHECK-NEXT:    nopb ; vlda.ups.s32.s8 cm0, s0, [p0], #32; nops ; movxm le, #.L_LEnd0; nopv
+  ; CHECK-NEXT:    nopb ; vlda.ups.s32.s8 cm1, s0, [p0], #32; vsrs.s8.s32 wh0, cm0, s1; nopx ; vups.s32.s8 cm2, wh0, s1; nopv
+  ; CHECK-NEXT:    nopb ; nopa ; vsrs.s8.s32 wh2, cm1, s1; nopxm ; nopv
   ; CHECK-NEXT:    nopb ; nopa ; nops ; nopx ; mov crSRSSign, r0; nopv
-  ; CHECK-NEXT:    nopb ; vlda.ups.s32.s8 cm1, s0, [p0], #32; nops ; nopx ; vups.s32.s8 cm2, wh0, s1; nopv
   ; CHECK-NEXT:    .p2align 4
   ; CHECK-NEXT:  .LBB0_2: // %for.body
   ; CHECK-NEXT:    // =>This Inner Loop Header: Depth=1
-  ; CHECK-NEXT:    nopb ; vlda.ups.s32.s8 cm0, s0, [p0], #32; vsrs.s8.s32 wh2, cm1, s1; nopx ; vups.s32.s8 cm3, wh2, s1; nopv
-  ; CHECK-NEXT:    nopb ; nopa ; vsrs.s8.s32 wh0, cm0, s1; nopxm ; nopv
-  ; CHECK-NEXT:    nopb ; nopa ; vst.srs.d8.s32 cm2, s0, [p1], #32; nopxm ; nopv
+  ; CHECK-NEXT:    nopb ; vlda.ups.s32.s8 cm0, s0, [p0], #32; vst.srs.d8.s32 cm2, s0, [p1], #32; nopx ; vups.s32.s8 cm3, wh2, s1; nopv
+  ; CHECK-NEXT:    nopb ; vlda.ups.s32.s8 cm1, s0, [p0], #32; vsrs.s8.s32 wh0, cm0, s1; nopx ; vups.s32.s8 cm2, wh0, s1; nopv
+  ; CHECK-NEXT:    nopb ; nopa ; vsrs.s8.s32 wh2, cm1, s1; nopxm ; nopv
   ; CHECK-NEXT:  .L_LEnd0:
-  ; CHECK-NEXT:    nopb ; vlda.ups.s32.s8 cm1, s0, [p0], #32; vst.srs.d8.s32 cm3, s0, [p1], #32; nopx ; vups.s32.s8 cm2, wh0, s1; nopv
+  ; CHECK-NEXT:    nopb ; nopa ; vst.srs.d8.s32 cm3, s0, [p1], #32; nopxm ; nopv
   ; CHECK-NEXT:  // %bb.3: // %loop.exit
-  ; CHECK-NEXT:    nopa ; vsrs.s8.s32 wh2, cm1, s1; nopx ; vups.s32.s8 cm3, wh2, s1
-  ; CHECK-NEXT:    vsrs.s8.s32 wh0, cm0, s1
-  ; CHECK-NEXT:    vst.srs.d8.s32 cm2, s0, [p1], #32
-  ; CHECK-NEXT:    vst.srs.d8.s32 cm3, s0, [p1], #32; vups.s32.s8 cm2, wh0, s1
-  ; CHECK-NEXT:    vsrs.s8.s32 wh2, cm1, s1; vups.s32.s8 cm3, wh2, s1
-  ; CHECK-NEXT:    vsrs.s8.s32 wh0, cm0, s1
-  ; CHECK-NEXT:    vst.srs.d8.s32 cm2, s0, [p1], #32
-  ; CHECK-NEXT:    vst.srs.d8.s32 cm3, s0, [p1], #32; vups.s32.s8 cm2, wh0, s1
-  ; CHECK-NEXT:    vsrs.s8.s32 wh2, cm1, s1; vups.s32.s8 cm3, wh2, s1
+  ; CHECK-NEXT:    nopa ; nopb ; nopx ; vups.s32.s8 cm3, wh2, s1; vst.srs.d8.s32 cm2, s0, [p1], #32
+  ; CHECK-NEXT:    vsrs.s8.s32 wh0, cm0, s1; vups.s32.s8 cm2, wh0, s1
+  ; CHECK-NEXT:    vsrs.s8.s32 wh2, cm1, s1
+  ; CHECK-NEXT:    vst.srs.d8.s32 cm3, s0, [p1], #32
+  ; CHECK-NEXT:    vst.srs.d8.s32 cm2, s0, [p1], #32; vups.s32.s8 cm3, wh2, s1
+  ; CHECK-NEXT:    vsrs.s8.s32 wh0, cm0, s1; vups.s32.s8 cm2, wh0, s1
+  ; CHECK-NEXT:    vsrs.s8.s32 wh2, cm1, s1
+  ; CHECK-NEXT:    vst.srs.d8.s32 cm3, s0, [p1], #32
+  ; CHECK-NEXT:    vst.srs.d8.s32 cm2, s0, [p1], #32; vups.s32.s8 cm3, wh2, s1
+  ; CHECK-NEXT:    vups.s32.s8 cm2, wh0, s1
   ; CHECK-NEXT:    nop
-  ; CHECK-NEXT:    vst.srs.d8.s32 cm2, s0, [p1], #32
-  ; CHECK-NEXT:    vst.srs.d8.s32 cm3, s0, [p1], #32; vups.s32.s8 cm2, wh0, s1
-  ; CHECK-NEXT:    vups.s32.s8 cm3, wh2, s1
+  ; CHECK-NEXT:    vst.srs.d8.s32 cm3, s0, [p1], #32
+  ; CHECK-NEXT:    vst.srs.d8.s32 cm2, s0, [p1], #32; vups.s32.s8 cm3, wh2, s1
   ; CHECK-NEXT:    nop
-  ; CHECK-NEXT:    vst.srs.d8.s32 cm2, s0, [p1], #32
+  ; CHECK-NEXT:    nop
   ; CHECK-NEXT:    vst.srs.d8.s32 cm3, s0, [p1], #32
   ; CHECK-NEXT:    nop
   ; CHECK-NEXT:    nop

--- a/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/pipelined-lock-ptr-fifo-alias.ll
+++ b/llvm/test/CodeGen/AIE/aie2p/schedule/postpipeliner/pipelined-lock-ptr-fifo-alias.ll
@@ -38,35 +38,33 @@ declare { ptr, <32 x i32>, i32 }
 define void @pipelined_acquire_ptr_fifo_same(ptr noalias %io, i32 %lock_id) {
 ; CHECK-LABEL: pipelined_acquire_ptr_fifo_same:
 ; CHECK:       // %bb.0: // %entry
-; CHECK-NEXT:    lda r1, [p0, #4]; nopxm
+; CHECK-NEXT:    lda r1, [p0, #4]; nopb ; nopxm
 ; CHECK-NEXT:    lda r2, [p0, #8]
 ; CHECK-NEXT:    lda r27, [p0, #12]
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
-; CHECK-NEXT:    nop
 ; CHECK-NEXT:    movxm ls, #.LBB0_1
 ; CHECK-NEXT:    movxm le, #.L_LEnd0
+; CHECK-NEXT:    paddxm [sp], #64
 ; CHECK-NEXT:    mova r2, #-1; sel.eqz r1, r1, r2, r27
 ; CHECK-NEXT:    acq r0, r2
-; CHECK-NEXT:    paddxm [sp], #64
 ; CHECK-NEXT:    mova r3, #16; movx r24, #0; mov p1, sp
 ; CHECK-NEXT:    padda [p1], #-64; nopb ; nops ; movx r30, #63; add.nc lc, r3, #0; nopv
 ; CHECK-NEXT:  .LBB0_1: // %for.body
 ; CHECK-NEXT:    // =>This Inner Loop Header: Depth=1
 ; CHECK-NEXT:    nopa ; nopb ; movs p0, r1; nopxm ; nopv
+; CHECK-NEXT:    nopa ; nopb ; nops ; nopxm ; nopv
 ; CHECK-NEXT:    nopa ; vldb.popx.512 x2, [p0, lf0, r24]; nops ; nopxm ; nopv
 ; CHECK-NEXT:    nopa ; nopb ; nops ; nopx ; mov r1, p0; nopv
 ; CHECK-NEXT:    nopa ; nopb ; nops ; nopxm ; nopv
-; CHECK-NEXT:    nopa ; nopb ; nops ; nopxm ; nopv
+; CHECK-NEXT:    nopa ; nopx
 ; CHECK-NEXT:    st.s8 r0, [p1, #0]
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
-; CHECK-NEXT:    vextract.8 r0, x2, #0, vaddsign1
-; CHECK-NEXT:    nop
 ; CHECK-NEXT:  .L_LEnd0:
-; CHECK-NEXT:    nopa ; nopb ; nops ; nopxm ; nopv
+; CHECK-NEXT:    nopa ; nopb ; nops ; nopx ; vextract.8 r0, x2, #0, vaddsign1; nopv
 ; CHECK-NEXT:  // %bb.2: // %for.exit
 ; CHECK-NEXT:    nopa ; nopb ; nops ; ret lr; nopm ; nopv
 ; CHECK-NEXT:    nopx // Delay Slot 5

--- a/llvm/unittests/CodeGen/ResourceScoreboardTest.cpp
+++ b/llvm/unittests/CodeGen/ResourceScoreboardTest.cpp
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-// (c) Copyright 2025 Advanced Micro Devices, Inc. or its affiliates
+// (c) Copyright 2025-2026 Advanced Micro Devices, Inc. or its affiliates
 //
 //===----------------------------------------------------------------------===//
 // This tests the ResourceScoreboard template, which represents a sliding
@@ -15,6 +15,8 @@
 #include "gtest/gtest.h"
 
 #include "llvm/CodeGen/ResourceScoreboard.h"
+
+namespace {
 
 // Something basic that can accommodate some methods.
 class RC {
@@ -30,6 +32,19 @@ public:
 };
 
 using SB = llvm::ResourceScoreboard<RC>;
+
+// Compare two modulo scoreboards slot-by-slot over the full period.
+// Both scoreboards must have the same period (getSize()). Every slot is
+// compared so that tests also verify that unintended slots were not modified.
+void compareModulo(const SB &Actual, const SB &Expected) {
+  const int Period = Actual.getSize();
+  ASSERT_EQ(Period, Expected.getSize());
+  for (int I = 0; I < Period; I++) {
+    EXPECT_EQ(Actual[I], Expected[I]) << "slot " << I << " differs";
+  }
+}
+
+} // namespace
 
 TEST(ResourceScoreboard, Construct) {
   SB Empty;
@@ -143,4 +158,132 @@ TEST(ResourceScoreboard, SlidingWindow) {
   for (int I = 0; I <= 11; I++) {
     EXPECT_EQ(Scoreboard[11 - I], 31 - I);
   }
+}
+
+// Modulo mode: configModulo(P) does not round size up to a power of two.
+// All slots must start empty.
+TEST(ResourceScoreboard, ModuloConstruct) {
+  SB Scoreboard;
+  Scoreboard.configModulo(7);
+  EXPECT_EQ(Scoreboard.getSize(), 7);
+
+  SB Expected;
+  Expected.configModulo(7);
+  // Expected is all-empty by construction.
+  compareModulo(Scoreboard, Expected);
+}
+
+// Modulo mode: all slots in [0, P) can be independently written and read.
+// No slot bleeds into its neighbours.
+TEST(ResourceScoreboard, ModuloPopulate) {
+  SB Scoreboard;
+  Scoreboard.configModulo(6);
+  for (int I = 0; I < 6; I++) {
+    Scoreboard[I] = RC(I + 1);
+  }
+
+  SB Expected;
+  Expected.configModulo(6);
+  for (int I = 0; I < 6; I++) {
+    Expected[I] = RC(I + 1);
+  }
+  compareModulo(Scoreboard, Expected);
+}
+
+// Modulo mode: cycle K and cycle K+P reach the same physical slot.
+// Writing via cycle K+P must not disturb any other slot.
+TEST(ResourceScoreboard, ModuloWrapping) {
+  SB Scoreboard;
+  Scoreboard.configModulo(5);
+
+  // Write at cycle 2; verify via cycle 2+5=7 and check no other slot changed.
+  Scoreboard[2] = RC(42);
+  EXPECT_EQ(Scoreboard[7], RC(42));
+
+  SB Expected;
+  Expected.configModulo(5);
+  Expected[2] = RC(42);
+  compareModulo(Scoreboard, Expected);
+
+  // Overwrite via cycle 7; only slot 2 must change.
+  Scoreboard[7] = RC(99);
+  Expected[2] = RC(99);
+  compareModulo(Scoreboard, Expected);
+}
+
+// Modulo mode: negative indices wrap correctly.
+// Cycle -1 aliases slot P-1; cycle -P aliases slot 0.
+// No other slot must be affected.
+TEST(ResourceScoreboard, ModuloNegativeIndices) {
+  SB Scoreboard;
+  Scoreboard.configModulo(4);
+
+  Scoreboard[-1] = RC(10);
+  SB Expected;
+  Expected.configModulo(4);
+  Expected[3] = RC(10);
+  compareModulo(Scoreboard, Expected);
+
+  Scoreboard[-4] = RC(20);
+  Expected[0] = RC(20);
+  compareModulo(Scoreboard, Expected);
+}
+
+// Modulo mode: clear() resets every slot to the empty state.
+TEST(ResourceScoreboard, ModuloClear) {
+  SB Scoreboard;
+  Scoreboard.configModulo(5);
+  for (int I = 0; I < 5; I++) {
+    Scoreboard[I] = RC(I + 1);
+  }
+  Scoreboard.clear();
+
+  // Expected is all-empty.
+  SB Expected;
+  Expected.configModulo(5);
+  compareModulo(Scoreboard, Expected);
+}
+
+// Modulo mode: isInRange() accepts [-Period, INT_MAX - Period] and rejects
+// anything below -Period.
+TEST(ResourceScoreboard, ModuloIsInRange) {
+  SB Scoreboard;
+  Scoreboard.configModulo(4);
+  // Every non-negative cycle is in range.
+  EXPECT_TRUE(Scoreboard.isInRange(0));
+  EXPECT_TRUE(Scoreboard.isInRange(3));
+  EXPECT_TRUE(Scoreboard.isInRange(100));
+  // Negative indices down to -Period are in range.
+  EXPECT_TRUE(Scoreboard.isInRange(-1));
+  EXPECT_TRUE(Scoreboard.isInRange(-4));
+  // Indices below -Period are out of range.
+  EXPECT_FALSE(Scoreboard.isInRange(-5));
+  EXPECT_FALSE(Scoreboard.isInRange(-100));
+}
+
+// Modulo mode: a resource use at the last cycle of the period and at the first
+// cycle of the next iteration (period + 0) both map to the same slot, so an
+// itinerary that straddles the stage boundary is captured correctly.
+// The full scoreboard state is verified after each write.
+TEST(ResourceScoreboard, ModuloStageBoundaryWrap) {
+  SB Scoreboard;
+  // Period of 4: slots 0, 1, 2, 3.
+  Scoreboard.configModulo(4);
+
+  // Occupy the last slot of the period.
+  Scoreboard[3] = RC(1);
+  SB Expected;
+  Expected.configModulo(4);
+  Expected[3] = RC(1);
+  compareModulo(Scoreboard, Expected);
+
+  // Cycle 4 wraps to slot 0; only slot 0 must change.
+  Scoreboard[4] = RC(2);
+  Expected[0] = RC(2);
+  compareModulo(Scoreboard, Expected);
+
+  // Cycle -1 aliases slot 3; only slot 3 must change.
+  Scoreboard[-1] = RC(3);
+  Expected[3] = RC(3);
+  compareModulo(Scoreboard, Expected);
 }


### PR DESCRIPTION
This adds a true modulo mode to ResourceScoreboard. Refactoring the postpipeliner with this, removes all nitty gritty details of emulating a modulo scoreboard in a linear scoreboard, for instance the final check in scheduleOtherIterations where we bring the linear scoreboard up to steady state.
The PR is mostly NFC. The unit tests show slightly different schedules, which are caused by preventing infeasible schedules to be proposed to scheduleOtherIterations, avoiding conflicts in scheduleFirstIteration instead.
We gain readibility, we have less rejections in the final round and, last but not least, logging of the modulo scoreboard is much more concise and understandable.