### PR TITLE
[AIEX] Add AIELoopUtils infrastructure for OLP structure analysis

### DIFF
--- a/llvm/lib/Target/AIE/Utils/AIELoopUtils.cpp
+++ b/llvm/lib/Target/AIE/Utils/AIELoopUtils.cpp
@@ -341,4 +341,121 @@ std::optional<unsigned> getSWPStageCount(const MachineBasicBlock &LoopBB,
   return Result;
 }
 
+bool isOuterLoopSpeculative(const MachineBasicBlock &LoopLatch) {
+  return getLoopMetadata(getLoopID(LoopLatch), OuterLoopSpeculativeKey)
+      .has_value();
+}
+
+std::optional<OuterLoopStructure>
+OuterLoopStructure::tryBuildFrom(MachineBasicBlock &OuterLatch) {
+  // Verify this is an OLP latch
+  if (!isOuterLoopPipelined(OuterLatch))
+    return std::nullopt;
+
+  // Helper to find the first predecessor/successor that isn't the excluded one.
+  auto FindOther = [](auto &&Range,
+                      MachineBasicBlock *Exclude) -> MachineBasicBlock * {
+    for (MachineBasicBlock *MBB : Range) {
+      if (MBB != Exclude)
+        return MBB;
+    }
+    return nullptr;
+  };
+
+  OuterLoopStructure OLS;
+  OLS.SteadyBottom = &OuterLatch;
+  OLS.Speculative = isOuterLoopSpeculative(OuterLatch);
+
+  // SteadyInner is the single predecessor of the latch - always a single-block
+  // loop in valid OLP output.
+  OLS.SteadyInner = *OuterLatch.pred_begin();
+  assert(isSingleMBBLoop(OLS.SteadyInner) &&
+         "OLP latch predecessor must be a single-block inner loop");
+
+  // Find SteadyTop: predecessor of SteadyInner (not the loop back-edge)
+  OLS.SteadyTop = FindOther(OLS.SteadyInner->predecessors(), OLS.SteadyInner);
+  if (!OLS.SteadyTop)
+    return std::nullopt;
+  assert(OLS.SteadyTop->isPredecessor(&OuterLatch) &&
+         "SteadyTop must have OuterLatch as back-edge predecessor");
+
+  // Find OuterPreheader: predecessor of SteadyTop that is not SteadyBottom
+  // (the back-edge). This is the entry block to the outer loop.
+  OLS.OuterPreheader =
+      FindOther(OLS.SteadyTop->predecessors(), OLS.SteadyBottom);
+  // OuterPreheader is optional - don't fail if not found
+
+  // For speculative loops, we're done - no peeled iteration region exists
+  if (OLS.Speculative) {
+    LLVM_DEBUG(dbgs() << "Built speculative OLP structure: SteadyInner="
+                      << OLS.SteadyInner->getName() << "\n");
+    return OLS;
+  }
+
+  // Find PeeledIterTop: non-looping successor of the outer latch
+  OLS.PeeledIterTop = FindOther(OuterLatch.successors(), OLS.SteadyTop);
+  if (!OLS.PeeledIterTop)
+    return std::nullopt;
+
+  // Find PeeledIterInner: successor of PeeledIterTop that is a single-block
+  // loop
+  for (MachineBasicBlock *Succ : OLS.PeeledIterTop->successors()) {
+    if (isSingleMBBLoop(Succ)) {
+      OLS.PeeledIterInner = Succ;
+      break;
+    }
+  }
+  if (!OLS.PeeledIterInner)
+    return std::nullopt;
+
+  // Find PeeledIterBottom: exit successor of PeeledIterInner
+  OLS.PeeledIterBottom =
+      FindOther(OLS.PeeledIterInner->successors(), OLS.PeeledIterInner);
+  if (!OLS.PeeledIterBottom)
+    return std::nullopt;
+
+  LLVM_DEBUG(dbgs() << "Built OLP structure: SteadyInner="
+                    << OLS.SteadyInner->getName() << " PeeledIterInner="
+                    << OLS.PeeledIterInner->getName() << "\n");
+  return OLS;
+}
+
+bool OuterLoopStructure::hasMatchingInnerLoops() const {
+  if (!SteadyInner || !PeeledIterInner)
+    return false;
+
+  // Check same number of instructions
+  if (SteadyInner->size() != PeeledIterInner->size()) {
+    LLVM_DEBUG(dbgs() << "Inner loop size mismatch: steady="
+                      << SteadyInner->size()
+                      << " peeled=" << PeeledIterInner->size() << "\n");
+    return false;
+  }
+
+  // Check matching opcodes in order
+  auto SI = SteadyInner->begin();
+  auto PI = PeeledIterInner->begin();
+  unsigned InstIdx = 0;
+
+  for (; SI != SteadyInner->end(); ++SI, ++PI, ++InstIdx) {
+    if (SI->getOpcode() != PI->getOpcode()) {
+      LLVM_DEBUG(dbgs() << "Opcode mismatch at instruction " << InstIdx
+                        << ": steady=" << SI->getOpcode()
+                        << " peeled=" << PI->getOpcode() << "\n");
+      return false;
+    }
+
+    // Also verify same number of operands for consistency
+    if (SI->getNumOperands() != PI->getNumOperands()) {
+      LLVM_DEBUG(dbgs() << "Operand count mismatch at instruction " << InstIdx
+                        << "\n");
+      return false;
+    }
+  }
+
+  LLVM_DEBUG(dbgs() << "Inner loops match: " << SteadyInner->size()
+                    << " instructions\n");
+  return true;
+}
+
 } // namespace llvm::AIELoopUtils

