### PR TITLE
[AIE] Implement mayBeEmittedAsTailCall

### DIFF
--- a/llvm/lib/Target/AIE/AIEBaseISelLowering.cpp
+++ b/llvm/lib/Target/AIE/AIEBaseISelLowering.cpp
@@ -19,6 +19,8 @@
 #include "MCTargetDesc/AIEMCTargetDesc.h"
 #include "MCTargetDesc/aie2p/AIE2PMCTargetDesc.h"
 #include "MCTargetDesc/aie2ps/AIE2PSMCTargetDesc.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/IR/Intrinsics.h"
 #include "llvm/IR/RuntimeLibcalls.h"
 #include "llvm/MC/MCRegister.h"
 using namespace llvm;
@@ -931,4 +933,12 @@ MVT AIEBaseTargetLowering::getRegisterTypeForCallingConv(LLVMContext &Context,
     return MVT::i32;
 
   return TargetLowering::getRegisterTypeForCallingConv(Context, CC, VT);
+}
+
+bool AIEBaseTargetLowering::mayBeEmittedAsTailCall(const CallInst *CI) const {
+  // Intrinsics are lowered away and never emit an actual call, so treating them
+  // as tail calls only leads to needless return duplication.
+  if (CI->getIntrinsicID() != Intrinsic::not_intrinsic)
+    return false;
+  return CI->isTailCall();
 }

--- a/llvm/lib/Target/AIE/AIEBaseISelLowering.h
+++ b/llvm/lib/Target/AIE/AIEBaseISelLowering.h
@@ -81,6 +81,8 @@ public:
                                             CallingConv::ID CC,
                                             EVT VT) const override;
 
+  bool mayBeEmittedAsTailCall(const CallInst *CI) const override;
+
 protected:
   bool isEligibleForTailCallOptimization(
       CCState &CCInfo, CallLoweringInfo &CLI, MachineFunction &MF,

--- a/llvm/test/CodeGen/AIE/GlobalISel/codegenprepare-tail-call-ret-dup.ll
+++ b/llvm/test/CodeGen/AIE/GlobalISel/codegenprepare-tail-call-ret-dup.ll
@@ -1,0 +1,33 @@
+;
+; This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+; See https://llvm.org/LICENSE.txt for license information.
+; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+;
+; (c) Copyright 2026 Advanced Micro Devices, Inc. or its affiliates
+;
+; RUN: llc -mtriple=aie2 -stop-after=codegenprepare %s -o - | FileCheck %s
+; RUN: llc -mtriple=aie2p -stop-after=codegenprepare %s -o - | FileCheck %s
+; RUN: llc -mtriple=aie2ps -stop-after=codegenprepare %s -o - | FileCheck %s
+
+declare i32 @f0()
+declare i32 @f1()
+
+define i32 @dup(i1 %c) {
+; CHECK-LABEL: @dup
+; CHECK:       %ta = tail call i32 @f0()
+; CHECK-NEXT:  ret i32 %ta
+; CHECK:       %tb = tail call i32 @f1()
+; CHECK-NEXT:  ret i32 %tb
+; CHECK-NOT:   phi
+entry:
+  br i1 %c, label %a, label %b
+a:
+  %ta = tail call i32 @f0()
+  br label %exit
+b:
+  %tb = tail call i32 @f1()
+  br label %exit
+exit:
+  %p = phi i32 [ %ta, %a ], [ %tb, %b ]
+  ret i32 %p
+}

--- a/llvm/test/CodeGen/AIE/aie2/bcond.ll
+++ b/llvm/test/CodeGen/AIE/aie2/bcond.ll
@@ -15,11 +15,11 @@
 ; CHECK:   bb.1.if.then:
 ; CHECK:     PseudoJL @f0
 ; CHECK:   bb.2.if.end:
-; CHECK:     PseudoJZ killed renamable $r16, %bb.4
-; CHECK:   bb.3.if.then2:
-; CHECK:     PseudoJL @f0
-; CHECK:   bb.4.if.end3:
+; CHECK:     PseudoJNZ killed renamable $r16, %bb.4
+; CHECK:   bb.3.if.end3:
 ; CHECK:     PseudoRET
+; CHECK:   bb.4.if.then2:
+; CHECK:     PseudoJ_TCO_jump_imm @f0
 
 define void @f(i32 %i, i32 %j) {
 entry:


### PR DESCRIPTION
Return CI->isTailCall() so calls already marked tail become tail-call candidates. This lets CodeGenPrepare duplicate returns into tail-call blocks; add a CodeGenPrepare test and update the affected codegen checks.