### PR TITLE
[AIEX] Guard matchMostlySequentialShuffleWithInsertions to only create legal G_AIE_UNPAD_VECTOR

### DIFF
--- a/llvm/lib/Target/AIE/AIECombinerHelper.cpp
+++ b/llvm/lib/Target/AIE/AIECombinerHelper.cpp
@@ -4324,6 +4324,16 @@ bool llvm::matchMostlySequentialShuffleWithInsertions(MachineInstr &MI,
 
   const bool IsShrinking = NumSrcElems > NumDstElems;
 
+  // Shrinking shuffles are implemented below with a G_AIE_UNPAD_VECTOR of
+  // Src1Reg. That is only valid when the source vector is a legal type to
+  // unpad.
+  if (IsShrinking) {
+    const AIEBaseInstrInfo &TII = *static_cast<const AIEBaseInstrInfo *>(
+        MI.getMF()->getSubtarget().getInstrInfo());
+    if (!TII.isLegalTypeToUnpad(Src1Ty))
+      return false;
+  }
+
   const LLT ElemTy = Src1Ty.getElementType();
 
   unsigned MaxNumInsertions;

--- a/llvm/test/CodeGen/AIE/GlobalISel/prelegalizercombiner-shuffle-vector.mir
+++ b/llvm/test/CodeGen/AIE/GlobalISel/prelegalizercombiner-shuffle-vector.mir
@@ -1744,11 +1744,11 @@ body:             |
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<16 x s32>) = COPY $x0
     ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(<16 x s32>) = COPY $x1
-    ; CHECK-NEXT: [[UNPAD:%[0-9]+]]:_(<8 x s32>) = G_AIE_UNPAD_VECTOR [[COPY]](<16 x s32>)
+    ; CHECK-NEXT: [[AIE_UNPAD_VECTOR:%[0-9]+]]:_(<8 x s32>) = G_AIE_UNPAD_VECTOR [[COPY]](<16 x s32>)
     ; CHECK-NEXT: [[C:%[0-9]+]]:_(s32) = G_CONSTANT i32 0
     ; CHECK-NEXT: [[EVEC:%[0-9]+]]:_(s32) = G_EXTRACT_VECTOR_ELT [[COPY1]](<16 x s32>), [[C]](s32)
     ; CHECK-NEXT: [[C1:%[0-9]+]]:_(s32) = G_CONSTANT i32 1
-    ; CHECK-NEXT: [[IVEC:%[0-9]+]]:_(<8 x s32>) = G_INSERT_VECTOR_ELT [[UNPAD]], [[EVEC]](s32), [[C1]](s32)
+    ; CHECK-NEXT: [[IVEC:%[0-9]+]]:_(<8 x s32>) = G_INSERT_VECTOR_ELT [[AIE_UNPAD_VECTOR]], [[EVEC]](s32), [[C1]](s32)
     ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[IVEC]](<8 x s32>)
     %0:_(<16 x s32>) = COPY $x0
     %1:_(<16 x s32>) = COPY $x1
@@ -1768,11 +1768,11 @@ body:             |
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<16 x s32>) = COPY $x0
     ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(<16 x s32>) = COPY $x1
-    ; CHECK-NEXT: [[UNPAD:%[0-9]+]]:_(<8 x s32>) = G_AIE_UNPAD_VECTOR [[COPY]](<16 x s32>)
+    ; CHECK-NEXT: [[AIE_UNPAD_VECTOR:%[0-9]+]]:_(<8 x s32>) = G_AIE_UNPAD_VECTOR [[COPY]](<16 x s32>)
     ; CHECK-NEXT: [[C:%[0-9]+]]:_(s32) = G_CONSTANT i32 0
     ; CHECK-NEXT: [[EVEC:%[0-9]+]]:_(s32) = G_EXTRACT_VECTOR_ELT [[COPY1]](<16 x s32>), [[C]](s32)
     ; CHECK-NEXT: [[C1:%[0-9]+]]:_(s32) = G_CONSTANT i32 2
