### PR TITLE
[AIE] Remove undefined virtual functions from AIEBaseTTIImpl

### DIFF
--- a/llvm/lib/Target/AIE/AIEBaseTargetTransformInfo.h
+++ b/llvm/lib/Target/AIE/AIEBaseTargetTransformInfo.h
@@ -98,12 +98,6 @@ public:
     // cost?
     return TTI::TCC_Basic;
   }
-  void adjustUnrollingPreferences(Loop *L, ScalarEvolution &SE,
-                                  TTI::UnrollingPreferences &UP,
-                                  OptimizationRemarkEmitter *ORE) const;
-  bool isHardwareLoopProfitable(Loop *L, ScalarEvolution &SE,
-                                AssumptionCache &AC, TargetLibraryInfo *LibInfo,
-                                HardwareLoopInfo &HWLoopInfo) const override;
 
   // AIE vector arithmetic operates on 512-bit registers. The default
   // getRegisterBitWidth returns 32 (scalar width), which causes the loop


### PR DESCRIPTION
These two functions were declared but never defined, leading to link errors on MSVC. The actual overrides for these functions live in the respective AIEXXXTIIImpl instances.