### PR TITLE
[AIE] Set jumpIsExpensive to avoid splitting short-circuit conditions

### DIFF
--- a/compiler-rt/lib/builtins/CMakeLists.txt
+++ b/compiler-rt/lib/builtins/CMakeLists.txt
@@ -418,6 +418,7 @@ set(aie_SOURCES
 list(REMOVE_ITEM aie_SOURCES
 apple_versioning.c # Not apple
 divsc3.c # Needs sitofp
+divdc3.c # ran out of registers
 emutls.c # Needs  __attribute__ ((__regparm__ (1)))
 enable_execute_stack.c # Trampoline stuff
 eprintf.c # Archaeology

--- a/llvm/lib/Target/AIE/AIEBaseISelLowering.cpp
+++ b/llvm/lib/Target/AIE/AIEBaseISelLowering.cpp
@@ -63,6 +63,7 @@ AIEBaseTargetLowering::AIEBaseTargetLowering(const TargetMachine &TM,
     MaxStoresPerMemmove = 32;
     MaxStoresPerMemmoveOptSize = 16;
   }
+  setJumpIsExpensive(true);
 }
 
 static bool AllocateSplitArg(CCState &State, ArrayRef<MCPhysReg> RegList) {

--- a/llvm/test/CodeGen/AIE/aie2ps/conv2d-outer-loop.ll
+++ b/llvm/test/CodeGen/AIE/aie2ps/conv2d-outer-loop.ll
@@ -14,7 +14,7 @@
 define void @conv2d_outer_loop(ptr noalias %ifm, ptr noalias %wts, ptr noalias %ofm, ptr nonnull align 64 dereferenceable(384) %conv2d_params, ptr noalias %psum_0_tdm, ptr noalias %psum_1_tdm) #0 {
 ; CHECK-LABEL: conv2d_outer_loop:
 ; CHECK:       // %bb.0: // %entry
-; CHECK-NEXT:    mova dj0, #92; nopb ; nopxm ; nops
+; CHECK-NEXT:    mova dj0, #92; nopb ; nopxm
 ; CHECK-NEXT:    lda r4, [p3, dj0]
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    mova dj1, #18
@@ -25,30 +25,24 @@ define void @conv2d_outer_loop(ptr noalias %ifm, ptr noalias %wts, ptr noalias %
 ; CHECK-NEXT:    mova r0, #-24; add r18, r4, r0
 ; CHECK-NEXT:    lshl r22, r18, r0
 ; CHECK-NEXT:    ltu r2, r2, r18
-; CHECK-NEXT:    paddxm [sp], #64; ltu r16, r22, r20
-; CHECK-NEXT:    lda.u8 r26, [p3, #7]; eq r24, r22, r20
+; CHECK-NEXT:    ltu r16, r22, r20
+; CHECK-NEXT:    lda.u8 r24, [p3, #7]; eq r26, r22, r20
 ; CHECK-NEXT:    mova r0, #0; and r27, r2, r16; mov r6, #3
 ; CHECK-NEXT:    mova r16, #1; sel.nez r2, r6, r0, r27
-; CHECK-NEXT:    st p6, [sp, #-64]; eq r26, r22, r16 // 4-byte Folded Spill
-; CHECK-NEXT:    mova m0, #96; st p7, [sp, #-60]; lshl r28, r24, r16 // 4-byte Folded Spill
-; CHECK-NEXT:    mova m0, #-20; paddb [p3], m0; or r26, r28, r26; st r18, [p3, dj0]
-; CHECK-NEXT:    st.s8 r18, [p3], m0; add r2, r26, r2
-; CHECK-NEXT:    ne r26, r26, r16
-; CHECK-NEXT:    jnz r26, #.LBB0_2
+; CHECK-NEXT:    paddxm [sp], #64; eq r24, r22, r16
+; CHECK-NEXT:    st p6, [sp, #-64]; lshl r28, r26, r16 // 4-byte Folded Spill
+; CHECK-NEXT:    mova m0, #96; st p7, [sp, #-60]; or r24, r28, r24 // 4-byte Folded Spill
+; CHECK-NEXT:    mova m0, #-20; paddb [p3], m0; add r2, r24, r2; st r18, [p3, dj0]
+; CHECK-NEXT:    st.s8 r18, [p3], m0; eq r24, r24, r16
+; CHECK-NEXT:    and r30, r24, r26
+; CHECK-NEXT:    jnz r30, #.LBB0_2
 ; CHECK-NEXT:    nop // Delay Slot 5
-; CHECK-NEXT:    ltu r27, r16, r20 // Delay Slot 4
-; CHECK-NEXT:    sel.nez r18, r2, r0, r27 // Delay Slot 3
-; CHECK-NEXT:    ltu r28, r16, r18; mov r7, r8 // Delay Slot 2
-; CHECK-NEXT:    mova r2, #5; st r28, [p3, #0]; or r17, r10, r10; mov r19, r12 // Delay Slot 1
-; CHECK-NEXT:  // %bb.1: // %entry
-; CHECK-NEXT:    jnz r24, #.LBB0_3
-; CHECK-NEXT:    nop // Delay Slot 5
-; CHECK-NEXT:    nop // Delay Slot 4
-; CHECK-NEXT:    nop // Delay Slot 3
-; CHECK-NEXT:    nop // Delay Slot 2
-; CHECK-NEXT:    mova r26, #3; movx r28, #1 // Delay Slot 1
-; CHECK-NEXT:  .LBB0_2: // %if.else.i
-; CHECK-NEXT:    mova dj0, #-48; nopx
+; CHECK-NEXT:    ltu r27, r16, r20; mov r7, r8 // Delay Slot 4
+; CHECK-NEXT:    sel.nez r18, r2, r0, r27; mov r17, r10 // Delay Slot 3
+; CHECK-NEXT:    ltu r28, r16, r18; mov r19, r12 // Delay Slot 2
+; CHECK-NEXT:    mova r26, #3; st r28, [p3, #0]; movx r24, #1; mov r2, #5 // Delay Slot 1
+; CHECK-NEXT:  // %bb.1: // %if.else.i
+; CHECK-NEXT:    mova dj0, #-48
 ; CHECK-NEXT:    lda.s8 r24, [p3, dj0]
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
@@ -65,41 +59,41 @@ define void @conv2d_outer_loop(ptr noalias %ifm, ptr noalias %wts, ptr noalias %
 ; CHECK-NEXT:    mova r28, #4; and r26, r28, r26
 ; CHECK-NEXT:    lshl r24, r24, r28
 ; CHECK-NEXT:    and r27, r30, r26
-; CHECK-NEXT:    and r26, r18, r2
-; CHECK-NEXT:    sel.nez r24, r24, r0, r27
-; CHECK-NEXT:    nez r28, r26
-; CHECK-NEXT:    or r26, r24, r18
-; CHECK-NEXT:  .LBB0_3: // %if.end.i
+; CHECK-NEXT:    sel.nez r26, r24, r0, r27
+; CHECK-NEXT:    and r24, r18, r2
+; CHECK-NEXT:    nez r24, r24
+; CHECK-NEXT:    or r26, r26, r18
+; CHECK-NEXT:  .LBB0_2: // %if.end.i
 ; CHECK-NEXT:    mova m0, #4; nopx
 ; CHECK-NEXT:    padda [p3], m0; ne r20, r22, r20
-; CHECK-NEXT:    st r28, [p3], #24; jnz r20, #.LBB0_5
+; CHECK-NEXT:    st r24, [p3], #24; jnz r20, #.LBB0_4
 ; CHECK-NEXT:    st.s8 r26, [p3, #0] // Delay Slot 5
 ; CHECK-NEXT:    nop // Delay Slot 4
 ; CHECK-NEXT:    nop // Delay Slot 3
 ; CHECK-NEXT:    nop // Delay Slot 2
 ; CHECK-NEXT:    nop // Delay Slot 1
-; CHECK-NEXT:  // %bb.4: // %if.then87.i
+; CHECK-NEXT:  // %bb.3: // %if.then87.i
 ; CHECK-NEXT:    movxm r20, #16777215
 ; CHECK-NEXT:    and r4, r4, r20
 ; CHECK-NEXT:    st r4, [p3, #-12]
-; CHECK-NEXT:  .LBB0_5: // %_Z24setup_conv2d_iter_paramsR13conv2d_params.exit
+; CHECK-NEXT:  .LBB0_4: // %_Z24setup_conv2d_iter_paramsR13conv2d_params.exit
 ; CHECK-NEXT:    nopa ; nopb ; extend.u8 r4, r26; nopm ; nops
 ; CHECK-NEXT:    eq r6, r4, r6
-; CHECK-NEXT:    jnz r6, #.LBB0_7
+; CHECK-NEXT:    jnz r6, #.LBB0_6
 ; CHECK-NEXT:    nop // Delay Slot 5
 ; CHECK-NEXT:    mova m0, #-20 // Delay Slot 4
 ; CHECK-NEXT:    mova m0, #36; paddb [p3], m0 // Delay Slot 3
 ; CHECK-NEXT:    lda r20, [p3], m0 // Delay Slot 2
 ; CHECK-NEXT:    lda r24, [p3, #0] // Delay Slot 1
-; CHECK-NEXT:  // %bb.6: // %_Z24setup_conv2d_iter_paramsR13conv2d_params.exit
+; CHECK-NEXT:  // %bb.5: // %_Z24setup_conv2d_iter_paramsR13conv2d_params.exit
 ; CHECK-NEXT:    ne r4, r4, r16
-; CHECK-NEXT:    jnz r4, #.LBB0_11
+; CHECK-NEXT:    jnz r4, #.LBB0_10
 ; CHECK-NEXT:    nop // Delay Slot 5
 ; CHECK-NEXT:    nop // Delay Slot 4
 ; CHECK-NEXT:    nop // Delay Slot 3
 ; CHECK-NEXT:    nop // Delay Slot 2
 ; CHECK-NEXT:    nop // Delay Slot 1
-; CHECK-NEXT:  .LBB0_7: // %sw.bb14
+; CHECK-NEXT:  .LBB0_6: // %sw.bb14
 ; CHECK-NEXT:    mova m0, #-8; nopxm
 ; CHECK-NEXT:    mova m0, #-104; paddb [p3], m0
 ; CHECK-NEXT:    lda r4, [p3], m0
@@ -133,9 +127,9 @@ define void @conv2d_outer_loop(ptr noalias %ifm, ptr noalias %wts, ptr noalias %
 ; CHECK-NEXT:    mova r16, #16; movs p2, p1; add r18, r26, #-1; mov r30, #63
 ; CHECK-NEXT:    padda [p2], m3; movs dc0, dc3; or r24, r0, r0; mov m3, r28
 ; CHECK-NEXT:    lda dj6, [p3, #0]; movs p3, p4; or r12, r8, r5; mov s1, r1
-; CHECK-NEXT:  .LBB0_8: // %for.body.i68
+; CHECK-NEXT:  .LBB0_7: // %for.body.i68
 ; CHECK-NEXT:    // =>This Loop Header: Depth=1
-; CHECK-NEXT:    // Child Loop BB0_9 Depth 2
+; CHECK-NEXT:    // Child Loop BB0_8 Depth 2
 ; CHECK-NEXT:    nopa ; vldb x1, [p1, #64]; nops ; nopx ; mov r0, dc6; nopv
 ; CHECK-NEXT:    vlda x10, [p1, #0]; vldb.popx x4, [p0, lf0, r24]; lshl r0, r0, r2; mov dc4, dc3; nops
 ; CHECK-NEXT:    vlda.pop.3d x6, [p0, lf0, r24, d0]; or r20, r0, r16; mov dj3, r0
@@ -147,21 +141,21 @@ define void @conv2d_outer_loop(ptr noalias %ifm, ptr noalias %wts, ptr noalias %
 ; CHECK-NEXT:    vlda.ups.2x cmh0, s0, upssign1, [p6], #64; vldb.popx x10, [p0, lf0, r24]; mov p7, p1
 ; CHECK-NEXT:    vlda x6, [p7, #128]; vldb.pop.3d x8, [p0, lf0, r24, d0]
 ; CHECK-NEXT:    vlda x4, [p7, #192]; vldb.popx x10, [p0, lf0, r24]; padds [p7], #128; add.nc lc, r18, #-6; vshuffle x2, x4, x6, r6; vmul dm2, x0, x2, r10
-; CHECK-NEXT:    vlda x6, [p7, #128]; vldb.pop.3d x8, [p0, lf0, r24, d0]; movxm ls, #.LBB0_9; vmul dm3, x0, x8, r10
+; CHECK-NEXT:    vlda x6, [p7, #128]; vldb.pop.3d x8, [p0, lf0, r24, d0]; movxm ls, #.LBB0_8; vmul dm3, x0, x8, r10
 ; CHECK-NEXT:    vlda x4, [p7, #192]; vldb.popx x10, [p0, lf0, r24]; padds [p7], #128; movxm le, #.L_LEnd0; vaddmac dm1, dm1, dm2, x2, x10, r12
 ; CHECK-NEXT:    vlda x6, [p7, #128]; vldb.pop.3d x8, [p0, lf0, r24, d0]; nops ; nopxm ; nopv
 ; CHECK-NEXT:    vlda x4, [p7, #192]; vldb.popx x10, [p0, lf0, r24]; padds [p7], #128; nopxm ; vaddmac dm0, dm0, dm3, x2, x1, r12
 ; CHECK-NEXT:    vlda x6, [p7, #128]; vldb.pop.3d x8, [p0, lf0, r24, d0]; nops ; nopx ; vshuffle x2, x10, x8, r6; nopv
 ; CHECK-NEXT:    vlda x4, [p7, #192]; vldb.popx x10, [p0, lf0, r24]; padds [p7], #128; nopxm ; nopv
 ; CHECK-NEXT:    vlda x6, [p7, #128]; vldb.pop.3d x8, [p0, lf0, r24, d0]; nops ; nopx ; vshuffle x2, x10, x8, r6; vmac dm1, dm1, x2, x6, r8
-; CHECK-NEXT:  .LBB0_9: // %for.body55.i82
-; CHECK-NEXT:    // Parent Loop BB0_8 Depth=1
+; CHECK-NEXT:  .LBB0_8: // %for.body55.i82
+; CHECK-NEXT:    // Parent Loop BB0_7 Depth=1
 ; CHECK-NEXT:    // => This Inner Loop Header: Depth=2
 ; CHECK-NEXT:    vlda x4, [p7, #192]; vldb.popx x10, [p0, lf0, r24]; padds [p7], #128; nopxm ; vmac dm0, dm0, x2, x4, r8
 ; CHECK-NEXT:  .L_LEnd0:
 ; CHECK-NEXT:    vlda x6, [p7, #128]; vldb.pop.3d x8, [p0, lf0, r24, d0]; nops ; nopx ; vshuffle x2, x10, x8, r6; vmac dm1, dm1, x2, x6, r8
-; CHECK-NEXT:  // %bb.10: // %for.cond.cleanup54.i89
-; CHECK-NEXT:    // in Loop: Header=BB0_8 Depth=1
+; CHECK-NEXT:  // %bb.9: // %for.cond.cleanup54.i89
+; CHECK-NEXT:    // in Loop: Header=BB0_7 Depth=1
 ; CHECK-NEXT:    vlda x4, [p7, #192]; paddb [p1], m3; add r4, r4, #-1; padds [p7], #128; vmac dm0, dm0, x2, x4, r8
 ; CHECK-NEXT:    vlda x6, [p7, #128]; paddb.3d [p1], d2; padds.3d [p0], d1; nopx ; vshuffle x2, x10, x8, r6; vmac dm1, dm1, x2, x6, r8
 ; CHECK-NEXT:    vlda x4, [p7, #192]; padds [p7], #128; vmac dm0, dm0, x2, x4, r8
@@ -175,13 +169,13 @@ define void @conv2d_outer_loop(ptr noalias %ifm, ptr noalias %wts, ptr noalias %
 ; CHECK-NEXT:    vmac dm0, dm0, x2, x4, r8
 ; CHECK-NEXT:    nop
 ; CHECK-NEXT:    nop
-; CHECK-NEXT:    jnz r4, #.LBB0_8
+; CHECK-NEXT:    jnz r4, #.LBB0_7
 ; CHECK-NEXT:    nop // Delay Slot 5
 ; CHECK-NEXT:    vst.srs.2x cml1, s1, srssign1, [p3], #64 // Delay Slot 4
 ; CHECK-NEXT:    vst.srs.2x cml0, s1, srssign1, [p5], #64 // Delay Slot 3
 ; CHECK-NEXT:    vst.srs.2x cmh1, s1, srssign1, [p3], #64 // Delay Slot 2
 ; CHECK-NEXT:    vst.srs.2x cmh0, s1, srssign1, [p5], #64 // Delay Slot 1
-; CHECK-NEXT:  .LBB0_11: // %sw.epilog
+; CHECK-NEXT:  .LBB0_10: // %sw.epilog
 ; CHECK-NEXT:    lda p7, [sp, #-60] // 4-byte Folded Reload
 ; CHECK-NEXT:    lda p6, [sp, #-64] // 4-byte Folded Reload
 ; CHECK-NEXT:    ret lr

--- a/llvm/test/CodeGen/AIE/aie2ps/end-to-end/conv2d_opt_outerloop_pipelining_out_mode_0.ll
+++ b/llvm/test/CodeGen/AIE/aie2ps/end-to-end/conv2d_opt_outerloop_pipelining_out_mode_0.ll
@@ -53,10 +53,10 @@ define void @conv2d_opt_outerloop_out_mode_0(
 ; REMARKS-NEXT:   - Pipeliner:       postpipeliner
 ; REMARKS-NEXT:   - II:              '2'
 ; REMARKS-NEXT:   - NS:              '7'
-; REMARKS-NEXT:   - Loop:            bb.7.steady.stage1.inner.for.body55.i
-; REMARKS-NEXT:   - Prologue:        bb.6.steady.stage1.top
+; REMARKS-NEXT:   - Loop:            bb.6.steady.stage1.inner.for.body55.i
+; REMARKS-NEXT:   - Prologue:        bb.5.steady.stage1.top
 ; REMARKS-NEXT:   - PrologueBundles: '12'
-; REMARKS-NEXT:   - Epilogue:        bb.8.steady.stage1.bottom.and.stage0.top
+; REMARKS-NEXT:   - Epilogue:        bb.7.steady.stage1.bottom.and.stage0.top
 ; REMARKS-NEXT:   - EpilogueBundles: '17'
 ; REMARKS-NEXT: ...
 ; REMARKS: --- !Passed
@@ -68,16 +68,16 @@ define void @conv2d_opt_outerloop_out_mode_0(
 ; REMARKS-NEXT:   - Pipeliner:       postpipeliner
 ; REMARKS-NEXT:   - II:              '2'
 ; REMARKS-NEXT:   - NS:              '7'
-; REMARKS-NEXT:   - Loop:            bb.10.lastiter.stage1.inner.for.body55.i
-; REMARKS-NEXT:   - Prologue:        bb.9.lastiter.stage1.top
+; REMARKS-NEXT:   - Loop:            bb.9.lastiter.stage1.inner.for.body55.i
+; REMARKS-NEXT:   - Prologue:        bb.8.lastiter.stage1.top
 ; REMARKS-NEXT:   - PrologueBundles: '12'
-; REMARKS-NEXT:   - Epilogue:        bb.11.lastiter.stage1.bottom
+; REMARKS-NEXT:   - Epilogue:        bb.10.lastiter.stage1.bottom
 ; REMARKS-NEXT:   - EpilogueBundles: '20'
 ; REMARKS-NEXT: ...
 ; ASM-LABEL: conv2d_opt_outerloop_out_mode_0:
 ; ASM:       // %bb.0: // %entry
-; ASM-NEXT:    mova dj0, #92; nopb ; nops ; nopxm ; nopv
-; ASM-NEXT:    lda r4, [p3, dj0]; nopx
+; ASM-NEXT:    mova dj0, #92; nopxm
+; ASM-NEXT:    lda r4, [p3, dj0]
 ; ASM-NEXT:    nop
 ; ASM-NEXT:    mova dj1, #18
 ; ASM-NEXT:    lda.u8 r16, [p3, dj1]
@@ -87,30 +87,26 @@ define void @conv2d_opt_outerloop_out_mode_0(
 ; ASM-NEXT:    mova r6, #-24; add r0, r4, r0
 ; ASM-NEXT:    lshl r18, r0, r6
 ; ASM-NEXT:    ltu r2, r2, r0
-; ASM-NEXT:    paddxm [sp], #64; ltu r20, r18, r16
-; ASM-NEXT:    lda.u8 r26, [p3, #7]; eq r22, r18, r16
+; ASM-NEXT:    ltu r20, r18, r16
+; ASM-NEXT:    eq r26, r18, r16
 ; ASM-NEXT:    mova r6, #3; and r27, r2, r20; mov r24, #0
-; ASM-NEXT:    mova r20, #1; sel.nez r2, r6, r24, r27
-; ASM-NEXT:    st p6, [sp, #-64]; eq r26, r18, r20 // 4-byte Folded Spill
-; ASM-NEXT:    mova m0, #96; st p7, [sp, #-60]; lshl r28, r22, r20 // 4-byte Folded Spill
-; ASM-NEXT:    mova m0, #-20; paddb [p3], m0; or r26, r28, r26; st r0, [p3, dj0]
-; ASM-NEXT:    st.s8 r0, [p3], m0; add r2, r26, r2
-; ASM-NEXT:    ne r26, r26, r20
-; ASM-NEXT:    jnz r26, #.LBB0_2
-; ASM-NEXT:    nop // Delay Slot 5
-; ASM-NEXT:    ltu r27, r20, r16 // Delay Slot 4
-; ASM-NEXT:    sel.nez r0, r2, r24, r27 // Delay Slot 3
-; ASM-NEXT:    ltu r28, r20, r0; mov r23, r8 // Delay Slot 2
-; ASM-NEXT:    mova r2, #5; st r28, [p3, #0]; or r25, r10, r10; mov r29, r12 // Delay Slot 1
-; ASM-NEXT:  // %bb.1: // %entry
-; ASM-NEXT:    jnz r22, #.LBB0_3
+; ASM-NEXT:    lda.u8 r22, [p3, #7]; sel.nez r2, r6, r24, r27; mov r20, #1
+; ASM-NEXT:    eq r22, r18, r20
+; ASM-NEXT:    lshl r28, r26, r20
+; ASM-NEXT:    paddxm [sp], #64; ltu r27, r20, r16
+; ASM-NEXT:    st p6, [sp, #-64]; or r22, r28, r22 // 4-byte Folded Spill
+; ASM-NEXT:    mova m0, #96; st p7, [sp, #-60]; add r2, r22, r2 // 4-byte Folded Spill
+; ASM-NEXT:    mova m0, #-20; paddb [p3], m0; sel.nez r0, r2, r24, r27; st r0, [p3, dj0]
+; ASM-NEXT:    st.s8 r0, [p3], m0; eq r2, r22, r20
+; ASM-NEXT:    and r22, r2, r26
+; ASM-NEXT:    jnz r22, #.LBB0_2
 ; ASM-NEXT:    nop // Delay Slot 5
 ; ASM-NEXT:    nop // Delay Slot 4
 ; ASM-NEXT:    nop // Delay Slot 3
-; ASM-NEXT:    nop // Delay Slot 2
-; ASM-NEXT:    nop // Delay Slot 1
-; ASM-NEXT:  .LBB0_2: // %if.else.i
-; ASM-NEXT:    mova dj0, #-48; nopx
+; ASM-NEXT:    ltu r28, r20, r0; mov r23, r8 // Delay Slot 2
+; ASM-NEXT:    mova r2, #5; st r28, [p3, #0]; or r25, r10, r10; mov r29, r12 // Delay Slot 1
+; ASM-NEXT:  // %bb.1: // %if.else.i
+; ASM-NEXT:    mova dj0, #-48
 ; ASM-NEXT:    lda.s8 r6, [p3, dj0]
 ; ASM-NEXT:    nop
 ; ASM-NEXT:    nop
@@ -131,22 +127,22 @@ define void @conv2d_opt_outerloop_out_mode_0(
 ; ASM-NEXT:    sel.nez r6, r6, r24, r27
 ; ASM-NEXT:    nez r20, r20
 ; ASM-NEXT:    or r6, r6, r0
-; ASM-NEXT:  .LBB0_3: // %if.end.i
+; ASM-NEXT:  .LBB0_2: // %if.end.i
 ; ASM-NEXT:    mova m0, #4; nopb ; nopxm
 ; ASM-NEXT:    padda [p3], m0
 ; ASM-NEXT:    st r20, [p3], #24
 ; ASM-NEXT:    st.s8 r6, [p3, #0]; ne r20, r18, r16
-; ASM-NEXT:    jnz r20, #.LBB0_5
+; ASM-NEXT:    jnz r20, #.LBB0_4
 ; ASM-NEXT:    nop // Delay Slot 5
 ; ASM-NEXT:    nop // Delay Slot 4
 ; ASM-NEXT:    nop // Delay Slot 3
 ; ASM-NEXT:    nop // Delay Slot 2
 ; ASM-NEXT:    mova r6, #2; movx r16, #256; mov r18, #9 // Delay Slot 1
-; ASM-NEXT:  // %bb.4: // %if.then87.i
+; ASM-NEXT:  // %bb.3: // %if.then87.i
 ; ASM-NEXT:    movxm r20, #16777215
 ; ASM-NEXT:    and r4, r4, r20
 ; ASM-NEXT:    st r4, [p3, #-12]
-; ASM-NEXT:  .LBB0_5: // %_Z24setup_conv2d_iter_paramsR13conv2d_params.exit
+; ASM-NEXT:  .LBB0_4: // %_Z24setup_conv2d_iter_paramsR13conv2d_params.exit
 ; ASM-NEXT:    mova m0, #-20; nopb ; nopx
 ; ASM-NEXT:    mova m0, #36; paddb [p3], m0
 ; ASM-NEXT:    lda r22, [p3], m0
@@ -192,34 +188,34 @@ define void @conv2d_opt_outerloop_out_mode_0(
 ; ASM-NEXT:    mov dc3, dc7
 ; ASM-NEXT:    vlda.ups.2x cml1, s0, upssign1, [p4], #64; movs dc6, dc7; mov dc2, dc7
 ; ASM-NEXT:    vlda.ups.2x cmh1, s0, upssign1, [p4], #64; movs dj3, r26; mov s0, r28
-; ASM-NEXT:    movs dj7, r22; vldb x8, [p6, dj3]; movxm p6, #.LBB0_6
+; ASM-NEXT:    movs dj7, r22; vldb x8, [p6, dj3]; movxm p6, #.LBB0_5
 ; ASM-NEXT:    mova r12, #264; vldb.128 wl2, [p3, dj7]; add r0, r20, #-1; vbcst.32 x0, r18; movs dc5, dc7
 ; ASM-NEXT:    vlda.ups.2x cml0, s0, upssign1, [p5], #64; vldb.128 wl4, [p1, #16]; add r18, r3, #-1; addm.nc r3, r0, #-1; movs dc1, dc7
 ; ASM-NEXT:    vlda.ups.2x cmh0, s0, upssign1, [p5], #64; movs dj3, r19; movx crupsmode, #0; mov s1, r6
 ; ASM-NEXT:    mova r16, #16; vldb x6, [p3, #64]; movx crsrsmode, #0; vshuffle x10, x10, x1, r4; movs m5, r21
-; ASM-NEXT:  .LBB0_6: // %steady.stage1.top
+; ASM-NEXT:  .LBB0_5: // %steady.stage1.top
 ; ASM-NEXT:    // =>This Loop Header: Depth=1
-; ASM-NEXT:    // Child Loop BB0_7 Depth 2
+; ASM-NEXT:    // Child Loop BB0_6 Depth 2
 ; ASM-NEXT:    nopa ; vldb.popx x10, [p0, lf0, r24]; nops ; nopxm ; nopv
 ; ASM-NEXT:    vldb.pop.3d x8, [p0, lf0, r24, d0]
 ; ASM-NEXT:    vldb.popx x10, [p0, lf0, r24]; mov p7, p3
 ; ASM-NEXT:    vlda x6, [p7, #128]; vldb.pop.3d x8, [p0, lf0, r24, d0]; vmul dm2, x0, x2, r12
 ; ASM-NEXT:    vlda x4, [p7, #192]; vldb.popx x10, [p0, lf0, r24]; add.nc lc, r18, #-6; padds [p7], #128; vmul dm3, x0, x4, r12
-; ASM-NEXT:    vlda x6, [p7, #128]; vldb.pop.3d x8, [p0, lf0, r24, d0]; movxm ls, #.LBB0_7; vaddmac dm1, dm1, dm2, x10, x8, r10
+; ASM-NEXT:    vlda x6, [p7, #128]; vldb.pop.3d x8, [p0, lf0, r24, d0]; movxm ls, #.LBB0_6; vaddmac dm1, dm1, dm2, x10, x8, r10
 ; ASM-NEXT:    vlda x4, [p7, #192]; vldb.popx x10, [p0, lf0, r24]; padds [p7], #128; movxm le, #.L_LEnd1; vaddmac dm0, dm0, dm3, x10, x6, r10
 ; ASM-NEXT:    vlda x6, [p7, #128]; vldb.pop.3d x8, [p0, lf0, r24, d0]; nops ; nopxm ; nopv
 ; ASM-NEXT:    vlda x4, [p7, #192]; vldb.popx x10, [p0, lf0, r24]; padds [p7], #128; nopxm ; nopv
 ; ASM-NEXT:    vlda x6, [p7, #128]; vldb.pop.3d x8, [p0, lf0, r24, d0]; nops ; nopx ; vshuffle x2, x10, x8, r4; nopv
 ; ASM-NEXT:    vlda x4, [p7, #192]; vldb.popx x10, [p0, lf0, r24]; padds [p7], #128; nopxm ; nopv
 ; ASM-NEXT:    vlda x6, [p7, #128]; vldb.pop.3d x8, [p0, lf0, r24, d0]; nops ; nopx ; vshuffle x2, x10, x8, r4; vmac dm1, dm1, x2, x6, r8
-; ASM-NEXT:  .LBB0_7: // %steady.stage1.inner.for.body55.i
-; ASM-NEXT:    // Parent Loop BB0_6 Depth=1
+; ASM-NEXT:  .LBB0_6: // %steady.stage1.inner.for.body55.i
+; ASM-NEXT:    // Parent Loop BB0_5 Depth=1
 ; ASM-NEXT:    // => This Inner Loop Header: Depth=2
 ; ASM-NEXT:    vlda x4, [p7, #192]; vldb.popx x10, [p0, lf0, r24]; padds [p7], #128; nopxm ; vmac dm0, dm0, x2, x4, r8
 ; ASM-NEXT:  .L_LEnd1:
 ; ASM-NEXT:    vlda x6, [p7, #128]; vldb.pop.3d x8, [p0, lf0, r24, d0]; nops ; nopx ; vshuffle x2, x10, x8, r4; vmac dm1, dm1, x2, x6, r8
-; ASM-NEXT:  // %bb.8: // %steady.stage1.bottom.and.stage0.top
-; ASM-NEXT:    // in Loop: Header=BB0_6 Depth=1
+; ASM-NEXT:  // %bb.7: // %steady.stage1.bottom.and.stage0.top
+; ASM-NEXT:    // in Loop: Header=BB0_5 Depth=1
 ; ASM-NEXT:    vlda x4, [p7, #192]; paddb.3d [p0], d1; padds [p7], #128; nopxm ; vmac dm0, dm0, x2, x4, r8
 ; ASM-NEXT:    vlda x6, [p7, #128]; paddb [p3], m4; movs dc4, dc7; nopx ; vshuffle x2, x10, x8, r4; vmac dm1, dm1, x2, x6, r8
 ; ASM-NEXT:    vlda x4, [p7, #192]; vldb.popx x10, [p0, lf0, r24]; padds [p7], #128; nopx ; mov srssign0, r1; vmac dm0, dm0, x2, x4, r8
@@ -237,25 +233,25 @@ define void @conv2d_opt_outerloop_out_mode_0(
 ; ASM-NEXT:    nop // Delay Slot 3
 ; ASM-NEXT:    vst.srs.4x dm1, s1, srssign0, [p2], m5 // Delay Slot 2
 ; ASM-NEXT:    vst.2d.srs.4x dm0, s1, srssign0, [p2], d3; movx srssign0, #0 // Delay Slot 1
-; ASM-NEXT:  // %bb.9: // %lastiter.stage1.top
+; ASM-NEXT:  // %bb.8: // %lastiter.stage1.top
 ; ASM-NEXT:    vldb.popx x8, [p0, lf0, r24]
 ; ASM-NEXT:    vldb.pop.3d x6, [p0, lf0, r24, d0]
 ; ASM-NEXT:    vldb.popx x8, [p0, lf0, r24]
 ; ASM-NEXT:    vlda x4, [p3, #128]; vldb.pop.3d x6, [p0, lf0, r24, d0]
 ; ASM-NEXT:    vlda x2, [p3, #192]; vldb.popx x8, [p0, lf0, r24]; add.nc lc, r18, #-6; padds [p3], #128; vmul dm2, x0, x2, r12
-; ASM-NEXT:    vlda x4, [p3, #128]; vldb.pop.3d x6, [p0, lf0, r24, d0]; movxm ls, #.LBB0_10; vmul dm3, x0, x4, r12
+; ASM-NEXT:    vlda x4, [p3, #128]; vldb.pop.3d x6, [p0, lf0, r24, d0]; movxm ls, #.LBB0_9; vmul dm3, x0, x4, r12
 ; ASM-NEXT:    vlda x2, [p3, #192]; vldb.popx x8, [p0, lf0, r24]; padds [p3], #128; movxm le, #.L_LEnd0; vaddmac dm1, dm1, dm2, x10, x8, r10
 ; ASM-NEXT:    vlda x4, [p3, #128]; vldb.pop.3d x6, [p0, lf0, r24, d0]; nops ; nopxm ; vaddmac dm0, dm0, dm3, x10, x6, r10
 ; ASM-NEXT:    vlda x2, [p3, #192]; vldb.popx x8, [p0, lf0, r24]; padds [p3], #128; nopxm ; nopv
 ; ASM-NEXT:    vlda x4, [p3, #128]; vldb.pop.3d x6, [p0, lf0, r24, d0]; nops ; nopx ; vshuffle x0, x8, x6, r4; nopv
 ; ASM-NEXT:    vlda x2, [p3, #192]; vldb.popx x8, [p0, lf0, r24]; padds [p3], #128; nopxm ; nopv
 ; ASM-NEXT:    vlda x4, [p3, #128]; vldb.pop.3d x6, [p0, lf0, r24, d0]; nops ; nopx ; vshuffle x0, x8, x6, r4; vmac dm1, dm1, x0, x4, r8
-; ASM-NEXT:  .LBB0_10: // %lastiter.stage1.inner.for.body55.i
+; ASM-NEXT:  .LBB0_9: // %lastiter.stage1.inner.for.body55.i
 ; ASM-NEXT:    // =>This Inner Loop Header: Depth=1
 ; ASM-NEXT:    vlda x2, [p3, #192]; vldb.popx x8, [p0, lf0, r24]; padds [p3], #128; nopxm ; vmac dm0, dm0, x0, x2, r8
 ; ASM-NEXT:  .L_LEnd0:
 ; ASM-NEXT:    vlda x4, [p3, #128]; vldb.pop.3d x6, [p0, lf0, r24, d0]; nops ; nopx ; vshuffle x0, x8, x6, r4; vmac dm1, dm1, x0, x4, r8
-; ASM-NEXT:  // %bb.11: // %lastiter.stage1.bottom
+; ASM-NEXT:  // %bb.10: // %lastiter.stage1.bottom
 ; ASM-NEXT:    vlda x2, [p3, #192]; padds [p3], #128; nopx ; vmac dm0, dm0, x0, x2, r8
 ; ASM-NEXT:    vlda x4, [p3, #128]; nopb ; movs dj0, r21; movx crsrsmode, #0; vshuffle x0, x8, x6, r4; vmac dm1, dm1, x0, x4, r8
 ; ASM-NEXT:    vlda x2, [p3, #192]; nopb ; padds [p3], #128; or r12, r29, r29; mov s0, r6; vmac dm0, dm0, x0, x2, r8

--- a/llvm/test/CodeGen/AIE/aie2ps/end-to-end/conv2d_opt_outerloop_pipelining_out_mode_1.ll
+++ b/llvm/test/CodeGen/AIE/aie2ps/end-to-end/conv2d_opt_outerloop_pipelining_out_mode_1.ll
@@ -53,10 +53,10 @@ define void @conv2d_opt_outerloop_out_mode_1(
 ; REMARKS-NEXT:   - Pipeliner:       postpipeliner
 ; REMARKS-NEXT:   - II:              '2'
 ; REMARKS-NEXT:   - NS:              '7'
-; REMARKS-NEXT:   - Loop:            bb.7.steady.stage1.inner.for.body55.i82
-; REMARKS-NEXT:   - Prologue:        bb.6.steady.stage1.top
+; REMARKS-NEXT:   - Loop:            bb.6.steady.stage1.inner.for.body55.i82
+; REMARKS-NEXT:   - Prologue:        bb.5.steady.stage1.top
 ; REMARKS-NEXT:   - PrologueBundles: '12'
-; REMARKS-NEXT:   - Epilogue:        bb.8.steady.stage1.bottom.and.stage0.top
+; REMARKS-NEXT:   - Epilogue:        bb.7.steady.stage1.bottom.and.stage0.top
 ; REMARKS-NEXT:   - EpilogueBundles: '19'
 ; REMARKS-NEXT: ...
 ; REMARKS: --- !Passed
@@ -68,92 +68,88 @@ define void @conv2d_opt_outerloop_out_mode_1(
 ; REMARKS-NEXT:   - Pipeliner:       postpipeliner
 ; REMARKS-NEXT:   - II:              '2'
 ; REMARKS-NEXT:   - NS:              '7'
-; REMARKS-NEXT:   - Loop:            bb.10.lastiter.stage1.inner.for.body55.i82
-; REMARKS-NEXT:   - Prologue:        bb.9.lastiter.stage1.top
+; REMARKS-NEXT:   - Loop:            bb.9.lastiter.stage1.inner.for.body55.i82
+; REMARKS-NEXT:   - Prologue:        bb.8.lastiter.stage1.top
 ; REMARKS-NEXT:   - PrologueBundles: '12'
-; REMARKS-NEXT:   - Epilogue:        bb.11.lastiter.stage1.bottom
+; REMARKS-NEXT:   - Epilogue:        bb.10.lastiter.stage1.bottom
 ; REMARKS-NEXT:   - EpilogueBundles: '22'
 ; REMARKS-NEXT: ...
 ; ASM-LABEL: conv2d_opt_outerloop_out_mode_1:
 ; ASM:       // %bb.0: // %entry
-; ASM-NEXT:    mova dj0, #92; nopb ; nops ; nopxm ; nopv
+; ASM-NEXT:    mova dj0, #92; nopb ; nopx
 ; ASM-NEXT:    lda r4, [p3, dj0]
 ; ASM-NEXT:    nop
 ; ASM-NEXT:    mova dj1, #18
-; ASM-NEXT:    lda.u8 r6, [p3, dj1]
+; ASM-NEXT:    lda.u8 r16, [p3, dj1]
 ; ASM-NEXT:    nop
 ; ASM-NEXT:    movxm r0, #16777216
 ; ASM-NEXT:    movxm r2, #33554431
-; ASM-NEXT:    mova r16, #-24; add r0, r4, r0
-; ASM-NEXT:    lshl r16, r0, r16
+; ASM-NEXT:    mova r6, #-24; add r0, r4, r0
+; ASM-NEXT:    lshl r18, r0, r6
 ; ASM-NEXT:    ltu r2, r2, r0
-; ASM-NEXT:    paddxm [sp], #64; ltu r20, r16, r6
-; ASM-NEXT:    lda.u8 r26, [p3, #7]; eq r22, r16, r6
-; ASM-NEXT:    mova r24, #0; and r27, r2, r20; mov r18, #3
-; ASM-NEXT:    mova r20, #1; sel.nez r2, r18, r24, r27
-; ASM-NEXT:    st p7, [sp, #-60]; eq r26, r16, r20 // 4-byte Folded Spill
-; ASM-NEXT:    mova m0, #96; st p6, [sp, #-64]; lshl r28, r22, r20 // 4-byte Folded Spill
-; ASM-NEXT:    mova m0, #-20; paddb [p3], m0; or r26, r28, r26; st r0, [p3, dj0]
-; ASM-NEXT:    st.s8 r0, [p3], m0; add r2, r26, r2
-; ASM-NEXT:    ne r26, r26, r20
-; ASM-NEXT:    jnz r26, #.LBB0_2
-; ASM-NEXT:    nop // Delay Slot 5
-; ASM-NEXT:    ltu r27, r20, r6 // Delay Slot 4
-; ASM-NEXT:    sel.nez r0, r2, r24, r27; mov r17, r8 // Delay Slot 3
-; ASM-NEXT:    ltu r28, r20, r0; mov r19, r10 // Delay Slot 2
-; ASM-NEXT:    mova r2, #5; st r28, [p3, #0]; or r21, r12, r12; mov p7, p1 // Delay Slot 1
-; ASM-NEXT:  // %bb.1: // %entry
-; ASM-NEXT:    jnz r22, #.LBB0_3
+; ASM-NEXT:    ltu r20, r18, r16
+; ASM-NEXT:    eq r26, r18, r16
+; ASM-NEXT:    mova r6, #3; and r27, r2, r20; mov r24, #0
+; ASM-NEXT:    lda.u8 r22, [p3, #7]; sel.nez r2, r6, r24, r27; mov r20, #1
+; ASM-NEXT:    eq r22, r18, r20
+; ASM-NEXT:    lshl r28, r26, r20
+; ASM-NEXT:    paddxm [sp], #64; ltu r27, r20, r16
+; ASM-NEXT:    st p7, [sp, #-60]; or r22, r28, r22 // 4-byte Folded Spill
+; ASM-NEXT:    mova m0, #96; st p6, [sp, #-64]; add r2, r22, r2 // 4-byte Folded Spill
+; ASM-NEXT:    mova m0, #-20; paddb [p3], m0; sel.nez r0, r2, r24, r27; st r0, [p3, dj0]
+; ASM-NEXT:    st.s8 r0, [p3], m0; eq r2, r22, r20
+; ASM-NEXT:    and r22, r2, r26
+; ASM-NEXT:    jnz r22, #.LBB0_2
 ; ASM-NEXT:    nop // Delay Slot 5
 ; ASM-NEXT:    nop // Delay Slot 4
-; ASM-NEXT:    nop // Delay Slot 3
-; ASM-NEXT:    nop // Delay Slot 2
-; ASM-NEXT:    nop // Delay Slot 1
-; ASM-NEXT:  .LBB0_2: // %if.else.i
-; ASM-NEXT:    mova dj0, #-48; nopx
-; ASM-NEXT:    lda.s8 r18, [p3, dj0]
+; ASM-NEXT:    mov r17, r8 // Delay Slot 3
+; ASM-NEXT:    ltu r28, r20, r0; mov r19, r10 // Delay Slot 2
+; ASM-NEXT:    mova r2, #5; st r28, [p3, #0]; or r21, r12, r12; mov p7, p1 // Delay Slot 1
+; ASM-NEXT:  // %bb.1: // %if.else.i
+; ASM-NEXT:    mova dj0, #-48
+; ASM-NEXT:    lda.s8 r6, [p3, dj0]
 ; ASM-NEXT:    nop
 ; ASM-NEXT:    nop
 ; ASM-NEXT:    nop
 ; ASM-NEXT:    nop
 ; ASM-NEXT:    nop
 ; ASM-NEXT:    nop
-; ASM-NEXT:    add r20, r18, #-4
-; ASM-NEXT:    extend.u8 r26, r18
+; ASM-NEXT:    add r20, r6, #-4
+; ASM-NEXT:    extend.u8 r26, r6
 ; ASM-NEXT:    mova r22, #254; extend.u8 r20, r20
 ; ASM-NEXT:    mova r22, #8; ltu r20, r20, r22
 ; ASM-NEXT:    ne r22, r26, r22
 ; ASM-NEXT:    ne r26, r26, r2
 ; ASM-NEXT:    mova r22, #4; and r20, r22, r20
-; ASM-NEXT:    lshl r18, r18, r22
+; ASM-NEXT:    lshl r6, r6, r22
 ; ASM-NEXT:    and r27, r26, r20
 ; ASM-NEXT:    and r20, r0, r2
-; ASM-NEXT:    sel.nez r18, r18, r24, r27
+; ASM-NEXT:    sel.nez r6, r6, r24, r27
 ; ASM-NEXT:    nez r20, r20
-; ASM-NEXT:    or r18, r18, r0
-; ASM-NEXT:  .LBB0_3: // %if.end.i
+; ASM-NEXT:    or r6, r6, r0
+; ASM-NEXT:  .LBB0_2: // %if.end.i
 ; ASM-NEXT:    mova m0, #4; nopb ; nopxm
 ; ASM-NEXT:    padda [p3], m0
 ; ASM-NEXT:    st r20, [p3], #24
-; ASM-NEXT:    st.s8 r18, [p3, #0]; ne r6, r16, r6
-; ASM-NEXT:    jnz r6, #.LBB0_5
+; ASM-NEXT:    st.s8 r6, [p3, #0]; ne r20, r18, r16
+; ASM-NEXT:    jnz r20, #.LBB0_4
 ; ASM-NEXT:    nop // Delay Slot 5
 ; ASM-NEXT:    nop // Delay Slot 4
 ; ASM-NEXT:    nop // Delay Slot 3
 ; ASM-NEXT:    nop // Delay Slot 2
-; ASM-NEXT:    mova r18, #9; movx r16, #256; mov r22, #2 // Delay Slot 1
-; ASM-NEXT:  // %bb.4: // %if.then87.i
-; ASM-NEXT:    movxm r6, #16777215
-; ASM-NEXT:    and r4, r4, r6
+; ASM-NEXT:    mova r6, #2; movx r16, #256; mov r18, #9 // Delay Slot 1
+; ASM-NEXT:  // %bb.3: // %if.then87.i
+; ASM-NEXT:    movxm r20, #16777215
+; ASM-NEXT:    and r4, r4, r20
 ; ASM-NEXT:    st r4, [p3, #-12]
-; ASM-NEXT:  .LBB0_5: // %_Z24setup_conv2d_iter_paramsR13conv2d_params.exit
+; ASM-NEXT:  .LBB0_4: // %_Z24setup_conv2d_iter_paramsR13conv2d_params.exit
 ; ASM-NEXT:    mova m0, #-20; nopb ; nops ; nopxm ; nopv
 ; ASM-NEXT:    mova m0, #36; paddb [p3], m0
-; ASM-NEXT:    lda r6, [p3], m0
+; ASM-NEXT:    lda r26, [p3], m0
 ; ASM-NEXT:    lda r28, [p3], #-8; mov m0, #-104
 ; ASM-NEXT:    lda r20, [p3], m0
 ; ASM-NEXT:    lda.u8 r30, [p3], #1; mov m0, #131
-; ASM-NEXT:    lda.s8 r26, [p3], m0
+; ASM-NEXT:    lda.s8 r22, [p3], m0
 ; ASM-NEXT:    lda m0, [p3], #-8
 ; ASM-NEXT:    lda dn0, [p3], #-8
 ; ASM-NEXT:    lda dj0, [p3], #12
@@ -166,54 +162,54 @@ define void @conv2d_opt_outerloop_out_mode_1(
 ; ASM-NEXT:    nop
 ; ASM-NEXT:    mova m1, #52
 ; ASM-NEXT:    lda r3, [p3], m1
-; ASM-NEXT:    lda m1, [p3], #-8; ltu r0, r0, r22
+; ASM-NEXT:    lda m1, [p3], #-8; ltu r0, r0, r6
 ; ASM-NEXT:    lda dn1, [p3], #-8; movx crupsmode, #0; mov r5, #2
-; ASM-NEXT:    lda dj1, [p3], #12; lshl r7, r6, r5; mov r22, #0
+; ASM-NEXT:    lda dj1, [p3], #12; lshl r7, r26, r5; mov r6, #0
 ; ASM-NEXT:    lda dn5, [p3], #-8; lshl r18, r1, r18; mov m2, #32
 ; ASM-NEXT:    lda dj5, [p3], m2; or r8, r18, r16; mov dj3, #-158
 ; ASM-NEXT:    lda m2, [p3], #-8; lshl r18, r0, r30; mov dc3, #0
 ; ASM-NEXT:    lda dn2, [p3], #-8; movx r30, #63; mov p6, p5
-; ASM-NEXT:    lda dj2, [p3], #12; vldb.popx x10, [p0, lf0, r24]; sub r22, r22, r6; mov dc4, dc3; movs dc0, dc3
+; ASM-NEXT:    lda dj2, [p3], #12; vldb.popx x10, [p0, lf0, r24]; sub r26, r6, r26; mov dc4, dc3; movs dc0, dc3
 ; ASM-NEXT:    vlda.ups.2x cml0, s0, upssign1, [p6], #64; vldb.pop.3d x1, [p0, lf0, r24, d0]; lshl r28, r28, r5; mov r12, #264
 ; ASM-NEXT:    lda dn6, [p3], #-8; movs p2, p7; add r1, r7, r28; mov m3, r7
-; ASM-NEXT:    lda.s8 r6, [p3, dj3]; paddb [p2], m3; lshl r22, r22, r5; mov m3, r1; movs p1, p7
-; ASM-NEXT:    padda [p1], m3; movs dj7, r22; add r5, r1, r22; mov s0, r26
+; ASM-NEXT:    lda.s8 r6, [p3, dj3]; paddb [p2], m3; lshl r26, r26, r5; mov m3, r1; movs p1, p7
+; ASM-NEXT:    padda [p1], m3; movs dj7, r26; add r5, r1, r26; mov s0, r22
 ; ASM-NEXT:    mova r0, #7; vldb.128 wl2, [p1, dj7]; or r10, r8, r0; mov m3, r5; movs dc6, dc3
 ; ASM-NEXT:    padda [p7], m3; vldb x6, [p1, #64]; lshl r0, r3, r0; vbcst.32 x0, r18; movs dc2, dc3
 ; ASM-NEXT:    vlda.ups.2x cmh0, s0, upssign1, [p6], #64; vldb.128 wl4, [p7, #16]; add r0, r20, #-1; mov dj3, r28; movs m3, r0
 ; ASM-NEXT:    lda dj6, [p3, #0]; vldb x8, [p2, dj3]; movx crsrsmode, #0; addm.nc r1, r0, #-1; movs p3, p4
 ; ASM-NEXT:    vlda.ups.2x cml1, s0, upssign1, [p3], #64; movs dc5, dc3; movx r16, #16; vshuffle x10, x10, x1, r4
 ; ASM-NEXT:    vlda.ups.2x cmh1, s0, upssign1, [p3], #64; movs dc1, dc3; add r18, r3, #-1; mov s1, r6
-; ASM-NEXT:  .LBB0_6: // %steady.stage1.top
+; ASM-NEXT:  .LBB0_5: // %steady.stage1.top
 ; ASM-NEXT:    // =>This Loop Header: Depth=1
-; ASM-NEXT:    // Child Loop BB0_7 Depth 2
+; ASM-NEXT:    // Child Loop BB0_6 Depth 2
 ; ASM-NEXT:    nopa ; vldb.popx x10, [p0, lf0, r24]; nops ; nopxm ; nopv
 ; ASM-NEXT:    vldb.pop.3d x8, [p0, lf0, r24, d0]
 ; ASM-NEXT:    vldb.popx x10, [p0, lf0, r24]; mov p2, p1
 ; ASM-NEXT:    vlda x6, [p2, #128]; vldb.pop.3d x8, [p0, lf0, r24, d0]; vmul dm2, x0, x2, r12
 ; ASM-NEXT:    vlda x4, [p2, #192]; vldb.popx x10, [p0, lf0, r24]; add.nc lc, r18, #-6; padds [p2], #128; vmul dm3, x0, x4, r12
-; ASM-NEXT:    vlda x6, [p2, #128]; vldb.pop.3d x8, [p0, lf0, r24, d0]; movxm ls, #.LBB0_7; vaddmac dm1, dm1, dm2, x10, x8, r10
+; ASM-NEXT:    vlda x6, [p2, #128]; vldb.pop.3d x8, [p0, lf0, r24, d0]; movxm ls, #.LBB0_6; vaddmac dm1, dm1, dm2, x10, x8, r10
 ; ASM-NEXT:    vlda x4, [p2, #192]; vldb.popx x10, [p0, lf0, r24]; padds [p2], #128; movxm le, #.L_LEnd1; vaddmac dm0, dm0, dm3, x10, x6, r10
 ; ASM-NEXT:    vlda x6, [p2, #128]; vldb.pop.3d x8, [p0, lf0, r24, d0]; nops ; nopxm ; nopv
 ; ASM-NEXT:    vlda x4, [p2, #192]; vldb.popx x10, [p0, lf0, r24]; padds [p2], #128; nopxm ; nopv
 ; ASM-NEXT:    vlda x6, [p2, #128]; vldb.pop.3d x8, [p0, lf0, r24, d0]; nops ; nopx ; vshuffle x2, x10, x8, r4; nopv
 ; ASM-NEXT:    vlda x4, [p2, #192]; vldb.popx x10, [p0, lf0, r24]; padds [p2], #128; nopxm ; nopv
 ; ASM-NEXT:    vlda x6, [p2, #128]; vldb.pop.3d x8, [p0, lf0, r24, d0]; nops ; nopx ; vshuffle x2, x10, x8, r4; vmac dm1, dm1, x2, x6, r8
-; ASM-NEXT:  .LBB0_7: // %steady.stage1.inner.for.body55.i82
-; ASM-NEXT:    // Parent Loop BB0_6 Depth=1
+; ASM-NEXT:  .LBB0_6: // %steady.stage1.inner.for.body55.i82
+; ASM-NEXT:    // Parent Loop BB0_5 Depth=1
 ; ASM-NEXT:    // => This Inner Loop Header: Depth=2
 ; ASM-NEXT:    vlda x4, [p2, #192]; vldb.popx x10, [p0, lf0, r24]; padds [p2], #128; nopxm ; vmac dm0, dm0, x2, x4, r8
 ; ASM-NEXT:  .L_LEnd1:
 ; ASM-NEXT:    vlda x6, [p2, #128]; vldb.pop.3d x8, [p0, lf0, r24, d0]; nops ; nopx ; vshuffle x2, x10, x8, r4; vmac dm1, dm1, x2, x6, r8
-; ASM-NEXT:  // %bb.8: // %steady.stage1.bottom.and.stage0.top
-; ASM-NEXT:    // in Loop: Header=BB0_6 Depth=1
+; ASM-NEXT:  // %bb.7: // %steady.stage1.bottom.and.stage0.top
+; ASM-NEXT:    // in Loop: Header=BB0_5 Depth=1
 ; ASM-NEXT:    vlda x4, [p2, #192]; paddb.3d [p0], d1; padds [p2], #128; nopx ; mov dc4, dc3; vmac dm0, dm0, x2, x4, r8
 ; ASM-NEXT:    vlda x6, [p2, #128]; paddb [p1], m3; nops ; nopx ; vshuffle x2, x10, x8, r4; vmac dm1, dm1, x2, x6, r8
 ; ASM-NEXT:    vlda x4, [p2, #192]; vldb.popx x10, [p0, lf0, r24]; nopx ; padds [p2], #128; vmac dm0, dm0, x2, x4, r8
 ; ASM-NEXT:    vlda.pop.3d x1, [p0, lf0, r24, d0]; paddb.3d [p1], d2; vshuffle x2, x10, x8, r4; vmac dm1, dm1, x2, x6, r8
 ; ASM-NEXT:    vldb x8, [p1, #0]; mov r0, dc6; vmac dm0, dm0, x2, x4, r8
 ; ASM-NEXT:    vldb x6, [p1, #64]; lshl r0, r0, r2; vshuffle x2, x10, x8, r4; vmac dm1, dm1, x2, x6, r8
-; ASM-NEXT:    movs dj3, r0; movxm p2, #.LBB0_6; vmac dm0, dm0, x2, x4, r8
+; ASM-NEXT:    movs dj3, r0; movxm p2, #.LBB0_5; vmac dm0, dm0, x2, x4, r8
 ; ASM-NEXT:    vldb.128 wl2, [p7, dj3]; vshuffle x2, x10, x8, r4; vmac dm1, dm1, x2, x6, r8
 ; ASM-NEXT:    vlda.ups.2x cml1, s0, upssign1, [p3], #64; or r20, r0, r16; vmac dm0, dm0, x2, x4, r8
 ; ASM-NEXT:    vlda.ups.2x cmh1, s0, upssign1, [p3], #64; mov dj3, r20; vmac dm1, dm1, x2, x6, r8
@@ -226,25 +222,25 @@ define void @conv2d_opt_outerloop_out_mode_1(
 ; ASM-NEXT:    vst.srs.2x cmh1, s1, srssign1, [p4], #64 // Delay Slot 3
 ; ASM-NEXT:    vst.srs.2x cml0, s1, srssign1, [p5], #64 // Delay Slot 2
 ; ASM-NEXT:    vst.srs.2x cmh0, s1, srssign1, [p5], #64 // Delay Slot 1
-; ASM-NEXT:  // %bb.9: // %lastiter.stage1.top
+; ASM-NEXT:  // %bb.8: // %lastiter.stage1.top
 ; ASM-NEXT:    vldb.popx x8, [p0, lf0, r24]
 ; ASM-NEXT:    vldb.pop.3d x6, [p0, lf0, r24, d0]
 ; ASM-NEXT:    vldb.popx x8, [p0, lf0, r24]
 ; ASM-NEXT:    vlda x4, [p1, #128]; vldb.pop.3d x6, [p0, lf0, r24, d0]
 ; ASM-NEXT:    vlda x2, [p1, #192]; vldb.popx x8, [p0, lf0, r24]; add.nc lc, r18, #-6; padds [p1], #128; vmul dm2, x0, x2, r12
-; ASM-NEXT:    vlda x4, [p1, #128]; vldb.pop.3d x6, [p0, lf0, r24, d0]; movxm ls, #.LBB0_10; vmul dm3, x0, x4, r12
+; ASM-NEXT:    vlda x4, [p1, #128]; vldb.pop.3d x6, [p0, lf0, r24, d0]; movxm ls, #.LBB0_9; vmul dm3, x0, x4, r12
 ; ASM-NEXT:    vlda x2, [p1, #192]; vldb.popx x8, [p0, lf0, r24]; padds [p1], #128; movxm le, #.L_LEnd0; vaddmac dm1, dm1, dm2, x10, x8, r10
 ; ASM-NEXT:    vlda x4, [p1, #128]; vldb.pop.3d x6, [p0, lf0, r24, d0]; nops ; nopxm ; vaddmac dm0, dm0, dm3, x10, x6, r10
 ; ASM-NEXT:    vlda x2, [p1, #192]; vldb.popx x8, [p0, lf0, r24]; padds [p1], #128; nopxm ; nopv
 ; ASM-NEXT:    vlda x4, [p1, #128]; vldb.pop.3d x6, [p0, lf0, r24, d0]; nops ; nopx ; vshuffle x0, x8, x6, r4; nopv
 ; ASM-NEXT:    vlda x2, [p1, #192]; vldb.popx x8, [p0, lf0, r24]; padds [p1], #128; nopxm ; nopv
 ; ASM-NEXT:    vlda x4, [p1, #128]; vldb.pop.3d x6, [p0, lf0, r24, d0]; nops ; nopx ; vshuffle x0, x8, x6, r4; vmac dm1, dm1, x0, x4, r8
-; ASM-NEXT:  .LBB0_10: // %lastiter.stage1.inner.for.body55.i82
+; ASM-NEXT:  .LBB0_9: // %lastiter.stage1.inner.for.body55.i82
 ; ASM-NEXT:    // =>This Inner Loop Header: Depth=1
 ; ASM-NEXT:    vlda x2, [p1, #192]; vldb.popx x8, [p0, lf0, r24]; padds [p1], #128; nopxm ; vmac dm0, dm0, x0, x2, r8
 ; ASM-NEXT:  .L_LEnd0:
 ; ASM-NEXT:    vlda x4, [p1, #128]; vldb.pop.3d x6, [p0, lf0, r24, d0]; nops ; nopx ; vshuffle x0, x8, x6, r4; vmac dm1, dm1, x0, x4, r8
-; ASM-NEXT:  // %bb.11: // %lastiter.stage1.bottom
+; ASM-NEXT:  // %bb.10: // %lastiter.stage1.bottom
 ; ASM-NEXT:    vlda x2, [p1, #192]; padds [p1], #128; nopx ; vmac dm0, dm0, x0, x2, r8
 ; ASM-NEXT:    vlda x4, [p1, #128]; movx crsrsmode, #0; vshuffle x0, x8, x6, r4; vmac dm1, dm1, x0, x4, r8
 ; ASM-NEXT:    vlda x2, [p1, #192]; nopb ; padds [p1], #128; or r12, r21, r21; mov s0, r6; vmac dm0, dm0, x0, x2, r8

--- a/llvm/test/CodeGen/AIE/jump-is-expensive.ll
+++ b/llvm/test/CodeGen/AIE/jump-is-expensive.ll
@@ -1,0 +1,54 @@
+;
+; This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+; See https://llvm.org/LICENSE.txt for license information.
+; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+;
+; (c) Copyright 2026 Advanced Micro Devices, Inc. or its affiliates
+; RUN: llc -O2 -mtriple=aie2   %s -o - | FileCheck %s
+; RUN: llc -O2 -mtriple=aie2p  %s -o - | FileCheck %s
+; RUN: llc -O2 -mtriple=aie2ps %s -o - | FileCheck %s
+;
+; The following runs disable the jumpIsExpensive hook to show the previous
+; behaviour, where the short-circuit condition was split and the guarded
+; branch duplicated into two separate conditional jumps.
+; RUN: llc -O2 -mtriple=aie2   -jump-is-expensive=false %s -o - | FileCheck --check-prefix=SPLIT %s
+; RUN: llc -O2 -mtriple=aie2p  -jump-is-expensive=false %s -o - | FileCheck --check-prefix=SPLIT %s
+; RUN: llc -O2 -mtriple=aie2ps -jump-is-expensive=false %s -o - | FileCheck --check-prefix=SPLIT %s
+
+; Test the effect of setJumpIsExpensive(true) for AIE. With the hook enabled a
+; short-circuit `a && b` condition is not split: both comparisons are combined
+; into a single guard value (or) and only one conditional jump (jnz) is emitted.
+; Without the hook (SPLIT) the condition is split into two conditional jumps,
+; each duplicating the branch to the same target, which increases branch count.
+
+; CHECK-LABEL: and_cond:
+; CHECK:         ge  {{.*}}
+; CHECK:         ge  {{.*}}
+; CHECK:         or  {{.*}}
+; CHECK-COUNT-1: jnz {{.*}}
+; CHECK-NOT:     jnz
+; CHECK:         j   #f0
+
+; SPLIT-LABEL: and_cond:
+; SPLIT:         ge  {{.*}}
+; SPLIT:         jnz {{.*}}, #[[END:.LBB[0-9_]+]]
+; SPLIT:         ge  {{.*}}
+; SPLIT:         jnz {{.*}}, #[[END]]
+; SPLIT:         j   #f0
+
+define void @and_cond(i32 %a, i32 %b) {
+entry:
+  %cmpa = icmp sgt i32 %a, 0
+  %cmpb = icmp sgt i32 %b, 0
+  %and = and i1 %cmpa, %cmpb
+  br i1 %and, label %if.then, label %if.end
+
+if.then:
+  tail call void @f0()
+  br label %if.end
+
+if.end:
+  ret void
+}
+
+declare void @f0()


### PR DESCRIPTION
Enable setJumpIsExpensive(true) so that short-circuit conditions such as 'a && b' are combined into a single guard instead of being split into multiple conditional branches, reducing the branch count. Add a dedicated test and update affected in-tree tests.