### PR TITLE
Tighten no-default-libraries driver checks

### DIFF
--- a/clang/test/Driver/aie/aie-toolchain-libs.c
+++ b/clang/test/Driver/aie/aie-toolchain-libs.c
@@ -25,9 +25,9 @@
 // RUN:   | FileCheck -check-prefix=NOLIBS %s
 // RUN: %clang %s -### --target=aie2p-none-unknown-elf -nostdlib -nodefaultlibs 2>&1 \
 // RUN:   | FileCheck -check-prefix=NOLIBS %s
-// NOLIBS-NOT: ld.lld{{.*}}libclang_rt.builtins.a
-// NOLIBS-NOT: ld.lld{{.*}}-lm
-// NOLIBS-NOT: ld.lld{{.*}}-lc
+// NOLIBS-NOT: libclang_rt.builtins
+// NOLIBS-NOT: "-lm"
+// NOLIBS-NOT: "-lc"
 
 // ... for -nostartfiles
 // RUN: %clang %s -### --target=aie2-none-unknown-elf -nostartfiles -ccc-install-dir  %S/../Inputs/basic_aie_tree/bin 2>&1 \


### PR DESCRIPTION
 Match the quoted -lc and -lm linker arguments directly. This avoids false
 positives when a randomly generated lit temporary path contains strings such
 as "lit-tmp-lcaoeccu".