-    ; CHECK-NEXT: [[IVEC:%[0-9]+]]:_(<8 x s32>) = G_INSERT_VECTOR_ELT [[UNPAD]], [[EVEC]](s32), [[C1]](s32)
+    ; CHECK-NEXT: [[IVEC:%[0-9]+]]:_(<8 x s32>) = G_INSERT_VECTOR_ELT [[AIE_UNPAD_VECTOR]], [[EVEC]](s32), [[C1]](s32)
     ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[IVEC]](<8 x s32>)
     %0:_(<16 x s32>) = COPY $x0
     %1:_(<16 x s32>) = COPY $x1
@@ -1792,14 +1792,38 @@ body:             |
     ; CHECK-NEXT: {{  $}}
     ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<16 x s32>) = COPY $x0
     ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(<16 x s32>) = COPY $x1
-    ; CHECK-NEXT: [[UNPAD:%[0-9]+]]:_(<8 x s32>) = G_AIE_UNPAD_VECTOR [[COPY]](<16 x s32>)
+    ; CHECK-NEXT: [[AIE_UNPAD_VECTOR:%[0-9]+]]:_(<8 x s32>) = G_AIE_UNPAD_VECTOR [[COPY]](<16 x s32>)
     ; CHECK-NEXT: [[C:%[0-9]+]]:_(s32) = G_CONSTANT i32 0
     ; CHECK-NEXT: [[EVEC:%[0-9]+]]:_(s32) = G_EXTRACT_VECTOR_ELT [[COPY1]](<16 x s32>), [[C]](s32)
     ; CHECK-NEXT: [[C1:%[0-9]+]]:_(s32) = G_CONSTANT i32 3
-    ; CHECK-NEXT: [[IVEC:%[0-9]+]]:_(<8 x s32>) = G_INSERT_VECTOR_ELT [[UNPAD]], [[EVEC]](s32), [[C1]](s32)
+    ; CHECK-NEXT: [[IVEC:%[0-9]+]]:_(<8 x s32>) = G_INSERT_VECTOR_ELT [[AIE_UNPAD_VECTOR]], [[EVEC]](s32), [[C1]](s32)
     ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[IVEC]](<8 x s32>)
     %0:_(<16 x s32>) = COPY $x0
     %1:_(<16 x s32>) = COPY $x1
     %2:_(<8 x s32>) = G_SHUFFLE_VECTOR %0(<16 x s32>), %1, shufflemask(0, 1, 2, 16, 4, 5, 6, 7)
+    PseudoRET implicit $lr, implicit %2
+...
+
+---
+# Negative test: a shrinking, mostly-sequential shuffle whose source is a
+# 1024-bit vector must NOT be combined into a G_AIE_UNPAD_VECTOR. Only 256- and
+# 512-bit sources are legal to unpad (isLegalTypeToUnpad); a 256<-1024 unpad
+# would be illegal and crash the instruction selector. The combine must bail
+# out and leave the G_SHUFFLE_VECTOR untouched.
+name: shuffle_vector_shrinking_insert_1024src_no_unpad
+tracksRegLiveness: true
+body:             |
+  bb.1:
+    liveins: $y0, $y1
+    ; CHECK-LABEL: name: shuffle_vector_shrinking_insert_1024src_no_unpad
+    ; CHECK: liveins: $y0, $y1
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<32 x s32>) = COPY $y0
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(<32 x s32>) = COPY $y1
+    ; CHECK-NEXT: [[SHUF:%[0-9]+]]:_(<8 x s32>) = G_SHUFFLE_VECTOR [[COPY]](<32 x s32>), [[COPY1]], shufflemask(0, 1, 2, 32, 4, 5, 6, 7)
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[SHUF]](<8 x s32>)
+    %0:_(<32 x s32>) = COPY $y0
+    %1:_(<32 x s32>) = COPY $y1
+    %2:_(<8 x s32>) = G_SHUFFLE_VECTOR %0(<32 x s32>), %1, shufflemask(0, 1, 2, 32, 4, 5, 6, 7)
     PseudoRET implicit $lr, implicit %2
 ...


### PR DESCRIPTION
This was missing a isLegalTypeToUnpad check, potentially creating illegal G_AIE_UNPAD_VECTOR that cannot be selected later.