### PR TITLE
[AIE][NFC] Hook G_PTR_ADD offsets into the GPR file from the base RBI

### DIFF
--- a/llvm/lib/Target/AIE/AIEBaseRegisterBankInfo.cpp
+++ b/llvm/lib/Target/AIE/AIEBaseRegisterBankInfo.cpp
@@ -311,9 +311,20 @@ AIEBaseRegisterBankInfo::getVecPartialMappingIdx(const LLT &Ty) const {
   }
 }
 
+bool AIEBaseRegisterBankInfo::shouldSelectPtrAddAsAddmNc(
+    const MachineInstr &, const MachineRegisterInfo &) const {
+  return false;
+}
+
 bool AIEBaseRegisterBankInfo::requiresGPRRegBank(const MachineInstr &MI,
                                                  const MachineRegisterInfo &MRI,
                                                  unsigned Depth) const {
+  // Targets that can select a G_PTR_ADD as ADDM_NC override
+  // shouldSelectPtrAddAsAddmNc so the offset stays in the GPR file instead of
+  // the default MOD bank.
+  if (shouldSelectPtrAddAsAddmNc(MI, MRI))
+    return true;
+
   switch (MI.getOpcode()) {
   case TargetOpcode::G_ANYEXT:
   case TargetOpcode::G_SEXT:

--- a/llvm/lib/Target/AIE/AIEBaseRegisterBankInfo.h
+++ b/llvm/lib/Target/AIE/AIEBaseRegisterBankInfo.h
@@ -91,6 +91,13 @@ public:
   bool requiresPTRRegBank(const MachineInstr &MI,
                           const MachineRegisterInfo &MRI, unsigned Depth) const;
 
+  /// Consulted while mapping a G_TRUNC / G_PTRTOINT, before the pointer add
+  /// itself is assigned banks. Override to return true when \p MI is a
+  /// G_PTR_ADD that should keep its offset in the GPR file so it can be
+  /// selected as ADDM_NC. The default is false (keep PADD / MOD).
+  virtual bool shouldSelectPtrAddAsAddmNc(const MachineInstr &MI,
+                                          const MachineRegisterInfo &MRI) const;
+
   using RegisterUsedAsSpecificBankFcn =
       std::function<bool(const MachineInstr &MI, const MachineRegisterInfo &MRI,
                          const TargetRegisterInfo &TRI, Register Reg)>;


### PR DESCRIPTION
Give targets a shouldSelectPtrAddAsAddmNc override and consult it from requiresGPRRegBank so a G_TRUNC / G_PTRTOINT offset can stay in GPRs before the pointer add itself is mapped.