--- a/llvm/lib/Target/AIE/Utils/AIELoopUtils.h
+++ b/llvm/lib/Target/AIE/Utils/AIELoopUtils.h
@@ -166,6 +166,62 @@ findPrologueEpilogue(const MachineBasicBlock &LoopBB);
 std::optional<unsigned> getSWPStageCount(const MachineBasicBlock &LoopBB,
                                          const AIEBaseInstrInfo &TII);
 
+/// Returns true if the loop was pipelined with speculative last iteration.
+/// In speculative mode, there's no separate peeled-iteration region.
+bool isOuterLoopSpeculative(const MachineBasicBlock &LoopLatch);
+
+/// Structure representing an outer-loop-pipelined loop at MIR level.
+/// Built from the outer loop latch that has the OLP success marker.
+///
+/// OLP creates the following CFG structure (non-speculative mode):
+///   [OuterPreheader] -> [SteadyTop] -> [SteadyInner] -> [SteadyBottom/Latch]
+///                            ^                                |
+///                            |________________________________|
+///                                        |
+///                                        v
+///   [PeeledIterTop] -> [PeeledIterInner] -> [PeeledIterBottom]
+///
+/// The SteadyInner and PeeledIterInner are the sibling inner loops that
+/// execute the same code but may have different register allocations.
+struct OuterLoopStructure {
+  /// Entry block to the outer loop.
+  MachineBasicBlock *OuterPreheader = nullptr;
+
+  /// First block inside the outer loop, entered from OuterPreheader.
+  MachineBasicBlock *SteadyTop = nullptr;
+  /// The steady inner loop body.
+  MachineBasicBlock *SteadyInner = nullptr;
+  /// The outer loop latch.
+  MachineBasicBlock *SteadyBottom = nullptr;
+
+  /// First block of the peeled iteration region.
+  MachineBasicBlock *PeeledIterTop = nullptr;
+  /// The peeled iteration inner loop body.
+  MachineBasicBlock *PeeledIterInner = nullptr;
+  /// Exit block of the peeled iteration region.
+  MachineBasicBlock *PeeledIterBottom = nullptr;
+
+  /// True if speculative mode (no peeled iteration region).
+  bool Speculative = false;
+
+  /// Returns true if this has a peeled iteration region (non-speculative).
+  bool hasPeeledIterRegion() const { return !Speculative; }
+
+  /// Try to build the structure from an outer loop latch that has OLP metadata.
+  /// For speculative loops, only the steady-state region is populated and
+  /// Speculative is set to true. Returns nullopt if the CFG doesn't match
+  /// the expected OLP pattern.
+  static std::optional<OuterLoopStructure>
+  tryBuildFrom(MachineBasicBlock &OuterLatch);
+
+  /// Return true if both inner loops have matching instruction structure.
+  /// This is a basic check comparing instruction count and opcodes only.
+  /// Does NOT verify registers or bundles - intended for use before the
+  /// post-machine scheduler when these may still differ between loops.
+  /// Only valid when hasPeeledIterRegion() is true.
+  bool hasMatchingInnerLoops() const;
+};
+
 } // namespace llvm::AIELoopUtils
 
 #endif

