### PR TITLE
[AIE][GlobalISel] Fix return pre-lowering for multiple returns

### DIFF
--- a/llvm/include/llvm/CodeGen/FunctionLoweringInfo.h
+++ b/llvm/include/llvm/CodeGen/FunctionLoweringInfo.h
@@ -299,7 +299,6 @@ public:
 
   /// Saved context when using CallLowering::preLowerReturn()
   struct SavedRetCCState {
-    const Value *RetVal = nullptr;
     SmallVector<Register, 4> AssignedRegs;
     unsigned ReservedStackSize = 0;
   };

--- a/llvm/lib/Target/AIE/AIECallLowering.cpp
+++ b/llvm/lib/Target/AIE/AIECallLowering.cpp
@@ -244,7 +244,6 @@ bool AIECallLowering::lowerReturnVal(
     MachineIRBuilder &MIRBuilder, const Value *Val, ArrayRef<Register> VRegs,
     FunctionLoweringInfo::SavedRetCCState &RetAssignments,
     MachineInstrBuilder &Ret) const {
-  assert(RetAssignments.RetVal == Val);
   if (!Val)
     // Nothing to do here.
     return true;
@@ -271,7 +270,7 @@ bool AIECallLowering::preLowerReturn(const Value *RetVal,
                                      ArrayRef<Register> VRegs,
                                      FunctionLoweringInfo &FLI) const {
   if (!RetVal) {
-    FLI.PreDeterminedRetAssignments = {RetVal, /*AssignedRegs=*/{},
+    FLI.PreDeterminedRetAssignments = {/*AssignedRegs=*/{},
                                        /*ReservedStackSize=*/0};
     return true;
   }
@@ -286,8 +285,9 @@ bool AIECallLowering::preLowerReturn(const Value *RetVal,
   }
 
   // Save the return assignments so they can be picked up when lowering
-  // formal arguments.
-  FLI.PreDeterminedRetAssignments = {RetVal, AA.getAssignedRegisters(),
+  // formal arguments. Assignments only depend on the return type, so they are
+  // valid for every return instruction of the function.
+  FLI.PreDeterminedRetAssignments = {AA.getAssignedRegisters(),
                                      AA.getAssignedStackSize()};
   return true;
 }

--- a/llvm/test/CodeGen/AIE/GlobalISel/irtranslator-multiple-returns.ll
+++ b/llvm/test/CodeGen/AIE/GlobalISel/irtranslator-multiple-returns.ll
@@ -5,21 +5,20 @@
 ;
 ; (c) Copyright 2026 Advanced Micro Devices, Inc. or its affiliates
 ;
-; REQUIRES: asserts
-; RUN: not --crash llc -mtriple=aie2 -stop-after=irtranslator %s -o - 2>&1 | FileCheck %s
-; RUN: not --crash llc -mtriple=aie2p -stop-after=irtranslator %s -o - 2>&1 | FileCheck %s
-; RUN: not --crash llc -mtriple=aie2ps -stop-after=irtranslator %s -o - 2>&1 | FileCheck %s
+; RUN: llc -mtriple=aie2 -stop-after=irtranslator %s -o - | FileCheck %s
+; RUN: llc -mtriple=aie2p -stop-after=irtranslator %s -o - | FileCheck %s
+; RUN: llc -mtriple=aie2ps -stop-after=irtranslator %s -o - | FileCheck %s
 
-; AIE pre-lowers the return via CallLowering::preLowerReturn(), but IRTranslator
-; only pre-lowers the *first* ReturnInst of the function. When a function has
-; several returns yielding different values, AIECallLowering::lowerReturnVal()
-; is later called with a Value that does not match the cached one, tripping the
-; RetAssignments.RetVal == Val assertion.
-; FIXME: preLowerReturn must handle multiple returns.
-
-; CHECK: RetAssignments.RetVal == Val
+; Return assignments only depend on the return type, so a function with several
+; returns of different values must translate without hitting the return
+; pre-lowering consistency check.
 
 define i32 @multiple_returns(i32 %x) {
+  ; CHECK-LABEL: name: multiple_returns
+  ; CHECK: bb.2.a:
+  ; CHECK: PseudoRET implicit $lr, implicit $r0
+  ; CHECK: bb.3.b:
+  ; CHECK: PseudoRET implicit $lr, implicit $r0
 entry:
   %c = icmp eq i32 %x, 0
   br i1 %c, label %a, label %b

--- a/llvm/test/CodeGen/AIE/GlobalISel/irtranslator-multiple-returns.ll
+++ b/llvm/test/CodeGen/AIE/GlobalISel/irtranslator-multiple-returns.ll
@@ -1,0 +1,30 @@
+;
+; This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+; See https://llvm.org/LICENSE.txt for license information.
+; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+;
+; (c) Copyright 2026 Advanced Micro Devices, Inc. or its affiliates
+;
+; REQUIRES: asserts
+; RUN: not --crash llc -mtriple=aie2 -stop-after=irtranslator %s -o - 2>&1 | FileCheck %s
+; RUN: not --crash llc -mtriple=aie2p -stop-after=irtranslator %s -o - 2>&1 | FileCheck %s
+; RUN: not --crash llc -mtriple=aie2ps -stop-after=irtranslator %s -o - 2>&1 | FileCheck %s
+
+; AIE pre-lowers the return via CallLowering::preLowerReturn(), but IRTranslator
+; only pre-lowers the *first* ReturnInst of the function. When a function has
+; several returns yielding different values, AIECallLowering::lowerReturnVal()
+; is later called with a Value that does not match the cached one, tripping the
+; RetAssignments.RetVal == Val assertion.
+; FIXME: preLowerReturn must handle multiple returns.
+
+; CHECK: RetAssignments.RetVal == Val
+
+define i32 @multiple_returns(i32 %x) {
+entry:
+  %c = icmp eq i32 %x, 0
+  br i1 %c, label %a, label %b
+a:
+  ret i32 10
+b:
+  ret i32 20
+}


### PR DESCRIPTION
Return CC assignments depend only on the return type, so they are shared by
every return of a function. Drop the vestigial RetVal from SavedRetCCState and
the RetVal==Val identity assert in lowerReturnVal, which wrongly assumed a
single return and crashed on functions with multiple differing returns.