### PR TITLE
[AIEX] Extend matchMostlySequentialShuffleWithInsertions

### DIFF
--- a/llvm/lib/Target/AIE/AIECombinerHelper.cpp
+++ b/llvm/lib/Target/AIE/AIECombinerHelper.cpp
@@ -4366,7 +4366,78 @@ bool llvm::matchMostlySequentialShuffleWithInsertions(MachineInstr &MI,
   if (DstTy.getElementType() != Src1Ty.getElementType())
     return false;
 
-  // No growing shuffles; shrinking requires divisibility
+  // Widen-by-undef case: the destination is a whole multiple of the source and
+  // every lane above the source width is undef. The lower NumSrcElems lanes are
+  // then a mostly-sequential run (from either source) plus a few insertions,
+  // and the result is widened to the destination by concatenating undef
+  // sub-vectors. This avoids scalarizing such shuffles during legalization.
+  if (NumDstElems > NumSrcElems) {
+    if (NumDstElems % NumSrcElems != 0)
+      return false;
+    if (Mask.size() != NumDstElems)
+      return false;
+    if (MaskMatch::isMaskWithAllUndefs(Mask))
+      return false;
+
+    for (unsigned I = NumSrcElems; I < NumDstElems; ++I)
+      if (Mask[I] != -1)
+        return false;
+
+    const unsigned MaxNumInsertions =
+        getShuffleMaxNumInsertions(*MI.getMF(), NumSrcElems);
+
+    ArrayRef<int> EffMask = Mask.take_front(NumSrcElems);
+
+    // Try a sequential run from either source (Src1 at Height 0, Src2 at Height
+    // NumSrcElems) and keep the base with the fewest insertions.
+    bool FoundBase = false;
+    unsigned BestHeight = 0;
+    SmallVector<unsigned, 4> BestExceptions;
+    for (unsigned Height : {0u, NumSrcElems}) {
+      MaskMatch SequentialMask{/*Height*/ Height};
+      ShuffleMaskValidity Validity =
+          SequentialMask.getShuffleMaskValidity(EffMask);
+      // A fully sequential run is a plain copy/widen; leave it to other
+      // combines.
+      if (Validity.IsValid)
+        return false;
+      if (!FoundBase ||
+          Validity.MaskExceptions.size() < BestExceptions.size()) {
+        FoundBase = true;
+        BestHeight = Height;
+        BestExceptions = Validity.MaskExceptions;
+      }
+    }
+
+    assert(FoundBase && !BestExceptions.empty() &&
+           "expected at least one insertion");
+    if (BestExceptions.size() >= MaxNumInsertions)
+      return false;
+
+    const LLT ElemTy = Src1Ty.getElementType();
+    // The sequential base selects the copy source.
+    const Register SeqSrcReg = (BestHeight == 0) ? Src1Reg : Src2Reg;
+    const SmallVector<unsigned, 4> Exceptions = BestExceptions;
+
+    MatchInfo = [=, &MRI](MachineIRBuilder &B) {
+      // Insert the exception lanes into the sequential source (built at the
+      // source width), then widen to the destination with undef sub-vectors.
+      Register Result = buildShuffleExceptionInserts(
+          B, MRI, Mask, Exceptions, NumSrcElems, Src1Reg, Src2Reg, ElemTy,
+          Src1Ty, SeqSrcReg, /*FinalDst=*/Register());
+
+      SmallVector<Register, 4> ConcatOps;
+      ConcatOps.push_back(Result);
+      const unsigned NumPads = NumDstElems / NumSrcElems - 1;
+      for (unsigned I = 0; I < NumPads; ++I)
+        ConcatOps.push_back(B.buildUndef(Src1Ty).getReg(0));
+      B.buildConcatVectors(DstReg, ConcatOps);
+    };
+
+    return true;
+  }
+
+  // Only the widen-by-undef case above grows; shrinking requires divisibility.
   if (NumSrcElems % NumDstElems != 0)
     return false;
 

--- a/llvm/lib/Target/AIE/AIECombinerHelper.cpp
+++ b/llvm/lib/Target/AIE/AIECombinerHelper.cpp
@@ -4272,6 +4272,54 @@ bool llvm::matchShuffleToExtractInsertEltToBroadcast(MachineInstr &MI,
   return true;
 }
 
+/// Return the maximum number of scalar insertions worth using to implement a
+/// shuffle before scalarization in the legalizer becomes preferable.
+static unsigned getShuffleMaxNumInsertions(const MachineFunction &MF,
+                                           unsigned NumSrcElems) {
+  // The scalarization of G_SHUFFLE_VECTOR in the legalizer is more beneficial
+  // if there are more exceptions than NumSrcElems / 2, as AIE2P's
+  // VINSERT instructions require a move to a register used for the index unlike
+  // VPUSH.
+  const Triple &T = MF.getTarget().getTargetTriple();
+  if (T.isAIE2P() || T.isAIE2PS())
+    return (ShuffleMaxNumInsertions != 0) ? ShuffleMaxNumInsertions
+                                          : NumSrcElems / 2;
+  llvm_unreachable(
+      "MaxNumInsertions unimplemented for target. Does the target's Insert "
+      "instruction take immediate indices or does it require a register for "
+      "the index?");
+}
+
+/// Insert the \p Exceptions lanes of \p Mask into \p StartReg, at their
+/// original positions, extracting each lane from whichever source it indexes.
+/// Intermediate results are fresh \p InsertTy vregs; the last insertion writes
+/// \p FinalDst when it is valid. Returns the final result register.
+static Register
+buildShuffleExceptionInserts(MachineIRBuilder &B, MachineRegisterInfo &MRI,
+                             ArrayRef<int> Mask, ArrayRef<unsigned> Exceptions,
+                             unsigned NumSrcElems, Register Src1Reg,
+                             Register Src2Reg, LLT ElemTy, LLT InsertTy,
+                             Register StartReg, Register FinalDst) {
+  Register InsertSrc = StartReg;
+  Register Result = StartReg;
+  for (unsigned I = 0, E = Exceptions.size(); I < E; ++I) {
+    const unsigned ExceptionIdx = Exceptions[I];
+    Register VecToExtract =
+        Mask[ExceptionIdx] < (int)NumSrcElems ? Src1Reg : Src2Reg;
+    int ExtractIdx = Mask[ExceptionIdx] % NumSrcElems;
+    auto ExtrElt =
+        B.buildExtractVectorElementConstant(ElemTy, VecToExtract, ExtractIdx);
+    auto ExceptionIdxReg = B.buildConstant(LLT::scalar(32), ExceptionIdx);
+    const bool IsLast = (I + 1 == E);
+    Result = (IsLast && FinalDst.isValid())
+                 ? FinalDst
+                 : MRI.createGenericVirtualRegister(InsertTy);
+    B.buildInsertVectorElement(Result, InsertSrc, ExtrElt, ExceptionIdxReg);
+    InsertSrc = Result;
+  }
+  return Result;
+}
+
 /// Match shuffle vectors that are mostly sequential (identity or extract
 /// subvector) with a few element insertions from either source.
 ///
@@ -4336,20 +4384,8 @@ bool llvm::matchMostlySequentialShuffleWithInsertions(MachineInstr &MI,
 
   const LLT ElemTy = Src1Ty.getElementType();
 
-  unsigned MaxNumInsertions;
-  const Triple &T = MI.getMF()->getTarget().getTargetTriple();
-  if (T.isAIE2P() || T.isAIE2PS())
-    // The scalarization of G_SHUFFLE_VECTOR in the legalizer is more beneficial
-    // if there are more exceptions than NumSrcElems / 2 as AIE2P's VINSERT
-    // instructions require a move to a register used for the index unlike
-    // VPUSH.
-    MaxNumInsertions = (ShuffleMaxNumInsertions != 0) ? ShuffleMaxNumInsertions
-                                                      : NumSrcElems / 2;
-  else
-    llvm_unreachable(
-        "MaxNumInsertions unimplemented for target. Does the target's Insert "
-        "instruction take immediate indices or does it require a register for "
-        "the index?");
+  const unsigned MaxNumInsertions =
+      getShuffleMaxNumInsertions(*MI.getMF(), NumSrcElems);
 
   if (Mask.size() != NumDstElems)
     return false;
@@ -4374,35 +4410,17 @@ bool llvm::matchMostlySequentialShuffleWithInsertions(MachineInstr &MI,
     return false;
 
   MatchInfo = [=, &MRI](MachineIRBuilder &B) {
-    // For shrinking shuffles, first extract the subvector using UNPAD
-    Register InsertSrc;
+    // For shrinking shuffles, first extract the subvector using UNPAD.
+    Register InsertSrc = Src1Reg;
     if (IsShrinking) {
       InsertSrc = MRI.createGenericVirtualRegister(DstTy);
       const AIEBaseInstrInfo &TII = getAIETII(B);
       B.buildInstr(TII.getGenericUnpadVectorOpcode(), {InsertSrc}, {Src1Reg});
-    } else {
-      InsertSrc = Src1Reg;
     }
 
-    Register InsertDst;
-    for (const unsigned ExceptionIdx : Exceptions) {
-      Register VecToExtract =
-          Mask[ExceptionIdx] < (int)NumSrcElems ? Src1Reg : Src2Reg;
-
-      int ExtractIdx = Mask[ExceptionIdx] % NumSrcElems;
-      auto ExtrElt =
-          B.buildExtractVectorElementConstant(ElemTy, VecToExtract, ExtractIdx);
-
-      auto ExceptionIdxReg = B.buildConstant(LLT::scalar(32), ExceptionIdx);
-
-      InsertDst = (ExceptionIdx == Exceptions.back())
-                      ? DstReg
-                      : MRI.createGenericVirtualRegister(DstTy);
-
-      B.buildInsertVectorElement(InsertDst, InsertSrc, ExtrElt,
-                                 ExceptionIdxReg);
-      InsertSrc = InsertDst;
-    }
+    buildShuffleExceptionInserts(B, MRI, Mask, Exceptions, NumSrcElems, Src1Reg,
+                                 Src2Reg, ElemTy, DstTy, InsertSrc,
+                                 /*FinalDst=*/DstReg);
   };
 
   return true;

--- a/llvm/test/CodeGen/AIE/aie2ps/GlobalIsel/prelegalizercombiner-shuffle-vector.mir
+++ b/llvm/test/CodeGen/AIE/aie2ps/GlobalIsel/prelegalizercombiner-shuffle-vector.mir
@@ -1701,3 +1701,87 @@ body:             |
     %2:_(<16 x s32>) = G_SHUFFLE_VECTOR %0:_(<16 x s32>), %1:_, shufflemask(17, 17, 17, 17, 17, 17, 17, 2, 3, 0, 0, 0, 0, 0, 0, 0)
     PseudoRET implicit $lr, implicit %2
 ...
+
+---
+name: shuffle_vector_widen_undef_one_insert_second_input
+tracksRegLiveness: true
+body:             |
+  bb.1:
+    liveins: $x0, $x1
+    ; CHECK-LABEL: name: shuffle_vector_widen_undef_one_insert_second_input
+    ; CHECK: liveins: $x0, $x1
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<16 x s32>) = COPY $x0
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(<16 x s32>) = COPY $x1
+    ; CHECK-NEXT: [[C:%[0-9]+]]:_(s32) = G_CONSTANT i32 0
+    ; CHECK-NEXT: [[EVEC:%[0-9]+]]:_(s32) = G_EXTRACT_VECTOR_ELT [[COPY]](<16 x s32>), [[C]](s32)
+    ; CHECK-NEXT: [[IVEC:%[0-9]+]]:_(<16 x s32>) = G_INSERT_VECTOR_ELT [[COPY1]], [[EVEC]](s32), [[C]](s32)
+    ; CHECK-NEXT: [[DEF:%[0-9]+]]:_(<16 x s32>) = G_IMPLICIT_DEF
+    ; CHECK-NEXT: [[CONCAT_VECTORS:%[0-9]+]]:_(<32 x s32>) = G_CONCAT_VECTORS [[IVEC]](<16 x s32>), [[DEF]](<16 x s32>)
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[CONCAT_VECTORS]](<32 x s32>)
+    %0:_(<16 x s32>) = COPY $x0
+    %1:_(<16 x s32>) = COPY $x1
+    %2:_(<32 x s32>) = G_SHUFFLE_VECTOR %0(<16 x s32>), %1, shufflemask(0, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, undef, undef, undef, undef, undef, undef, undef, undef, undef, undef, undef, undef, undef, undef, undef, undef)
+    PseudoRET implicit $lr, implicit %2
+...
+
+---
+name: shuffle_vector_widen_undef_one_insert_first_input
+tracksRegLiveness: true
+body:             |
+  bb.1:
+    liveins: $x0, $x1
+    ; CHECK-LABEL: name: shuffle_vector_widen_undef_one_insert_first_input
+    ; CHECK: liveins: $x0, $x1
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<16 x s32>) = COPY $x0
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(<16 x s32>) = COPY $x1
+    ; CHECK-NEXT: [[C:%[0-9]+]]:_(s32) = G_CONSTANT i32 5
+    ; CHECK-NEXT: [[EVEC:%[0-9]+]]:_(s32) = G_EXTRACT_VECTOR_ELT [[COPY1]](<16 x s32>), [[C]](s32)
+    ; CHECK-NEXT: [[IVEC:%[0-9]+]]:_(<16 x s32>) = G_INSERT_VECTOR_ELT [[COPY]], [[EVEC]](s32), [[C]](s32)
+    ; CHECK-NEXT: [[DEF:%[0-9]+]]:_(<16 x s32>) = G_IMPLICIT_DEF
+    ; CHECK-NEXT: [[CONCAT_VECTORS:%[0-9]+]]:_(<32 x s32>) = G_CONCAT_VECTORS [[IVEC]](<16 x s32>), [[DEF]](<16 x s32>)
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[CONCAT_VECTORS]](<32 x s32>)
+    %0:_(<16 x s32>) = COPY $x0
+    %1:_(<16 x s32>) = COPY $x1
+    %2:_(<32 x s32>) = G_SHUFFLE_VECTOR %0(<16 x s32>), %1, shufflemask(0, 1, 2, 3, 4, 21, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, undef, undef, undef, undef, undef, undef, undef, undef, undef, undef, undef, undef, undef, undef, undef, undef)
+    PseudoRET implicit $lr, implicit %2
+...
+
+---
+name: shuffle_vector_widen_upper_not_undef_no_combine
+tracksRegLiveness: true
+body:             |
+  bb.1:
+    liveins: $x0, $x1
+    ; CHECK-LABEL: name: shuffle_vector_widen_upper_not_undef_no_combine
+    ; CHECK: liveins: $x0, $x1
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<16 x s32>) = COPY $x0
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(<16 x s32>) = COPY $x1
+    ; CHECK-NEXT: [[SHUF:%[0-9]+]]:_(<32 x s32>) = G_SHUFFLE_VECTOR [[COPY]](<16 x s32>), [[COPY1]], shufflemask(0, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 0, undef, undef, undef, undef, undef, undef, undef, undef, undef, undef, undef, undef, undef, undef, undef)
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[SHUF]](<32 x s32>)
+    %0:_(<16 x s32>) = COPY $x0
+    %1:_(<16 x s32>) = COPY $x1
+    %2:_(<32 x s32>) = G_SHUFFLE_VECTOR %0(<16 x s32>), %1, shufflemask(0, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 0, undef, undef, undef, undef, undef, undef, undef, undef, undef, undef, undef, undef, undef, undef, undef)
+    PseudoRET implicit $lr, implicit %2
+...
+
+---
+name: shuffle_vector_widen_undef_beyond_max_exceptions_no_combine
+tracksRegLiveness: true
+body:             |
+  bb.1:
+    liveins: $x0, $x1
+    ; CHECK-LABEL: name: shuffle_vector_widen_undef_beyond_max_exceptions_no_combine
+    ; CHECK: liveins: $x0, $x1
+    ; CHECK-NEXT: {{  $}}
+    ; CHECK-NEXT: [[COPY:%[0-9]+]]:_(<16 x s32>) = COPY $x0
+    ; CHECK-NEXT: [[COPY1:%[0-9]+]]:_(<16 x s32>) = COPY $x1
+    ; CHECK-NEXT: [[SHUF:%[0-9]+]]:_(<32 x s32>) = G_SHUFFLE_VECTOR [[COPY]](<16 x s32>), [[COPY1]], shufflemask(0, 1, 2, 3, 4, 5, 6, 7, 24, 25, 26, 27, 28, 29, 30, 31, undef, undef, undef, undef, undef, undef, undef, undef, undef, undef, undef, undef, undef, undef, undef, undef)
+    ; CHECK-NEXT: PseudoRET implicit $lr, implicit [[SHUF]](<32 x s32>)
+    %0:_(<16 x s32>) = COPY $x0
+    %1:_(<16 x s32>) = COPY $x1
+    %2:_(<32 x s32>) = G_SHUFFLE_VECTOR %0(<16 x s32>), %1, shufflemask(0, 1, 2, 3, 4, 5, 6, 7, 24, 25, 26, 27, 28, 29, 30, 31, undef, undef, undef, undef, undef, undef, undef, undef, undef, undef, undef, undef, undef, undef, undef, undef)
+    PseudoRET implicit $lr, implicit %2
+...


### PR DESCRIPTION
This matches
    %2:_(<32 x s32>) = G_SHUFFLE_VECTOR %0(<16 x s32>), %1, shufflemask(0, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, undef, undef, undef, undef,...)
into extract + insert + concat