--- a/llvm/unittests/Target/AIE/AIELoopUtilsTest.cpp
+++ b/llvm/unittests/Target/AIE/AIELoopUtilsTest.cpp
@@ -1,0 +1,462 @@
+//===- AIELoopUtilsTest.cpp -----------------------------------------------===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// (c) Copyright 2026 Advanced Micro Devices, Inc. or its affiliates
+//
+//===----------------------------------------------------------------------===//
+
+#include "Utils/AIELoopUtils.h"
+#include "llvm/CodeGen/MIRParser/MIRParser.h"
+#include "llvm/CodeGen/MachineModuleInfo.h"
+#include "llvm/IR/Module.h"
+#include "llvm/MC/TargetRegistry.h"
+#include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/TargetSelect.h"
+#include "llvm/Target/TargetMachine.h"
+#include "gtest/gtest.h"
+
+using namespace llvm;
+using namespace llvm::AIELoopUtils;
+
+namespace {
+
+std::unique_ptr<TargetMachine> createTargetMachine() {
+  auto TT(Triple::normalize("aie2ps--"));
+  std::string Error;
+  const Target *TheTarget = TargetRegistry::lookupTarget(TT, Error);
+  if (!TheTarget) {
+    llvm::errs() << Error << "\n";
+    return nullptr;
+  }
+  return std::unique_ptr<TargetMachine>(
+      TheTarget->createTargetMachine(TT, "", "", TargetOptions(), std::nullopt,
+                                     std::nullopt, CodeGenOptLevel::Default));
+}
+
+class AIELoopUtilsTest : public testing::Test {
+protected:
+  LLVMContext Context;
+  std::unique_ptr<TargetMachine> TM;
+  std::unique_ptr<MachineModuleInfo> MMI;
+  std::unique_ptr<MIRParser> Parser;
+  std::unique_ptr<Module> M;
+
+  static void SetUpTestCase() {
+    LLVMInitializeAIETargetInfo();
+    LLVMInitializeAIETarget();
+    LLVMInitializeAIETargetMC();
+  }
+
+  void parseMIR(const char *MIRString) {
+    TM = createTargetMachine();
+    if (!TM)
+      GTEST_SKIP() << "AIE target not available";
+
+    std::unique_ptr<MemoryBuffer> MBuffer =
+        MemoryBuffer::getMemBuffer(MIRString);
+    Parser = createMIRParser(std::move(MBuffer), Context);
+    if (!Parser)
+      report_fatal_error("null MIRParser");
+    M = Parser->parseIRModule();
+    if (!M)
+      report_fatal_error("parseIRModule failed");
+    M->setTargetTriple(TM->getTargetTriple());
+    M->setDataLayout(TM->createDataLayout());
+    MMI = std::make_unique<MachineModuleInfo>(TM.get());
+    if (Parser->parseMachineFunctions(*M, *MMI.get()))
+      report_fatal_error("parseMachineFunctions failed");
+  }
+
+  MachineFunction *getMachineFunction(StringRef Name) {
+    auto F = M->getFunction(Name);
+    if (!F)
+      report_fatal_error("null Function");
+    return &MMI->getOrCreateMachineFunction(*F);
+  }
+
+  MachineBasicBlock *getMBB(MachineFunction *MF, unsigned Num) {
+    return MF->getBlockNumbered(Num);
+  }
+};
+
+// MIR with OLP structure: OuterPreheader -> SteadyTop -> SteadyInner ->
+// SteadyBottom -> PeeledIterTop -> PeeledIterInner -> PeeledIterBottom
+// The outer latch (bb.3) has the OLP success metadata.
+const char *NonSpeculativeMIR = R"MIR(
+--- |
+  define void @olp_non_speculative() {
+  entry:
+    br label %outer.preheader
+
+  outer.preheader:
+    br label %steady.top
+
+  steady.top:
+    br label %steady.inner
+
+  steady.inner:
+    br i1 true, label %steady.inner, label %steady.bottom, !llvm.loop !0
+
+  steady.bottom:
+    br i1 true, label %steady.top, label %peeled.top, !llvm.loop !1
+
+  peeled.top:
+    br label %peeled.inner
+
+  peeled.inner:
+    br i1 true, label %peeled.inner, label %peeled.bottom, !llvm.loop !2
+
+  peeled.bottom:
+    ret void
+  }
+
+  !0 = distinct !{!0}
+  !1 = distinct !{!1, !3}
+  !2 = distinct !{!2}
+  !3 = !{!"llvm.loop.hint.aie_outerloop_pipeliner_success", i64 1}
+
+...
+---
+name:            olp_non_speculative
+tracksRegLiveness: true
+body:             |
+  bb.0.entry:
+    successors: %bb.1
+
+  bb.1.outer.preheader:
+    successors: %bb.2
+
+  bb.2.steady.top:
+    successors: %bb.3
+
+  bb.3.steady.inner:
+    successors: %bb.3, %bb.4
+    liveins: $r0, $r3
+    $r1 = ADD_add_r_ri $r0, 1, implicit-def $srcarry
+    $r2 = ADD_add_r_ri $r1, 2, implicit-def $srcarry
+    $r3 = ADD_add_r_ri $r3, -1, implicit-def $srcarry
+    PseudoJNZ $r3, %bb.3
+
+  bb.4.steady.bottom:
+    successors: %bb.2, %bb.5
+    liveins: $r0
+    PseudoJNZ $r0, %bb.2
+
+  bb.5.peeled.top:
+    successors: %bb.6
+
+  bb.6.peeled.inner:
+    successors: %bb.6, %bb.7
+    liveins: $r0, $r3
+    $r1 = ADD_add_r_ri $r0, 1, implicit-def $srcarry
+    $r2 = ADD_add_r_ri $r1, 2, implicit-def $srcarry
+    $r3 = ADD_add_r_ri $r3, -1, implicit-def $srcarry
+    PseudoJNZ $r3, %bb.6
+
+  bb.7.peeled.bottom:
+    RET implicit $lr
+    DelayedSchedBarrier
+
+...
+)MIR";
+
+// MIR with speculative OLP structure (no peeled iteration region)
+const char *SpeculativeMIR = R"MIR(
+--- |
+  define void @olp_speculative() {
+  entry:
+    br label %outer.preheader
+
+  outer.preheader:
+    br label %steady.top
+
+  steady.top:
+    br label %steady.inner
+
+  steady.inner:
+    br i1 true, label %steady.inner, label %steady.bottom, !llvm.loop !0
+
+  steady.bottom:
+    br i1 true, label %steady.top, label %exit, !llvm.loop !1
+
+  exit:
+    ret void
+  }
+
+  !0 = distinct !{!0}
+  !1 = distinct !{!1, !2, !3}
+  !2 = !{!"llvm.loop.hint.aie_outerloop_pipeliner_success", i64 1}
+  !3 = !{!"llvm.loop.hint.aie_outerloop_pipeliner_speculative", i64 1}
+
+...
+---
+name:            olp_speculative
+tracksRegLiveness: true
+body:             |
+  bb.0.entry:
+    successors: %bb.1
+
+  bb.1.outer.preheader:
+    successors: %bb.2
+
+  bb.2.steady.top:
+    successors: %bb.3
+
+  bb.3.steady.inner:
+    successors: %bb.3, %bb.4
+    liveins: $r0, $r3
+    $r1 = ADD_add_r_ri $r0, 1, implicit-def $srcarry
+    $r3 = ADD_add_r_ri $r3, -1, implicit-def $srcarry
+    PseudoJNZ $r3, %bb.3
+
+  bb.4.steady.bottom:
+    successors: %bb.2, %bb.5
+    liveins: $r0
+    PseudoJNZ $r0, %bb.2
+
+  bb.5.exit:
+    RET implicit $lr
+    DelayedSchedBarrier
+
+...
+)MIR";
+
+// MIR without OLP metadata
+const char *NonOLPMIR = R"MIR(
+--- |
+  define void @non_olp() {
+  entry:
+    br label %loop
+
+  loop:
+    br i1 true, label %loop, label %exit, !llvm.loop !0
+
+  exit:
+    ret void
+  }
+
+  !0 = distinct !{!0}
+
+...
+---
+name:            non_olp
+tracksRegLiveness: true
+body:             |
+  bb.0.entry:
+    successors: %bb.1
+
+  bb.1.loop:
+    successors: %bb.1, %bb.2
+    liveins: $r0, $r3
+    $r1 = ADD_add_r_ri $r0, 1, implicit-def $srcarry
+    $r3 = ADD_add_r_ri $r3, -1, implicit-def $srcarry
+    PseudoJNZ $r3, %bb.1
+
+  bb.2.exit:
+    RET implicit $lr
+    DelayedSchedBarrier
+
+...
+)MIR";
+
+// MIR with mismatched inner loops (different opcodes)
+const char *MismatchedInnerLoopsMIR = R"MIR(
+--- |
+  define void @olp_mismatched() {
+  entry:
+    br label %outer.preheader
+
+  outer.preheader:
+    br label %steady.top
+
+  steady.top:
+    br label %steady.inner
+
+  steady.inner:
+    br i1 true, label %steady.inner, label %steady.bottom, !llvm.loop !0
+
+  steady.bottom:
+    br i1 true, label %steady.top, label %peeled.top, !llvm.loop !1
+
+  peeled.top:
+    br label %peeled.inner
+
+  peeled.inner:
+    br i1 true, label %peeled.inner, label %peeled.bottom, !llvm.loop !2
+
+  peeled.bottom:
+    ret void
+  }
+
+  !0 = distinct !{!0}
+  !1 = distinct !{!1, !3}
+  !2 = distinct !{!2}
+  !3 = !{!"llvm.loop.hint.aie_outerloop_pipeliner_success", i64 1}
+
+...
+---
+name:            olp_mismatched
+tracksRegLiveness: true
+body:             |
+  bb.0.entry:
+    successors: %bb.1
+
+  bb.1.outer.preheader:
+    successors: %bb.2
+
+  bb.2.steady.top:
+    successors: %bb.3
+
+  bb.3.steady.inner:
+    successors: %bb.3, %bb.4
+    liveins: $r0, $r3
+    $r1 = ADD_add_r_ri $r0, 1, implicit-def $srcarry
+    $r2 = ADD_add_r_ri $r1, 2, implicit-def $srcarry
+    $r3 = ADD_add_r_ri $r3, -1, implicit-def $srcarry
+    PseudoJNZ $r3, %bb.3
+
+  bb.4.steady.bottom:
+    successors: %bb.2, %bb.5
+    liveins: $r0
+    PseudoJNZ $r0, %bb.2
+
+  bb.5.peeled.top:
+    successors: %bb.6
+
+  bb.6.peeled.inner:
+    successors: %bb.6, %bb.7
+    liveins: $r0, $r3
+    NOP
+    NOP
+    $r3 = ADD_add_r_ri $r3, -1, implicit-def $srcarry
+    PseudoJNZ $r3, %bb.6
+
+  bb.7.peeled.bottom:
+    RET implicit $lr
+    DelayedSchedBarrier
+
+...
+)MIR";
+
+TEST_F(AIELoopUtilsTest, OuterLoopStructure_BuildFromNonSpeculative) {
+  parseMIR(NonSpeculativeMIR);
+  MachineFunction *MF = getMachineFunction("olp_non_speculative");
+
+  // bb.4 is the outer latch (steady.bottom)
+  MachineBasicBlock *OuterLatch = getMBB(MF, 4);
+  ASSERT_NE(OuterLatch, nullptr);
+
+  auto OLS = OuterLoopStructure::tryBuildFrom(*OuterLatch);
+  ASSERT_TRUE(OLS.has_value());
+
+  // Verify all fields are populated
+  EXPECT_EQ(OLS->OuterPreheader, getMBB(MF, 1));   // outer.preheader
+  EXPECT_EQ(OLS->SteadyTop, getMBB(MF, 2));        // steady.top
+  EXPECT_EQ(OLS->SteadyInner, getMBB(MF, 3));      // steady.inner
+  EXPECT_EQ(OLS->SteadyBottom, getMBB(MF, 4));     // steady.bottom
+  EXPECT_EQ(OLS->PeeledIterTop, getMBB(MF, 5));    // peeled.top
+  EXPECT_EQ(OLS->PeeledIterInner, getMBB(MF, 6));  // peeled.inner
+  EXPECT_EQ(OLS->PeeledIterBottom, getMBB(MF, 7)); // peeled.bottom
+
+  EXPECT_FALSE(OLS->Speculative);
+  EXPECT_TRUE(OLS->hasPeeledIterRegion());
+}
+
+TEST_F(AIELoopUtilsTest, OuterLoopStructure_BuildFromSpeculative) {
+  parseMIR(SpeculativeMIR);
+  MachineFunction *MF = getMachineFunction("olp_speculative");
+
+  // bb.4 is the outer latch (steady.bottom)
+  MachineBasicBlock *OuterLatch = getMBB(MF, 4);
+  ASSERT_NE(OuterLatch, nullptr);
+
+  auto OLS = OuterLoopStructure::tryBuildFrom(*OuterLatch);
+  ASSERT_TRUE(OLS.has_value());
+
+  // Steady region should be populated
+  EXPECT_EQ(OLS->OuterPreheader, getMBB(MF, 1));
+  EXPECT_EQ(OLS->SteadyTop, getMBB(MF, 2));
+  EXPECT_EQ(OLS->SteadyInner, getMBB(MF, 3));
+  EXPECT_EQ(OLS->SteadyBottom, getMBB(MF, 4));
+
+  // Peeled region should be null (speculative mode)
+  EXPECT_EQ(OLS->PeeledIterTop, nullptr);
+  EXPECT_EQ(OLS->PeeledIterInner, nullptr);
+  EXPECT_EQ(OLS->PeeledIterBottom, nullptr);
+
+  EXPECT_TRUE(OLS->Speculative);
+  EXPECT_FALSE(OLS->hasPeeledIterRegion());
+}
+
+TEST_F(AIELoopUtilsTest, OuterLoopStructure_NonOLPReturnsNullopt) {
+  parseMIR(NonOLPMIR);
+  MachineFunction *MF = getMachineFunction("non_olp");
+
+  // bb.1 is a simple loop without OLP metadata
+  MachineBasicBlock *LoopBlock = getMBB(MF, 1);
+  ASSERT_NE(LoopBlock, nullptr);
+
+  auto OLS = OuterLoopStructure::tryBuildFrom(*LoopBlock);
+  EXPECT_FALSE(OLS.has_value());
+}
+
+TEST_F(AIELoopUtilsTest, OuterLoopStructure_HasMatchingInnerLoops) {
+  parseMIR(NonSpeculativeMIR);
+  MachineFunction *MF = getMachineFunction("olp_non_speculative");
+
+  MachineBasicBlock *OuterLatch = getMBB(MF, 4);
+  auto OLS = OuterLoopStructure::tryBuildFrom(*OuterLatch);
+  ASSERT_TRUE(OLS.has_value());
+
+  // Both inner loops have the same instructions (ADD, ADD, PseudoLoopEnd)
+  EXPECT_TRUE(OLS->hasMatchingInnerLoops());
+}
+
+TEST_F(AIELoopUtilsTest, OuterLoopStructure_MismatchedInnerLoops) {
+  parseMIR(MismatchedInnerLoopsMIR);
+  MachineFunction *MF = getMachineFunction("olp_mismatched");
+
+  MachineBasicBlock *OuterLatch = getMBB(MF, 4);
+  auto OLS = OuterLoopStructure::tryBuildFrom(*OuterLatch);
+  ASSERT_TRUE(OLS.has_value());
+
+  // Inner loops have different opcodes (ADD vs SUB)
+  EXPECT_FALSE(OLS->hasMatchingInnerLoops());
+}
+
+TEST_F(AIELoopUtilsTest, IsSingleMBBLoop) {
+  parseMIR(NonSpeculativeMIR);
+  MachineFunction *MF = getMachineFunction("olp_non_speculative");
+
+  // bb.3 (steady.inner) is a single-MBB loop
+  EXPECT_TRUE(isSingleMBBLoop(getMBB(MF, 3)));
+  // bb.6 (peeled.inner) is a single-MBB loop
+  EXPECT_TRUE(isSingleMBBLoop(getMBB(MF, 6)));
+  // bb.4 (steady.bottom) is not a single-MBB loop
+  EXPECT_FALSE(isSingleMBBLoop(getMBB(MF, 4)));
+  // bb.1 (outer.preheader) is not a loop
+  EXPECT_FALSE(isSingleMBBLoop(getMBB(MF, 1)));
+}
+
+TEST_F(AIELoopUtilsTest, IsOuterLoopPipelined) {
+  parseMIR(NonSpeculativeMIR);
+  MachineFunction *MF = getMachineFunction("olp_non_speculative");
+
+  // bb.4 (steady.bottom) has OLP metadata
+  EXPECT_TRUE(isOuterLoopPipelined(*getMBB(MF, 4)));
+  // bb.3 (steady.inner) does not have OLP metadata
+  EXPECT_FALSE(isOuterLoopPipelined(*getMBB(MF, 3)));
+}
+
+TEST_F(AIELoopUtilsTest, IsOuterLoopSpeculative) {
+  parseMIR(SpeculativeMIR);
+  MachineFunction *MF = getMachineFunction("olp_speculative");
+
+  // bb.4 (steady.bottom) has speculative metadata
+  EXPECT_TRUE(isOuterLoopSpeculative(*getMBB(MF, 4)));
+}
+
+} // anonymous namespace

--- a/llvm/unittests/Target/AIE/CMakeLists.txt
+++ b/llvm/unittests/Target/AIE/CMakeLists.txt
@@ -28,6 +28,7 @@ set(LLVM_LINK_COMPONENTS
 
 add_llvm_target_unittest(AIETests
   ${LLVM_MAIN_SRC_DIR}/unittests/CodeGen/ScheduleDAGMITestUtils.cpp
+  AIELoopUtilsTest.cpp
   AIEScheduleDAGMITest.cpp
   AIEOuterLoopPipelinerTest.cpp
   AIETestTarget.cpp


### PR DESCRIPTION
Introduce AIELoopUtils.h/.cpp with utilities for analyzing Outer Loop Pipeliner (OLP) CFG structures at the machine IR level. This includes:

- OuterLoopStructure: Parses and represents the OLP CFG regions (steady state, peeled iteration) from a given outer latch MBB
- hasMatchingInnerLoops: Validates inner loop instruction sequences

Add comprehensive unit tests in AIELoopUtilsTest.cpp using MIR parsing.